### PR TITLE
config: add prompt_file support to TaskConfig

### DIFF
--- a/internal/autonomous/scheduler.go
+++ b/internal/autonomous/scheduler.go
@@ -249,7 +249,11 @@ func (s *Scheduler) executeAgentRun(ctx context.Context, repo string, agent conf
 	}
 	return s.memories.WithLock(agent.Name, repo, func(memoryPath string, memory string) error {
 		for _, task := range agent.Tasks {
-			if err := s.runTask(ctx, runner, backend, repo, agent, task.Name, task.Prompt, memoryPath, memory, logger); err != nil {
+			prompt, err := task.Resolve(s.cfg.AgentsDir)
+			if err != nil {
+				return fmt.Errorf("resolve prompt for task %q: %w", task.Name, err)
+			}
+			if err := s.runTask(ctx, runner, backend, repo, agent, task.Name, prompt, memoryPath, memory, logger); err != nil {
 				return err
 			}
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -89,8 +89,26 @@ type AgentConfig struct {
 }
 
 type TaskConfig struct {
-	Name   string `yaml:"name"`
-	Prompt string `yaml:"prompt"`
+	Name       string `yaml:"name"`
+	PromptFile string `yaml:"prompt_file"`
+	Prompt     string `yaml:"prompt"`
+}
+
+// Resolve returns the task prompt content. If Prompt is set it is returned
+// directly. Otherwise the file at baseDir/PromptFile is read.
+func (t TaskConfig) Resolve(baseDir string) (string, error) {
+	if t.Prompt != "" {
+		return t.Prompt, nil
+	}
+	path := t.PromptFile
+	if baseDir != "" && !filepath.IsAbs(path) {
+		path = filepath.Join(baseDir, path)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read task prompt file %s: %w", path, err)
+	}
+	return string(data), nil
 }
 
 type LogConfig struct {
@@ -275,6 +293,7 @@ func (c *Config) normalizeAutonomousAgents() {
 			}
 			for k := range a.Tasks {
 				a.Tasks[k].Name = strings.ToLower(strings.TrimSpace(a.Tasks[k].Name))
+				a.Tasks[k].PromptFile = strings.TrimSpace(a.Tasks[k].PromptFile)
 				a.Tasks[k].Prompt = strings.TrimSpace(a.Tasks[k].Prompt)
 			}
 		}
@@ -437,8 +456,13 @@ func (c *Config) validateAutonomousAgents(skillNames map[string]struct{}) error 
 				if task.Name == "" {
 					return fmt.Errorf("config: autonomous agent %q for repo %s has a task with empty name", agent.Name, repo.Repo)
 				}
-				if task.Prompt == "" {
-					return fmt.Errorf("config: autonomous agent %q for repo %s task %q must have a prompt", agent.Name, repo.Repo, task.Name)
+				hasPrompt := task.Prompt != ""
+				hasFile := task.PromptFile != ""
+				if !hasPrompt && !hasFile {
+					return fmt.Errorf("config: autonomous agent %q for repo %s task %q must have either prompt or prompt_file", agent.Name, repo.Repo, task.Name)
+				}
+				if hasPrompt && hasFile {
+					return fmt.Errorf("config: autonomous agent %q for repo %s task %q must have only one of prompt or prompt_file, not both", agent.Name, repo.Repo, task.Name)
 				}
 			}
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -354,6 +354,34 @@ autonomous_agents:
 `,
 		},
 		{
+			name: "autonomous agent task has both prompt and prompt_file",
+			content: `http:
+  webhook_secret_env: WEBHOOK_SECRET
+ai_backends:
+  claude:
+    mode: noop
+skills:
+  - name: architect
+    prompt: "focus on architecture"
+agents:
+  - name: architect
+    skills: [architect]
+repos:
+  - full_name: "owner/repo"
+autonomous_agents:
+  - repo: "owner/repo"
+    enabled: true
+    agents:
+      - name: "architect"
+        cron: "* * * * *"
+        skills: [architect]
+        tasks:
+          - name: "issues"
+            prompt: "inline"
+            prompt_file: "tasks/issues.md"
+`,
+		},
+		{
 			name: "prompts has both prompt and prompt_file",
 			content: `http:
   webhook_secret_env: WEBHOOK_SECRET
@@ -635,5 +663,113 @@ repos:
 				t.Fatalf("unexpected error for mode=%q: %v", tc.mode, err)
 			}
 		})
+	}
+}
+
+func TestTaskConfigResolve(t *testing.T) {
+	t.Parallel()
+
+	t.Run("inline prompt returned directly", func(t *testing.T) {
+		t.Parallel()
+		tc := TaskConfig{Name: "scan", Prompt: "scan all issues"}
+		got, err := tc.Resolve("")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "scan all issues" {
+			t.Fatalf("expected %q, got %q", "scan all issues", got)
+		}
+	})
+
+	t.Run("prompt_file with relative path joined to baseDir", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "task.md"), []byte("file prompt"), 0o644); err != nil {
+			t.Fatalf("write file: %v", err)
+		}
+		tc := TaskConfig{Name: "scan", PromptFile: "task.md"}
+		got, err := tc.Resolve(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "file prompt" {
+			t.Fatalf("expected %q, got %q", "file prompt", got)
+		}
+	})
+
+	t.Run("prompt_file with absolute path ignores baseDir", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		absPath := filepath.Join(dir, "abs_task.md")
+		if err := os.WriteFile(absPath, []byte("absolute prompt"), 0o644); err != nil {
+			t.Fatalf("write file: %v", err)
+		}
+		tc := TaskConfig{Name: "scan", PromptFile: absPath}
+		got, err := tc.Resolve("/some/other/dir")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "absolute prompt" {
+			t.Fatalf("expected %q, got %q", "absolute prompt", got)
+		}
+	})
+
+	t.Run("prompt_file missing returns error", func(t *testing.T) {
+		t.Parallel()
+		tc := TaskConfig{Name: "scan", PromptFile: "nonexistent.md"}
+		if _, err := tc.Resolve(t.TempDir()); err == nil {
+			t.Fatal("expected error for missing file")
+		}
+	})
+}
+
+func TestTaskConfigPromptFileAccepted(t *testing.T) {
+	t.Setenv("WEBHOOK_SECRET", "secret")
+
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "issues.md")
+	if err := os.WriteFile(promptFile, []byte("scan all issues"), 0o644); err != nil {
+		t.Fatalf("write prompt file: %v", err)
+	}
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	content := `http:
+  webhook_secret_env: WEBHOOK_SECRET
+ai_backends:
+  claude:
+    mode: noop
+skills:
+  - name: architect
+    prompt: "focus on architecture"
+agents:
+  - name: architect
+    skills: [architect]
+repos:
+  - full_name: "owner/repo"
+autonomous_agents:
+  - repo: "owner/repo"
+    enabled: true
+    agents:
+      - name: "sweep"
+        cron: "* * * * *"
+        skills: [architect]
+        tasks:
+          - name: "issues"
+            prompt_file: "issues.md"
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("expected valid config, got: %v", err)
+	}
+	task := cfg.AutonomousAgents[0].Agents[0].Tasks[0]
+	if task.PromptFile != "issues.md" {
+		t.Fatalf("expected PromptFile %q, got %q", "issues.md", task.PromptFile)
+	}
+	if task.Prompt != "" {
+		t.Fatalf("expected empty inline Prompt, got %q", task.Prompt)
 	}
 }


### PR DESCRIPTION
## Summary

`TaskConfig` only supported inline `prompt`, while every other prompt-bearing config type (`SkillConfig`, `PromptSourceConfig`) supports both `prompt` and `prompt_file`. This forced users with long or shared task prompts to inline them, breaking the config model's convention.

- Add `PromptFile string \`yaml:"prompt_file"\`` field to `TaskConfig`
- Add `TaskConfig.Resolve(baseDir string) (string, error)` following the `PromptSourceConfig` pattern; absolute paths bypass the baseDir join
- Update `normalizeAutonomousAgents` to trim `PromptFile` alongside the existing `Prompt` trimming
- Update `validateAutonomousAgents` to enforce `prompt`/`prompt_file` mutual exclusion (same pattern as `validateSkills`)
- Update `Scheduler.executeAgentRun` to resolve task prompts via `task.Resolve(s.cfg.AgentsDir)` before passing content to `runTask`

## Test plan

- [x] `TestTaskConfigResolve` — table-driven unit test covering inline prompt, relative `prompt_file` (joined to baseDir), absolute `prompt_file` (baseDir ignored), and missing file error
- [x] `TestTaskConfigPromptFileAccepted` — integration test: config with `prompt_file`-only task loads and validates successfully
- [x] New validation case `"autonomous agent task has both prompt and prompt_file"` added to existing `TestAgentValidation` table — expects error
- [x] `go test ./...` passes

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)