### PR TITLE
config: validate mode=command requires non-empty command at startup

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -312,9 +312,12 @@ func (c *Config) validateBackends() error {
 	if len(c.AIBackends) == 0 {
 		return errors.New("config: at least one ai_backends entry is required")
 	}
-	for name := range c.AIBackends {
+	for name, backend := range c.AIBackends {
 		if name != "claude" && name != "codex" {
 			return fmt.Errorf("config: unsupported ai backend %q (supported: claude, codex)", name)
+		}
+		if backend.Mode == "command" && strings.TrimSpace(backend.Command) == "" {
+			return fmt.Errorf("config: ai backend %q has mode=command but no command specified", name)
 		}
 	}
 	return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -239,6 +239,7 @@ func (c *Config) normalizeBackends() {
 		setDefault(&backend.Mode, "noop")
 		setDefaultInt(&backend.TimeoutSeconds, defaultAITimeoutSeconds)
 		setDefaultInt(&backend.MaxPromptChars, defaultMaxPromptChars)
+		backend.Command = strings.TrimSpace(backend.Command)
 		normalized[key] = backend
 	}
 	c.AIBackends = normalized

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -518,3 +518,54 @@ repos:
 		t.Fatalf("unexpected error for valid command mode config: %v", err)
 	}
 }
+
+func TestLoadRejectsCommandModeWithWhitespaceOnlyCommand(t *testing.T) {
+	t.Setenv("WEBHOOK_SECRET", "secret")
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := `http:
+  webhook_secret_env: WEBHOOK_SECRET
+ai_backends:
+  claude:
+    mode: command
+    command: "   "
+    args: ["-p", "--dangerously-skip-permissions"]
+repos:
+  - full_name: "owner/repo"
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected load to fail when mode=command and command is whitespace-only")
+	}
+}
+
+func TestLoadNormalizesWhitespacePaddedCommand(t *testing.T) {
+	t.Setenv("WEBHOOK_SECRET", "secret")
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := `http:
+  webhook_secret_env: WEBHOOK_SECRET
+ai_backends:
+  claude:
+    mode: command
+    command: "  claude  "
+    args: ["-p", "--dangerously-skip-permissions"]
+repos:
+  - full_name: "owner/repo"
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error for padded command: %v", err)
+	}
+	if got := cfg.AIBackends["claude"].Command; got != "claude" {
+		t.Errorf("expected normalized command %q, got %q", "claude", got)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -471,3 +471,50 @@ autonomous_agents:
 		t.Fatalf("expected validation error for autonomous agents")
 	}
 }
+
+func TestLoadRejectsCommandModeWithEmptyCommand(t *testing.T) {
+	t.Setenv("WEBHOOK_SECRET", "secret")
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := `http:
+  webhook_secret_env: WEBHOOK_SECRET
+ai_backends:
+  claude:
+    mode: command
+    # command field intentionally omitted
+    args: ["-p", "--dangerously-skip-permissions"]
+repos:
+  - full_name: "owner/repo"
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected load to fail when mode=command and command is empty")
+	}
+}
+
+func TestLoadAcceptsCommandModeWithNonEmptyCommand(t *testing.T) {
+	t.Setenv("WEBHOOK_SECRET", "secret")
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := `http:
+  webhook_secret_env: WEBHOOK_SECRET
+ai_backends:
+  claude:
+    mode: command
+    command: claude
+    args: ["-p", "--dangerously-skip-permissions"]
+repos:
+  - full_name: "owner/repo"
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if _, err := Load(path); err != nil {
+		t.Fatalf("unexpected error for valid command mode config: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a check in `validateBackends()` that rejects configs where `mode: command` is set but the `command` field is empty
- Error is surfaced at daemon startup rather than at the first AI invocation (which could be hours later for cron agents)
- Two tests added: one for the rejection case, one confirming valid `mode=command` + non-empty `command` still loads cleanly

## Related

- Closes #70
- Complements #39 (mode value validation) — this handles the `command` field absence for `mode=command`

## Test plan

- [ ] `go test ./internal/config/... -count=1` passes
- [ ] Config with `mode: command` and empty `command` fails to load with a clear error
- [ ] Config with `mode: command` and `command: claude` loads cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)