### PR TITLE
webhook: extract EventQueue interface; decouple Server from *workflow.DataChannels

### DIFF
--- a/internal/webhook/server.go
+++ b/internal/webhook/server.go
@@ -39,17 +39,25 @@ type AgentTriggerer interface {
 	TriggerAgent(ctx context.Context, agentName, repo string) error
 }
 
+// EventQueue accepts issue and PR webhook events for async processing and
+// reports queue depth. *workflow.DataChannels satisfies this interface.
+type EventQueue interface {
+	PushIssue(ctx context.Context, req workflow.IssueRequest) error
+	PushPR(ctx context.Context, req workflow.PRRequest) error
+	QueueStats() (issues, prs workflow.QueueStat)
+}
+
 type Server struct {
 	cfg       *config.Config
 	delivery  *DeliveryStore
 	logger    zerolog.Logger
-	channels  *workflow.DataChannels
+	channels  EventQueue
 	provider  StatusProvider
 	startTime time.Time
 	triggerer AgentTriggerer
 }
 
-func NewServer(cfg *config.Config, delivery *DeliveryStore, channels *workflow.DataChannels, provider StatusProvider, logger zerolog.Logger, triggerer AgentTriggerer) *Server {
+func NewServer(cfg *config.Config, delivery *DeliveryStore, channels EventQueue, provider StatusProvider, logger zerolog.Logger, triggerer AgentTriggerer) *Server {
 	return &Server{
 		cfg:       cfg,
 		delivery:  delivery,

--- a/internal/webhook/server_test.go
+++ b/internal/webhook/server_test.go
@@ -492,6 +492,60 @@ func (s *stubStatusProvider) AgentStatuses() []AgentStatus {
 	return s.statuses
 }
 
+// stubEventQueue is a minimal EventQueue that records pushes and can be
+// configured to return a specific error.
+type stubEventQueue struct {
+	issuePushed int
+	prPushed    int
+	err         error
+}
+
+func (q *stubEventQueue) PushIssue(_ context.Context, _ workflow.IssueRequest) error {
+	q.issuePushed++
+	return q.err
+}
+
+func (q *stubEventQueue) PushPR(_ context.Context, _ workflow.PRRequest) error {
+	q.prPushed++
+	return q.err
+}
+
+func (q *stubEventQueue) QueueStats() (issues, prs workflow.QueueStat) {
+	return workflow.QueueStat{Buffered: q.issuePushed, Capacity: 256},
+		workflow.QueueStat{Buffered: q.prPushed, Capacity: 256}
+}
+
+func TestServerAcceptsEventQueueInterface(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{
+		HTTP: config.HTTPConfig{
+			MaxBodyBytes:       1024,
+			WebhookSecret:      "secret",
+			DeliveryTTLSeconds: 3600,
+		},
+		Repos: []config.RepoConfig{{FullName: "owner/repo", Enabled: true}},
+	}
+	queue := &stubEventQueue{}
+	server := NewServer(cfg, NewDeliveryStore(time.Hour), queue, nil, zerolog.Nop(), nil)
+
+	body := []byte(`{"action":"labeled","label":{"name":"ai:refine"},"repository":{"full_name":"owner/repo"},"issue":{"number":1,"title":"t","body":"b","updated_at":"2026-02-15T00:00:00Z","labels":[{"name":"ai:refine"}]}}`)
+	sig := signatureForTests(body, "secret")
+
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/github", strings.NewReader(string(body)))
+	req.Header.Set("X-GitHub-Event", "issues")
+	req.Header.Set("X-GitHub-Delivery", "delivery-stub-1")
+	req.Header.Set("X-Hub-Signature-256", sig)
+	rr := httptest.NewRecorder()
+	server.handleGitHubWebhook(rr, req)
+
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("expected %d, got %d", http.StatusAccepted, rr.Code)
+	}
+	if queue.issuePushed != 1 {
+		t.Fatalf("expected 1 issue pushed via stub, got %d", queue.issuePushed)
+	}
+}
+
 func signatureForTests(payload []byte, secret string) string {
 	mac := hmac.New(sha256.New, []byte(secret))
 	_, _ = mac.Write(payload)


### PR DESCRIPTION
## Summary

`Server.channels` was typed as `*workflow.DataChannels`, coupling the `webhook` package to a concrete struct in the `workflow` package. `Server` only calls three methods on it: `PushIssue`, `PushPR`, and `QueueStats`.

- Define a minimal `EventQueue` interface inside the `webhook` package
- Change `Server.channels` and `NewServer` parameter to `EventQueue`
- Add `TestServerAcceptsEventQueueInterface` showing a stub can be injected without real channels

`*workflow.DataChannels` satisfies the interface unchanged; no behaviour changes.

Closes #33

## Test plan

- [ ] `go test ./...` passes
- [ ] `TestServerAcceptsEventQueueInterface` verifies stub injection works
- [ ] All existing webhook server tests continue to pass with real `*workflow.DataChannels`

🤖 Generated with [Claude Code](https://claude.com/claude-code)