### PR TITLE
feat: rich /status endpoint with uptime, queue depths, and agent schedules

### DIFF
--- a/cmd/agents/main.go
+++ b/cmd/agents/main.go
@@ -62,7 +62,7 @@ func run() error {
 		return err
 	}
 	deliveryStore := webhook.NewDeliveryStore(time.Duration(cfg.HTTP.DeliveryTTLSeconds) * time.Second)
-	server := webhook.NewServer(cfg, deliveryStore, dataChannels, logger)
+	server := webhook.NewServer(cfg, deliveryStore, dataChannels, schedulerStatusAdapter{scheduler}, logger)
 	group, groupCtx := errgroup.WithContext(ctx)
 	group.Go(func() error {
 		return processor.Run(groupCtx)
@@ -139,6 +139,28 @@ func collectAutonomousAgentSkills(cfg *config.Config) []ai.AgentSkills {
 		}
 	}
 	return result
+}
+
+// schedulerStatusAdapter adapts *autonomous.Scheduler to webhook.StatusProvider,
+// converting autonomous.AgentStatus to webhook.AgentStatus without coupling the
+// two packages to each other.
+type schedulerStatusAdapter struct {
+	s *autonomous.Scheduler
+}
+
+func (a schedulerStatusAdapter) AgentStatuses() []webhook.AgentStatus {
+	raw := a.s.AgentStatuses()
+	out := make([]webhook.AgentStatus, len(raw))
+	for i, s := range raw {
+		out[i] = webhook.AgentStatus{
+			Name:       s.Name,
+			Repo:       s.Repo,
+			LastRun:    s.LastRun,
+			NextRun:    s.NextRun,
+			LastStatus: s.LastStatus,
+		}
+	}
+	return out
 }
 
 func resolvePrompts(cfg *config.Config) (issue ai.PromptSource, pr ai.PromptSource, auto ai.PromptSource) {

--- a/internal/autonomous/scheduler.go
+++ b/internal/autonomous/scheduler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/robfig/cron/v3"
 	"github.com/rs/zerolog"
@@ -12,15 +13,40 @@ import (
 	"github.com/eloylp/agents/internal/config"
 )
 
+// AgentStatus is the runtime state of a single registered autonomous agent.
+type AgentStatus struct {
+	Name       string
+	Repo       string
+	LastRun    *time.Time // nil if the agent has never run in this process lifetime
+	NextRun    time.Time
+	LastStatus string // "success", "error", or "" if never run
+}
+
+// agentEntry records the metadata for a registered cron job.
+type agentEntry struct {
+	name   string
+	repo   string
+	cronID cron.EntryID
+}
+
+// lastRunRecord holds the outcome of the most recent agent execution.
+type lastRunRecord struct {
+	at     time.Time
+	status string
+}
+
 type Scheduler struct {
-	cfg      *config.Config
-	runners  map[string]ai.Runner
-	prompts  *ai.PromptStore
-	memories *MemoryStore
-	cron     *cron.Cron
-	logger   zerolog.Logger
-	ctxMu    sync.RWMutex
-	runCtx   context.Context
+	cfg          *config.Config
+	runners      map[string]ai.Runner
+	prompts      *ai.PromptStore
+	memories     *MemoryStore
+	cron         *cron.Cron
+	logger       zerolog.Logger
+	ctxMu        sync.RWMutex
+	runCtx       context.Context
+	agentEntries []agentEntry
+	lastRunsMu   sync.RWMutex
+	lastRuns     map[string]lastRunRecord // key: "name\x00repo"
 }
 
 func NewScheduler(cfg *config.Config, runners map[string]ai.Runner, prompts *ai.PromptStore, memories *MemoryStore, logger zerolog.Logger) (*Scheduler, error) {
@@ -33,6 +59,7 @@ func NewScheduler(cfg *config.Config, runners map[string]ai.Runner, prompts *ai.
 		memories: memories,
 		cron:     c,
 		logger:   logger.With().Str("component", "autonomous_scheduler").Logger(),
+		lastRuns: make(map[string]lastRunRecord),
 	}
 	if err := s.registerJobs(); err != nil {
 		return nil, err
@@ -70,6 +97,7 @@ func (s *Scheduler) registerJobs() error {
 			if err != nil {
 				return fmt.Errorf("schedule autonomous agent %s for repo %s: %w", agent.Name, repo.FullName, err)
 			}
+			s.agentEntries = append(s.agentEntries, agentEntry{name: agent.Name, repo: repo.FullName, cronID: id})
 			entry := s.cron.Entry(id)
 			s.logger.Info().
 				Str("repo", repo.FullName).
@@ -107,10 +135,63 @@ func (s *Scheduler) runAgent(repo string, agent config.AutonomousAgentConfig) fu
 			}
 			return nil
 		})
+		runStatus := "success"
 		if err != nil {
 			logger.Error().Err(err).Msg("autonomous agent run completed with errors")
+			runStatus = "error"
 		}
+		s.recordLastRun(agent.Name, repo, time.Now(), runStatus)
 	}
