### PR TITLE
cmd: fix absolute prompt_file paths silently broken by AgentsDir join

### DIFF
--- a/cmd/agents/main.go
+++ b/cmd/agents/main.go
@@ -137,7 +137,7 @@ func resolveSkills(cfg *config.Config) []ai.SkillGuidance {
 	for _, s := range cfg.Skills {
 		sg := ai.SkillGuidance{Name: s.Name, Prompt: s.Prompt}
 		if s.PromptFile != "" {
-			sg.PromptFile = filepath.Join(cfg.AgentsDir, s.PromptFile)
+			sg.PromptFile = agentsPath(cfg.AgentsDir, s.PromptFile)
 		}
 		skills = append(skills, sg)
 	}
@@ -193,8 +193,18 @@ func resolvePrompts(cfg *config.Config) (issue ai.PromptSource, pr ai.PromptSour
 		if src.Prompt != "" {
 			return ai.PromptSource{Prompt: src.Prompt}
 		}
-		return ai.PromptSource{PromptFile: filepath.Join(cfg.AgentsDir, src.PromptFile)}
+		return ai.PromptSource{PromptFile: agentsPath(cfg.AgentsDir, src.PromptFile)}
 	}
 	return resolve(cfg.Prompts.IssueRefinement), resolve(cfg.Prompts.PRReview), resolve(cfg.Prompts.Autonomous)
+}
+
+// agentsPath resolves a prompt file path relative to agentsDir unless it is
+// already absolute, in which case it is returned unchanged. This mirrors the
+// POSIX convention that an absolute path always names an exact location.
+func agentsPath(agentsDir, promptFile string) string {
+	if filepath.IsAbs(promptFile) {
+		return promptFile
+	}
+	return filepath.Join(agentsDir, promptFile)
 }
 

--- a/cmd/agents/main_test.go
+++ b/cmd/agents/main_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestAgentsPath(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		agentsDir  string
+		promptFile string
+		want       string
+	}{
+		{
+			name:       "relative-path-joined",
+			agentsDir:  "/base/agents",
+			promptFile: "prompts/review.md",
+			want:       "/base/agents/prompts/review.md",
+		},
+		{
+			name:       "absolute-path-unchanged",
+			agentsDir:  "/base/agents",
+			promptFile: "/etc/custom/PROMPT.md",
+			want:       "/etc/custom/PROMPT.md",
+		},
+		{
+			name:       "absolute-path-not-concatenated",
+			agentsDir:  "/base/agents",
+			promptFile: "/etc/custom/PROMPT.md",
+			// filepath.Join would produce /base/agents/etc/custom/PROMPT.md (wrong)
+			want: "/etc/custom/PROMPT.md",
+		},
+		{
+			name:       "relative-no-subdir",
+			agentsDir:  "/agents",
+			promptFile: "PROMPT.md",
+			want:       "/agents/PROMPT.md",
+		},
+		{
+			name:       "empty-promptfile-returns-agentsdir",
+			agentsDir:  "/agents",
+			promptFile: "",
+			want:       filepath.Join("/agents", ""),
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := agentsPath(tc.agentsDir, tc.promptFile)
+			if got != tc.want {
+				t.Errorf("agentsPath(%q, %q) = %q, want %q", tc.agentsDir, tc.promptFile, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/agents/main_test.go
+++ b/cmd/agents/main_test.go
@@ -8,6 +8,12 @@ import (
 func TestAgentsPath(t *testing.T) {
 	t.Parallel()
 
+	// Use real OS temp dirs so absolute-path assertions are portable across
+	// platforms (filepath.IsAbs uses OS-specific rules; hard-coded Unix paths
+	// would fail on Windows).
+	absBase := t.TempDir()
+	absPromptFile := filepath.Join(t.TempDir(), "custom", "PROMPT.md")
+
 	cases := []struct {
 		name       string
 		agentsDir  string
@@ -16,38 +22,37 @@ func TestAgentsPath(t *testing.T) {
 	}{
 		{
 			name:       "relative-path-joined",
-			agentsDir:  "/base/agents",
-			promptFile: "prompts/review.md",
-			want:       "/base/agents/prompts/review.md",
+			agentsDir:  absBase,
+			promptFile: filepath.Join("prompts", "review.md"),
+			want:       filepath.Join(absBase, "prompts", "review.md"),
 		},
 		{
 			name:       "absolute-path-unchanged",
-			agentsDir:  "/base/agents",
-			promptFile: "/etc/custom/PROMPT.md",
-			want:       "/etc/custom/PROMPT.md",
+			agentsDir:  absBase,
+			promptFile: absPromptFile,
+			want:       absPromptFile,
 		},
 		{
 			name:       "absolute-path-not-concatenated",
-			agentsDir:  "/base/agents",
-			promptFile: "/etc/custom/PROMPT.md",
-			// filepath.Join would produce /base/agents/etc/custom/PROMPT.md (wrong)
-			want: "/etc/custom/PROMPT.md",
+			agentsDir:  absBase,
+			promptFile: absPromptFile,
+			// filepath.Join would absorb the absolute promptFile into agentsDir (wrong)
+			want: absPromptFile,
 		},
 		{
 			name:       "relative-no-subdir",
-			agentsDir:  "/agents",
+			agentsDir:  absBase,
 			promptFile: "PROMPT.md",
-			want:       "/agents/PROMPT.md",
+			want:       filepath.Join(absBase, "PROMPT.md"),
 		},
 		{
 			name:       "empty-promptfile-returns-agentsdir",
-			agentsDir:  "/agents",
+			agentsDir:  absBase,
 			promptFile: "",
-			want:       filepath.Join("/agents", ""),
+			want:       filepath.Join(absBase, ""),
 		},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got := agentsPath(tc.agentsDir, tc.promptFile)


### PR DESCRIPTION
## Summary

- `resolvePrompts` and `resolveSkills` in `cmd/agents/main.go` called `filepath.Join(agentsDir, promptFile)` unconditionally
- On Linux, `filepath.Join` does **not** treat a later absolute path as an override — it concatenates, so `/base/agents` + `/etc/custom/PROMPT.md` → `/base/agents/etc/custom/PROMPT.md` (wrong path, fails at load time with a misleading error)
- Fix: extract `agentsPath(agentsDir, promptFile)` which calls `filepath.IsAbs` and returns the path unchanged when already absolute; relative paths still use `filepath.Join`

Closes #48

## Test plan

- [ ] `go test ./...` passes (new table-driven tests in `cmd/agents/main_test.go` cover relative join, absolute passthrough, and the wrong-concatenation regression)
- [ ] Verify with `config.yaml` that `prompt_file: /absolute/path.md` resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)