### PR TITLE
ai: replace hand-rolled backward-scanner in extractJSON with json.Decoder

### DIFF
--- a/internal/ai/cmdrunner.go
+++ b/internal/ai/cmdrunner.go
@@ -185,47 +185,30 @@ func buildCommandEnv(req Request) []string {
 }
 
 // extractJSON finds the last top-level JSON object in data.
-// AI CLIs sometimes emit conversational text before the JSON payload;
-// this function scans backwards to locate the closing '}' and then
-// walks back to find its matching '{', accounting for nested braces
-// and JSON strings.
+// AI CLIs sometimes emit conversational text before the JSON payload.
+// This function scans forward through data looking for '{' characters and
+// attempts to decode a complete JSON object at each one using encoding/json.
+// The last successfully decoded object is returned.  Using the standard
+// decoder avoids the string-escape edge cases in a hand-rolled backward
+// scanner (e.g. a string ending with '\\' would be misread as an escaped
+// quote by a naive backward scan).
 func extractJSON(data []byte) ([]byte, error) {
-	// Find last '}'.
-	end := -1
-	for i := len(data) - 1; i >= 0; i-- {
-		if data[i] == '}' {
-			end = i
-			break
-		}
-	}
-	if end < 0 {
-		return nil, fmt.Errorf("no JSON object found in output")
-	}
-
-	// Walk backwards from end to find the matching '{'.
-	depth := 0
-	inString := false
-	for i := end; i >= 0; i-- {
-		b := data[i]
-		if inString {
-			if b == '"' && (i == 0 || data[i-1] != '\\') {
-				inString = false
-			}
+	var last json.RawMessage
+	for i := 0; i < len(data); i++ {
+		if data[i] != '{' {
 			continue
 		}
-		switch b {
-		case '"':
-			inString = true
-		case '}':
-			depth++
-		case '{':
-			depth--
-			if depth == 0 {
-				return data[i : end+1], nil
-			}
+		dec := json.NewDecoder(bytes.NewReader(data[i:]))
+		var raw json.RawMessage
+		if err := dec.Decode(&raw); err == nil {
+			last = raw
+			i += len(raw) - 1 // advance past the decoded object
 		}
 	}
-	return nil, fmt.Errorf("no matching '{' found for JSON object in output")
+	if last == nil {
+		return nil, fmt.Errorf("no JSON object found in output")
+	}
+	return last, nil
 }
 
 // allowCommandEnvKey reports whether key is safe to forward to the AI backend

--- a/internal/ai/cmdrunner_test.go
+++ b/internal/ai/cmdrunner_test.go
@@ -37,6 +37,42 @@ func TestExtractJSON(t *testing.T) {
 			want:  `{"key":"value with } and { inside"}`,
 		},
 		{
+			// Escaped backslash immediately before closing quote: the JSON value
+			// "path\\" ends with 0x5c 0x5c 0x22 in the byte stream.  The old
+			// backward scanner misread the final '"' as escaped (the preceding
+			// byte is '\'), so it walked past the true object boundary.
+			name:  "string ending with escaped backslash",
+			input: `{"path":"C:\\Users\\foo\\"}`,
+			want:  `{"path":"C:\\Users\\foo\\"}`,
+		},
+		{
+			name:  "text before json with escaped backslash in value",
+			input: "Preamble.\n" + `{"path":"C:\\Users\\foo\\"}`,
+			want:  `{"path":"C:\\Users\\foo\\"}`,
+		},
+		{
+			// When the output contains multiple top-level JSON objects the last
+			// one is returned (matches original backward-scan contract).
+			name:  "multiple top-level objects returns last",
+			input: `{"a":1} some text {"b":2}`,
+			want:  `{"b":2}`,
+		},
+		{
+			// A top-level JSON array whose only element is an object: the scanner
+			// locates the '{' inside the array and returns that object.  This pins
+			// the documented contract — future changes that alter this behaviour
+			// should update this test intentionally.
+			name:  "top-level array containing object returns the inner object",
+			input: `[{"a":1}]`,
+			want:  `{"a":1}`,
+		},
+		{
+			// A top-level array followed by a top-level object returns the object.
+			name:  "top-level array then object returns object",
+			input: `[1,2,3] {"summary":"ok"}`,
+			want:  `{"summary":"ok"}`,
+		},
+		{
 			name:    "no json",
 			input:   "just plain text",
 			wantErr: true,


### PR DESCRIPTION
## Summary

- The old `extractJSON` backward scanner tracked `inString` state by checking if `data[i-1] != '\\'`. This fails for strings ending with `\\` (escaped backslash): the byte sequence is `5c 5c 22`, and the final `"` is misread as an escaped quote because the preceding byte is `\`. The scanner walks past the true object boundary and returns a truncated or syntactically invalid slice.
- In practice this fires whenever an AI CLI includes a Windows-style path (e.g. `C:\\Users\\foo\\`) or any `\\`-terminated string in its JSON output.

## Fix

Replace the hand-rolled backward scanner with a forward scan:

1. Walk through `data` byte by byte looking for `{` characters.
2. At each `{`, attempt `json.Decoder.Decode` into a `json.RawMessage`.
3. If decoding succeeds, store the result and advance past the decoded object.
4. Return the last successfully decoded object.

`json.Decoder` handles all string-escape sequences (including `\\`) correctly, eliminating the whole class of escape-related bugs. The "find the last JSON object" contract is preserved.

## Test plan

- `string_ending_with_escaped_backslash` — the exact bug: `{"path":"C:\\Users\\foo\\"}` now round-trips correctly
- `text_before_json_with_escaped_backslash_in_value` — preamble text + buggy value
- `multiple_top-level_objects_returns_last` — last-object contract preserved
- `top-level_array_containing_object_returns_the_inner_object` — pins documented contract (scanner finds `{` inside the array)
- `top-level_array_then_object_returns_object` — mixed output case
- All existing tests continue to pass
- `go test ./...` passes

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)