+}
+
+func (s *Scheduler) recordLastRun(name, repo string, at time.Time, status string) {
+	key := name + "\x00" + repo
+	s.lastRunsMu.Lock()
+	s.lastRuns[key] = lastRunRecord{at: at, status: status}
+	s.lastRunsMu.Unlock()
+}
+
+// AgentStatuses returns the current scheduling state for all registered agents.
+func (s *Scheduler) AgentStatuses() []AgentStatus {
+	s.lastRunsMu.RLock()
+	runs := make(map[string]lastRunRecord, len(s.lastRuns))
+	for k, v := range s.lastRuns {
+		runs[k] = v
+	}
+	s.lastRunsMu.RUnlock()
+
+	entries := s.cron.Entries()
+	entryByID := make(map[cron.EntryID]cron.Entry, len(entries))
+	for _, e := range entries {
+		entryByID[e.ID] = e
+	}
+
+	statuses := make([]AgentStatus, 0, len(s.agentEntries))
+	for _, ae := range s.agentEntries {
+		entry, ok := entryByID[ae.cronID]
+		if !ok {
+			continue
+		}
+		key := ae.name + "\x00" + ae.repo
+		lr := runs[key]
+		var lastRun *time.Time
+		if !lr.at.IsZero() {
+			t := lr.at
+			lastRun = &t
+		}
+		nextRun := entry.Next
+		if nextRun.IsZero() && entry.Schedule != nil {
+			nextRun = entry.Schedule.Next(time.Now())
+		}
+		statuses = append(statuses, AgentStatus{
+			Name:       ae.name,
+			Repo:       ae.repo,
+			LastRun:    lastRun,
+			NextRun:    nextRun,
+			LastStatus: lr.status,
+		})
+	}
+	return statuses
 }
 
 func (s *Scheduler) resolveBackend(configured string) string {

--- a/internal/autonomous/scheduler_test.go
+++ b/internal/autonomous/scheduler_test.go
@@ -284,6 +284,101 @@ func TestSchedulerRunAgentAutoFallsBackToDefaultConfiguredBackend(t *testing.T) 
 	}
 }
 
