### PR TITLE
config: reject startup when all repos have enabled: false

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -368,10 +369,17 @@ func (c *Config) validateRepos() error {
 	if len(c.Repos) == 0 {
 		return errors.New("config: at least one repo is required")
 	}
+	enabledCount := 0
 	for _, repo := range c.Repos {
 		if repo.FullName == "" {
 			return errors.New("config: repo full_name is required")
 		}
+		if repo.Enabled {
+			enabledCount++
+		}
+	}
+	if enabledCount == 0 {
+		return errors.New("config: at least one repo must have enabled: true")
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -19,6 +19,7 @@ ai_backends:
     mode: noop
 repos:
   - full_name: "owner/repo"
+    enabled: true
 `
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
@@ -46,6 +47,7 @@ agents:
     skills: [architect]
 repos:
   - full_name: "owner/repo"
+    enabled: true
 autonomous_agents:
   - repo: "owner/repo"
     enabled: true
@@ -183,6 +185,7 @@ agents:
     skills: [architect]
 repos:
   - full_name: "owner/repo"
+    enabled: true
 `,
 		},
 		{
@@ -199,6 +202,7 @@ agents:
     skills: [architect]
 repos:
   - full_name: "owner/repo"
+    enabled: true
 `,
 		},
 		{
@@ -217,6 +221,7 @@ agents:
     skills: [architect]
 repos:
   - full_name: "owner/repo"
+    enabled: true
 `,
 		},
 	}
@@ -258,6 +263,7 @@ agents:
     skills: [architect]
 repos:
   - full_name: "owner/repo"
+    enabled: true
 `,
 		},
 		{
@@ -274,6 +280,7 @@ agents:
   - name: architect
 repos:
   - full_name: "owner/repo"
+    enabled: true
 `,
 		},
 		{
@@ -291,6 +298,7 @@ agents:
     skills: [nonexistent]
 repos:
   - full_name: "owner/repo"
+    enabled: true
 `,
 		},
 		{
@@ -308,6 +316,7 @@ agents:
     skills: [architect]
 repos:
   - full_name: "owner/repo"
+    enabled: true
 autonomous_agents:
   - repo: "owner/repo"
     enabled: true
@@ -335,6 +344,7 @@ agents:
     skills: [architect]
 repos:
   - full_name: "owner/repo"
+    enabled: true
 autonomous_agents:
   - repo: "owner/repo"
     enabled: true
@@ -363,6 +373,7 @@ agents:
     skills: [architect]
 repos:
   - full_name: "owner/repo"
+    enabled: true
 autonomous_agents:
   - repo: "owner/repo"
     enabled: true
@@ -387,6 +398,7 @@ agents:
     skills: [architect]
 repos:
   - full_name: "owner/repo"
+    enabled: true
 autonomous_agents:
   - repo: "owner/repo"
     enabled: true
@@ -413,6 +425,7 @@ agents:
     skills: [architect]
 repos:
   - full_name: "owner/repo"
+    enabled: true
 autonomous_agents:
   - repo: "owner/repo"
     enabled: true
@@ -445,6 +458,7 @@ prompts:
     prompt: "inline issue"
 repos:
   - full_name: "owner/repo"
+    enabled: true
 `,
 		},
 	}
@@ -485,6 +499,7 @@ agents:
     skills: [security]
 repos:
   - full_name: "owner/repo"
+    enabled: true
 `
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
@@ -546,6 +561,7 @@ ai_backends:
     args:` + argsYAML + `
 repos:
   - full_name: "owner/repo"
+    enabled: true
 `
 			if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 				t.Fatalf("write config: %v", err)
@@ -609,6 +625,7 @@ agents:
     skills: [architect]
 repos:
   - full_name: "owner/repo"
+    enabled: true
 autonomous_agents:
   - repo: ""
     enabled: true
@@ -642,6 +659,7 @@ ai_backends:
     args: ["-p", "--dangerously-skip-permissions"]
 repos:
   - full_name: "owner/repo"
+    enabled: true
 `
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
@@ -666,6 +684,7 @@ ai_backends:
     args: ["-p", "--dangerously-skip-permissions"]
 repos:
   - full_name: "owner/repo"
+    enabled: true
 `
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
@@ -689,6 +708,7 @@ ai_backends:
     args: ["-p", "--dangerously-skip-permissions"]
 repos:
   - full_name: "owner/repo"
