### PR TITLE
config: fix codex backend args from -p to exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ ai_backends:
   codex:
     mode: command
     command: codex
-    args: ["-p"]
+    args: ["exec"]
     timeout_seconds: 600
     max_prompt_chars: 12000
     redaction_salt_env: LOG_SALT

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -135,7 +135,7 @@ ai_backends:
     mode: command
     command: codex
     args:
-      - "-p"
+      - "exec"
     timeout_seconds: 600
     max_prompt_chars: 12000
     redaction_salt_env: LOG_SALT

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,6 +6,29 @@ import (
 	"testing"
 )
 
+func TestExampleConfigLoadsAndHasCorrectCodexArgs(t *testing.T) {
+	t.Setenv("GITHUB_WEBHOOK_SECRET", "test-secret")
+	t.Setenv("LOG_SALT", "salt")
+
+	// Resolve path to the root-level config.example.yaml relative to this package.
+	examplePath := filepath.Join("..", "..", "config.example.yaml")
+	cfg, err := Load(examplePath)
+	if err != nil {
+		t.Fatalf("config.example.yaml failed to load: %v", err)
+	}
+
+	codex, ok := cfg.AIBackends["codex"]
+	if !ok {
+		t.Fatal("config.example.yaml must define a codex ai_backend")
+	}
+	if len(codex.Args) == 0 {
+		t.Fatal("codex backend args must not be empty")
+	}
+	if codex.Args[0] != "exec" {
+		t.Fatalf("codex backend first arg must be \"exec\", got %q (wrong -p flag causes '--profile' parse error)", codex.Args[0])
+	}
+}
+
 func TestLoadRequiresSupportedBackendNames(t *testing.T) {
 	t.Setenv("WEBHOOK_SECRET", "secret")
 


### PR DESCRIPTION
## Summary

- Codex CLI uses the `exec` subcommand for non-interactive invocations, not `-p`
- Using `-p` was interpreted as `--profile` which requires a value, causing every codex-backed agent run to fail
- Updated both `config.example.yaml` and `README.md` to use `args: ["exec"]`
- Added `TestExampleConfigLoadsAndHasCorrectCodexArgs` in `internal/config/config_test.go` to load the example config and assert the codex first arg is `"exec"`, preventing this regression

Closes #61

## Test plan

- [ ] `go test ./...` passes (including the new `TestExampleConfigLoadsAndHasCorrectCodexArgs`)
- [ ] `config.example.yaml` codex args show `exec`
- [ ] `README.md` codex args show `exec`

🤖 Generated with [Claude Code](https://claude.com/claude-code)