### PR TITLE
config: use pointer fields so explicit zero backend values are honoured

### DIFF
--- a/cmd/agents/main.go
+++ b/cmd/agents/main.go
@@ -122,7 +122,7 @@ func setupPromptStore(cfg *config.Config, logger zerolog.Logger) (*ai.PromptStor
 func setupRunners(cfg *config.Config, logger zerolog.Logger) map[string]ai.Runner {
 	runners := make(map[string]ai.Runner, len(cfg.AIBackends))
 	for name, backend := range cfg.AIBackends {
-		runners[name] = ai.NewCommandRunner(name, backend.Mode, backend.Command, backend.Args, backend.TimeoutSeconds, backend.MaxPromptChars, backend.RedactionSaltEnv, logger)
+		runners[name] = ai.NewCommandRunner(name, backend.Mode, backend.Command, backend.Args, *backend.TimeoutSeconds, *backend.MaxPromptChars, backend.RedactionSaltEnv, logger)
 	}
 	return runners
 }

--- a/internal/ai/cmdrunner.go
+++ b/internal/ai/cmdrunner.go
@@ -73,7 +73,13 @@ func (r *CommandRunner) Run(ctx context.Context, req Request) (Response, error) 
 }
 
 func (r *CommandRunner) runCommand(ctx context.Context, logger zerolog.Logger, req Request, prompt string) (Response, error) {
-	cmdCtx, cancel := context.WithTimeout(ctx, r.timeout)
+	var cmdCtx context.Context
+	var cancel context.CancelFunc
+	if r.timeout > 0 {
+		cmdCtx, cancel = context.WithTimeout(ctx, r.timeout)
+	} else {
+		cmdCtx, cancel = ctx, func() {}
+	}
 	defer cancel()
 
 	cmd := exec.CommandContext(cmdCtx, r.command, r.args...)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -129,8 +129,8 @@ type AIBackendConfig struct {
 	Mode             string   `yaml:"mode"`
 	Command          string   `yaml:"command"`
 	Args             []string `yaml:"args"`
-	TimeoutSeconds   int      `yaml:"timeout_seconds"`
-	MaxPromptChars   int      `yaml:"max_prompt_chars"`
+	TimeoutSeconds   *int     `yaml:"timeout_seconds"`
+	MaxPromptChars   *int     `yaml:"max_prompt_chars"`
 	RedactionSaltEnv string   `yaml:"redaction_salt_env"`
 }
 
@@ -244,8 +244,14 @@ func (c *Config) normalizeBackends() {
 			continue
 		}
 		setDefault(&backend.Mode, "noop")
-		setDefaultInt(&backend.TimeoutSeconds, defaultAITimeoutSeconds)
-		setDefaultInt(&backend.MaxPromptChars, defaultMaxPromptChars)
+		if backend.TimeoutSeconds == nil {
+			v := defaultAITimeoutSeconds
+			backend.TimeoutSeconds = &v
+		}
+		if backend.MaxPromptChars == nil {
+			v := defaultMaxPromptChars
+			backend.MaxPromptChars = &v
+		}
 		backend.Command = strings.TrimSpace(backend.Command)
 		normalized[key] = backend
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -336,6 +336,12 @@ func (c *Config) validateBackends() error {
 		if backend.Mode == "command" && strings.TrimSpace(backend.Command) == "" {
 			return fmt.Errorf("config: ai backend %q has mode=command but no command specified", name)
 		}
+		if backend.TimeoutSeconds != nil && *backend.TimeoutSeconds < 0 {
+			return fmt.Errorf("config: ai backend %q has negative timeout_seconds %d (use 0 to disable the timeout)", name, *backend.TimeoutSeconds)
+		}
+		if backend.MaxPromptChars != nil && *backend.MaxPromptChars < 0 {
+			return fmt.Errorf("config: ai backend %q has negative max_prompt_chars %d (use 0 to disable truncation)", name, *backend.MaxPromptChars)
+		}
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -64,8 +64,12 @@ autonomous_agents:
 		t.Fatalf("load config: %v", err)
 	}
 	backend := cfg.AIBackends["claude"]
-	if backend.TimeoutSeconds != defaultAITimeoutSeconds {
-		t.Fatalf("expected timeout default %d, got %d", defaultAITimeoutSeconds, backend.TimeoutSeconds)
+	if backend.TimeoutSeconds == nil || *backend.TimeoutSeconds != defaultAITimeoutSeconds {
+		got := 0
+		if backend.TimeoutSeconds != nil {
+			got = *backend.TimeoutSeconds
+		}
+		t.Fatalf("expected timeout default %d, got %d", defaultAITimeoutSeconds, got)
 	}
 	if cfg.Processor.IssueQueueBuffer != defaultIssueQueueBufferSize {
 		t.Fatalf("expected issue queue buffer default %d, got %d", defaultIssueQueueBufferSize, cfg.Processor.IssueQueueBuffer)
@@ -598,6 +602,87 @@ repos:
 			_, err := Load(path)
 			if err == nil {
 				t.Fatalf("expected load to fail for mode=%q", tc.mode)
+			}
+		})
+	}
+}
+
+func TestExplicitZeroBackendFieldsHonoured(t *testing.T) {
+	t.Setenv("WEBHOOK_SECRET", "secret")
+
+	tests := []struct {
+		name          string
+		yaml          string
+		wantTimeout   int
+		wantMaxPrompt int
+	}{
+		{
+			name: "explicit zero timeout_seconds disables subprocess timeout",
+			yaml: `http:
+  webhook_secret_env: WEBHOOK_SECRET
+ai_backends:
+  claude:
+    mode: noop
+    timeout_seconds: 0
+repos:
+  - full_name: "owner/repo"
+`,
+			wantTimeout:   0,
+			wantMaxPrompt: defaultMaxPromptChars,
+		},
+		{
+			name: "explicit zero max_prompt_chars disables prompt truncation",
+			yaml: `http:
+  webhook_secret_env: WEBHOOK_SECRET
+ai_backends:
+  claude:
+    mode: noop
+    max_prompt_chars: 0
+repos:
+  - full_name: "owner/repo"
+`,
+			wantTimeout:   defaultAITimeoutSeconds,
+			wantMaxPrompt: 0,
+		},
+		{
+			name: "both explicit zeros honoured",
+			yaml: `http:
+  webhook_secret_env: WEBHOOK_SECRET
+ai_backends:
+  claude:
+    mode: noop
+    timeout_seconds: 0
+    max_prompt_chars: 0
+repos:
+  - full_name: "owner/repo"
+`,
+			wantTimeout:   0,
+			wantMaxPrompt: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.yaml")
+			if err := os.WriteFile(path, []byte(tt.yaml), 0o644); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+			cfg, err := Load(path)
+			if err != nil {
+				t.Fatalf("unexpected load error: %v", err)
+			}
+			backend := cfg.AIBackends["claude"]
+			if backend.TimeoutSeconds == nil {
+				t.Fatal("TimeoutSeconds is nil, expected a pointer to an int")
+			}
+			if *backend.TimeoutSeconds != tt.wantTimeout {
+				t.Errorf("TimeoutSeconds: got %d, want %d", *backend.TimeoutSeconds, tt.wantTimeout)
+			}
+			if backend.MaxPromptChars == nil {
+				t.Fatal("MaxPromptChars is nil, expected a pointer to an int")
+			}
+			if *backend.MaxPromptChars != tt.wantMaxPrompt {
+				t.Errorf("MaxPromptChars: got %d, want %d", *backend.MaxPromptChars, tt.wantMaxPrompt)
 			}
 		})
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -688,6 +688,60 @@ repos:
 	}
 }
 
