### PR TITLE
config: reject startup when autonomous agent has conflicting skills across repos

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -461,6 +462,11 @@ func (c *Config) validateAgents(skillNames map[string]struct{}) error {
 }
 
 func (c *Config) validateAutonomousAgents(skillNames map[string]struct{}) error {
+	// globalAgentSkills tracks the skill set registered for each agent name across
+	// all repos. collectAutonomousAgentSkills deduplicates by name, so an agent
+	// with the same name in multiple repos must have identical skills — otherwise
+	// one repo silently receives the wrong prompt.
+	globalAgentSkills := make(map[string][]string)
 	for _, repo := range c.AutonomousAgents {
 		if repo.Repo == "" {
 			return errors.New("config: autonomous agent repo is required")
@@ -514,9 +520,35 @@ func (c *Config) validateAutonomousAgents(skillNames map[string]struct{}) error 
 					return fmt.Errorf("config: autonomous agent %q for repo %s task %q must have only one of prompt or prompt_file, not both", agent.Name, repo.Repo, task.Name)
 				}
 			}
+			if first, seen := globalAgentSkills[agent.Name]; seen {
+				if !sameStringSet(first, agent.Skills) {
+					return fmt.Errorf("config: autonomous agent %q in repo %s has skills %v that conflict with skills %v registered under the same name in another repo", agent.Name, repo.Repo, agent.Skills, first)
+				}
+			} else {
+				globalAgentSkills[agent.Name] = agent.Skills
+			}
 		}
 	}
 	return nil
+}
+
+// sameStringSet reports whether a and b contain the same strings (order-independent).
+func sameStringSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	ca := make([]string, len(a))
+	cb := make([]string, len(b))
+	copy(ca, a)
+	copy(cb, b)
+	sort.Strings(ca)
+	sort.Strings(cb)
+	for i := range ca {
+		if ca[i] != cb[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // AgentByName returns the agent configuration for the given name.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -697,6 +697,100 @@ autonomous_agents:
 	}
 }
 
+func TestValidateAutonomousAgentCrossRepoSkillConflict(t *testing.T) {
+	t.Setenv("WEBHOOK_SECRET", "secret")
+
+	baseYAML := `http:
+  webhook_secret_env: WEBHOOK_SECRET
+ai_backends:
+  claude:
+    mode: noop
+skills:
+  - name: architect
+    prompt: "focus on architecture"
+  - name: security
+    prompt: "focus on security"
+repos:
+  - full_name: "owner/repo-a"
+    enabled: true
+  - full_name: "owner/repo-b"
+    enabled: true
+`
+	validAgentBlock := func(skills string) string {
+		return `    agents:
+      - name: scout
+        cron: "* * * * *"
+        skills: [` + skills + `]
+        tasks:
+          - name: scan
+            prompt: "scan the repo"
+`
+	}
+
+	tests := []struct {
+		name       string
+		repoA      string
+		repoB      string
+		wantErr    bool
+		wantErrMsg string
+	}{
+		{
+			name:    "same name same skills across repos accepted",
+			repoA:   validAgentBlock("architect"),
+			repoB:   validAgentBlock("architect"),
+			wantErr: false,
+		},
+		{
+			name:       "same name different skills across repos rejected",
+			repoA:      validAgentBlock("architect"),
+			repoB:      validAgentBlock("security"),
+			wantErr:    true,
+			wantErrMsg: `config: autonomous agent "scout" in repo owner/repo-b has skills [security] that conflict with skills [architect] registered under the same name in another repo`,
+		},
+		{
+			name:    "different names across repos accepted",
+			repoA:   validAgentBlock("architect"),
+			repoB: `    agents:
+      - name: guardian
+        cron: "* * * * *"
+        skills: [security]
+        tasks:
+          - name: audit
+            prompt: "audit security"
+`,
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.yaml")
+			content := baseYAML + `autonomous_agents:
+  - repo: "owner/repo-a"
+    enabled: true
+` + tc.repoA + `  - repo: "owner/repo-b"
+    enabled: true
+` + tc.repoB
+			if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+			_, err := Load(path)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error but Load succeeded")
+				}
+				if err.Error() != tc.wantErrMsg {
+					t.Fatalf("wrong error\ngot:  %q\nwant: %q", err.Error(), tc.wantErrMsg)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 func TestValidateAutonomousAgentsRepoExists(t *testing.T) {
 	t.Setenv("WEBHOOK_SECRET", "secret")
 
@@ -817,6 +911,7 @@ autonomous_agents:
 		})
 	}
 }
+
 
 func TestLoadRejectsCommandModeWithEmptyCommand(t *testing.T) {
 	t.Setenv("WEBHOOK_SECRET", "secret")


### PR DESCRIPTION
## Problem

`collectAutonomousAgentSkills` in `cmd/agents/main.go` deduplicates by `agent.Name` alone. If two `autonomous_agents` entries define an agent with the same name but different `skills`, only the first repo's skill set is registered in the `PromptStore`. The second repo's agent then receives the wrong prompt at runtime with no error, log warning, or any indication of the misconfiguration.

## Fix

`validateAutonomousAgents` now tracks agent names globally (across all repos) with the skill set seen at first occurrence. If the same name appears in a subsequent repo with a different skill set, `Load` returns a startup error:

```
config: autonomous agent "scout" in repo owner/repo-b has skills [security] that conflict with skills [architect] registered under the same name in another repo
```

Same name + identical skills across repos is accepted — `collectAutonomousAgentSkills` produces the correct and only prompt in that case.

Added `sameStringSet` helper (order-independent string slice comparison using sorted copies) used by the new validation.

## Tests

`TestValidateAutonomousAgentCrossRepoSkillConflict` — table-driven, covers:
- Same name + same skills across two repos → accepted
- Same name + different skills across two repos → rejected with exact error message
- Different names across repos → accepted

## Test plan

- [x] `go test ./...` passes

Closes #43