### PR TITLE
feat(autonomous): on-demand agent trigger via CLI flag and API endpoint

### DIFF
--- a/cmd/agents/main.go
+++ b/cmd/agents/main.go
@@ -37,6 +37,8 @@ func run() error {
 	_ = godotenv.Load()
 
 	configPath := flag.String("config", "config.yaml", "path to config file")
+	runAgent := flag.String("run-agent", "", "run a single autonomous agent pass and exit (requires --repo)")
+	runRepo := flag.String("repo", "", "repo to target when using --run-agent (e.g. owner/repo)")
 	flag.Parse()
 
 	cfg, err := config.Load(*configPath)
@@ -45,7 +47,6 @@ func run() error {
 	}
 
 	logger := logging.NewLogger(cfg.Log)
-	logger.Info().Msg("starting agents daemon")
 
 	promptStore, err := setupPromptStore(cfg, logger)
 	if err != nil {
@@ -53,16 +54,32 @@ func run() error {
 	}
 
 	runners := setupRunners(cfg, logger)
-	engine := workflow.NewEngine(cfg, runners, promptStore, logger)
-	dataChannels := workflow.NewDataChannels(cfg.Processor.IssueQueueBuffer, cfg.Processor.PRQueueBuffer)
-	processor := workflow.NewProcessor(dataChannels, engine, time.Duration(cfg.HTTP.ShutdownTimeoutSeconds)*time.Second, logger)
 
 	scheduler, err := setupScheduler(cfg, runners, promptStore, logger)
 	if err != nil {
 		return err
 	}
+
+	// --run-agent mode: execute one agent pass synchronously and exit.
+	if *runAgent != "" {
+		if *runRepo == "" {
+			return fmt.Errorf("--repo is required when using --run-agent")
+		}
+		logger.Info().Str("agent", *runAgent).Str("repo", *runRepo).Msg("running autonomous agent on demand")
+		if err := scheduler.TriggerAgent(ctx, *runAgent, *runRepo); err != nil {
+			return fmt.Errorf("run agent: %w", err)
+		}
+		logger.Info().Str("agent", *runAgent).Str("repo", *runRepo).Msg("on-demand agent run completed")
+		return nil
+	}
+
+	logger.Info().Msg("starting agents daemon")
+
+	engine := workflow.NewEngine(cfg, runners, promptStore, logger)
+	dataChannels := workflow.NewDataChannels(cfg.Processor.IssueQueueBuffer, cfg.Processor.PRQueueBuffer)
+	processor := workflow.NewProcessor(dataChannels, engine, time.Duration(cfg.HTTP.ShutdownTimeoutSeconds)*time.Second, logger)
 	deliveryStore := webhook.NewDeliveryStore(time.Duration(cfg.HTTP.DeliveryTTLSeconds) * time.Second)
-	server := webhook.NewServer(cfg, deliveryStore, dataChannels, schedulerStatusAdapter{scheduler}, logger)
+	server := webhook.NewServer(cfg, deliveryStore, dataChannels, schedulerStatusAdapter{scheduler}, logger, scheduler)
 	group, groupCtx := errgroup.WithContext(ctx)
 	group.Go(func() error {
 		return processor.Run(groupCtx)

--- a/internal/autonomous/scheduler.go
+++ b/internal/autonomous/scheduler.go
@@ -3,6 +3,7 @@ package autonomous
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -116,27 +117,9 @@ func (s *Scheduler) runAgent(repo string, agent config.AutonomousAgentConfig) fu
 		if ctx.Err() != nil {
 			return
 		}
-		logger := s.logger.With().Str("repo", repo).Str("agent", agent.Name).Logger()
-		backend := s.resolveBackend(agent.Backend)
-		if backend == "" {
-			logger.Error().Str("configured_backend", agent.Backend).Msg("no configured backend for autonomous agent run")
-			return
-		}
-		runner, ok := s.runners[backend]
-		if !ok {
-			logger.Error().Str("backend", backend).Msg("no runner for configured backend")
-			return
-		}
-		err := s.memories.WithLock(agent.Name, repo, func(memoryPath string, memory string) error {
-			for _, task := range agent.Tasks {
-				if err := s.runTask(ctx, runner, backend, repo, agent, task.Name, task.Prompt, memoryPath, memory, logger); err != nil {
-					return err
-				}
-			}
-			return nil
-		})
 		runStatus := "success"
-		if err != nil {
+		if err := s.executeAgentRun(ctx, repo, agent); err != nil {
+			logger := s.logger.With().Str("repo", repo).Str("agent", agent.Name).Logger()
 			logger.Error().Err(err).Msg("autonomous agent run completed with errors")
 			runStatus = "error"
 		}
@@ -192,6 +175,50 @@ func (s *Scheduler) AgentStatuses() []AgentStatus {
 		})
 	}
 	return statuses
+}
+
+// TriggerAgent runs the named agent for the given repo synchronously using the
+// provided context. It returns an error if the agent or repo is not found, or
+// if the run itself fails.
+func (s *Scheduler) TriggerAgent(ctx context.Context, agentName, repo string) error {
+	agentName = strings.ToLower(strings.TrimSpace(agentName))
+	repo = strings.TrimSpace(repo)
+	for _, repoCfg := range s.cfg.AutonomousAgents {
+		if !strings.EqualFold(repoCfg.Repo, repo) || !repoCfg.Enabled {
+			continue
+		}
+		repoInfo, ok := s.cfg.RepoByName(repo)
+		if !ok || !repoInfo.Enabled {
+			return fmt.Errorf("repo %q is disabled or not found in repos list", repo)
+		}
+		for _, agent := range repoCfg.Agents {
+			if agent.Name == agentName {
+				return s.executeAgentRun(ctx, repoInfo.FullName, agent)
+			}
+		}
+		return fmt.Errorf("autonomous agent %q not found for repo %q", agentName, repo)
+	}
+	return fmt.Errorf("no autonomous agents configured for repo %q", repo)
+}
+
+func (s *Scheduler) executeAgentRun(ctx context.Context, repo string, agent config.AutonomousAgentConfig) error {
+	logger := s.logger.With().Str("repo", repo).Str("agent", agent.Name).Logger()
+	backend := s.resolveBackend(agent.Backend)
+	if backend == "" {
+		return fmt.Errorf("no configured backend for autonomous agent run (configured: %q)", agent.Backend)
+	}
+	runner, ok := s.runners[backend]
+	if !ok {
+		return fmt.Errorf("no runner for configured backend %q", backend)
+	}
+	return s.memories.WithLock(agent.Name, repo, func(memoryPath string, memory string) error {
+		for _, task := range agent.Tasks {
+			if err := s.runTask(ctx, runner, backend, repo, agent, task.Name, task.Prompt, memoryPath, memory, logger); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }
 
 func (s *Scheduler) resolveBackend(configured string) string {

--- a/internal/autonomous/scheduler_test.go
+++ b/internal/autonomous/scheduler_test.go
@@ -284,6 +284,32 @@ func TestSchedulerRunAgentAutoFallsBackToDefaultConfiguredBackend(t *testing.T) 
 	}
 }
 
+func buildTestConfig(t *testing.T, dir string) *config.Config {
+	t.Helper()
+	return &config.Config{
+		AgentsDir: dir,
+		AIBackends: map[string]config.AIBackendConfig{
+			"claude": {},
+		},
+		Repos: []config.RepoConfig{
+			{FullName: "owner/repo", Enabled: true},
+		},
+		AutonomousAgents: []config.AutonomousRepoConfig{
+			{
+				Repo:    "owner/repo",
+				Enabled: true,
+				Agents: []config.AutonomousAgentConfig{
+					{Name: "architect", Description: "desc", Cron: "* * * * *", Skills: []string{"architect"},
+						Tasks: []config.TaskConfig{
+							{Name: "issues", Prompt: "scan issues"},
+							{Name: "code", Prompt: "inspect code"},
+						}},
+				},
+			},
+		},
+	}
+}
+
 func TestSchedulerAgentStatusesBeforeFirstRun(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
@@ -376,6 +402,98 @@ func TestSchedulerAgentStatusesAfterRun(t *testing.T) {
 	}
 	if statuses[0].LastRun == nil {
 		t.Errorf("expected last_run to be set after a run")
+	}
+}
+
+func TestTriggerAgentRunsTasksSynchronously(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	prompts := buildTestPromptStore(t, dir)
+	cfg := buildTestConfig(t, dir)
+	memory := NewMemoryStore(dir)
+	runner := &stubRunner{}
+	scheduler, err := NewScheduler(cfg, map[string]ai.Runner{"claude": runner}, prompts, memory, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("scheduler: %v", err)
+	}
+
+	if err := scheduler.TriggerAgent(context.Background(), "architect", "owner/repo"); err != nil {
+		t.Fatalf("TriggerAgent: %v", err)
+	}
+
+	runner.mu.Lock()
+	defer runner.mu.Unlock()
+	if runner.calls != 2 {
+		t.Fatalf("expected two tasks, got %d", runner.calls)
+	}
+}
+
+func TestTriggerAgentReturnsErrorForUnknownAgent(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	prompts := buildTestPromptStore(t, dir)
+	cfg := buildTestConfig(t, dir)
+	memory := NewMemoryStore(dir)
+	runner := &stubRunner{}
+	scheduler, err := NewScheduler(cfg, map[string]ai.Runner{"claude": runner}, prompts, memory, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("scheduler: %v", err)
+	}
+
+	if err := scheduler.TriggerAgent(context.Background(), "unknown-agent", "owner/repo"); err == nil {
+		t.Fatal("expected error for unknown agent, got nil")
+	}
+}
+
+func TestTriggerAgentReturnsErrorForUnknownRepo(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	prompts := buildTestPromptStore(t, dir)
+	cfg := buildTestConfig(t, dir)
+	memory := NewMemoryStore(dir)
+	runner := &stubRunner{}
+	scheduler, err := NewScheduler(cfg, map[string]ai.Runner{"claude": runner}, prompts, memory, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("scheduler: %v", err)
+	}
+
+	if err := scheduler.TriggerAgent(context.Background(), "architect", "nobody/nothere"); err == nil {
+		t.Fatal("expected error for unknown repo, got nil")
+	}
+}
+
+func TestTriggerAgentReturnsErrorForDisabledRepo(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	prompts := buildTestPromptStore(t, dir)
+	cfg := &config.Config{
+		AgentsDir: dir,
+		AIBackends: map[string]config.AIBackendConfig{
+			"claude": {},
+		},
+		Repos: []config.RepoConfig{
+			{FullName: "owner/repo", Enabled: false},
+		},
+		AutonomousAgents: []config.AutonomousRepoConfig{
+			{
+				Repo:    "owner/repo",
+				Enabled: true,
+				Agents: []config.AutonomousAgentConfig{
+					{Name: "architect", Description: "desc", Cron: "* * * * *", Skills: []string{"architect"},
+						Tasks: []config.TaskConfig{{Name: "issues", Prompt: "scan"}}},
+				},
+			},
+		},
+	}
+	memory := NewMemoryStore(dir)
+	runner := &stubRunner{}
+	scheduler, err := NewScheduler(cfg, map[string]ai.Runner{"claude": runner}, prompts, memory, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("scheduler: %v", err)
+	}
+
+	if err := scheduler.TriggerAgent(context.Background(), "architect", "owner/repo"); err == nil {
+		t.Fatal("expected error for disabled repo, got nil")
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,7 @@ const (
 	defaultHTTPListenAddr          = ":8080"
 	defaultHTTPStatusPath          = "/status"
 	defaultHTTPWebhookPath         = "/webhooks/github"
+	defaultHTTPAgentsRunPath       = "/agents/run"
 	defaultHTTPReadTimeoutSeconds  = 15
 	defaultHTTPWriteTimeoutSeconds = 15
 	defaultHTTPIdleTimeoutSeconds  = 60
@@ -101,6 +102,7 @@ type HTTPConfig struct {
 	ListenAddr             string `yaml:"listen_addr"`
 	StatusPath             string `yaml:"status_path"`
 	WebhookPath            string `yaml:"webhook_path"`
+	AgentsRunPath          string `yaml:"agents_run_path"`
 	ReadTimeoutSeconds     int    `yaml:"read_timeout_seconds"`
 	WriteTimeoutSeconds    int    `yaml:"write_timeout_seconds"`
 	IdleTimeoutSeconds     int    `yaml:"idle_timeout_seconds"`
@@ -193,6 +195,7 @@ func (c *Config) applyHTTPDefaults() {
 	setDefault(&c.HTTP.ListenAddr, defaultHTTPListenAddr)
 	setDefault(&c.HTTP.StatusPath, defaultHTTPStatusPath)
 	setDefault(&c.HTTP.WebhookPath, defaultHTTPWebhookPath)
+	setDefault(&c.HTTP.AgentsRunPath, defaultHTTPAgentsRunPath)
 	setDefaultInt(&c.HTTP.ReadTimeoutSeconds, defaultHTTPReadTimeoutSeconds)
 	setDefaultInt(&c.HTTP.WriteTimeoutSeconds, defaultHTTPWriteTimeoutSeconds)
 	setDefaultInt(&c.HTTP.IdleTimeoutSeconds, defaultHTTPIdleTimeoutSeconds)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -103,6 +103,8 @@ type HTTPConfig struct {
 	StatusPath             string `yaml:"status_path"`
 	WebhookPath            string `yaml:"webhook_path"`
 	AgentsRunPath          string `yaml:"agents_run_path"`
+	APIKeyEnv              string `yaml:"api_key_env"`
+	APIKey                 string `yaml:"-"`
 	ReadTimeoutSeconds     int    `yaml:"read_timeout_seconds"`
 	WriteTimeoutSeconds    int    `yaml:"write_timeout_seconds"`
 	IdleTimeoutSeconds     int    `yaml:"idle_timeout_seconds"`
@@ -175,6 +177,7 @@ func (c *Config) applyDefaults() {
 	c.normalizeRepos()
 	c.normalizeAutonomousAgents()
 	c.resolveWebhookSecret()
+	c.resolveAPIKey()
 }
 
 func (c *Config) applyPromptDefaults() {
@@ -273,6 +276,12 @@ func (c *Config) normalizeAutonomousAgents() {
 func (c *Config) resolveWebhookSecret() {
 	if c.HTTP.WebhookSecret == "" && c.HTTP.WebhookSecretEnv != "" {
 		c.HTTP.WebhookSecret = os.Getenv(c.HTTP.WebhookSecretEnv)
+	}
+}
+
+func (c *Config) resolveAPIKey() {
+	if c.HTTP.APIKey == "" && c.HTTP.APIKeyEnv != "" {
+		c.HTTP.APIKey = os.Getenv(c.HTTP.APIKeyEnv)
 	}
 }
 

--- a/internal/webhook/server.go
+++ b/internal/webhook/server.go
@@ -134,6 +134,15 @@ type agentsRunRequest struct {
 }
 
 func (s *Server) handleAgentsRun(w http.ResponseWriter, r *http.Request) {
+	if s.cfg.HTTP.APIKey == "" {
+		http.Error(w, "endpoint disabled: no API key configured", http.StatusForbidden)
+		return
+	}
+	token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+	if token == "" || token != s.cfg.HTTP.APIKey {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
 	if s.triggerer == nil {
 		http.Error(w, "no autonomous agents configured", http.StatusNotImplemented)
 		return
@@ -149,7 +158,7 @@ func (s *Server) handleAgentsRun(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := s.triggerer.TriggerAgent(r.Context(), req.Agent, req.Repo); err != nil {
 		s.logger.Error().Err(err).Str("agent", req.Agent).Str("repo", req.Repo).Msg("on-demand agent run failed")
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		http.Error(w, "agent run failed", http.StatusInternalServerError)
 		return
 	}
 	w.WriteHeader(http.StatusOK)

--- a/internal/webhook/server.go
+++ b/internal/webhook/server.go
@@ -34,6 +34,11 @@ type StatusProvider interface {
 	AgentStatuses() []AgentStatus
 }
 
+// AgentTriggerer can run a named autonomous agent on demand.
+type AgentTriggerer interface {
+	TriggerAgent(ctx context.Context, agentName, repo string) error
+}
+
 type Server struct {
 	cfg       *config.Config
 	delivery  *DeliveryStore
@@ -41,9 +46,10 @@ type Server struct {
 	channels  *workflow.DataChannels
 	provider  StatusProvider
 	startTime time.Time
+	triggerer AgentTriggerer
 }
 
-func NewServer(cfg *config.Config, delivery *DeliveryStore, channels *workflow.DataChannels, provider StatusProvider, logger zerolog.Logger) *Server {
+func NewServer(cfg *config.Config, delivery *DeliveryStore, channels *workflow.DataChannels, provider StatusProvider, logger zerolog.Logger, triggerer AgentTriggerer) *Server {
 	return &Server{
 		cfg:       cfg,
 		delivery:  delivery,
@@ -51,6 +57,7 @@ func NewServer(cfg *config.Config, delivery *DeliveryStore, channels *workflow.D
 		channels:  channels,
 		provider:  provider,
 		startTime: time.Now(),
+		triggerer: triggerer,
 	}
 }
 
@@ -58,6 +65,7 @@ func (s *Server) Run(ctx context.Context) error {
 	router := mux.NewRouter()
 	router.HandleFunc(s.cfg.HTTP.StatusPath, s.handleStatus).Methods(http.MethodGet)
 	router.HandleFunc(s.cfg.HTTP.WebhookPath, s.handleGitHubWebhook).Methods(http.MethodPost)
+	router.HandleFunc(s.cfg.HTTP.AgentsRunPath, s.handleAgentsRun).Methods(http.MethodPost)
 
 	srv := &http.Server{
 		Addr:         s.cfg.HTTP.ListenAddr,
@@ -78,7 +86,7 @@ func (s *Server) Run(ctx context.Context) error {
 		errCh <- srv.Shutdown(shutdownCtx)
 	}()
 
-	s.logger.Info().Str("addr", s.cfg.HTTP.ListenAddr).Str("status_path", s.cfg.HTTP.StatusPath).Str("webhook_path", s.cfg.HTTP.WebhookPath).Msg("starting webhook server")
+	s.logger.Info().Str("addr", s.cfg.HTTP.ListenAddr).Str("status_path", s.cfg.HTTP.StatusPath).Str("webhook_path", s.cfg.HTTP.WebhookPath).Str("agents_run_path", s.cfg.HTTP.AgentsRunPath).Msg("starting webhook server")
 	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return err
 	}
@@ -118,6 +126,33 @@ func (s *Server) handleStatus(w http.ResponseWriter, _ *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(resp)
+}
+
+type agentsRunRequest struct {
+	Agent string `json:"agent"`
+	Repo  string `json:"repo"`
+}
+
+func (s *Server) handleAgentsRun(w http.ResponseWriter, r *http.Request) {
+	if s.triggerer == nil {
+		http.Error(w, "no autonomous agents configured", http.StatusNotImplemented)
+		return
+	}
+	var req agentsRunRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, s.cfg.HTTP.MaxBodyBytes)).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if req.Agent == "" || req.Repo == "" {
+		http.Error(w, "agent and repo fields are required", http.StatusBadRequest)
+		return
+	}
+	if err := s.triggerer.TriggerAgent(r.Context(), req.Agent, req.Repo); err != nil {
+		s.logger.Error().Err(err).Str("agent", req.Agent).Str("repo", req.Repo).Msg("on-demand agent run failed")
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
 }
 
 func (s *Server) handleGitHubWebhook(w http.ResponseWriter, r *http.Request) {

--- a/internal/webhook/server_test.go
+++ b/internal/webhook/server_test.go
@@ -238,14 +238,23 @@ func (s *stubTriggerer) TriggerAgent(_ context.Context, agentName, repo string) 
 	return s.err
 }
 
+const testAPIKey = "test-secret-key"
+
 func newRunServer(triggerer AgentTriggerer) *Server {
 	cfg := &config.Config{
 		HTTP: config.HTTPConfig{
 			MaxBodyBytes:  1024,
 			AgentsRunPath: "/agents/run",
+			APIKey:        testAPIKey,
 		},
 	}
 	return NewServer(cfg, NewDeliveryStore(time.Hour), workflow.NewDataChannels(1, 1), nil, zerolog.Nop(), triggerer)
+}
+
+func authedRequest(method, path string, body string) *http.Request {
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+testAPIKey)
+	return req
 }
 
 func TestHandleAgentsRunCallsTriggerer(t *testing.T) {
@@ -253,8 +262,7 @@ func TestHandleAgentsRunCallsTriggerer(t *testing.T) {
 	trig := &stubTriggerer{}
 	server := newRunServer(trig)
 
-	body := `{"agent":"bug-fixer","repo":"owner/repo"}`
-	req := httptest.NewRequest(http.MethodPost, "/agents/run", strings.NewReader(body))
+	req := authedRequest(http.MethodPost, "/agents/run", `{"agent":"bug-fixer","repo":"owner/repo"}`)
 	rr := httptest.NewRecorder()
 	server.handleAgentsRun(rr, req)
 
@@ -266,6 +274,48 @@ func TestHandleAgentsRunCallsTriggerer(t *testing.T) {
 	}
 	if trig.agentName != "bug-fixer" || trig.repo != "owner/repo" {
 		t.Fatalf("unexpected args: agent=%q repo=%q", trig.agentName, trig.repo)
+	}
+}
+
+func TestHandleAgentsRunRejectsNoAuth(t *testing.T) {
+	t.Parallel()
+	server := newRunServer(&stubTriggerer{})
+	req := httptest.NewRequest(http.MethodPost, "/agents/run", strings.NewReader(`{"agent":"a","repo":"r"}`))
+	rr := httptest.NewRecorder()
+	server.handleAgentsRun(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected %d, got %d", http.StatusUnauthorized, rr.Code)
+	}
+}
+
+func TestHandleAgentsRunRejectsWrongToken(t *testing.T) {
+	t.Parallel()
+	server := newRunServer(&stubTriggerer{})
+	req := httptest.NewRequest(http.MethodPost, "/agents/run", strings.NewReader(`{"agent":"a","repo":"r"}`))
+	req.Header.Set("Authorization", "Bearer wrong-key")
+	rr := httptest.NewRecorder()
+	server.handleAgentsRun(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected %d, got %d", http.StatusUnauthorized, rr.Code)
+	}
+}
+
+func TestHandleAgentsRunReturnsForbiddenWhenNoAPIKeyConfigured(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{
+		HTTP: config.HTTPConfig{
+			MaxBodyBytes:  1024,
+			AgentsRunPath: "/agents/run",
+			APIKey:        "", // no key configured
+		},
+	}
+	server := NewServer(cfg, NewDeliveryStore(time.Hour), workflow.NewDataChannels(1, 1), nil, zerolog.Nop(), &stubTriggerer{})
+	req := httptest.NewRequest(http.MethodPost, "/agents/run", strings.NewReader(`{"agent":"a","repo":"r"}`))
+	req.Header.Set("Authorization", "Bearer something")
+	rr := httptest.NewRecorder()
+	server.handleAgentsRun(rr, req)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected %d, got %d", http.StatusForbidden, rr.Code)
 	}
 }
 
@@ -284,7 +334,7 @@ func TestHandleAgentsRunReturnsBadRequestOnMissingFields(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			server := newRunServer(&stubTriggerer{})
-			req := httptest.NewRequest(http.MethodPost, "/agents/run", strings.NewReader(tc.body))
+			req := authedRequest(http.MethodPost, "/agents/run", tc.body)
 			rr := httptest.NewRecorder()
 			server.handleAgentsRun(rr, req)
 			if rr.Code != http.StatusBadRequest {
@@ -296,8 +346,15 @@ func TestHandleAgentsRunReturnsBadRequestOnMissingFields(t *testing.T) {
 
 func TestHandleAgentsRunReturnsNotImplementedWhenNoTriggerer(t *testing.T) {
 	t.Parallel()
-	server := newRunServer(nil)
-	req := httptest.NewRequest(http.MethodPost, "/agents/run", strings.NewReader(`{"agent":"a","repo":"r"}`))
+	cfg := &config.Config{
+		HTTP: config.HTTPConfig{
+			MaxBodyBytes:  1024,
+			AgentsRunPath: "/agents/run",
+			APIKey:        testAPIKey,
+		},
+	}
+	server := NewServer(cfg, NewDeliveryStore(time.Hour), workflow.NewDataChannels(1, 1), nil, zerolog.Nop(), nil)
+	req := authedRequest(http.MethodPost, "/agents/run", `{"agent":"a","repo":"r"}`)
 	rr := httptest.NewRecorder()
 	server.handleAgentsRun(rr, req)
 	if rr.Code != http.StatusNotImplemented {
@@ -309,8 +366,7 @@ func TestHandleAgentsRunReturnsInternalServerErrorOnTriggerFailure(t *testing.T)
 	t.Parallel()
 	trig := &stubTriggerer{err: errors.New("agent not found")}
 	server := newRunServer(trig)
-	body := `{"agent":"nonexistent","repo":"owner/repo"}`
-	req := httptest.NewRequest(http.MethodPost, "/agents/run", strings.NewReader(body))
+	req := authedRequest(http.MethodPost, "/agents/run", `{"agent":"nonexistent","repo":"owner/repo"}`)
 	rr := httptest.NewRecorder()
 	server.handleAgentsRun(rr, req)
 	if rr.Code != http.StatusInternalServerError {

--- a/internal/webhook/server_test.go
+++ b/internal/webhook/server_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -29,7 +30,7 @@ func TestHandleIssueWebhookDeduplicatesDelivery(t *testing.T) {
 		Repos: []config.RepoConfig{{FullName: "owner/repo", Enabled: true}},
 	}
 	dataChannels := workflow.NewDataChannels(1, 1)
-	server := NewServer(cfg, NewDeliveryStore(time.Hour), dataChannels, nil, zerolog.Nop())
+	server := NewServer(cfg, NewDeliveryStore(time.Hour), dataChannels, nil, zerolog.Nop(), nil)
 
 	body := `{"action":"labeled","label":{"name":"ai:refine"},"repository":{"full_name":"owner/repo"},"issue":{"number":1,"title":"t","body":"b","updated_at":"2026-02-15T00:00:00Z","labels":[{"name":"ai:refine"}]}}`
 	sig := signatureForTests([]byte(body), "secret")
@@ -78,7 +79,7 @@ func TestHandleWebhookIgnoresNonAILabel(t *testing.T) {
 		Repos: []config.RepoConfig{{FullName: "owner/repo", Enabled: true}},
 	}
 	dataChannels := workflow.NewDataChannels(1, 1)
-	server := NewServer(cfg, NewDeliveryStore(time.Hour), dataChannels, nil, zerolog.Nop())
+	server := NewServer(cfg, NewDeliveryStore(time.Hour), dataChannels, nil, zerolog.Nop(), nil)
 
 	body := `{"action":"labeled","label":{"name":"bug"},"repository":{"full_name":"owner/repo"},"pull_request":{"number":2,"title":"t","body":"b","updated_at":"2026-02-15T00:00:00Z","labels":[{"name":"bug"}],"head":{"sha":"abc"}}}`
 	sig := signatureForTests([]byte(body), "secret")
@@ -109,7 +110,7 @@ func TestInvalidSignatureDoesNotPoisonDeliveryDedupe(t *testing.T) {
 		Repos: []config.RepoConfig{{FullName: "owner/repo", Enabled: true}},
 	}
 	dataChannels := workflow.NewDataChannels(1, 1)
-	server := NewServer(cfg, NewDeliveryStore(time.Hour), dataChannels, nil, zerolog.Nop())
+	server := NewServer(cfg, NewDeliveryStore(time.Hour), dataChannels, nil, zerolog.Nop(), nil)
 
 	body := `{"action":"labeled","label":{"name":"ai:refine"},"repository":{"full_name":"owner/repo"},"issue":{"number":7}}`
 
@@ -149,7 +150,7 @@ func TestHandleIssueWebhookUsesEventLabelAsTrigger(t *testing.T) {
 		Repos: []config.RepoConfig{{FullName: "owner/repo", Enabled: true}},
 	}
 	dataChannels := workflow.NewDataChannels(1, 1)
-	server := NewServer(cfg, NewDeliveryStore(time.Hour), dataChannels, nil, zerolog.Nop())
+	server := NewServer(cfg, NewDeliveryStore(time.Hour), dataChannels, nil, zerolog.Nop(), nil)
 
 	body := `{"action":"labeled","label":{"name":"ai:refine:codex"},"repository":{"full_name":"owner/repo"},"issue":{"number":3,"title":"t","body":"b","updated_at":"2026-02-15T00:00:00Z","labels":[{"name":"ai:refine:claude"}]}}`
 	sig := signatureForTests([]byte(body), "secret")
@@ -190,7 +191,7 @@ func TestHandleIssueWebhookReturnsServiceUnavailableWhenQueueFull(t *testing.T) 
 	}); err != nil {
 		t.Fatalf("preload issue queue: %v", err)
 	}
-	server := NewServer(cfg, NewDeliveryStore(time.Hour), dataChannels, nil, zerolog.Nop())
+	server := NewServer(cfg, NewDeliveryStore(time.Hour), dataChannels, nil, zerolog.Nop(), nil)
 
 	body := `{"action":"labeled","label":{"name":"ai:refine"},"repository":{"full_name":"owner/repo"},"issue":{"number":2}}`
 	sig := signatureForTests([]byte(body), "secret")
@@ -223,6 +224,100 @@ func TestHandleIssueWebhookReturnsServiceUnavailableWhenQueueFull(t *testing.T) 
 	}
 }
 
+type stubTriggerer struct {
+	called    bool
+	agentName string
+	repo      string
+	err       error
+}
+
+func (s *stubTriggerer) TriggerAgent(_ context.Context, agentName, repo string) error {
+	s.called = true
+	s.agentName = agentName
+	s.repo = repo
+	return s.err
+}
+
+func newRunServer(triggerer AgentTriggerer) *Server {
+	cfg := &config.Config{
+		HTTP: config.HTTPConfig{
+			MaxBodyBytes:  1024,
+			AgentsRunPath: "/agents/run",
+		},
+	}
+	return NewServer(cfg, NewDeliveryStore(time.Hour), workflow.NewDataChannels(1, 1), nil, zerolog.Nop(), triggerer)
+}
+
+func TestHandleAgentsRunCallsTriggerer(t *testing.T) {
+	t.Parallel()
+	trig := &stubTriggerer{}
+	server := newRunServer(trig)
+
+	body := `{"agent":"bug-fixer","repo":"owner/repo"}`
+	req := httptest.NewRequest(http.MethodPost, "/agents/run", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	server.handleAgentsRun(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected %d, got %d: %s", http.StatusOK, rr.Code, rr.Body.String())
+	}
+	if !trig.called {
+		t.Fatal("expected TriggerAgent to be called")
+	}
+	if trig.agentName != "bug-fixer" || trig.repo != "owner/repo" {
+		t.Fatalf("unexpected args: agent=%q repo=%q", trig.agentName, trig.repo)
+	}
+}
+
+func TestHandleAgentsRunReturnsBadRequestOnMissingFields(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"missing agent", `{"repo":"owner/repo"}`},
+		{"missing repo", `{"agent":"bug-fixer"}`},
+		{"empty body", `{}`},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			server := newRunServer(&stubTriggerer{})
+			req := httptest.NewRequest(http.MethodPost, "/agents/run", strings.NewReader(tc.body))
+			rr := httptest.NewRecorder()
+			server.handleAgentsRun(rr, req)
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("expected %d, got %d", http.StatusBadRequest, rr.Code)
+			}
+		})
+	}
+}
+
+func TestHandleAgentsRunReturnsNotImplementedWhenNoTriggerer(t *testing.T) {
+	t.Parallel()
+	server := newRunServer(nil)
+	req := httptest.NewRequest(http.MethodPost, "/agents/run", strings.NewReader(`{"agent":"a","repo":"r"}`))
+	rr := httptest.NewRecorder()
+	server.handleAgentsRun(rr, req)
+	if rr.Code != http.StatusNotImplemented {
+		t.Fatalf("expected %d, got %d", http.StatusNotImplemented, rr.Code)
+	}
+}
+
+func TestHandleAgentsRunReturnsInternalServerErrorOnTriggerFailure(t *testing.T) {
+	t.Parallel()
+	trig := &stubTriggerer{err: errors.New("agent not found")}
+	server := newRunServer(trig)
+	body := `{"agent":"nonexistent","repo":"owner/repo"}`
+	req := httptest.NewRequest(http.MethodPost, "/agents/run", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	server.handleAgentsRun(rr, req)
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("expected %d, got %d", http.StatusInternalServerError, rr.Code)
+	}
+}
+
 func TestVerifySignature(t *testing.T) {
 	body := []byte(`{"hello":"world"}`)
 	secret := "secret"
@@ -246,7 +341,7 @@ func TestHandleStatusReturnsJSON(t *testing.T) {
 		Repos: []config.RepoConfig{{FullName: "owner/repo", Enabled: true}},
 	}
 	dataChannels := workflow.NewDataChannels(8, 4)
-	server := NewServer(cfg, NewDeliveryStore(time.Hour), dataChannels, nil, zerolog.Nop())
+	server := NewServer(cfg, NewDeliveryStore(time.Hour), dataChannels, nil, zerolog.Nop(), nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/status", nil)
 	rr := httptest.NewRecorder()
@@ -307,7 +402,7 @@ func TestHandleStatusIncludesAgentStatuses(t *testing.T) {
 		},
 	}
 	dataChannels := workflow.NewDataChannels(1, 1)
-	server := NewServer(cfg, NewDeliveryStore(time.Hour), dataChannels, provider, zerolog.Nop())
+	server := NewServer(cfg, NewDeliveryStore(time.Hour), dataChannels, provider, zerolog.Nop(), nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/status", nil)
 	rr := httptest.NewRecorder()


### PR DESCRIPTION
## Summary

- Adds `--run-agent <name> --repo <owner/repo>` CLI flags that run a single autonomous agent pass synchronously and exit — no daemon startup needed.
- Adds `POST /agents/run` HTTP endpoint (path defaults to `/agents/run`, configurable via `http.agents_run_path`) that triggers a named agent from the running daemon.
- Both paths share the same `executeAgentRun` code path as cron-triggered runs (extracted from the existing `runAgent` closure).
- Introduces `AgentTriggerer` interface in the `webhook` package to keep the import direction clean.

## Test plan

- [ ] `TestTriggerAgentRunsTasksSynchronously` — happy path: two tasks executed
- [ ] `TestTriggerAgentReturnsErrorForUnknownAgent` — error propagated for missing agent
- [ ] `TestTriggerAgentReturnsErrorForUnknownRepo` — error propagated for missing repo
- [ ] `TestTriggerAgentReturnsErrorForDisabledRepo` — disabled repo is rejected
- [ ] `TestHandleAgentsRunCallsTriggerer` — POST /agents/run calls TriggerAgent with correct args
- [ ] `TestHandleAgentsRunReturnsBadRequestOnMissingFields` — missing agent/repo returns 400
- [ ] `TestHandleAgentsRunReturnsNotImplementedWhenNoTriggerer` — nil triggerer returns 501
- [ ] `TestHandleAgentsRunReturnsInternalServerErrorOnTriggerFailure` — trigger error returns 500
- [ ] `go test ./...` passes

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)