### PR TITLE
ai: omit AI_DAEMON_NUMBER from subprocess env for autonomous runs

### DIFF
--- a/internal/ai/cmdrunner.go
+++ b/internal/ai/cmdrunner.go
@@ -179,8 +179,10 @@ func buildCommandEnv(req Request) []string {
 	env = append(env,
 		"AI_DAEMON_WORKFLOW="+req.Workflow,
 		"AI_DAEMON_REPO="+req.Repo,
-		fmt.Sprintf("AI_DAEMON_NUMBER=%d", req.Number),
 	)
+	if req.Number != 0 {
+		env = append(env, fmt.Sprintf("AI_DAEMON_NUMBER=%d", req.Number))
+	}
 	return env
 }
 

--- a/internal/ai/cmdrunner_test.go
+++ b/internal/ai/cmdrunner_test.go
@@ -1,8 +1,52 @@
 package ai
 
 import (
+	"slices"
 	"testing"
 )
+
+func TestBuildCommandEnvDaemonNumber(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name           string
+		number         int
+		wantNumberVar  bool
+	}{
+		{
+			name:          "numbered-workflow-sets-AI_DAEMON_NUMBER",
+			number:        42,
+			wantNumberVar: true,
+		},
+		{
+			name:          "autonomous-workflow-omits-AI_DAEMON_NUMBER",
+			number:        0,
+			wantNumberVar: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			env := buildCommandEnv(Request{
+				Workflow: "test-workflow",
+				Repo:     "owner/repo",
+				Number:   tc.number,
+			})
+			hasNumber := slices.ContainsFunc(env, func(e string) bool {
+				return len(e) >= len("AI_DAEMON_NUMBER=") && e[:len("AI_DAEMON_NUMBER=")] == "AI_DAEMON_NUMBER="
+			})
+			if hasNumber != tc.wantNumberVar {
+				t.Errorf("AI_DAEMON_NUMBER present=%v, want present=%v (env=%v)", hasNumber, tc.wantNumberVar, env)
+			}
+			if tc.wantNumberVar {
+				want := "AI_DAEMON_NUMBER=42"
+				if !slices.Contains(env, want) {
+					t.Errorf("expected %q in env, got %v", want, env)
+				}
+			}
+		})
+	}
+}
 
 func TestExtractJSON(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

- `buildCommandEnv` was unconditionally appending `AI_DAEMON_NUMBER=0` for autonomous scheduler runs where `req.Number` is never set (no issue or PR is associated).
- An AI backend tool using this env var to look up a GitHub resource would silently act on non-existent object #0.
- Fix: only append `AI_DAEMON_NUMBER` when `req.Number != 0` (Option A from the issue).
- Added table-driven test covering both the numbered-workflow case (`AI_DAEMON_NUMBER=42` present) and the autonomous case (`AI_DAEMON_NUMBER` absent).

## Test plan

- [ ] `go test ./...` passes
- [ ] Verify `AI_DAEMON_NUMBER` absent in env for autonomous run (number=0)
- [ ] Verify `AI_DAEMON_NUMBER=N` present for normal issue/PR workflow run

Closes #53

🤖 Generated with [Claude Code](https://claude.ai/claude-code)