### PR TITLE
go.mod: move gorilla/mux from indirect to direct dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/eloylp/agents
 go 1.24.12
 
 require (
+	github.com/gorilla/mux v1.8.1
 	github.com/joho/godotenv v1.5.1
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/rs/zerolog v1.34.0
@@ -11,7 +12,6 @@ require (
 )
 
 require (
-	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect


### PR DESCRIPTION
## Summary

`gorilla/mux` is imported directly by `internal/webhook/server.go` but was annotated as `// indirect` in `go.mod`. This mis-states the dependency graph and could cause automated tooling to incorrectly classify or remove it.

**Fix:** Run `go mod tidy`, which moves `gorilla/mux` from the `require (... // indirect)` block into the direct-dependency block.

## Test plan

- [x] `go test ./...` passes unchanged (no behaviour change — only metadata corrected)
- [x] `go mod tidy` produces a clean working tree after applying the fix

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)