### PR TITLE
config: extract shared ResolveBackend helper, unify Engine and Scheduler

### DIFF
--- a/internal/autonomous/scheduler.go
+++ b/internal/autonomous/scheduler.go
@@ -258,14 +258,7 @@ func (s *Scheduler) executeAgentRun(ctx context.Context, repo string, agent conf
 }
 
 func (s *Scheduler) resolveBackend(configured string) string {
-	configured = ai.NormalizeToken(configured)
-	if configured == "" || configured == "auto" {
-		return s.cfg.DefaultConfiguredBackend()
-	}
-	if _, ok := s.cfg.AIBackends[configured]; !ok {
-		return ""
-	}
-	return configured
+	return s.cfg.ResolveBackend(configured)
 }
 
 func (s *Scheduler) setRunCtx(ctx context.Context) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -488,6 +488,21 @@ func (c *Config) DefaultConfiguredBackend() string {
 	return ""
 }
 
+// ResolveBackend maps a raw backend token from a label or config field to a
+// configured backend name. An empty token or the special value "auto" falls
+// back to the default configured backend. An explicit token that does not
+// match any configured backend returns "" so the caller can skip the event.
+func (c *Config) ResolveBackend(raw string) string {
+	normalized := strings.ToLower(strings.TrimSpace(raw))
+	if normalized == "" || normalized == "auto" {
+		return c.DefaultConfiguredBackend()
+	}
+	if _, ok := c.AIBackends[normalized]; !ok {
+		return ""
+	}
+	return normalized
+}
+
 func setDefault(field *string, value string) {
 	if strings.TrimSpace(*field) == "" {
 		*field = value

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -114,6 +114,38 @@ func TestDefaultConfiguredBackend(t *testing.T) {
 	}
 }
 
+func TestResolveBackend(t *testing.T) {
+	t.Parallel()
+	cfg := &Config{
+		AIBackends: map[string]AIBackendConfig{
+			"claude": {},
+			"codex":  {},
+		},
+	}
+	tests := []struct {
+		name  string
+		raw   string
+		want  string
+	}{
+		{"empty falls back to default", "", "claude"},
+		{"auto falls back to default", "auto", "claude"},
+		{"AUTO case-insensitive", "AUTO", "claude"},
+		{"explicit claude", "claude", "claude"},
+		{"explicit codex", "codex", "codex"},
+		{"uppercase CLAUDE normalised", "CLAUDE", "claude"},
+		{"whitespace-padded token", "  claude  ", "claude"},
+		{"unknown backend returns empty", "gpt", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := cfg.ResolveBackend(tt.raw); got != tt.want {
+				t.Fatalf("ResolveBackend(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSkillValidation(t *testing.T) {
 	t.Setenv("WEBHOOK_SECRET", "secret")
 

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -147,16 +147,9 @@ func (e *Engine) HandlePullRequestLabelEvent(ctx context.Context, req PRRequest)
 // token that does not match any configured backend returns "" so the caller
 // can skip the event rather than fail.
 func (e *Engine) resolveBackend(backend string) string {
-	if strings.TrimSpace(backend) == "" {
-		defaultBackend := e.cfg.DefaultConfiguredBackend()
-		if defaultBackend == "" {
-			e.logger.Error().Msg("no default backend configured; expected one of claude or codex")
-		}
-		return defaultBackend
+	resolved := e.cfg.ResolveBackend(backend)
+	if resolved == "" && strings.TrimSpace(backend) == "" {
+		e.logger.Error().Msg("no default backend configured; expected one of claude or codex")
 	}
-	backend = strings.ToLower(strings.TrimSpace(backend))
-	if _, ok := e.cfg.AIBackends[backend]; !ok {
-		return ""
-	}
-	return backend
+	return resolved
 }

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -54,3 +54,36 @@ func TestHandleIssueLabelEventUsesPayloadLabel(t *testing.T) {
 		t.Fatalf("expected event label backend codex, got %q", runner.last.Workflow)
 	}
 }
+
+// TestHandleIssueLabelEventAutoBackend verifies that the "auto" token in a
+// label resolves to the default configured backend instead of being treated as
+// an unknown backend and silently dropped.
+func TestHandleIssueLabelEventAutoBackend(t *testing.T) {
+	runner := &stubRunner{}
+	// Only claude is configured; "auto" must resolve to it.
+	cfg := &config.Config{
+		AIBackends: map[string]config.AIBackendConfig{
+			"claude": {},
+		},
+		Agents: []config.AgentConfig{
+			{Name: "architect", Skills: []string{"architect"}},
+		},
+	}
+	promptStore := testutil.BuildPromptStore(t, []string{"architect"}, nil)
+	engine := NewEngine(cfg, map[string]ai.Runner{"claude": runner}, promptStore, zerolog.Nop())
+
+	err := engine.HandleIssueLabelEvent(context.Background(), IssueRequest{
+		Repo:  RepoRef{FullName: "owner/repo", Enabled: true},
+		Issue: Issue{Number: 1},
+		Label: "ai:refine:auto",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if runner.calls != 1 {
+		t.Fatalf("expected one runner call for auto backend, got %d", runner.calls)
+	}
+	if runner.last.Workflow != "issue_refine:claude" {
+		t.Fatalf("auto backend should resolve to claude, got workflow %q", runner.last.Workflow)
+	}
+}


### PR DESCRIPTION
## Summary

- Extracts a single `Config.ResolveBackend(raw string) string` method that normalises a backend token and handles both empty string and the `"auto"` literal as "use default backend"
- Replaces `Engine.resolveBackend` with a thin wrapper that delegates to `Config.ResolveBackend`, fixing a silent event-drop bug where `ai:refine:auto` or `ai:review:auto:<agent>` labels were treated as unknown backends
- Replaces `Scheduler.resolveBackend` with a one-liner that delegates to the same helper, eliminating the duplicated normalization code
- Adds `TestResolveBackend` covering all input forms (empty, auto, explicit, case variants, whitespace, unknown) and `TestHandleIssueLabelEventAutoBackend` to prove `ai:refine:auto` reaches the runner

## Test plan

- [x] `go test ./...` passes
- [x] `TestResolveBackend` covers all token forms
- [x] `TestHandleIssueLabelEventAutoBackend` verifies the previously-silent drop is fixed
- [x] No regressions in autonomous scheduler or webhook packages

Closes #37