### PR TITLE
ai: validate prompt templates at startup with dry-run render

### DIFF
--- a/internal/ai/prompt.go
+++ b/internal/ai/prompt.go
@@ -38,6 +38,13 @@ type PromptSource struct {
 	Prompt     string // inline text, mutually exclusive with PromptFile
 }
 
+func (s PromptSource) description() string {
+	if s.PromptFile != "" {
+		return s.PromptFile
+	}
+	return "inline prompt"
+}
+
 // SkillGuidance holds the resolved guidance for a skill, either from
 // a file path or an inline prompt string.
 type SkillGuidance struct {
@@ -117,6 +124,9 @@ func (p *PromptStore) loadTemplates(issueBase PromptSource, prBase PromptSource,
 	if err != nil {
 		return err
 	}
+	if err := dryRunTemplate(issueTpl, IssuePromptData{}, issueBase.description()); err != nil {
+		return err
+	}
 	p.issueTpl = issueTpl
 
 	prBaseTpl, err := loadPromptSource(prBase)
@@ -129,6 +139,9 @@ func (p *PromptStore) loadTemplates(issueBase PromptSource, prBase PromptSource,
 		normalized := NormalizeToken(agent.Name)
 		tpl, err := p.composeSkillsTemplate(prBaseTpl, normalized, agent.Skills)
 		if err != nil {
+			return err
+		}
+		if err := dryRunTemplate(tpl, PRReviewPromptData{}, fmt.Sprintf("%s (pr review agent %q)", prBase.description(), normalized)); err != nil {
 			return err
 		}
 		p.prTemplates[normalized] = tpl
@@ -144,6 +157,9 @@ func (p *PromptStore) loadTemplates(issueBase PromptSource, prBase PromptSource,
 		normalized := NormalizeToken(agent.Name)
 		tpl, err := p.composeSkillsTemplate(autoBaseTpl, normalized, agent.Skills)
 		if err != nil {
+			return err
+		}
+		if err := dryRunTemplate(tpl, AutonomousPromptData{}, fmt.Sprintf("%s (autonomous agent %q)", autoBase.description(), normalized)); err != nil {
 			return err
 		}
 		p.autoTemplates[normalized] = tpl
@@ -205,6 +221,17 @@ func loadPromptSource(src PromptSource) (*template.Template, error) {
 		return tpl, nil
 	}
 	return nil, fmt.Errorf("prompt source has neither file nor inline content")
+}
+
+// dryRunTemplate executes a template with zero-value data to catch field
+// access errors (e.g. typos like {{.Nubmer}}) at startup rather than at the
+// first real invocation, which may be hours later for cron-scheduled agents.
+func dryRunTemplate(tpl *template.Template, data any, source string) error {
+	var buf bytes.Buffer
+	if err := tpl.Execute(&buf, data); err != nil {
+		return fmt.Errorf("prompt template validation failed for %s: %w", source, err)
+	}
+	return nil
 }
 
 func executeTemplate(tpl *template.Template, data any, name string) (string, error) {

--- a/internal/ai/prompt_test.go
+++ b/internal/ai/prompt_test.go
@@ -125,3 +125,67 @@ func TestPromptStoreValidateFailsOnMissingTemplate(t *testing.T) {
 		t.Fatalf("expected construction failure for missing templates")
 	}
 }
+
+func TestPromptStoreRejectsIssueTemplateWithUnknownField(t *testing.T) {
+	t.Parallel()
+	// {{.Nubmer}} is a typo for {{.Number}}; the error must surface at startup.
+	issueBase := ai.PromptSource{Prompt: "issue {{.Repo}} #{{.Nubmer}}"}
+	prBase := ai.PromptSource{Prompt: `{{template "agent_guidance" .}}`}
+	autoBase := ai.PromptSource{Prompt: `{{template "agent_guidance" .}}`}
+	_, err := ai.NewPromptStore(issueBase, prBase, autoBase, nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected error for unknown field .Nubmer in issue template, got nil")
+	}
+	if !strings.Contains(err.Error(), "Nubmer") {
+		t.Fatalf("expected error to mention the unknown field, got: %v", err)
+	}
+}
+
+func TestPromptStoreRejectsPRTemplateWithUnknownField(t *testing.T) {
+	t.Parallel()
+	// {{.AgentHeadng}} is a typo for {{.AgentHeading}}.
+	issueBase := ai.PromptSource{Prompt: "issue {{.Repo}} #{{.Number}}"}
+	prBase := ai.PromptSource{Prompt: `{{.AgentHeadng}} {{template "agent_guidance" .}}`}
+	autoBase := ai.PromptSource{Prompt: `{{template "agent_guidance" .}}`}
+	skills := []ai.SkillGuidance{{Name: "sec", Prompt: "security guidance"}}
+	prAgents := []ai.AgentSkills{{Name: "sec", Skills: []string{"sec"}}}
+	_, err := ai.NewPromptStore(issueBase, prBase, autoBase, skills, prAgents, nil)
+	if err == nil {
+		t.Fatal("expected error for unknown field .AgentHeadng in pr template, got nil")
+	}
+	if !strings.Contains(err.Error(), "AgentHeadng") {
+		t.Fatalf("expected error to mention the unknown field, got: %v", err)
+	}
+}
+
+func TestPromptStoreRejectsAutonomousTemplateWithUnknownField(t *testing.T) {
+	t.Parallel()
+	// {{.AgentNam}} is a typo for {{.AgentName}}.
+	issueBase := ai.PromptSource{Prompt: "issue {{.Repo}} #{{.Number}}"}
+	prBase := ai.PromptSource{Prompt: `{{template "agent_guidance" .}}`}
+	autoBase := ai.PromptSource{Prompt: `{{.AgentNam}} {{template "agent_guidance" .}}`}
+	skills := []ai.SkillGuidance{{Name: "sec", Prompt: "security guidance"}}
+	autoAgents := []ai.AgentSkills{{Name: "sec", Skills: []string{"sec"}}}
+	_, err := ai.NewPromptStore(issueBase, prBase, autoBase, skills, nil, autoAgents)
+	if err == nil {
+		t.Fatal("expected error for unknown field .AgentNam in autonomous template, got nil")
+	}
+	if !strings.Contains(err.Error(), "AgentNam") {
+		t.Fatalf("expected error to mention the unknown field, got: %v", err)
+	}
+}
+
+func TestPromptStoreErrorIncludesSourceDescription(t *testing.T) {
+	t.Parallel()
+	// Confirm the error message includes a useful source reference.
+	issueBase := ai.PromptSource{Prompt: "issue {{.Nubmer}}"}
+	prBase := ai.PromptSource{Prompt: `{{template "agent_guidance" .}}`}
+	autoBase := ai.PromptSource{Prompt: `{{template "agent_guidance" .}}`}
+	_, err := ai.NewPromptStore(issueBase, prBase, autoBase, nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected construction error, got nil")
+	}
+	if !strings.Contains(err.Error(), "inline prompt") {
+		t.Fatalf("expected error to reference 'inline prompt', got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a `dryRunTemplate` function that executes each fully-composed template with zero-value data immediately during `NewPromptStore` construction.
- Errors from typos like `{{.Nubmer}}` (instead of `{{.Number}}`) are now returned at daemon startup, not hours later when a cron-scheduled agent first runs.
- Error messages include the prompt source (file path or `"inline prompt"`) and the agent name, so users can locate the misconfigured template in `config.yaml`.

## Test plan

- [x] `TestPromptStoreRejectsIssueTemplateWithUnknownField` — typo in issue template caught at construction
- [x] `TestPromptStoreRejectsPRTemplateWithUnknownField` — typo in PR review template caught at construction
- [x] `TestPromptStoreRejectsAutonomousTemplateWithUnknownField` — typo in autonomous template caught at construction
- [x] `TestPromptStoreErrorIncludesSourceDescription` — error message references `"inline prompt"` so users can find the bad template
- [x] All existing tests still pass: `go test ./...`

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)