### PR TITLE
refactor(ai): remove duplicate truncatePrompt

### DIFF
--- a/internal/ai/cmdrunner.go
+++ b/internal/ai/cmdrunner.go
@@ -47,7 +47,7 @@ func NewCommandRunner(backendName string, mode string, command string, args []st
 }
 
 func (r *CommandRunner) Run(ctx context.Context, req Request) (Response, error) {
-	prompt := truncatePrompt(req.Prompt, r.maxPromptChars)
+	prompt := truncateString(req.Prompt, r.maxPromptChars)
 	promptMeta := r.promptMeta(prompt)
 	logger := r.logger.With().
 		Str("workflow", req.Workflow).
@@ -138,17 +138,6 @@ func (r *CommandRunner) promptMeta(prompt string) promptMeta {
 		Hash:   hex.EncodeToString(hasher.Sum(nil)),
 		Length: len(prompt),
 	}
-}
-
-func truncatePrompt(prompt string, maxChars int) string {
-	if maxChars <= 0 {
-		return prompt
-	}
-	runes := []rune(prompt)
-	if len(runes) <= maxChars {
-		return prompt
-	}
-	return string(runes[:maxChars])
 }
 
 func truncateString(value string, maxChars int) string {


### PR DESCRIPTION
## Why

`truncatePrompt` and `truncateString` in `internal/ai/cmdrunner.go` are byte-for-byte identical — both truncate a string to a rune-safe `maxChars` limit and return the input unchanged when `maxChars <= 0`. `truncatePrompt` had exactly one call site (`Run`, line 50) and was presumably added before `truncateString` existed or to signal intent, but it adds no semantic distinction.

## What changed

- Removed `truncatePrompt` (11 lines)
- Its single call site in `Run()` now calls `truncateString` directly

No behavior change. All tests pass (`go test ./...`).