### PR TITLE
config: validate AIBackendConfig.Mode at startup

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -324,6 +324,9 @@ func (c *Config) validateBackends() error {
 		if name != "claude" && name != "codex" {
 			return fmt.Errorf("config: unsupported ai backend %q (supported: claude, codex)", name)
 		}
+		if backend.Mode != "noop" && backend.Mode != "command" {
+			return fmt.Errorf("config: backend %q has unsupported mode %q (supported: noop, command)", name, backend.Mode)
+		}
 		if backend.Mode == "command" && strings.TrimSpace(backend.Command) == "" {
 			return fmt.Errorf("config: ai backend %q has mode=command but no command specified", name)
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -569,3 +569,71 @@ repos:
 		t.Errorf("expected normalized command %q, got %q", "claude", got)
 	}
 }
+
+func TestLoadRejectsUnsupportedBackendMode(t *testing.T) {
+	t.Setenv("WEBHOOK_SECRET", "secret")
+
+	cases := []struct {
+		name string
+		mode string
+	}{
+		{"typo", "cmd"},
+		{"unknown", "subprocess"},
+		{"empty-like", "nOop"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.yaml")
+			content := `http:
+  webhook_secret_env: WEBHOOK_SECRET
+ai_backends:
+  claude:
+    mode: ` + tc.mode + `
+repos:
+  - full_name: "owner/repo"
+`
+			if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+			_, err := Load(path)
+			if err == nil {
+				t.Fatalf("expected load to fail for mode=%q", tc.mode)
+			}
+		})
+	}
+}
+
+func TestLoadAcceptsSupportedBackendModes(t *testing.T) {
+	t.Setenv("WEBHOOK_SECRET", "secret")
+
+	cases := []struct {
+		name string
+		mode string
+	}{
+		{"noop", "noop"},
+		{"command", "command"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.yaml")
+			var commandLine string
+			if tc.mode == "command" {
+				commandLine = "\n    command: claude"
+			}
+			content := `http:
+  webhook_secret_env: WEBHOOK_SECRET
+ai_backends:
+  claude:
+    mode: ` + tc.mode + commandLine + `
+repos:
+  - full_name: "owner/repo"
+`
+			if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+			if _, err := Load(path); err != nil {
+				t.Fatalf("unexpected error for mode=%q: %v", tc.mode, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a mode check in `validateBackends()` that rejects any `mode` value other than `"noop"` or `"command"`
- Previously, typos like `mode: cmd` passed startup validation and produced a silent runtime error on the first webhook event (`unknown claude mode: cmd`)
- `normalizeBackends()` already defaults an empty mode to `"noop"`, so the new check only fires for explicitly wrong values — no behaviour change for correct configs

## Test plan

- [x] `go test ./...` passes
- [x] Table-driven rejection tests: `cmd` (typo), `subprocess` (unknown), `nOop` (wrong case) all fail at load
- [x] Acceptance tests: `noop` and `command` still load cleanly

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)