### PR TITLE
config: extract validAIBackendNames as single source of truth for backend allowlist

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// validAIBackendNames is the canonical ordered list of supported AI backend
+// names. Preference order for DefaultConfiguredBackend follows slice order.
+// Adding a new backend only requires updating this slice.
+var validAIBackendNames = []string{"claude", "codex"}
+
 const (
 	defaultHTTPListenAddr          = ":8080"
 	defaultHTTPStatusPath          = "/status"
@@ -339,9 +344,13 @@ func (c *Config) validateBackends() error {
 	if len(c.AIBackends) == 0 {
 		return errors.New("config: at least one ai_backends entry is required")
 	}
+	allowed := make(map[string]struct{}, len(validAIBackendNames))
+	for _, n := range validAIBackendNames {
+		allowed[n] = struct{}{}
+	}
 	for name, backend := range c.AIBackends {
-		if name != "claude" && name != "codex" {
-			return fmt.Errorf("config: unsupported ai backend %q (supported: claude, codex)", name)
+		if _, ok := allowed[name]; !ok {
+			return fmt.Errorf("config: unsupported ai backend %q (supported: %s)", name, strings.Join(validAIBackendNames, ", "))
 		}
 		if backend.Mode != "noop" && backend.Mode != "command" {
 			return fmt.Errorf("config: backend %q has unsupported mode %q (supported: noop, command)", name, backend.Mode)
@@ -438,8 +447,15 @@ func (c *Config) validateAutonomousAgents(skillNames map[string]struct{}) error 
 			if agent.Cron == "" {
 				return fmt.Errorf("config: autonomous agent cron required for repo %s", repo.Repo)
 			}
-			if agent.Backend != "auto" && agent.Backend != "claude" && agent.Backend != "codex" {
-				return fmt.Errorf("config: autonomous agent backend %q for repo %s must be one of auto, claude, codex", agent.Backend, repo.Repo)
+			validBackend := agent.Backend == "auto"
+			for _, n := range validAIBackendNames {
+				if agent.Backend == n {
+					validBackend = true
+					break
+				}
+			}
+			if !validBackend {
+				return fmt.Errorf("config: autonomous agent backend %q for repo %s must be one of auto, %s", agent.Backend, repo.Repo, strings.Join(validAIBackendNames, ", "))
 			}
 			if len(agent.Skills) == 0 {
 				return fmt.Errorf("config: autonomous agent %q for repo %s must reference at least one skill", agent.Name, repo.Repo)
@@ -500,14 +516,13 @@ func (c *Config) RepoByName(fullName string) (RepoConfig, bool) {
 }
 
 // DefaultConfiguredBackend returns the name of the preferred backend when no
-// explicit backend is specified in a label. claude is preferred over codex
-// when both are configured.
+// explicit backend is specified in a label. Preference follows the order of
+// validAIBackendNames (claude before codex).
 func (c *Config) DefaultConfiguredBackend() string {
-	if _, ok := c.AIBackends["claude"]; ok {
-		return "claude"
-	}
-	if _, ok := c.AIBackends["codex"]; ok {
-		return "codex"
+	for _, name := range validAIBackendNames {
+		if _, ok := c.AIBackends[name]; ok {
+			return name
+		}
 	}
 	return ""
 }


### PR DESCRIPTION
## Summary

- Introduces a package-level `var validAIBackendNames = []string{"claude", "codex"}` as the single authoritative list of supported AI backend names.
- Updates `validateBackends` to build the allowlist from the slice instead of hardcoding the names in the condition.
- Updates `validateAutonomousAgents` to derive valid backend values from the same slice (plus `"auto"`).
- Updates `DefaultConfiguredBackend` to iterate `validAIBackendNames` in order instead of hardcoding two if-statements.

Adding a third backend now only requires updating one line.

Closes #25

## Test plan

- [x] `go test ./...` passes with no changes to test files — existing `TestLoadRequiresSupportedBackendNames`, `TestDefaultConfiguredBackend`, and `TestResolveBackend` tests continue to exercise the three changed sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)