### PR TITLE
workflow: cap concurrent agent goroutines in PR-review fan-out

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -27,6 +27,11 @@ http:
 processor:
   issue_queue_buffer: 256
   pr_queue_buffer: 256
+  # Maximum number of agent goroutines that may run concurrently for a single
+  # PR-review fan-out event. Limits subprocess resource usage when many agents
+  # are configured and ai:review (agent=all) labels are used frequently.
+  # Default: 4. Must be >= 1.
+  max_concurrent_agents: 4
 
 # ──────────────────────────────────────────────
 # Paths

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ const (
 	defaultDeliveryTTLSeconds      = 3600
 	defaultIssueQueueBufferSize    = 256
 	defaultPRQueueBufferSize       = 256
+	defaultMaxConcurrentAgents     = 4
 	defaultHTTPShutdownSeconds     = 15
 	defaultAITimeoutSeconds        = 600
 	defaultMaxPromptChars          = 12000
@@ -134,8 +135,9 @@ type HTTPConfig struct {
 }
 
 type ProcessorConfig struct {
-	IssueQueueBuffer int `yaml:"issue_queue_buffer"`
-	PRQueueBuffer    int `yaml:"pr_queue_buffer"`
+	IssueQueueBuffer    int `yaml:"issue_queue_buffer"`
+	PRQueueBuffer       int `yaml:"pr_queue_buffer"`
+	MaxConcurrentAgents int `yaml:"max_concurrent_agents"`
 }
 
 type RepoConfig struct {
@@ -235,6 +237,7 @@ func (c *Config) applyHTTPDefaults() {
 func (c *Config) applyProcessorDefaults() {
 	setDefaultInt(&c.Processor.IssueQueueBuffer, defaultIssueQueueBufferSize)
 	setDefaultInt(&c.Processor.PRQueueBuffer, defaultPRQueueBufferSize)
+	setDefaultInt(&c.Processor.MaxConcurrentAgents, defaultMaxConcurrentAgents)
 }
 
 func (c *Config) normalizeSkills() {
@@ -316,6 +319,9 @@ func (c *Config) validate() error {
 	if c.HTTP.WebhookSecret == "" {
 		return errors.New("config: http webhook secret is required")
 	}
+	if err := c.validateProcessor(); err != nil {
+		return err
+	}
 	if err := c.validateBackends(); err != nil {
 		return err
 	}
@@ -333,6 +339,13 @@ func (c *Config) validate() error {
 		return err
 	}
 	return c.validateAutonomousAgents(skillNames)
+}
+
+func (c *Config) validateProcessor() error {
+	if c.Processor.MaxConcurrentAgents < 1 {
+		return fmt.Errorf("config: processor.max_concurrent_agents must be >= 1, got %d", c.Processor.MaxConcurrentAgents)
+	}
+	return nil
 }
 
 func (c *Config) validateBackends() error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -135,9 +135,9 @@ type HTTPConfig struct {
 }
 
 type ProcessorConfig struct {
-	IssueQueueBuffer    int `yaml:"issue_queue_buffer"`
-	PRQueueBuffer       int `yaml:"pr_queue_buffer"`
-	MaxConcurrentAgents int `yaml:"max_concurrent_agents"`
+	IssueQueueBuffer    int  `yaml:"issue_queue_buffer"`
+	PRQueueBuffer       int  `yaml:"pr_queue_buffer"`
+	MaxConcurrentAgents *int `yaml:"max_concurrent_agents"`
 }
 
 type RepoConfig struct {
@@ -237,7 +237,10 @@ func (c *Config) applyHTTPDefaults() {
 func (c *Config) applyProcessorDefaults() {
 	setDefaultInt(&c.Processor.IssueQueueBuffer, defaultIssueQueueBufferSize)
 	setDefaultInt(&c.Processor.PRQueueBuffer, defaultPRQueueBufferSize)
-	setDefaultInt(&c.Processor.MaxConcurrentAgents, defaultMaxConcurrentAgents)
+	if c.Processor.MaxConcurrentAgents == nil {
+		v := defaultMaxConcurrentAgents
+		c.Processor.MaxConcurrentAgents = &v
+	}
 }
 
 func (c *Config) normalizeSkills() {
@@ -342,8 +345,8 @@ func (c *Config) validate() error {
 }
 
 func (c *Config) validateProcessor() error {
-	if c.Processor.MaxConcurrentAgents < 1 {
-		return fmt.Errorf("config: processor.max_concurrent_agents must be >= 1, got %d", c.Processor.MaxConcurrentAgents)
+	if c.Processor.MaxConcurrentAgents != nil && *c.Processor.MaxConcurrentAgents < 1 {
+		return fmt.Errorf("config: processor.max_concurrent_agents must be >= 1, got %d", *c.Processor.MaxConcurrentAgents)
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,8 +1,10 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -73,8 +75,12 @@ autonomous_agents:
 	if cfg.Processor.PRQueueBuffer != defaultPRQueueBufferSize {
 		t.Fatalf("expected pr queue buffer default %d, got %d", defaultPRQueueBufferSize, cfg.Processor.PRQueueBuffer)
 	}
-	if cfg.Processor.MaxConcurrentAgents != defaultMaxConcurrentAgents {
-		t.Fatalf("expected max_concurrent_agents default %d, got %d", defaultMaxConcurrentAgents, cfg.Processor.MaxConcurrentAgents)
+	if cfg.Processor.MaxConcurrentAgents == nil || *cfg.Processor.MaxConcurrentAgents != defaultMaxConcurrentAgents {
+		got := 0
+		if cfg.Processor.MaxConcurrentAgents != nil {
+			got = *cfg.Processor.MaxConcurrentAgents
+		}
+		t.Fatalf("expected max_concurrent_agents default %d, got %d", defaultMaxConcurrentAgents, got)
 	}
 	if cfg.HTTP.ShutdownTimeoutSeconds != defaultHTTPShutdownSeconds {
 		t.Fatalf("expected shutdown timeout default %d, got %d", defaultHTTPShutdownSeconds, cfg.HTTP.ShutdownTimeoutSeconds)
@@ -809,11 +815,8 @@ autonomous_agents:
 	}
 }
 
-func TestLoadRejectsNegativeMaxConcurrentAgents(t *testing.T) {
-	t.Setenv("WEBHOOK_SECRET", "secret")
-
-	path := filepath.Join(t.TempDir(), "config.yaml")
-	content := `http:
+func TestLoadRejectsInvalidMaxConcurrentAgents(t *testing.T) {
+	baseYAML := `http:
   webhook_secret_env: WEBHOOK_SECRET
 ai_backends:
   claude:
@@ -821,13 +824,24 @@ ai_backends:
 repos:
   - full_name: "owner/repo"
 processor:
-  max_concurrent_agents: -1
+  max_concurrent_agents: %d
 `
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-	_, err := Load(path)
-	if err == nil {
-		t.Fatalf("expected Load to fail for negative max_concurrent_agents, but it succeeded")
+	for _, invalidValue := range []int{0, -1} {
+		invalidValue := invalidValue
+		t.Run(fmt.Sprintf("value=%d", invalidValue), func(t *testing.T) {
+			t.Setenv("WEBHOOK_SECRET", "secret")
+			path := filepath.Join(t.TempDir(), "config.yaml")
+			content := fmt.Sprintf(baseYAML, invalidValue)
+			if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+			_, err := Load(path)
+			if err == nil {
+				t.Fatalf("expected Load to fail for max_concurrent_agents=%d, but it succeeded", invalidValue)
+			}
+			if !strings.Contains(err.Error(), "max_concurrent_agents") {
+				t.Errorf("expected error to mention max_concurrent_agents, got: %v", err)
+			}
+		})
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -73,6 +73,9 @@ autonomous_agents:
 	if cfg.Processor.PRQueueBuffer != defaultPRQueueBufferSize {
 		t.Fatalf("expected pr queue buffer default %d, got %d", defaultPRQueueBufferSize, cfg.Processor.PRQueueBuffer)
 	}
+	if cfg.Processor.MaxConcurrentAgents != defaultMaxConcurrentAgents {
+		t.Fatalf("expected max_concurrent_agents default %d, got %d", defaultMaxConcurrentAgents, cfg.Processor.MaxConcurrentAgents)
+	}
 	if cfg.HTTP.ShutdownTimeoutSeconds != defaultHTTPShutdownSeconds {
 		t.Fatalf("expected shutdown timeout default %d, got %d", defaultHTTPShutdownSeconds, cfg.HTTP.ShutdownTimeoutSeconds)
 	}
@@ -803,5 +806,28 @@ autonomous_agents:
 	}
 	if task.Prompt != "" {
 		t.Fatalf("expected empty inline Prompt, got %q", task.Prompt)
+	}
+}
+
+func TestLoadRejectsNegativeMaxConcurrentAgents(t *testing.T) {
+	t.Setenv("WEBHOOK_SECRET", "secret")
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := `http:
+  webhook_secret_env: WEBHOOK_SECRET
+ai_backends:
+  claude:
+    mode: noop
+repos:
+  - full_name: "owner/repo"
+processor:
+  max_concurrent_agents: -1
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	_, err := Load(path)
+	if err == nil {
+		t.Fatalf("expected Load to fail for negative max_concurrent_agents, but it succeeded")
 	}
 }

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/rs/zerolog"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/semaphore"
 
 	"github.com/eloylp/agents/internal/ai"
 	"github.com/eloylp/agents/internal/config"
@@ -109,9 +110,19 @@ func (e *Engine) HandlePullRequestLabelEvent(ctx context.Context, req PRRequest)
 		mu        sync.Mutex
 		agentErrs []error
 	)
+	// sem limits the number of agent goroutines that run concurrently for this
+	// event. The cap is per-event (not global) so a large fan-out on one PR
+	// cannot starve another. Acquiring before group.Go avoids spawning goroutines
+	// that immediately block, keeping OS resource usage proportional to the limit.
+	sem := semaphore.NewWeighted(int64(e.cfg.Processor.MaxConcurrentAgents))
 	group, groupCtx := errgroup.WithContext(ctx)
 	for _, ag := range agents {
+		if err := sem.Acquire(groupCtx, 1); err != nil {
+			// groupCtx was cancelled; skip remaining agents.
+			break
+		}
 		group.Go(func() error {
+			defer sem.Release(1)
 			wf := fmt.Sprintf("%s:%s:%s", workflowPRReview, resolvedBackend, ag)
 			prompt, err := e.prompts.PRReviewPrompt(ag, resolvedBackend, req.Repo.FullName, req.PR.Number)
 			if err != nil {

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -18,21 +18,33 @@ import (
 const (
 	workflowIssueRefine = "issue_refine"
 	workflowPRReview    = "pr_review"
+
+	// defaultMaxConcurrentAgents is the fallback used by NewEngine when the
+	// caller provides a zero-value Config (e.g. in unit tests that construct
+	// config.Config{} directly without running config.Load).  It matches the
+	// default set by config.applyDefaults so behaviour is consistent.
+	defaultMaxConcurrentAgents = 4
 )
 
 type Engine struct {
-	cfg     *config.Config
-	runners map[string]ai.Runner
-	prompts *ai.PromptStore
-	logger  zerolog.Logger
+	cfg                 *config.Config
+	maxConcurrentAgents int
+	runners             map[string]ai.Runner
+	prompts             *ai.PromptStore
+	logger              zerolog.Logger
 }
 
 func NewEngine(cfg *config.Config, runners map[string]ai.Runner, prompts *ai.PromptStore, logger zerolog.Logger) *Engine {
+	maxConcurrent := cfg.Processor.MaxConcurrentAgents
+	if maxConcurrent <= 0 {
+		maxConcurrent = defaultMaxConcurrentAgents
+	}
 	return &Engine{
-		cfg:     cfg,
-		runners: runners,
-		prompts: prompts,
-		logger:  logger.With().Str("component", "workflow_engine").Logger(),
+		cfg:                 cfg,
+		maxConcurrentAgents: maxConcurrent,
+		runners:             runners,
+		prompts:             prompts,
+		logger:              logger.With().Str("component", "workflow_engine").Logger(),
 	}
 }
 
@@ -114,7 +126,7 @@ func (e *Engine) HandlePullRequestLabelEvent(ctx context.Context, req PRRequest)
 	// event. The cap is per-event (not global) so a large fan-out on one PR
 	// cannot starve another. Acquiring before group.Go avoids spawning goroutines
 	// that immediately block, keeping OS resource usage proportional to the limit.
-	sem := semaphore.NewWeighted(int64(e.cfg.Processor.MaxConcurrentAgents))
+	sem := semaphore.NewWeighted(int64(e.maxConcurrentAgents))
 	group, groupCtx := errgroup.WithContext(ctx)
 	for _, ag := range agents {
 		if err := sem.Acquire(groupCtx, 1); err != nil {

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -35,7 +35,10 @@ type Engine struct {
 }
 
 func NewEngine(cfg *config.Config, runners map[string]ai.Runner, prompts *ai.PromptStore, logger zerolog.Logger) *Engine {
-	maxConcurrent := cfg.Processor.MaxConcurrentAgents
+	maxConcurrent := 0
+	if cfg.Processor.MaxConcurrentAgents != nil {
+		maxConcurrent = *cfg.Processor.MaxConcurrentAgents
+	}
 	if maxConcurrent <= 0 {
 		maxConcurrent = defaultMaxConcurrentAgents
 	}

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -177,3 +177,35 @@ func TestHandlePRLabelEventRespectsConcurrencyLimit(t *testing.T) {
 		t.Errorf("peak concurrency %d exceeds configured limit %d", tracker.peak, limit)
 	}
 }
+
+// TestNewEngineZeroMaxConcurrentAgentsFallsBackToDefault verifies that
+// NewEngine applied to a zero-value Config (as test code often builds)
+// does not create a semaphore with weight 0, which would block every
+// Acquire call indefinitely.
+func TestNewEngineZeroMaxConcurrentAgentsFallsBackToDefault(t *testing.T) {
+	t.Parallel()
+	// Config with MaxConcurrentAgents unset (zero value).
+	cfg := &config.Config{
+		AIBackends: map[string]config.AIBackendConfig{"claude": {}},
+		Agents:     []config.AgentConfig{{Name: "architect", Skills: []string{"architect"}}},
+	}
+	runner := &stubRunner{}
+	promptStore := testutil.BuildPromptStore(t, []string{"architect"}, nil)
+	engine := NewEngine(cfg, map[string]ai.Runner{"claude": runner}, promptStore, zerolog.Nop())
+
+	if engine.maxConcurrentAgents <= 0 {
+		t.Fatalf("expected maxConcurrentAgents > 0, got %d", engine.maxConcurrentAgents)
+	}
+
+	// A PR-review fan-out must complete without deadlocking.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err := engine.HandlePullRequestLabelEvent(ctx, PRRequest{
+		Repo:  RepoRef{FullName: "owner/repo"},
+		PR:    PullRequest{Number: 1},
+		Label: "ai:review",
+	})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -2,7 +2,9 @@ package workflow
 
 import (
 	"context"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/rs/zerolog"
 
@@ -32,6 +34,7 @@ func TestHandleIssueLabelEventUsesPayloadLabel(t *testing.T) {
 		Agents: []config.AgentConfig{
 			{Name: "architect", Skills: []string{"architect"}},
 		},
+		Processor: config.ProcessorConfig{MaxConcurrentAgents: 4},
 	}
 	promptStore := testutil.BuildPromptStore(t, []string{"architect"}, nil)
 	engine := NewEngine(cfg, map[string]ai.Runner{"claude": runner, "codex": runner}, promptStore, zerolog.Nop())
@@ -85,5 +88,92 @@ func TestHandleIssueLabelEventAutoBackend(t *testing.T) {
 	}
 	if runner.last.Workflow != "issue_refine:claude" {
 		t.Fatalf("auto backend should resolve to claude, got workflow %q", runner.last.Workflow)
+	}
+}
+
+// concurrencyTrackingRunner records the peak number of concurrent Run calls.
+type concurrencyTrackingRunner struct {
+	mu      sync.Mutex
+	current int
+	peak    int
+	// blockUntil is closed to unblock all in-flight Run calls simultaneously,
+	// ensuring overlap is measurable.
+	blockUntil chan struct{}
+}
+
+func newConcurrencyTrackingRunner() *concurrencyTrackingRunner {
+	return &concurrencyTrackingRunner{blockUntil: make(chan struct{})}
+}
+
+func (r *concurrencyTrackingRunner) Run(_ context.Context, _ ai.Request) (ai.Response, error) {
+	r.mu.Lock()
+	r.current++
+	if r.current > r.peak {
+		r.peak = r.current
+	}
+	r.mu.Unlock()
+
+	<-r.blockUntil // hold the slot until the test releases all callers
+
+	r.mu.Lock()
+	r.current--
+	r.mu.Unlock()
+	return ai.Response{}, nil
+}
+
+// TestHandlePRLabelEventRespectsConcurrencyLimit verifies that when
+// agent=all fans out to more agents than MaxConcurrentAgents, at most
+// MaxConcurrentAgents subprocesses run at any one time.
+func TestHandlePRLabelEventRespectsConcurrencyLimit(t *testing.T) {
+	t.Parallel()
+	const limit = 2
+	agents := []string{"architect", "scout", "coder", "reviewer"}
+
+	tracker := newConcurrencyTrackingRunner()
+	cfg := &config.Config{
+		AIBackends: map[string]config.AIBackendConfig{"claude": {}},
+		Agents: []config.AgentConfig{
+			{Name: "architect", Skills: []string{"architect"}},
+			{Name: "scout", Skills: []string{"scout"}},
+			{Name: "coder", Skills: []string{"coder"}},
+			{Name: "reviewer", Skills: []string{"reviewer"}},
+		},
+		Processor: config.ProcessorConfig{MaxConcurrentAgents: limit},
+	}
+	promptStore := testutil.BuildPromptStore(t, agents, nil)
+	engine := NewEngine(cfg, map[string]ai.Runner{"claude": tracker}, promptStore, zerolog.Nop())
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = engine.HandlePullRequestLabelEvent(context.Background(), PRRequest{
+			Repo:  RepoRef{FullName: "owner/repo"},
+			PR:    PullRequest{Number: 1},
+			Label: "ai:review",
+		})
+	}()
+
+	// Give the fan-out time to fill up to the limit and block.
+	time.Sleep(50 * time.Millisecond)
+
+	tracker.mu.Lock()
+	peakSoFar := tracker.peak
+	tracker.mu.Unlock()
+
+	if peakSoFar > limit {
+		t.Errorf("peak concurrency %d exceeds limit %d before all agents were released", peakSoFar, limit)
+	}
+
+	// Release all blocked runners so the handler can complete.
+	close(tracker.blockUntil)
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("HandlePullRequestLabelEvent did not complete after releasing runners")
+	}
+
+	if tracker.peak > limit {
+		t.Errorf("peak concurrency %d exceeds configured limit %d", tracker.peak, limit)
 	}
 }

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/eloylp/agents/internal/config"
 )
 
+func intPtr(v int) *int { return &v }
+
 type stubRunner struct {
 	calls int
 	last  ai.Request
@@ -34,7 +36,7 @@ func TestHandleIssueLabelEventUsesPayloadLabel(t *testing.T) {
 		Agents: []config.AgentConfig{
 			{Name: "architect", Skills: []string{"architect"}},
 		},
-		Processor: config.ProcessorConfig{MaxConcurrentAgents: 4},
+		Processor: config.ProcessorConfig{MaxConcurrentAgents: intPtr(4)},
 	}
 	promptStore := testutil.BuildPromptStore(t, []string{"architect"}, nil)
 	engine := NewEngine(cfg, map[string]ai.Runner{"claude": runner, "codex": runner}, promptStore, zerolog.Nop())
@@ -96,13 +98,19 @@ type concurrencyTrackingRunner struct {
 	mu      sync.Mutex
 	current int
 	peak    int
+	// started is sent to once each time a Run call begins, allowing tests to
+	// synchronize on exactly N calls being in-flight simultaneously.
+	started chan struct{}
 	// blockUntil is closed to unblock all in-flight Run calls simultaneously,
 	// ensuring overlap is measurable.
 	blockUntil chan struct{}
 }
 
 func newConcurrencyTrackingRunner() *concurrencyTrackingRunner {
-	return &concurrencyTrackingRunner{blockUntil: make(chan struct{})}
+	return &concurrencyTrackingRunner{
+		started:    make(chan struct{}, 16),
+		blockUntil: make(chan struct{}),
+	}
 }
 
 func (r *concurrencyTrackingRunner) Run(_ context.Context, _ ai.Request) (ai.Response, error) {
@@ -113,6 +121,8 @@ func (r *concurrencyTrackingRunner) Run(_ context.Context, _ ai.Request) (ai.Res
 	}
 	r.mu.Unlock()
 
+	r.started <- struct{}{} // notify test that one more Run is in-flight
+
 	<-r.blockUntil // hold the slot until the test releases all callers
 
 	r.mu.Lock()
@@ -122,8 +132,8 @@ func (r *concurrencyTrackingRunner) Run(_ context.Context, _ ai.Request) (ai.Res
 }
 
 // TestHandlePRLabelEventRespectsConcurrencyLimit verifies that when
-// agent=all fans out to more agents than MaxConcurrentAgents, at most
-// MaxConcurrentAgents subprocesses run at any one time.
+// agent=all fans out to more agents than MaxConcurrentAgents, the semaphore
+// saturates at exactly the configured limit before any call is released.
 func TestHandlePRLabelEventRespectsConcurrencyLimit(t *testing.T) {
 	t.Parallel()
 	const limit = 2
@@ -138,7 +148,7 @@ func TestHandlePRLabelEventRespectsConcurrencyLimit(t *testing.T) {
 			{Name: "coder", Skills: []string{"coder"}},
 			{Name: "reviewer", Skills: []string{"reviewer"}},
 		},
-		Processor: config.ProcessorConfig{MaxConcurrentAgents: limit},
+		Processor: config.ProcessorConfig{MaxConcurrentAgents: intPtr(limit)},
 	}
 	promptStore := testutil.BuildPromptStore(t, agents, nil)
 	engine := NewEngine(cfg, map[string]ai.Runner{"claude": tracker}, promptStore, zerolog.Nop())
@@ -153,15 +163,22 @@ func TestHandlePRLabelEventRespectsConcurrencyLimit(t *testing.T) {
 		})
 	}()
 
-	// Give the fan-out time to fill up to the limit and block.
-	time.Sleep(50 * time.Millisecond)
+	// Wait for exactly `limit` Run calls to start and block, proving the
+	// semaphore has been fully saturated before we inspect peak.
+	for i := 0; i < limit; i++ {
+		select {
+		case <-tracker.started:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for Run call %d/%d to start", i+1, limit)
+		}
+	}
 
 	tracker.mu.Lock()
-	peakSoFar := tracker.peak
+	peakAtSaturation := tracker.peak
 	tracker.mu.Unlock()
 
-	if peakSoFar > limit {
-		t.Errorf("peak concurrency %d exceeds limit %d before all agents were released", peakSoFar, limit)
+	if peakAtSaturation != limit {
+		t.Errorf("expected peak == limit (%d) when semaphore is saturated, got %d", limit, peakAtSaturation)
 	}
 
 	// Release all blocked runners so the handler can complete.


### PR DESCRIPTION
## Summary

- Adds `processor.max_concurrent_agents` config field (default `4`, must be `>= 1`) to bound the number of agent goroutines that can run concurrently for a single PR-review fan-out event
- Uses `golang.org/x/sync/semaphore` (already in go.mod) to gate goroutine spawning; the semaphore is per-event so large fan-outs on one PR cannot starve another
- Validates the new field at startup: negative values are rejected (`config: processor.max_concurrent_agents must be >= 1`)
- Documents the field in `config.example.yaml`

## Root cause

`HandlePullRequestLabelEvent` with `agent=all` launches one goroutine per configured agent with no concurrency limit. Each goroutine forks a subprocess that can hold OS resources for up to `timeout_seconds` (default 600 s). With N agents and frequent `ai:review` labels, N × events subprocesses can accumulate simultaneously.

## Test plan

- [ ] `TestHandlePRLabelEventRespectsConcurrencyLimit` — forces all `Run` calls to block until released; asserts peak concurrency never exceeds the configured limit (2 out of 4 agents)
- [ ] `TestLoadAppliesDefaults` — asserts `max_concurrent_agents` defaults to `4`
- [ ] `TestLoadRejectsNegativeMaxConcurrentAgents` — asserts negative values are rejected at startup
- [ ] `go test ./... -race` passes

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)