### PR TITLE
autonomous: add SkipIfStillRunning guard to prevent goroutine accumulation

### DIFF
--- a/internal/autonomous/scheduler.go
+++ b/internal/autonomous/scheduler.go
@@ -14,6 +14,28 @@ import (
 	"github.com/eloylp/agents/internal/config"
 )
 
+// zerologCronLogger adapts zerolog.Logger to the cron.Logger interface required
+// by chain wrappers such as SkipIfStillRunning.
+type zerologCronLogger struct {
+	logger zerolog.Logger
+}
+
+func (z zerologCronLogger) Info(msg string, keysAndValues ...interface{}) {
+	e := z.logger.Info()
+	for i := 0; i+1 < len(keysAndValues); i += 2 {
+		e = e.Interface(fmt.Sprintf("%v", keysAndValues[i]), keysAndValues[i+1])
+	}
+	e.Msg(msg)
+}
+
+func (z zerologCronLogger) Error(err error, msg string, keysAndValues ...interface{}) {
+	e := z.logger.Error().Err(err)
+	for i := 0; i+1 < len(keysAndValues); i += 2 {
+		e = e.Interface(fmt.Sprintf("%v", keysAndValues[i]), keysAndValues[i+1])
+	}
+	e.Msg(msg)
+}
+
 // AgentStatus is the runtime state of a single registered autonomous agent.
 type AgentStatus struct {
 	Name       string
@@ -52,7 +74,11 @@ type Scheduler struct {
 
 func NewScheduler(cfg *config.Config, runners map[string]ai.Runner, prompts *ai.PromptStore, memories *MemoryStore, logger zerolog.Logger) (*Scheduler, error) {
 	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
-	c := cron.New(cron.WithParser(parser))
+	cronLogger := zerologCronLogger{logger: logger.With().Str("component", "autonomous_scheduler").Logger()}
+	c := cron.New(
+		cron.WithParser(parser),
+		cron.WithChain(cron.SkipIfStillRunning(cronLogger)),
+	)
 	s := &Scheduler{
 		cfg:      cfg,
 		runners:  runners,

--- a/internal/autonomous/scheduler_test.go
+++ b/internal/autonomous/scheduler_test.go
@@ -28,6 +28,23 @@ func (s *stubRunner) Run(_ context.Context, req ai.Request) (ai.Response, error)
 	return ai.Response{}, nil
 }
 
+// blockingRunner signals on ready when a run starts, then blocks until block is closed.
+type blockingRunner struct {
+	mu    sync.Mutex
+	calls int
+	ready chan struct{}
+	block chan struct{}
+}
+
+func (b *blockingRunner) Run(_ context.Context, _ ai.Request) (ai.Response, error) {
+	b.mu.Lock()
+	b.calls++
+	b.mu.Unlock()
+	b.ready <- struct{}{}
+	<-b.block
+	return ai.Response{}, nil
+}
+
 func buildTestPromptStore(t *testing.T, dir string) *ai.PromptStore {
 	t.Helper()
 	writeIssuePrompt(t, dir)
@@ -494,6 +511,66 @@ func TestTriggerAgentReturnsErrorForDisabledRepo(t *testing.T) {
 
 	if err := scheduler.TriggerAgent(context.Background(), "architect", "owner/repo"); err == nil {
 		t.Fatal("expected error for disabled repo, got nil")
+	}
+}
+
+func TestSchedulerSkipsJobWhenPreviousRunStillRunning(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	prompts := buildTestPromptStore(t, dir)
+
+	ready := make(chan struct{}, 1)
+	block := make(chan struct{})
+	runner := &blockingRunner{ready: ready, block: block}
+
+	cfg := &config.Config{
+		AgentsDir: dir,
+		AIBackends: map[string]config.AIBackendConfig{
+			"claude": {},
+		},
+		Repos: []config.RepoConfig{
+			{FullName: "owner/repo", Enabled: true},
+		},
+		AutonomousAgents: []config.AutonomousRepoConfig{
+			{
+				Repo:    "owner/repo",
+				Enabled: true,
+				Agents: []config.AutonomousAgentConfig{
+					{Name: "architect", Description: "desc", Cron: "* * * * *", Skills: []string{"architect"},
+						Tasks: []config.TaskConfig{{Name: "scan", Prompt: "scan"}}},
+				},
+			},
+		},
+	}
+	scheduler, err := NewScheduler(cfg, map[string]ai.Runner{"claude": runner}, prompts, NewMemoryStore(dir), zerolog.Nop())
+	if err != nil {
+		t.Fatalf("scheduler: %v", err)
+	}
+
+	wrappedJob := scheduler.cron.Entry(scheduler.agentEntries[0].cronID).WrappedJob
+
+	// Start first run in background — it blocks until we close block.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		wrappedJob.Run()
+	}()
+
+	// Wait until the first run has started so the skip-guard token is held.
+	<-ready
+
+	// This second invocation should be skipped (not queued) by SkipIfStillRunning.
+	wrappedJob.Run()
+
+	// Unblock the first run and wait for it to finish.
+	close(block)
+	<-done
+
+	runner.mu.Lock()
+	calls := runner.calls
+	runner.mu.Unlock()
+	if calls != 1 {
+		t.Fatalf("expected exactly 1 runner invocation (second should be skipped), got %d", calls)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `cron.WithChain(cron.SkipIfStillRunning(...))` to the cron runner in `NewScheduler` so that overlapping ticks for a slow agent are dropped rather than queued as unbounded goroutines.
- Introduces `zerologCronLogger` — a thin adapter implementing `cron.Logger` — so skip events are emitted through the structured zerolog pipeline instead of stdlib log.
- Adds `TestSchedulerSkipsJobWhenPreviousRunStillRunning` which uses a blocking runner to verify that a second concurrent invocation of the same cron job is skipped and only one runner call is made.

## Test plan
- [x] `go test ./...` passes
- [x] New test `TestSchedulerSkipsJobWhenPreviousRunStillRunning` confirms skip behaviour end-to-end via the cron entry's `WrappedJob`

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)