### PR TITLE
config: remove dead PromptSourceConfig.Resolve method

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -60,22 +59,6 @@ type PromptSourceConfig struct {
 	Prompt     string `yaml:"prompt"`
 }
 
-// Resolve returns the prompt content. If Prompt is set it is returned directly.
-// Otherwise the file at baseDir/PromptFile is read.
-func (p PromptSourceConfig) Resolve(baseDir string) (string, error) {
-	if p.Prompt != "" {
-		return p.Prompt, nil
-	}
-	path := p.PromptFile
-	if baseDir != "" {
-		path = filepath.Join(baseDir, p.PromptFile)
-	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return "", fmt.Errorf("read prompt file %s: %w", path, err)
-	}
-	return string(data), nil
-}
 
 type SkillConfig struct {
 	Name       string `yaml:"name"`


### PR DESCRIPTION
## Summary

`PromptSourceConfig.Resolve()` was dead code — never called anywhere in the codebase. Prompt loading goes through `ai.loadPromptSource()` instead, with `cmd/agents/main.go:resolvePrompts()` bridging `PromptSourceConfig` to `ai.PromptSource`.

Removing it:
- eliminates the duplicate file-or-inline resolution logic
- drops the now-unused `path/filepath` import
- no behaviour change

Closes #34

## Test plan

- [x] `go test ./... -race` passes (all existing tests green; no test exercised the dead method)