+    enabled: true
 `
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
@@ -713,6 +733,7 @@ ai_backends:
     args: ["-p", "--dangerously-skip-permissions"]
 repos:
   - full_name: "owner/repo"
+    enabled: true
 `
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
@@ -748,6 +769,7 @@ ai_backends:
     mode: ` + tc.mode + `
 repos:
   - full_name: "owner/repo"
+    enabled: true
 `
 			if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 				t.Fatalf("write config: %v", err)
@@ -779,6 +801,7 @@ ai_backends:
     timeout_seconds: 0
 repos:
   - full_name: "owner/repo"
+    enabled: true
 `,
 			wantTimeout:   0,
 			wantMaxPrompt: defaultMaxPromptChars,
@@ -793,6 +816,7 @@ ai_backends:
     max_prompt_chars: 0
 repos:
   - full_name: "owner/repo"
+    enabled: true
 `,
 			wantTimeout:   defaultAITimeoutSeconds,
 			wantMaxPrompt: 0,
@@ -808,6 +832,7 @@ ai_backends:
     max_prompt_chars: 0
 repos:
   - full_name: "owner/repo"
+    enabled: true
 `,
 			wantTimeout:   0,
 			wantMaxPrompt: 0,
@@ -919,6 +944,7 @@ ai_backends:
     mode: ` + tc.mode + commandLine + `
 repos:
   - full_name: "owner/repo"
+    enabled: true
 `
 			if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 				t.Fatalf("write config: %v", err)
@@ -1010,6 +1036,7 @@ agents:
     skills: [architect]
 repos:
   - full_name: "owner/repo"
+    enabled: true
 autonomous_agents:
   - repo: "owner/repo"
     enabled: true
@@ -1035,6 +1062,68 @@ autonomous_agents:
 	}
 	if task.Prompt != "" {
 		t.Fatalf("expected empty inline Prompt, got %q", task.Prompt)
+	}
+}
+
+func TestValidateReposAllDisabled(t *testing.T) {
+	t.Setenv("WEBHOOK_SECRET", "secret")
+
+	tests := []struct {
+		name       string
+		content    string
+		wantErr    bool
+		wantErrMsg string
+	}{
+		{
+			name: "all repos disabled rejects at startup",
+			content: `http:
+  webhook_secret_env: WEBHOOK_SECRET
+ai_backends:
+  claude:
+    mode: noop
+repos:
+  - full_name: "owner/repo"
+    enabled: false
+  - full_name: "owner/other"
+    enabled: false
+`,
+			wantErr:    true,
+			wantErrMsg: "config: at least one repo must have enabled: true",
+		},
+		{
+			name: "single enabled repo is accepted",
+			content: `http:
+  webhook_secret_env: WEBHOOK_SECRET
+ai_backends:
+  claude:
+    mode: noop
+repos:
+  - full_name: "owner/repo"
+    enabled: false
+  - full_name: "owner/other"
+    enabled: true
+`,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.yaml")
+			if err := os.WriteFile(path, []byte(tt.content), 0o644); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+			_, err := Load(path)
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected validation error for all-disabled repos, got nil")
+			}
+			if tt.wantErr && err != nil && tt.wantErrMsg != "" && err.Error() != tt.wantErrMsg {
+				t.Fatalf("expected error %q, got %q", tt.wantErrMsg, err.Error())
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected valid config, got: %v", err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- `validateRepos()` previously accepted configs where every repo had `enabled: false`, letting the daemon start and silently drop all webhook events.
- Adds an enabled-count check so the daemon fails fast at startup with `config: at least one repo must have enabled: true`.
- Updates all existing test repo entries to set `enabled: true` so each test continues to exercise its intended validation (not the new repos check).
- Adds `TestValidateReposAllDisabled` with table-driven cases covering all-disabled (rejects) and mixed-enabled (accepts).

Closes #52

## Test plan
- [ ] `go test ./... ` passes
- [ ] Config with all repos `enabled: false` fails at startup with a clear error
- [ ] Config with at least one `enabled: true` repo loads successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)