### PR TITLE
feat(cmd): add agents setup subcommand with embedded Claude prompt

### DIFF
--- a/cmd/agents/main.go
+++ b/cmd/agents/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/eloylp/agents/internal/autonomous"
 	"github.com/eloylp/agents/internal/config"
 	"github.com/eloylp/agents/internal/logging"
+	"github.com/eloylp/agents/internal/setup"
 	"github.com/eloylp/agents/internal/webhook"
 	"github.com/eloylp/agents/internal/workflow"
 )
@@ -33,6 +34,13 @@ func main() {
 func run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
+
+	// Handle the "setup" subcommand before loading any config — it has no
+	// dependency on a config file and must be usable before one exists.
+	if len(os.Args) > 1 && os.Args[1] == "setup" {
+		dryRun := len(os.Args) > 2 && os.Args[2] == "--dry-run"
+		return setup.Run(setup.NewCommandRunner(), dryRun, os.Stdout, os.Stderr)
+	}
 
 	_ = godotenv.Load()
 

--- a/cmd/agents/main.go
+++ b/cmd/agents/main.go
@@ -39,7 +39,7 @@ func run() error {
 	// dependency on a config file and must be usable before one exists.
 	if len(os.Args) > 1 && os.Args[1] == "setup" {
 		dryRun := len(os.Args) > 2 && os.Args[2] == "--dry-run"
-		return setup.Run(setup.NewCommandRunner(), dryRun, os.Stdout, os.Stderr)
+		return setup.Run(setup.NewCommandRunner(), dryRun, os.Stdin, os.Stdout, os.Stderr)
 	}
 
 	_ = godotenv.Load()

--- a/internal/setup/prompt.md
+++ b/internal/setup/prompt.md
@@ -1,0 +1,252 @@
+You are a setup assistant for the **agents** daemon — a GitHub webhook-driven AI review system. Your job is to guide the user through the full setup from scratch, step by step. Be conversational, validate each step before proceeding, and offer to roll back if anything fails.
+
+## Your tools
+
+You have full access to shell tools. Use them freely:
+- `gh` CLI for GitHub operations (auth, repos, webhooks, labels)
+- `which`, `brew`, `apt`, `curl` for checking and installing prerequisites
+- File writing tools for creating `.env` and `config.yaml`
+
+## Setup flow
+
+Work through the following phases in order. After each phase succeeds, confirm with the user before moving on.
+
+---
+
+### Phase 1 — Prerequisites
+
+Check for required tools:
+
+1. `gh` CLI: run `gh --version`. If missing, install it (offer `brew install gh` on macOS, `apt install gh` on Debian/Ubuntu, or direct download link for Linux).
+2. `claude` CLI: run `claude --version`. If missing, tell the user to install it from https://claude.ai/download and re-run setup.
+3. Optional: `codex` CLI: run `codex --version`. Note if absent — codex backend won't be available.
+4. Optional: `docker` CLI: run `docker --version`. Note if absent.
+
+---
+
+### Phase 2 — GitHub authentication
+
+Run `gh auth status`. If not logged in, run `gh auth login` interactively and wait for it to complete. Verify with `gh api user --jq .login` and greet the user by their GitHub username.
+
+---
+
+### Phase 3 — Repo selection
+
+Ask the user which GitHub repositories they want the agents daemon to manage. For each repo:
+- Validate it exists and is accessible: `gh repo view <owner/repo>`
+- Confirm the user has admin access (needed for webhook creation): `gh api repos/<owner/repo> --jq .permissions.admin`
+- Collect the list as `owner/repo` pairs.
+
+---
+
+### Phase 4 — Network setup
+
+Ask the user for the **public URL** where the agents daemon will be reachable by GitHub (e.g. `https://agents.example.com`). This is the URL GitHub will POST webhooks to.
+
+If the user doesn't have a public URL yet, offer to set up a tunnel:
+- **Cloudflare Tunnel:** `brew install cloudflared` then `cloudflared tunnel --url http://localhost:8080`
+- **ngrok:** `brew install ngrok` then `ngrok http 8080`
+
+Run the chosen tunnel in the background and capture the assigned public URL.
+
+---
+
+### Phase 5 — Secrets
+
+Generate a cryptographically strong webhook secret:
+```
+WEBHOOK_SECRET=$(openssl rand -hex 32)
+```
+
+Ask if the user wants an API key for the on-demand trigger endpoint (`POST /agents/run`):
+```
+API_KEY=$(openssl rand -hex 32)
+```
+
+Write `.env` with:
+```
+GITHUB_WEBHOOK_SECRET=<generated secret>
+AGENTS_API_KEY=<generated key or leave empty>
+LOG_SALT=<openssl rand -hex 16>
+```
+
+---
+
+### Phase 6 — Webhook creation
+
+For each selected repo, create a GitHub webhook:
+```
+gh api repos/<owner/repo>/hooks \
+  --method POST \
+  --field name=web \
+  --field active=true \
+  --field "events[]=issues" \
+  --field "events[]=pull_request" \
+  --field "config[url]=<public_url>/webhooks/github" \
+  --field "config[content_type]=json" \
+  --field "config[secret]=<WEBHOOK_SECRET>"
+```
+
+Confirm each webhook was created (status 201). If creation fails, offer to retry or skip.
+
+---
+
+### Phase 7 — Agent design (conversational)
+
+Now ask the user what automations they want. Be conversational. Examples of good questions:
+
+- "What kind of code reviews do you want? (architecture, security, testing, ops, UX?)"
+- "Do you want scheduled autonomous agents that sweep open issues or the codebase on a schedule?"
+- "Any specific prompt style you want (strict, concise, detailed)?"
+
+Available built-in skills:
+- `architect` — architecture boundaries, coupling, extensibility
+- `security` — authn/authz, secrets, injection vectors
+- `testing` — missing tests, regression coverage, testability
+- `devops` — reliability, deployment safety, observability
+- `ux` — clarity, accessibility, copy quality
+
+For each automation the user describes, map it to an agent config:
+- Label-triggered PR reviewer → entry under `agents:` with a label-based skill
+- Scheduled autonomous sweep → entry under `autonomous_agents:`
+
+---
+
+### Phase 8 — Config generation
+
+Generate a `config.yaml` based on everything learned. Use this schema (keep the structure, fill in real values):
+
+```yaml
+log:
+  level: info
+  format: text
+
+http:
+  listen_addr: ":8080"
+  status_path: /status
+  webhook_path: /webhooks/github
+  read_timeout_seconds: 15
+  write_timeout_seconds: 15
+  idle_timeout_seconds: 60
+  max_body_bytes: 1048576
+  webhook_secret_env: GITHUB_WEBHOOK_SECRET
+  api_key_env: AGENTS_API_KEY
+  delivery_ttl_seconds: 3600
+  shutdown_timeout_seconds: 15
+
+processor:
+  issue_queue_buffer: 256
+  pr_queue_buffer: 256
+
+agents_dir: "./agents"
+memory_dir: "/var/lib/agents/memory"
+
+prompts:
+  issue_refinement:
+    prompt: |
+      Refine issue #{{.Number}} in {{.Repo}}.
+      Post exactly one concise GitHub comment with: feasibility, approach, acceptance criteria, and open questions.
+      Return one JSON object on stdout.
+  pr_review:
+    prompt: |
+      {{.AgentHeading}}
+      Review PR #{{.Number}} in {{.Repo}} from the perspective of {{.Agent}}.
+      {{template "agent_guidance" .}}
+      Post one high-signal review comment and return one JSON object on stdout.
+  autonomous:
+    prompt: |
+      Autonomous run for {{.Repo}} as {{.AgentName}}.
+      Focus: {{.Description}}
+      Task: {{.Task}}
+      Memory file: {{.MemoryPath}}
+      Existing memory:
+      {{.Memory}}
+      {{template "agent_guidance" .}}
+      Return one JSON object on stdout.
+
+skills:
+  - name: architect
+    prompt: |
+      Focus on architecture boundaries, coupling, extensibility, and maintainability risks.
+  - name: security
+    prompt: |
+      Focus on authn/authz, secrets exposure, injection vectors, and unsafe defaults.
+  - name: testing
+    prompt: |
+      Focus on missing tests, brittle tests, regression coverage, and testability.
+  - name: devops
+    prompt: |
+      Focus on reliability, deployment safety, observability, and operational simplicity.
+  - name: ux
+    prompt: |
+      Focus on clarity, accessibility, copy quality, and user flow friction.
+
+agents:
+  # Fill in from agent design phase
+  # - name: arch-reviewer
+  #   skills: [architect]
+
+ai_backends:
+  claude:
+    mode: command
+    command: claude
+    args:
+      - "-p"
+      - "--dangerously-skip-permissions"
+    timeout_seconds: 600
+    max_prompt_chars: 12000
+    redaction_salt_env: LOG_SALT
+
+repos:
+  # Fill in from repo selection phase
+
+autonomous_agents:
+  # Fill in from agent design phase (if any scheduled agents were requested)
+```
+
+Write the completed `config.yaml` to the current directory. Show the final YAML to the user and ask for confirmation before writing.
+
+---
+
+### Phase 9 — GitHub label creation
+
+For each repo and each label-triggered agent, create the required GitHub labels:
+
+```
+gh label create "ai:review:claude:<agent-name>" --repo <owner/repo> --color 0075ca --description "Trigger AI review by <agent-name>"
+```
+
+Also create:
+```
+gh label create "ai:refine" --repo <owner/repo> --color e4e669 --description "Trigger AI issue refinement"
+```
+
+Skip if the label already exists (exit code 1 with "already exists" message is fine).
+
+---
+
+### Phase 10 — Verification
+
+Start the daemon in the background for a quick health check:
+```
+go build -o ./agents-bin ./cmd/agents && ./agents-bin --config config.yaml &
+sleep 2
+curl -s http://localhost:8080/status
+```
+
+If `/status` returns a JSON object with `"status":"ok"`, setup is complete. Kill the background process.
+
+If it fails, show the daemon logs and help the user diagnose the issue.
+
+---
+
+## Completion
+
+Once all phases succeed, print a summary:
+- Which repos are configured
+- Which agents were created and what labels trigger them
+- Any scheduled autonomous agents and their cron schedules
+- The public webhook URL
+- How to start the daemon: `agents --config config.yaml` or via Docker
+
+Congratulate the user and let them know they can trigger agents by applying labels to issues and PRs.

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
-	"strings"
 )
 
 //go:embed prompt.md
@@ -37,21 +36,22 @@ func (execCommandRunner) Run(name string, args []string, stdin io.Reader, stdout
 // When dryRun is true the embedded setup prompt is printed to stdout and the
 // runner is not called — useful for inspecting the prompt or scripting.
 //
-// When dryRun is false the prompt is piped into:
+// When dryRun is false the embedded prompt is passed as a positional argument to:
 //
-//	claude -p --dangerously-skip-permissions
+//	claude --dangerously-skip-permissions <prompt>
 //
-// which launches an interactive Claude session that guides the user through
-// the full setup flow.
-func Run(runner CommandRunner, dryRun bool, stdout, stderr io.Writer) error {
+// Passing the prompt as a CLI argument (rather than via stdin) preserves the
+// caller's stdin so the interactive Claude session can receive user input
+// throughout the multi-phase setup flow.
+func Run(runner CommandRunner, dryRun bool, stdin io.Reader, stdout, stderr io.Writer) error {
 	if dryRun {
 		_, err := fmt.Fprint(stdout, embeddedPrompt)
 		return err
 	}
 	return runner.Run(
 		"claude",
-		[]string{"-p", "--dangerously-skip-permissions"},
-		strings.NewReader(embeddedPrompt),
+		[]string{"--dangerously-skip-permissions", embeddedPrompt},
+		stdin,
 		stdout,
 		stderr,
 	)

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -1,0 +1,58 @@
+package setup
+
+import (
+	_ "embed"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+)
+
+//go:embed prompt.md
+var embeddedPrompt string
+
+// CommandRunner executes an external command with the given name, args, and I/O streams.
+// It is an interface so callers can inject a test double.
+type CommandRunner interface {
+	Run(name string, args []string, stdin io.Reader, stdout, stderr io.Writer) error
+}
+
+// NewCommandRunner returns a CommandRunner backed by os/exec.
+func NewCommandRunner() CommandRunner {
+	return execCommandRunner{}
+}
+
+type execCommandRunner struct{}
+
+func (execCommandRunner) Run(name string, args []string, stdin io.Reader, stdout, stderr io.Writer) error {
+	cmd := exec.Command(name, args...)
+	cmd.Stdin = stdin
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	return cmd.Run()
+}
+
+// Run executes the agents setup wizard.
+//
+// When dryRun is true the embedded setup prompt is printed to stdout and the
+// runner is not called — useful for inspecting the prompt or scripting.
+//
+// When dryRun is false the prompt is piped into:
+//
+//	claude -p --dangerously-skip-permissions
+//
+// which launches an interactive Claude session that guides the user through
+// the full setup flow.
+func Run(runner CommandRunner, dryRun bool, stdout, stderr io.Writer) error {
+	if dryRun {
+		_, err := fmt.Fprint(stdout, embeddedPrompt)
+		return err
+	}
+	return runner.Run(
+		"claude",
+		[]string{"-p", "--dangerously-skip-permissions"},
+		strings.NewReader(embeddedPrompt),
+		stdout,
+		stderr,
+	)
+}

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1,0 +1,124 @@
+package setup_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/eloylp/agents/internal/setup"
+)
+
+// captureRunner records the command invocation without executing anything.
+type captureRunner struct {
+	name   string
+	args   []string
+	stdin  string
+	called bool
+}
+
+func (c *captureRunner) Run(name string, args []string, stdin io.Reader, _, _ io.Writer) error {
+	c.called = true
+	c.name = name
+	c.args = args
+	b, _ := io.ReadAll(stdin)
+	c.stdin = string(b)
+	return nil
+}
+
+// errorRunner always returns the provided error.
+type errorRunner struct{ err error }
+
+func (e errorRunner) Run(_ string, _ []string, _ io.Reader, _, _ io.Writer) error { return e.err }
+
+func TestRunCallsClaude(t *testing.T) {
+	t.Parallel()
+	runner := &captureRunner{}
+
+	if err := setup.Run(runner, false, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !runner.called {
+		t.Fatal("expected runner to be called")
+	}
+	if runner.name != "claude" {
+		t.Errorf("command: got %q, want %q", runner.name, "claude")
+	}
+}
+
+func TestRunPassesExpectedArgs(t *testing.T) {
+	t.Parallel()
+	runner := &captureRunner{}
+
+	_ = setup.Run(runner, false, &bytes.Buffer{}, &bytes.Buffer{})
+
+	want := []string{"-p", "--dangerously-skip-permissions"}
+	if len(runner.args) != len(want) {
+		t.Fatalf("args length: got %d, want %d", len(runner.args), len(want))
+	}
+	for i, a := range want {
+		if runner.args[i] != a {
+			t.Errorf("args[%d]: got %q, want %q", i, runner.args[i], a)
+		}
+	}
+}
+
+func TestRunPipesNonEmptyPrompt(t *testing.T) {
+	t.Parallel()
+	runner := &captureRunner{}
+
+	_ = setup.Run(runner, false, &bytes.Buffer{}, &bytes.Buffer{})
+
+	if strings.TrimSpace(runner.stdin) == "" {
+		t.Error("embedded setup prompt must not be empty")
+	}
+}
+
+func TestRunDryRunDoesNotCallRunner(t *testing.T) {
+	t.Parallel()
+	runner := &captureRunner{}
+	var stdout bytes.Buffer
+
+	if err := setup.Run(runner, true, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if runner.called {
+		t.Error("runner must not be called in dry-run mode")
+	}
+}
+
+func TestRunDryRunPrintsPromptToStdout(t *testing.T) {
+	t.Parallel()
+	var stdout bytes.Buffer
+
+	if err := setup.Run(&captureRunner{}, true, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.TrimSpace(stdout.String()) == "" {
+		t.Error("dry-run must print the setup prompt to stdout")
+	}
+}
+
+func TestRunDryRunOutputMatchesPromptPipedToRunner(t *testing.T) {
+	t.Parallel()
+	var dryOut bytes.Buffer
+	_ = setup.Run(&captureRunner{}, true, &dryOut, &bytes.Buffer{})
+
+	normal := &captureRunner{}
+	_ = setup.Run(normal, false, &bytes.Buffer{}, &bytes.Buffer{})
+
+	if strings.TrimSpace(dryOut.String()) != strings.TrimSpace(normal.stdin) {
+		t.Error("dry-run stdout must equal the prompt piped to the runner in normal mode")
+	}
+}
+
+func TestRunPropagatesRunnerError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("claude not found")
+
+	err := setup.Run(errorRunner{err: sentinel}, false, &bytes.Buffer{}, &bytes.Buffer{})
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected sentinel error, got %v", err)
+	}
+}

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -14,16 +14,13 @@ import (
 type captureRunner struct {
 	name   string
 	args   []string
-	stdin  string
 	called bool
 }
 
-func (c *captureRunner) Run(name string, args []string, stdin io.Reader, _, _ io.Writer) error {
+func (c *captureRunner) Run(name string, args []string, _ io.Reader, _, _ io.Writer) error {
 	c.called = true
 	c.name = name
 	c.args = args
-	b, _ := io.ReadAll(stdin)
-	c.stdin = string(b)
 	return nil
 }
 
@@ -36,7 +33,7 @@ func TestRunCallsClaude(t *testing.T) {
 	t.Parallel()
 	runner := &captureRunner{}
 
-	if err := setup.Run(runner, false, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+	if err := setup.Run(runner, false, &bytes.Buffer{}, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !runner.called {
@@ -47,32 +44,58 @@ func TestRunCallsClaude(t *testing.T) {
 	}
 }
 
-func TestRunPassesExpectedArgs(t *testing.T) {
+func TestRunPassesExpectedFlags(t *testing.T) {
 	t.Parallel()
 	runner := &captureRunner{}
 
-	_ = setup.Run(runner, false, &bytes.Buffer{}, &bytes.Buffer{})
+	_ = setup.Run(runner, false, &bytes.Buffer{}, &bytes.Buffer{}, &bytes.Buffer{})
 
-	want := []string{"-p", "--dangerously-skip-permissions"}
-	if len(runner.args) != len(want) {
-		t.Fatalf("args length: got %d, want %d", len(runner.args), len(want))
+	if len(runner.args) < 1 {
+		t.Fatal("expected at least one arg")
 	}
-	for i, a := range want {
-		if runner.args[i] != a {
-			t.Errorf("args[%d]: got %q, want %q", i, runner.args[i], a)
-		}
+	if runner.args[0] != "--dangerously-skip-permissions" {
+		t.Errorf("args[0]: got %q, want %q", runner.args[0], "--dangerously-skip-permissions")
 	}
 }
 
-func TestRunPipesNonEmptyPrompt(t *testing.T) {
+func TestRunPassesPromptAsArg(t *testing.T) {
 	t.Parallel()
 	runner := &captureRunner{}
 
-	_ = setup.Run(runner, false, &bytes.Buffer{}, &bytes.Buffer{})
+	_ = setup.Run(runner, false, &bytes.Buffer{}, &bytes.Buffer{}, &bytes.Buffer{})
 
-	if strings.TrimSpace(runner.stdin) == "" {
-		t.Error("embedded setup prompt must not be empty")
+	// The embedded prompt must be the last argument, non-empty.
+	if len(runner.args) < 2 {
+		t.Fatal("expected at least two args: flag + prompt")
 	}
+	prompt := runner.args[len(runner.args)-1]
+	if strings.TrimSpace(prompt) == "" {
+		t.Error("embedded setup prompt passed as arg must not be empty")
+	}
+}
+
+func TestRunForwardsStdin(t *testing.T) {
+	t.Parallel()
+	var capturedStdin io.Reader
+	var forwardRunner forwardStdinRunner
+	forwardRunner.capture = func(r io.Reader) { capturedStdin = r }
+
+	fakeStdin := strings.NewReader("user input")
+	_ = setup.Run(&forwardRunner, false, fakeStdin, &bytes.Buffer{}, &bytes.Buffer{})
+
+	if capturedStdin != fakeStdin {
+		t.Error("Run must forward the caller's stdin to the child process, not replace it")
+	}
+}
+
+// forwardStdinRunner calls capture with the stdin passed to Run.
+type forwardStdinRunner struct {
+	capture func(io.Reader)
+}
+
+func (f *forwardStdinRunner) Run(_ string, _ []string, stdin io.Reader, _, _ io.Writer) error {
+	f.capture(stdin)
+	return nil
 }
 
 func TestRunDryRunDoesNotCallRunner(t *testing.T) {
@@ -80,7 +103,7 @@ func TestRunDryRunDoesNotCallRunner(t *testing.T) {
 	runner := &captureRunner{}
 	var stdout bytes.Buffer
 
-	if err := setup.Run(runner, true, &stdout, &bytes.Buffer{}); err != nil {
+	if err := setup.Run(runner, true, &bytes.Buffer{}, &stdout, &bytes.Buffer{}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if runner.called {
@@ -92,7 +115,7 @@ func TestRunDryRunPrintsPromptToStdout(t *testing.T) {
 	t.Parallel()
 	var stdout bytes.Buffer
 
-	if err := setup.Run(&captureRunner{}, true, &stdout, &bytes.Buffer{}); err != nil {
+	if err := setup.Run(&captureRunner{}, true, &bytes.Buffer{}, &stdout, &bytes.Buffer{}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if strings.TrimSpace(stdout.String()) == "" {
@@ -100,16 +123,17 @@ func TestRunDryRunPrintsPromptToStdout(t *testing.T) {
 	}
 }
 
-func TestRunDryRunOutputMatchesPromptPipedToRunner(t *testing.T) {
+func TestRunDryRunOutputMatchesPromptArg(t *testing.T) {
 	t.Parallel()
 	var dryOut bytes.Buffer
-	_ = setup.Run(&captureRunner{}, true, &dryOut, &bytes.Buffer{})
+	_ = setup.Run(&captureRunner{}, true, &bytes.Buffer{}, &dryOut, &bytes.Buffer{})
 
 	normal := &captureRunner{}
-	_ = setup.Run(normal, false, &bytes.Buffer{}, &bytes.Buffer{})
+	_ = setup.Run(normal, false, &bytes.Buffer{}, &bytes.Buffer{}, &bytes.Buffer{})
 
-	if strings.TrimSpace(dryOut.String()) != strings.TrimSpace(normal.stdin) {
-		t.Error("dry-run stdout must equal the prompt piped to the runner in normal mode")
+	promptArg := normal.args[len(normal.args)-1]
+	if strings.TrimSpace(dryOut.String()) != strings.TrimSpace(promptArg) {
+		t.Error("dry-run stdout must equal the prompt passed as arg in normal mode")
 	}
 }
 
@@ -117,7 +141,7 @@ func TestRunPropagatesRunnerError(t *testing.T) {
 	t.Parallel()
 	sentinel := errors.New("claude not found")
 
-	err := setup.Run(errorRunner{err: sentinel}, false, &bytes.Buffer{}, &bytes.Buffer{})
+	err := setup.Run(errorRunner{err: sentinel}, false, &bytes.Buffer{}, &bytes.Buffer{}, &bytes.Buffer{})
 	if !errors.Is(err, sentinel) {
 		t.Errorf("expected sentinel error, got %v", err)
 	}


### PR DESCRIPTION
## Summary

- Adds `agents setup` subcommand that launches a Claude session with an embedded setup prompt, guiding users through the full daemon setup from scratch (prerequisites, GitHub auth, repo selection, webhook creation, config generation, label setup)
- Adds `agents setup --dry-run` that prints the embedded prompt to stdout without executing Claude — useful for inspection and scripting
- The setup prompt (`internal/setup/prompt.md`) is compiled into the binary via `//go:embed` so it is always version-compatible with the binary
- The `CommandRunner` interface is injectable for testing; all logic is covered by unit tests

## Test plan

- [x] `go test ./internal/setup/... -v` — 7 tests covering: correct command invocation, expected args, non-empty embedded prompt, dry-run isolation, dry-run stdout matches piped prompt, error propagation
- [x] `go test ./...` — all existing tests still pass

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)