+func TestSchedulerAgentStatusesBeforeFirstRun(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	prompts := buildTestPromptStore(t, dir)
+	cfg := &config.Config{
+		AgentsDir: dir,
+		AIBackends: map[string]config.AIBackendConfig{
+			"claude": {},
+		},
+		Repos: []config.RepoConfig{
+			{FullName: "owner/repo", Enabled: true},
+		},
+		AutonomousAgents: []config.AutonomousRepoConfig{
+			{
+				Repo:    "owner/repo",
+				Enabled: true,
+				Agents: []config.AutonomousAgentConfig{
+					{Name: "architect", Description: "desc", Cron: "0 9 * * *", Skills: []string{"architect"},
+						Tasks: []config.TaskConfig{{Name: "scan", Prompt: "scan issues"}}},
+				},
+			},
+		},
+	}
+	scheduler, err := NewScheduler(cfg, map[string]ai.Runner{"claude": &stubRunner{}}, prompts, NewMemoryStore(dir), zerolog.Nop())
+	if err != nil {
+		t.Fatalf("scheduler: %v", err)
+	}
+
+	statuses := scheduler.AgentStatuses()
+	if len(statuses) != 1 {
+		t.Fatalf("expected 1 agent status, got %d", len(statuses))
+	}
+	if statuses[0].Name != "architect" {
+		t.Errorf("expected agent name architect, got %q", statuses[0].Name)
+	}
+	if statuses[0].Repo != "owner/repo" {
+		t.Errorf("expected repo owner/repo, got %q", statuses[0].Repo)
+	}
+	if statuses[0].LastRun != nil {
+		t.Errorf("expected last_run nil before first run, got %v", statuses[0].LastRun)
+	}
+	if statuses[0].LastStatus != "" {
+		t.Errorf("expected empty last_status before first run, got %q", statuses[0].LastStatus)
+	}
+	if statuses[0].NextRun.IsZero() {
+		t.Errorf("expected non-zero next_run")
+	}
+}
+
+func TestSchedulerAgentStatusesAfterRun(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	prompts := buildTestPromptStore(t, dir)
+	agentCfg := config.AutonomousAgentConfig{
+		Name:    "architect",
+		Cron:    "0 9 * * *",
+		Backend: "claude",
+		Skills:  []string{"architect"},
+		Tasks:   []config.TaskConfig{{Name: "scan", Prompt: "scan issues"}},
+	}
+	cfg := &config.Config{
+		AgentsDir: dir,
+		AIBackends: map[string]config.AIBackendConfig{
+			"claude": {},
+		},
+		Repos: []config.RepoConfig{
+			{FullName: "owner/repo", Enabled: true},
+		},
+		AutonomousAgents: []config.AutonomousRepoConfig{
+			{
+				Repo:    "owner/repo",
+				Enabled: true,
+				Agents:  []config.AutonomousAgentConfig{agentCfg},
+			},
+		},
+	}
+	scheduler, err := NewScheduler(cfg, map[string]ai.Runner{"claude": &stubRunner{}}, prompts, NewMemoryStore(dir), zerolog.Nop())
+	if err != nil {
+		t.Fatalf("scheduler: %v", err)
+	}
+
+	scheduler.runAgent("owner/repo", agentCfg)()
+
+	statuses := scheduler.AgentStatuses()
+	if len(statuses) != 1 {
+		t.Fatalf("expected 1 agent status, got %d", len(statuses))
+	}
+	if statuses[0].LastStatus != "success" {
+		t.Errorf("expected last_status success, got %q", statuses[0].LastStatus)
+	}
+	if statuses[0].LastRun == nil {
+		t.Errorf("expected last_run to be set after a run")
+	}
+}
+
 func writeIssuePrompt(t *testing.T, dir string) {
 	t.Helper()
 	issueDir := filepath.Join(dir, "issue_refinement_prompts")

--- a/internal/webhook/server.go
+++ b/internal/webhook/server.go
@@ -19,19 +19,38 @@ import (
 	"github.com/eloylp/agents/internal/workflow"
 )
 
-type Server struct {
-	cfg      *config.Config
-	delivery *DeliveryStore
-	logger   zerolog.Logger
-	channels *workflow.DataChannels
+// AgentStatus is the runtime state of one autonomous agent as reported by /status.
+type AgentStatus struct {
+	Name       string     `json:"name"`
+	Repo       string     `json:"repo"`
+	LastRun    *time.Time `json:"last_run,omitempty"`
+	NextRun    time.Time  `json:"next_run"`
+	LastStatus string     `json:"last_status,omitempty"`
 }
 
-func NewServer(cfg *config.Config, delivery *DeliveryStore, channels *workflow.DataChannels, logger zerolog.Logger) *Server {
+// StatusProvider reports the current scheduling state of autonomous agents.
+// The implementation is optional; passing nil results in an empty agents list.
+type StatusProvider interface {
+	AgentStatuses() []AgentStatus
+}
+
+type Server struct {
+	cfg       *config.Config
+	delivery  *DeliveryStore
+	logger    zerolog.Logger
+	channels  *workflow.DataChannels
+	provider  StatusProvider
+	startTime time.Time
+}
+
+func NewServer(cfg *config.Config, delivery *DeliveryStore, channels *workflow.DataChannels, provider StatusProvider, logger zerolog.Logger) *Server {
 	return &Server{
-		cfg:      cfg,
-		delivery: delivery,
-		logger:   logger.With().Str("component", "webhook_server").Logger(),
-		channels: channels,
+		cfg:       cfg,
+		delivery:  delivery,
+		logger:    logger.With().Str("component", "webhook_server").Logger(),
+		channels:  channels,
+		provider:  provider,
+		startTime: time.Now(),
 	}
 }
 
@@ -67,8 +86,38 @@ func (s *Server) Run(ctx context.Context) error {
 }
 
 func (s *Server) handleStatus(w http.ResponseWriter, _ *http.Request) {
-	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte("ok"))
+	issueQ, prQ := s.channels.QueueStats()
+
+	type queueJSON struct {
+		Buffered int `json:"buffered"`
+		Capacity int `json:"capacity"`
+	}
+	type statusJSON struct {
+		Status        string               `json:"status"`
+		UptimeSeconds int64                `json:"uptime_seconds"`
+		Queues        map[string]queueJSON `json:"queues"`
+		Agents        []AgentStatus        `json:"agents"`
+	}
+
+	agents := []AgentStatus{}
+	if s.provider != nil {
+		if got := s.provider.AgentStatuses(); len(got) > 0 {
+			agents = got
+		}
+	}
+
+	resp := statusJSON{
+		Status:        "ok",
+		UptimeSeconds: int64(time.Since(s.startTime).Seconds()),
+		Queues: map[string]queueJSON{
+			"issues": {Buffered: issueQ.Buffered, Capacity: issueQ.Capacity},
+			"prs":    {Buffered: prQ.Buffered, Capacity: prQ.Capacity},
+		},
+		Agents: agents,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
 }
 
 func (s *Server) handleGitHubWebhook(w http.ResponseWriter, r *http.Request) {

--- a/internal/webhook/server_test.go
+++ b/internal/webhook/server_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -28,7 +29,7 @@ func TestHandleIssueWebhookDeduplicatesDelivery(t *testing.T) {
 		Repos: []config.RepoConfig{{FullName: "owner/repo", Enabled: true}},
 	}
 	dataChannels := workflow.NewDataChannels(1, 1)
-	server := NewServer(cfg, NewDeliveryStore(time.Hour), dataChannels, zerolog.Nop())
+	server := NewServer(cfg, NewDeliveryStore(time.Hour), dataChannels, nil, zerolog.Nop())
 
 	body := `{"action":"labeled","label":{"name":"ai:refine"},"repository":{"full_name":"owner/repo"},"issue":{"number":1,"title":"t","body":"b","updated_at":"2026-02-15T00:00:00Z","labels":[{"name":"ai:refine"}]}}`
 	sig := signatureForTests([]byte(body), "secret")
@@ -77,7 +78,7 @@ func TestHandleWebhookIgnoresNonAILabel(t *testing.T) {
 		Repos: []config.RepoConfig{{FullName: "owner/repo", Enabled: true}},
 	}
 	dataChannels := workflow.NewDataChannels(1, 1)
-	server := NewServer(cfg, NewDeliveryStore(time.Hour), dataChannels, zerolog.Nop())
+	server := NewServer(cfg, NewDeliveryStore(time.Hour), dataChannels, nil, zerolog.Nop())
 
 	body := `{"action":"labeled","label":{"name":"bug"},"repository":{"full_name":"owner/repo"},"pull_request":{"number":2,"title":"t","body":"b","updated_at":"2026-02-15T00:00:00Z","labels":[{"name":"bug"}],"head":{"sha":"abc"}}}`
 	sig := signatureForTests([]byte(body), "secret")
@@ -108,7 +109,7 @@ func TestInvalidSignatureDoesNotPoisonDeliveryDedupe(t *testing.T) {
 		Repos: []config.RepoConfig{{FullName: "owner/repo", Enabled: true}},
 	}
 	dataChannels := workflow.NewDataChannels(1, 1)
-	server := NewServer(cfg, NewDeliveryStore(time.Hour), dataChannels, zerolog.Nop())
+	server := NewServer(cfg, NewDeliveryStore(time.Hour), dataChannels, nil, zerolog.Nop())
 
 	body := `{"action":"labeled","label":{"name":"ai:refine"},"repository":{"full_name":"owner/repo"},"issue":{"number":7}}`
 
@@ -148,7 +149,7 @@ func TestHandleIssueWebhookUsesEventLabelAsTrigger(t *testing.T) {
 		Repos: []config.RepoConfig{{FullName: "owner/repo", Enabled: true}},
 	}
 	dataChannels := workflow.NewDataChannels(1, 1)
-	server := NewServer(cfg, NewDeliveryStore(time.Hour), dataChannels, zerolog.Nop())
+	server := NewServer(cfg, NewDeliveryStore(time.Hour), dataChannels, nil, zerolog.Nop())
 
 	body := `{"action":"labeled","label":{"name":"ai:refine:codex"},"repository":{"full_name":"owner/repo"},"issue":{"number":3,"title":"t","body":"b","updated_at":"2026-02-15T00:00:00Z","labels":[{"name":"ai:refine:claude"}]}}`
 	sig := signatureForTests([]byte(body), "secret")
@@ -189,7 +190,7 @@ func TestHandleIssueWebhookReturnsServiceUnavailableWhenQueueFull(t *testing.T) 
 	}); err != nil {
 		t.Fatalf("preload issue queue: %v", err)
 	}
-	server := NewServer(cfg, NewDeliveryStore(time.Hour), dataChannels, zerolog.Nop())
+	server := NewServer(cfg, NewDeliveryStore(time.Hour), dataChannels, nil, zerolog.Nop())
 
 	body := `{"action":"labeled","label":{"name":"ai:refine"},"repository":{"full_name":"owner/repo"},"issue":{"number":2}}`
 	sig := signatureForTests([]byte(body), "secret")
@@ -232,6 +233,112 @@ func TestVerifySignature(t *testing.T) {
 	if verifySignature(body, secret, "sha256=deadbeef") {
 		t.Fatalf("expected invalid signature to fail")
 	}
+}
+
+func TestHandleStatusReturnsJSON(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{
+		HTTP: config.HTTPConfig{
+			MaxBodyBytes:       1024,
+			WebhookSecret:      "secret",
+			DeliveryTTLSeconds: 3600,
+		},
+		Repos: []config.RepoConfig{{FullName: "owner/repo", Enabled: true}},
+	}
+	dataChannels := workflow.NewDataChannels(8, 4)
+	server := NewServer(cfg, NewDeliveryStore(time.Hour), dataChannels, nil, zerolog.Nop())
+
+	req := httptest.NewRequest(http.MethodGet, "/status", nil)
+	rr := httptest.NewRecorder()
+	server.handleStatus(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("expected Content-Type application/json, got %q", ct)
+	}
+
+	var resp struct {
+		Status        string `json:"status"`
+		UptimeSeconds int64  `json:"uptime_seconds"`
+		Queues        struct {
+			Issues struct {
+				Buffered int `json:"buffered"`
+				Capacity int `json:"capacity"`
+			} `json:"issues"`
+			PRs struct {
+				Buffered int `json:"buffered"`
+				Capacity int `json:"capacity"`
+			} `json:"prs"`
+		} `json:"queues"`
+		Agents []AgentStatus `json:"agents"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Status != "ok" {
+		t.Errorf("expected status ok, got %q", resp.Status)
+	}
+	if resp.Queues.Issues.Capacity != 8 {
+		t.Errorf("expected issue queue capacity 8, got %d", resp.Queues.Issues.Capacity)
+	}
+	if resp.Queues.PRs.Capacity != 4 {
+		t.Errorf("expected PR queue capacity 4, got %d", resp.Queues.PRs.Capacity)
+	}
+	if resp.Agents == nil {
+		t.Errorf("expected non-nil agents slice")
+	}
+}
+
+func TestHandleStatusIncludesAgentStatuses(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{
+		HTTP: config.HTTPConfig{
+			MaxBodyBytes:       1024,
+			WebhookSecret:      "secret",
+			DeliveryTTLSeconds: 3600,
+		},
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	provider := &stubStatusProvider{
+		statuses: []AgentStatus{
+			{Name: "bug-fixer", Repo: "owner/repo", LastRun: &now, NextRun: now.Add(time.Hour), LastStatus: "success"},
+		},
+	}
+	dataChannels := workflow.NewDataChannels(1, 1)
+	server := NewServer(cfg, NewDeliveryStore(time.Hour), dataChannels, provider, zerolog.Nop())
+
+	req := httptest.NewRequest(http.MethodGet, "/status", nil)
+	rr := httptest.NewRecorder()
+	server.handleStatus(rr, req)
+
+	var resp struct {
+		Agents []AgentStatus `json:"agents"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.Agents) != 1 {
+		t.Fatalf("expected 1 agent, got %d", len(resp.Agents))
+	}
+	if resp.Agents[0].Name != "bug-fixer" {
+		t.Errorf("expected agent name bug-fixer, got %q", resp.Agents[0].Name)
+	}
+	if resp.Agents[0].LastStatus != "success" {
+		t.Errorf("expected last_status success, got %q", resp.Agents[0].LastStatus)
+	}
+	if resp.Agents[0].LastRun == nil {
+		t.Errorf("expected last_run to be set")
+	}
+}
+
+type stubStatusProvider struct {
+	statuses []AgentStatus
+}
+
+func (s *stubStatusProvider) AgentStatuses() []AgentStatus {
+	return s.statuses
 }
 
 func signatureForTests(payload []byte, secret string) string {

--- a/internal/workflow/data_channels.go
+++ b/internal/workflow/data_channels.go
@@ -69,6 +69,21 @@ func (dc *DataChannels) PRChan() <-chan PRRequest {
 	return dc.prQueue
 }
 
+// QueueStat describes the current depth and capacity of one event queue.
+type QueueStat struct {
+	Buffered int
+	Capacity int
+}
+
+// QueueStats returns the current depth and capacity of the issue and PR queues.
+// Reading channel length and capacity is safe without holding the mutex because
+// these are intrinsic properties of the channel value and the lock only guards
+// the closed flag and send operations.
+func (dc *DataChannels) QueueStats() (issues, prs QueueStat) {
+	return QueueStat{len(dc.issueQueue), cap(dc.issueQueue)},
+		QueueStat{len(dc.prQueue), cap(dc.prQueue)}
+}
+
 // Close shuts down both queues. The write lock ensures no in-flight Push call
 // can race with channel closure. Subsequent Close calls are safe because the
 // closed flag is checked first.


### PR DESCRIPTION
## Summary

- Replaces the static `"ok"` string from `GET /status` with a JSON response containing `status`, `uptime_seconds`, per-queue `buffered`/`capacity` stats, and per-agent scheduling state (`name`, `repo`, `last_run`, `next_run`, `last_status`).
- `workflow.DataChannels` gains `QueueStats()` returning the depth and capacity of both event queues.
- `autonomous.Scheduler` now tracks cron entry metadata and last-run outcomes (success/error) in a `RWMutex`-guarded map; `AgentStatuses()` derives `next_run` from the cron schedule so it is non-zero even before `Run()` is called.
- `webhook.Server` accepts a `StatusProvider` interface (nil-safe for deployments without autonomous agents) and a `startTime` field; `handleStatus` serialises the full status as JSON with `Content-Type: application/json`.
- `main.go` wires `*autonomous.Scheduler` → `webhook.StatusProvider` via a local `schedulerStatusAdapter`, keeping the two packages decoupled.

Closes #55

## Test plan

- [ ] `TestHandleStatusReturnsJSON` — verifies JSON shape, Content-Type, and correct queue capacity reflection.
- [ ] `TestHandleStatusIncludesAgentStatuses` — verifies agent name, repo, last_run, and last_status are included when a StatusProvider is wired.
- [ ] `TestSchedulerAgentStatusesBeforeFirstRun` — verifies `last_run` is nil and `next_run` is non-zero before any run.
- [ ] `TestSchedulerAgentStatusesAfterRun` — verifies `last_status: success` and `last_run` is set after a successful run.
- [ ] All existing tests pass: `go test ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)