### PR TITLE
webhook: replace per-request O(n) eviction with background ticker in DeliveryStore

### DIFF
--- a/cmd/agents/main.go
+++ b/cmd/agents/main.go
@@ -85,6 +85,7 @@ func run() error {
 	server := webhook.NewServer(cfg, deliveryStore, dataChannels, schedulerStatusAdapter{scheduler}, logger, scheduler)
 
 	group, groupCtx := errgroup.WithContext(ctx)
+	deliveryStore.Start(groupCtx)
 	group.Go(func() error { return processor.Run(groupCtx) })
 	group.Go(func() error { return scheduler.Run(groupCtx) })
 	group.Go(func() error { return server.Run(groupCtx) })

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -381,6 +381,9 @@ func (c *Config) validate() error {
 	if c.Daemon.HTTP.WebhookSecret == "" {
 		return errors.New("config: http webhook secret is required (set webhook_secret_env)")
 	}
+	if c.Daemon.HTTP.DeliveryTTLSeconds < 0 {
+		return fmt.Errorf("config: http delivery_ttl_seconds must be positive, got %d", c.Daemon.HTTP.DeliveryTTLSeconds)
+	}
 	if err := c.validateBackends(); err != nil {
 		return err
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -331,3 +331,36 @@ func TestConfigExampleYAMLLoads(t *testing.T) {
 		t.Fatal("example has no skills")
 	}
 }
+
+func TestLoadRejectsNegativeDeliveryTTL(t *testing.T) {
+	t.Setenv("TEST_SECRET", "secret")
+
+	content := `
+daemon:
+  http:
+    webhook_secret_env: TEST_SECRET
+    delivery_ttl_seconds: -1
+  ai_backends:
+    claude:
+      command: claude
+      args: ["-p"]
+skills:
+  architect:
+    prompt: "Focus on architecture."
+agents:
+  - name: reviewer
+    backend: claude
+    skills: [architect]
+    prompt: "You review PRs."
+repos:
+  - name: "owner/repo"
+    enabled: true
+    use:
+      - agent: reviewer
+        labels: ["ai:review:reviewer"]
+`
+	path := writeConfig(t, content)
+	if _, err := Load(path); err == nil {
+		t.Fatal("expected validation error for negative delivery_ttl_seconds")
+	}
+}

--- a/internal/webhook/delivery_store.go
+++ b/internal/webhook/delivery_store.go
@@ -1,6 +1,7 @@
 package webhook
 
 import (
+	"context"
 	"sync"
 	"time"
 )
@@ -18,18 +19,45 @@ func NewDeliveryStore(ttl time.Duration) *DeliveryStore {
 	}
 }
 
-// SeenOrAdd returns true if id has been seen within the TTL window, otherwise
-// it records id and returns false. Expired entries are lazily evicted on each
-// call to avoid a separate background goroutine.
-func (s *DeliveryStore) SeenOrAdd(id string, now time.Time) bool {
+// Start launches a background goroutine that periodically evicts expired entries.
+// It runs until ctx is cancelled. Call this once after constructing the store.
+// If the TTL is non-positive Start is a no-op; entries will never be evicted in
+// the background (they are still correctly expired on SeenOrAdd access).
+func (s *DeliveryStore) Start(ctx context.Context) {
+	if s.ttl <= 0 {
+		return
+	}
+	go func() {
+		ticker := time.NewTicker(s.ttl / 4)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case now := <-ticker.C:
+				s.evict(now)
+			}
+		}
+	}()
+}
+
+// evict removes all entries whose TTL has expired. Callers must not hold s.mu.
+func (s *DeliveryStore) evict(now time.Time) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-
 	for key, expiresAt := range s.deliveries {
 		if now.After(expiresAt) {
 			delete(s.deliveries, key)
 		}
 	}