+func TestLoadRejectsNegativeBackendFields(t *testing.T) {
+	t.Setenv("WEBHOOK_SECRET", "secret")
+
+	tests := []struct {
+		name       string
+		yaml       string
+		wantErrMsg string
+	}{
+		{
+			name: "negative timeout_seconds rejected",
+			yaml: `http:
+  webhook_secret_env: WEBHOOK_SECRET
+ai_backends:
+  claude:
+    mode: noop
+    timeout_seconds: -1
+repos:
+  - full_name: "owner/repo"
+`,
+			wantErrMsg: `config: ai backend "claude" has negative timeout_seconds -1 (use 0 to disable the timeout)`,
+		},
+		{
+			name: "negative max_prompt_chars rejected",
+			yaml: `http:
+  webhook_secret_env: WEBHOOK_SECRET
+ai_backends:
+  claude:
+    mode: noop
+    max_prompt_chars: -10
+repos:
+  - full_name: "owner/repo"
+`,
+			wantErrMsg: `config: ai backend "claude" has negative max_prompt_chars -10 (use 0 to disable truncation)`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), "config.yaml")
+			if err := os.WriteFile(path, []byte(tt.yaml), 0o644); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+			_, err := Load(path)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if err.Error() != tt.wantErrMsg {
+				t.Errorf("error message:\n  got:  %q\n  want: %q", err.Error(), tt.wantErrMsg)
+			}
+		})
+	}
+}
+
 func TestLoadAcceptsSupportedBackendModes(t *testing.T) {
 	t.Setenv("WEBHOOK_SECRET", "secret")
 


### PR DESCRIPTION
## Why

`AIBackendConfig.TimeoutSeconds` and `MaxPromptChars` were plain `int` fields. `setDefaultInt()` used `if *field == 0` as the sentinel for "not configured", making it impossible to distinguish an omitted field from one explicitly set to `0`.

This blocked two legitimate operator intents:
- `timeout_seconds: 0` → disable subprocess timeout for long-running AI tasks
- `max_prompt_chars: 0` → disable prompt truncation entirely

## What changed

- `AIBackendConfig.TimeoutSeconds` and `MaxPromptChars` changed from `int` to `*int`
- `normalizeBackends()` now only applies defaults when the pointer is `nil` (field omitted from YAML); explicit `0` passes through untouched
- `runCommand()` in `cmdrunner.go` skips `context.WithTimeout` when `timeout == 0`, inheriting the parent context instead (no subprocess deadline)
- `truncatePrompt` already treated `maxChars <= 0` as "no truncation" — no change needed there
- `main.go` dereferences the (now-always-non-nil after normalization) pointers when calling `NewCommandRunner`

## Tests

New table-driven test `TestExplicitZeroBackendFieldsHonoured` covers:
- explicit `timeout_seconds: 0` not overridden to default
- explicit `max_prompt_chars: 0` not overridden to default
- both zeros simultaneously

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)