### PR TITLE
refactor(ai): remove dead map allocations in NewPromptStore

### DIFF
--- a/internal/ai/prompt.go
+++ b/internal/ai/prompt.go
@@ -72,9 +72,7 @@ func NewPromptStore(issueBase PromptSource, prBase PromptSource, autoBase Prompt
 		skillMap[NormalizeToken(s.Name)] = s
 	}
 	store := &PromptStore{
-		skills:        skillMap,
-		prTemplates:   make(map[string]*template.Template),
-		autoTemplates: make(map[string]*template.Template),
+		skills: skillMap,
 	}
 	if err := store.loadTemplates(issueBase, prBase, autoBase, prAgents, autoAgents); err != nil {
 		return nil, err


### PR DESCRIPTION
## Why

`NewPromptStore` initialised `prTemplates` and `autoTemplates` in the struct literal, but `loadTemplates` unconditionally replaces both fields with fresh `make` calls before any template is stored. The struct-literal allocations were immediately overwritten and garbage collected — they had no effect on behaviour.

## What changed

Remove the two `make` calls from the struct literal in `NewPromptStore`:

```go
// before
store := &PromptStore{
    skills:        skillMap,
    prTemplates:   make(map[string]*template.Template),
    autoTemplates: make(map[string]*template.Template),
}

// after
store := &PromptStore{
    skills: skillMap,
}
```

`loadTemplates` remains the single, authoritative place that initialises both maps — as it was already doing unconditionally.

## Test plan

- `go test ./...` passes unchanged (no behaviour change, only dead allocations removed).