+}
+
+// SeenOrAdd returns true if id has been seen within the TTL window, otherwise
+// it records id and returns false. Expired entries are evicted by the background
+// goroutine started with Start.
+func (s *DeliveryStore) SeenOrAdd(id string, now time.Time) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	if expiresAt, ok := s.deliveries[id]; ok && now.Before(expiresAt) {
 		return true

--- a/internal/webhook/delivery_store_test.go
+++ b/internal/webhook/delivery_store_test.go
@@ -1,0 +1,160 @@
+package webhook
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestDeliveryStore_SeenOrAdd(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	ttl := time.Hour
+
+	tests := []struct {
+		name      string
+		setup     func(s *DeliveryStore)
+		id        string
+		now       time.Time
+		wantSeen  bool
+		wantCount int
+	}{
+		{
+			name:      "new id returns false",
+			id:        "abc",
+			now:       now,
+			wantSeen:  false,
+			wantCount: 1,
+		},
+		{
+			name: "duplicate id within TTL returns true",
+			setup: func(s *DeliveryStore) {
+				s.SeenOrAdd("abc", now)
+			},
+			id:        "abc",
+			now:       now.Add(30 * time.Minute),
+			wantSeen:  true,
+			wantCount: 1,
+		},
+		{
+			name: "expired id treated as new",
+			setup: func(s *DeliveryStore) {
+				s.SeenOrAdd("abc", now)
+			},
+			id:        "abc",
+			now:       now.Add(2 * ttl),
+			wantSeen:  false,
+			wantCount: 1,
+		},
+		{
+			name: "different ids are independent",
+			setup: func(s *DeliveryStore) {
+				s.SeenOrAdd("abc", now)
+			},
+			id:        "xyz",
+			now:       now,
+			wantSeen:  false,
+			wantCount: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := NewDeliveryStore(ttl)
+			if tc.setup != nil {
+				tc.setup(s)
+			}
+			got := s.SeenOrAdd(tc.id, tc.now)
+			if got != tc.wantSeen {
+				t.Errorf("SeenOrAdd() = %v, want %v", got, tc.wantSeen)
+			}
+			s.mu.Lock()
+			count := len(s.deliveries)
+			s.mu.Unlock()
+			if count != tc.wantCount {
+				t.Errorf("deliveries count = %d, want %d", count, tc.wantCount)
+			}
+		})
+	}
+}
+
+func TestDeliveryStore_Delete(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	s := NewDeliveryStore(time.Hour)
+	s.SeenOrAdd("abc", now)
+
+	s.Delete("abc")
+
+	// After deletion the id should be treated as new.
+	if s.SeenOrAdd("abc", now) {
+		t.Error("expected SeenOrAdd to return false after Delete, got true")
+	}
+}
+
+func TestDeliveryStore_BackgroundEviction(t *testing.T) {
+	t.Parallel()
+
+	ttl := 40 * time.Millisecond
+	s := NewDeliveryStore(ttl)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s.Start(ctx)
+
+	now := time.Now()
+	s.SeenOrAdd("abc", now)
+
+	// Confirm the entry is live.
+	if !s.SeenOrAdd("abc", now) {
+		t.Fatal("expected entry to be seen immediately after insertion")
+	}
+
+	// Wait longer than one eviction interval (ttl/4) plus one TTL so the entry expires
+	// and the background ticker has had a chance to evict it.
+	time.Sleep(ttl + ttl/4 + 20*time.Millisecond)
+
+	s.mu.Lock()
+	count := len(s.deliveries)
+	s.mu.Unlock()
+
+	if count != 0 {
+		t.Errorf("expected 0 deliveries after background eviction, got %d", count)
+	}
+}
+
+func TestDeliveryStore_StartStopsOnContextCancel(t *testing.T) {
+	t.Parallel()
+
+	ttl := 50 * time.Millisecond
+	s := NewDeliveryStore(ttl)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s.Start(ctx)
+	cancel() // Stop the background goroutine immediately.
+
+	// Add an entry after the goroutine has stopped.
+	s.SeenOrAdd("abc", time.Now())
+	s.mu.Lock()
+	count := len(s.deliveries)
+	s.mu.Unlock()
+
+	// Entry should still be present since eviction goroutine stopped.
+	if count != 1 {
+		t.Errorf("expected 1 delivery, got %d", count)
+	}
+}
+
+func TestDeliveryStore_StartIsNoOpForNonPositiveTTL(t *testing.T) {
+	t.Parallel()
+
+	// Start must not panic when TTL is zero or negative.
+	for _, ttl := range []time.Duration{0, -1 * time.Second} {
+		s := NewDeliveryStore(ttl)
+		// Should return immediately without spawning a goroutine or panicking.
+		s.Start(context.Background())
+	}
+}


### PR DESCRIPTION
## Summary

- `SeenOrAdd` previously scanned all entries on every call to evict expired deliveries, holding the mutex for an O(n) scan that grows with hourly traffic volume.
- Replaced with a background goroutine started via `Start(ctx context.Context)` that ticks at `ttl/4` and evicts expired entries independently of request handling.
- `SeenOrAdd` is now a simple O(1) lookup + insert with no eviction loop.
- `deliveryStore.Start(groupCtx)` is called in `main.go` so the goroutine stops cleanly when the daemon shuts down.
- Added `delivery_store_test.go` with table-driven tests for `SeenOrAdd`, `Delete`, background eviction, and context-cancel stop behaviour.

Closes #46

## Test plan

- [ ] `go test ./internal/webhook/... -v -run TestDeliveryStore` — all 4 test functions pass
- [ ] `go test ./...` — full suite green