### PR TITLE
config: normalize PromptFile paths at load time; remove baseDir from Resolve

### DIFF
--- a/cmd/agents/main.go
+++ b/cmd/agents/main.go
@@ -135,11 +135,7 @@ func setupScheduler(cfg *config.Config, runners map[string]ai.Runner, prompts *a
 func resolveSkills(cfg *config.Config) []ai.SkillGuidance {
 	skills := make([]ai.SkillGuidance, 0, len(cfg.Skills))
 	for _, s := range cfg.Skills {
-		sg := ai.SkillGuidance{Name: s.Name, Prompt: s.Prompt}
-		if s.PromptFile != "" {
-			sg.PromptFile = agentsPath(cfg.AgentsDir, s.PromptFile)
-		}
-		skills = append(skills, sg)
+		skills = append(skills, ai.SkillGuidance{Name: s.Name, Prompt: s.Prompt, PromptFile: s.PromptFile})
 	}
 	return skills
 }
@@ -190,10 +186,7 @@ func (a schedulerStatusAdapter) AgentStatuses() []webhook.AgentStatus {
 
 func resolvePrompts(cfg *config.Config) (issue ai.PromptSource, pr ai.PromptSource, auto ai.PromptSource) {
 	resolve := func(src config.PromptSourceConfig) ai.PromptSource {
-		if src.Prompt != "" {
-			return ai.PromptSource{Prompt: src.Prompt}
-		}
-		return ai.PromptSource{PromptFile: agentsPath(cfg.AgentsDir, src.PromptFile)}
+		return ai.PromptSource{Prompt: src.Prompt, PromptFile: src.PromptFile}
 	}
 	return resolve(cfg.Prompts.IssueRefinement), resolve(cfg.Prompts.PRReview), resolve(cfg.Prompts.Autonomous)
 }

--- a/internal/autonomous/scheduler.go
+++ b/internal/autonomous/scheduler.go
@@ -250,7 +250,7 @@ func (s *Scheduler) executeAgentRun(ctx context.Context, repo string, agent conf
 	}
 	return s.memories.WithLock(agent.Name, repo, func(memoryPath string, memory string) error {
 		for _, task := range agent.Tasks {
-			prompt, err := task.Resolve(s.cfg.AgentsDir)
+			prompt, err := task.Resolve()
 			if err != nil {
 				return fmt.Errorf("resolve prompt for task %q: %w", task.Name, err)
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -186,6 +186,15 @@ func Load(path string) (*Config, error) {
 		return nil, fmt.Errorf("parse config: %w", err)
 	}
 	cfg.applyDefaults()
+	// Resolve AgentsDir to an absolute path so that absolutePromptPaths
+	// produces real absolute file paths regardless of where the daemon is
+	// started from. Relative paths are joined with the config file's
+	// directory so that `agents_dir: agents` (the default) resolves to
+	// <config-dir>/agents, not <cwd>/agents.
+	if !filepath.IsAbs(cfg.AgentsDir) {
+		cfg.AgentsDir = filepath.Join(filepath.Dir(path), cfg.AgentsDir)
+	}
+	cfg.absolutePromptPaths()
 	if err := cfg.validate(); err != nil {
 		return nil, err
 	}
@@ -203,7 +212,6 @@ func (c *Config) applyDefaults() {
 	c.normalizeBackends()
 	c.normalizeRepos()
 	c.normalizeAutonomousAgents()
-	c.absolutePromptPaths()
 	c.resolveWebhookSecret()
 	c.resolveAPIKey()
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,6 +67,18 @@ type PromptSourceConfig struct {
 	Prompt     string `yaml:"prompt"`
 }
 
+// Resolve returns the prompt content. If Prompt is set it is returned directly.
+// Otherwise PromptFile (already an absolute path after config loading) is read.
+func (p PromptSourceConfig) Resolve() (string, error) {
+	if p.Prompt != "" {
+		return p.Prompt, nil
+	}
+	data, err := os.ReadFile(p.PromptFile)
+	if err != nil {
+		return "", fmt.Errorf("read prompt file %s: %w", p.PromptFile, err)
+	}
+	return string(data), nil
+}
 
 type SkillConfig struct {
 	Name       string `yaml:"name"`
@@ -86,18 +98,15 @@ type TaskConfig struct {
 }
 
 // Resolve returns the task prompt content. If Prompt is set it is returned
-// directly. Otherwise the file at baseDir/PromptFile is read.
-func (t TaskConfig) Resolve(baseDir string) (string, error) {
+// directly. Otherwise PromptFile (already an absolute path after config loading)
+// is read.
+func (t TaskConfig) Resolve() (string, error) {
 	if t.Prompt != "" {
 		return t.Prompt, nil
 	}
-	path := t.PromptFile
-	if baseDir != "" && !filepath.IsAbs(path) {
-		path = filepath.Join(baseDir, path)
-	}
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(t.PromptFile)
 	if err != nil {
-		return "", fmt.Errorf("read task prompt file %s: %w", path, err)
+		return "", fmt.Errorf("read task prompt file %s: %w", t.PromptFile, err)
 	}
 	return string(data), nil
 }
@@ -194,8 +203,36 @@ func (c *Config) applyDefaults() {
 	c.normalizeBackends()
 	c.normalizeRepos()
 	c.normalizeAutonomousAgents()
+	c.absolutePromptPaths()
 	c.resolveWebhookSecret()
 	c.resolveAPIKey()
+}
+
+// absolutePromptPaths converts all relative PromptFile fields to absolute paths
+// by joining them with AgentsDir. Absolute paths and empty strings are left
+// unchanged. This must be called after AgentsDir is set and after all
+// normalization passes that trim PromptFile strings.
+func (c *Config) absolutePromptPaths() {
+	abs := func(p string) string {
+		if p == "" || filepath.IsAbs(p) {
+			return p
+		}
+		return filepath.Join(c.AgentsDir, p)
+	}
+	c.Prompts.IssueRefinement.PromptFile = abs(c.Prompts.IssueRefinement.PromptFile)
+	c.Prompts.PRReview.PromptFile = abs(c.Prompts.PRReview.PromptFile)
+	c.Prompts.Autonomous.PromptFile = abs(c.Prompts.Autonomous.PromptFile)
+	for i := range c.Skills {
+		c.Skills[i].PromptFile = abs(c.Skills[i].PromptFile)
+	}
+	for i := range c.AutonomousAgents {
+		for j := range c.AutonomousAgents[i].Agents {
+			for k := range c.AutonomousAgents[i].Agents[j].Tasks {
+				c.AutonomousAgents[i].Agents[j].Tasks[k].PromptFile =
+					abs(c.AutonomousAgents[i].Agents[j].Tasks[k].PromptFile)
+			}
+		}
+	}
 }
 
 func (c *Config) applyPromptDefaults() {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -191,8 +191,16 @@ func Load(path string) (*Config, error) {
 	// started from. Relative paths are joined with the config file's
 	// directory so that `agents_dir: agents` (the default) resolves to
 	// <config-dir>/agents, not <cwd>/agents.
+	//
+	// filepath.Abs is called first to handle a relative config path (e.g.
+	// `-config config.yaml`); without it filepath.Dir returns "." and the
+	// join still leaves AgentsDir relative.
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve config path: %w", err)
+	}
 	if !filepath.IsAbs(cfg.AgentsDir) {
-		cfg.AgentsDir = filepath.Join(filepath.Dir(path), cfg.AgentsDir)
+		cfg.AgentsDir = filepath.Join(filepath.Dir(absPath), cfg.AgentsDir)
 	}
 	cfg.absolutePromptPaths()
 	if err := cfg.validate(); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1592,6 +1592,7 @@ agents:
     skills: [architect]
 repos:
   - full_name: "owner/repo"
+    enabled: true
 `
 	t.Run("absolute-config-path", func(t *testing.T) {
 		dir := t.TempDir()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1579,8 +1579,6 @@ func TestAbsolutePromptPaths(t *testing.T) {
 func TestLoadMakesAgentsDirAbsoluteRelativeToConfigFile(t *testing.T) {
 	t.Setenv("WEBHOOK_SECRET", "secret")
 
-	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "config.yaml")
 	content := `http:
   webhook_secret_env: WEBHOOK_SECRET
 ai_backends:
@@ -1595,26 +1593,62 @@ agents:
 repos:
   - full_name: "owner/repo"
 `
-	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
+	t.Run("absolute-config-path", func(t *testing.T) {
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, "config.yaml")
+		if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
 
-	cfg, err := Load(cfgPath)
-	if err != nil {
-		t.Fatalf("Load: %v", err)
-	}
+		cfg, err := Load(cfgPath)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
 
-	// AgentsDir defaults to "agents" relative to the config file's directory.
-	wantDir := filepath.Join(dir, defaultAgentsDir)
-	if cfg.AgentsDir != wantDir {
-		t.Fatalf("expected AgentsDir %q, got %q", wantDir, cfg.AgentsDir)
-	}
-	// Prompt file paths must be absolute so they can be opened independently
-	// of the process working directory.
-	if !filepath.IsAbs(cfg.Prompts.IssueRefinement.PromptFile) {
-		t.Errorf("IssueRefinement.PromptFile should be absolute, got %q", cfg.Prompts.IssueRefinement.PromptFile)
-	}
-	if !filepath.IsAbs(cfg.Prompts.PRReview.PromptFile) {
-		t.Errorf("PRReview.PromptFile should be absolute, got %q", cfg.Prompts.PRReview.PromptFile)
-	}
+		wantDir := filepath.Join(dir, defaultAgentsDir)
+		if cfg.AgentsDir != wantDir {
+			t.Fatalf("expected AgentsDir %q, got %q", wantDir, cfg.AgentsDir)
+		}
+		if !filepath.IsAbs(cfg.Prompts.IssueRefinement.PromptFile) {
+			t.Errorf("IssueRefinement.PromptFile should be absolute, got %q", cfg.Prompts.IssueRefinement.PromptFile)
+		}
+		if !filepath.IsAbs(cfg.Prompts.PRReview.PromptFile) {
+			t.Errorf("PRReview.PromptFile should be absolute, got %q", cfg.Prompts.PRReview.PromptFile)
+		}
+	})
+
+	// When the daemon is started with `-config config.yaml` (no leading path),
+	// filepath.Dir returns ".".  Verify that Load still produces absolute paths
+	// by calling filepath.Abs on the config path before deriving AgentsDir.
+	t.Run("relative-config-path", func(t *testing.T) {
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, "config.yaml")
+		if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+
+		// Change into the config's directory so that "config.yaml" resolves to
+		// the file we just wrote, then restore the original cwd when done.
+		origDir, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("getwd: %v", err)
+		}
+		if err := os.Chdir(dir); err != nil {
+			t.Fatalf("chdir: %v", err)
+		}
+		t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+		cfg, err := Load("config.yaml")
+		if err != nil {
+			t.Fatalf("Load with relative path: %v", err)
+		}
+
+		if !filepath.IsAbs(cfg.AgentsDir) {
+			t.Errorf("AgentsDir should be absolute when config path is relative, got %q", cfg.AgentsDir)
+		}
+		wantDir := filepath.Join(dir, defaultAgentsDir)
+		if cfg.AgentsDir != wantDir {
+			t.Fatalf("expected AgentsDir %q, got %q", wantDir, cfg.AgentsDir)
+		}
+	})
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -98,21 +98,24 @@ autonomous_agents:
 	if cfg.HTTP.ShutdownTimeoutSeconds != defaultHTTPShutdownSeconds {
 		t.Fatalf("expected shutdown timeout default %d, got %d", defaultHTTPShutdownSeconds, cfg.HTTP.ShutdownTimeoutSeconds)
 	}
-	if cfg.AgentsDir != defaultAgentsDir {
-		t.Fatalf("expected default agents dir %q, got %q", defaultAgentsDir, cfg.AgentsDir)
+	// AgentsDir must be absolute after Load; relative defaults are anchored to
+	// the directory that contains the config file.
+	wantAgentsDir := filepath.Join(filepath.Dir(path), defaultAgentsDir)
+	if cfg.AgentsDir != wantAgentsDir {
+		t.Fatalf("expected agents dir %q, got %q", wantAgentsDir, cfg.AgentsDir)
 	}
 	if cfg.MemoryDir != defaultMemoryDir {
 		t.Fatalf("expected default memory dir %q, got %q", defaultMemoryDir, cfg.MemoryDir)
 	}
-	wantIssueFile := filepath.Join(defaultAgentsDir, defaultIssueRefinementPromptFile)
+	wantIssueFile := filepath.Join(wantAgentsDir, defaultIssueRefinementPromptFile)
 	if cfg.Prompts.IssueRefinement.PromptFile != wantIssueFile {
 		t.Fatalf("expected default issue prompt file %q, got %q", wantIssueFile, cfg.Prompts.IssueRefinement.PromptFile)
 	}
-	wantPRFile := filepath.Join(defaultAgentsDir, defaultPRReviewPromptFile)
+	wantPRFile := filepath.Join(wantAgentsDir, defaultPRReviewPromptFile)
 	if cfg.Prompts.PRReview.PromptFile != wantPRFile {
 		t.Fatalf("expected default pr prompt file %q, got %q", wantPRFile, cfg.Prompts.PRReview.PromptFile)
 	}
-	wantAutoFile := filepath.Join(defaultAgentsDir, defaultAutonomousPromptFile)
+	wantAutoFile := filepath.Join(wantAgentsDir, defaultAutonomousPromptFile)
 	if cfg.Prompts.Autonomous.PromptFile != wantAutoFile {
 		t.Fatalf("expected default auto prompt file %q, got %q", wantAutoFile, cfg.Prompts.Autonomous.PromptFile)
 	}
@@ -1571,5 +1574,47 @@ func TestAbsolutePromptPaths(t *testing.T) {
 			t.Errorf("PromptFile should remain empty, got %q", got)
 		}
 	})
+}
 
+func TestLoadMakesAgentsDirAbsoluteRelativeToConfigFile(t *testing.T) {
+	t.Setenv("WEBHOOK_SECRET", "secret")
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	content := `http:
+  webhook_secret_env: WEBHOOK_SECRET
+ai_backends:
+  claude:
+    mode: noop
+skills:
+  - name: architect
+    prompt: "focus on architecture"
+agents:
+  - name: architect
+    skills: [architect]
+repos:
+  - full_name: "owner/repo"
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	// AgentsDir defaults to "agents" relative to the config file's directory.
+	wantDir := filepath.Join(dir, defaultAgentsDir)
+	if cfg.AgentsDir != wantDir {
+		t.Fatalf("expected AgentsDir %q, got %q", wantDir, cfg.AgentsDir)
+	}
+	// Prompt file paths must be absolute so they can be opened independently
+	// of the process working directory.
+	if !filepath.IsAbs(cfg.Prompts.IssueRefinement.PromptFile) {
+		t.Errorf("IssueRefinement.PromptFile should be absolute, got %q", cfg.Prompts.IssueRefinement.PromptFile)
+	}
+	if !filepath.IsAbs(cfg.Prompts.PRReview.PromptFile) {
+		t.Errorf("PRReview.PromptFile should be absolute, got %q", cfg.Prompts.PRReview.PromptFile)
+	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -104,14 +104,17 @@ autonomous_agents:
 	if cfg.MemoryDir != defaultMemoryDir {
 		t.Fatalf("expected default memory dir %q, got %q", defaultMemoryDir, cfg.MemoryDir)
 	}
-	if cfg.Prompts.IssueRefinement.PromptFile != defaultIssueRefinementPromptFile {
-		t.Fatalf("expected default issue prompt file %q, got %q", defaultIssueRefinementPromptFile, cfg.Prompts.IssueRefinement.PromptFile)
+	wantIssueFile := filepath.Join(defaultAgentsDir, defaultIssueRefinementPromptFile)
+	if cfg.Prompts.IssueRefinement.PromptFile != wantIssueFile {
+		t.Fatalf("expected default issue prompt file %q, got %q", wantIssueFile, cfg.Prompts.IssueRefinement.PromptFile)
 	}
-	if cfg.Prompts.PRReview.PromptFile != defaultPRReviewPromptFile {
-		t.Fatalf("expected default pr prompt file %q, got %q", defaultPRReviewPromptFile, cfg.Prompts.PRReview.PromptFile)
+	wantPRFile := filepath.Join(defaultAgentsDir, defaultPRReviewPromptFile)
+	if cfg.Prompts.PRReview.PromptFile != wantPRFile {
+		t.Fatalf("expected default pr prompt file %q, got %q", wantPRFile, cfg.Prompts.PRReview.PromptFile)
 	}
-	if cfg.Prompts.Autonomous.PromptFile != defaultAutonomousPromptFile {
-		t.Fatalf("expected default auto prompt file %q, got %q", defaultAutonomousPromptFile, cfg.Prompts.Autonomous.PromptFile)
+	wantAutoFile := filepath.Join(defaultAgentsDir, defaultAutonomousPromptFile)
+	if cfg.Prompts.Autonomous.PromptFile != wantAutoFile {
+		t.Fatalf("expected default auto prompt file %q, got %q", wantAutoFile, cfg.Prompts.Autonomous.PromptFile)
 	}
 	if len(cfg.AutonomousAgents) != 1 || len(cfg.AutonomousAgents[0].Agents) != 1 {
 		t.Fatalf("expected one autonomous agent configured")
@@ -1134,7 +1137,7 @@ func TestTaskConfigResolve(t *testing.T) {
 	t.Run("inline prompt returned directly", func(t *testing.T) {
 		t.Parallel()
 		tc := TaskConfig{Name: "scan", Prompt: "scan all issues"}
-		got, err := tc.Resolve("")
+		got, err := tc.Resolve()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1143,14 +1146,15 @@ func TestTaskConfigResolve(t *testing.T) {
 		}
 	})
 
-	t.Run("prompt_file with relative path joined to baseDir", func(t *testing.T) {
+	t.Run("prompt_file reads content from absolute path", func(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
-		if err := os.WriteFile(filepath.Join(dir, "task.md"), []byte("file prompt"), 0o644); err != nil {
+		absPath := filepath.Join(dir, "task.md")
+		if err := os.WriteFile(absPath, []byte("file prompt"), 0o644); err != nil {
 			t.Fatalf("write file: %v", err)
 		}
-		tc := TaskConfig{Name: "scan", PromptFile: "task.md"}
-		got, err := tc.Resolve(dir)
+		tc := TaskConfig{Name: "scan", PromptFile: absPath}
+		got, err := tc.Resolve()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1159,27 +1163,10 @@ func TestTaskConfigResolve(t *testing.T) {
 		}
 	})
 
-	t.Run("prompt_file with absolute path ignores baseDir", func(t *testing.T) {
-		t.Parallel()
-		dir := t.TempDir()
-		absPath := filepath.Join(dir, "abs_task.md")
-		if err := os.WriteFile(absPath, []byte("absolute prompt"), 0o644); err != nil {
-			t.Fatalf("write file: %v", err)
-		}
-		tc := TaskConfig{Name: "scan", PromptFile: absPath}
-		got, err := tc.Resolve("/some/other/dir")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if got != "absolute prompt" {
-			t.Fatalf("expected %q, got %q", "absolute prompt", got)
-		}
-	})
-
 	t.Run("prompt_file missing returns error", func(t *testing.T) {
 		t.Parallel()
-		tc := TaskConfig{Name: "scan", PromptFile: "nonexistent.md"}
-		if _, err := tc.Resolve(t.TempDir()); err == nil {
+		tc := TaskConfig{Name: "scan", PromptFile: "/nonexistent/path/task.md"}
+		if _, err := tc.Resolve(); err == nil {
 			t.Fatal("expected error for missing file")
 		}
 	})
@@ -1189,14 +1176,19 @@ func TestTaskConfigPromptFileAccepted(t *testing.T) {
 	t.Setenv("WEBHOOK_SECRET", "secret")
 
 	dir := t.TempDir()
-	promptFile := filepath.Join(dir, "issues.md")
+	agentsDir := filepath.Join(dir, "agents")
+	if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+		t.Fatalf("mkdir agents_dir: %v", err)
+	}
+	promptFile := filepath.Join(agentsDir, "issues.md")
 	if err := os.WriteFile(promptFile, []byte("scan all issues"), 0o644); err != nil {
 		t.Fatalf("write prompt file: %v", err)
 	}
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	content := `http:
+	content := fmt.Sprintf(`http:
   webhook_secret_env: WEBHOOK_SECRET
+agents_dir: %s
 ai_backends:
   claude:
     mode: noop
@@ -1219,7 +1211,7 @@ autonomous_agents:
         tasks:
           - name: "issues"
             prompt_file: "issues.md"
-`
+`, agentsDir)
 	if err := os.WriteFile(cfgPath, []byte(content), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -1229,8 +1221,10 @@ autonomous_agents:
 		t.Fatalf("expected valid config, got: %v", err)
 	}
 	task := cfg.AutonomousAgents[0].Agents[0].Tasks[0]
-	if task.PromptFile != "issues.md" {
-		t.Fatalf("expected PromptFile %q, got %q", "issues.md", task.PromptFile)
+	// After loading, relative PromptFile paths are joined with AgentsDir.
+	wantFile := filepath.Join(agentsDir, "issues.md")
+	if task.PromptFile != wantFile {
+		t.Fatalf("expected PromptFile %q, got %q", wantFile, task.PromptFile)
 	}
 	if task.Prompt != "" {
 		t.Fatalf("expected empty inline Prompt, got %q", task.Prompt)
@@ -1501,4 +1495,81 @@ processor:
 			}
 		})
 	}
+}
+func TestAbsolutePromptPaths(t *testing.T) {
+	t.Parallel()
+
+	t.Run("relative PromptFile is joined with AgentsDir", func(t *testing.T) {
+		t.Parallel()
+		c := &Config{
+			AgentsDir: "/agents",
+			Prompts: PromptsConfig{
+				IssueRefinement: PromptSourceConfig{PromptFile: "issue.md"},
+				PRReview:        PromptSourceConfig{PromptFile: "pr.md"},
+				Autonomous:      PromptSourceConfig{PromptFile: "auto.md"},
+			},
+			Skills: []SkillConfig{{Name: "arch", PromptFile: "arch.md"}},
+			AutonomousAgents: []AutonomousRepoConfig{{
+				Agents: []AutonomousAgentConfig{{
+					Tasks: []TaskConfig{{Name: "t", PromptFile: "task.md"}},
+				}},
+			}},
+		}
+		c.absolutePromptPaths()
+
+		if got := c.Prompts.IssueRefinement.PromptFile; got != "/agents/issue.md" {
+			t.Errorf("IssueRefinement: got %q, want /agents/issue.md", got)
+		}
+		if got := c.Prompts.PRReview.PromptFile; got != "/agents/pr.md" {
+			t.Errorf("PRReview: got %q, want /agents/pr.md", got)
+		}
+		if got := c.Prompts.Autonomous.PromptFile; got != "/agents/auto.md" {
+			t.Errorf("Autonomous: got %q, want /agents/auto.md", got)
+		}
+		if got := c.Skills[0].PromptFile; got != "/agents/arch.md" {
+			t.Errorf("Skills[0]: got %q, want /agents/arch.md", got)
+		}
+		if got := c.AutonomousAgents[0].Agents[0].Tasks[0].PromptFile; got != "/agents/task.md" {
+			t.Errorf("Tasks[0]: got %q, want /agents/task.md", got)
+		}
+	})
+
+	t.Run("absolute PromptFile is not modified", func(t *testing.T) {
+		t.Parallel()
+		c := &Config{
+			AgentsDir: "/agents",
+			Prompts: PromptsConfig{
+				IssueRefinement: PromptSourceConfig{PromptFile: "/absolute/issue.md"},
+			},
+			AutonomousAgents: []AutonomousRepoConfig{{
+				Agents: []AutonomousAgentConfig{{
+					Tasks: []TaskConfig{{Name: "t", PromptFile: "/absolute/task.md"}},
+				}},
+			}},
+		}
+		c.absolutePromptPaths()
+
+		if got := c.Prompts.IssueRefinement.PromptFile; got != "/absolute/issue.md" {
+			t.Errorf("IssueRefinement: got %q, want /absolute/issue.md", got)
+		}
+		if got := c.AutonomousAgents[0].Agents[0].Tasks[0].PromptFile; got != "/absolute/task.md" {
+			t.Errorf("Tasks[0]: got %q, want /absolute/task.md", got)
+		}
+	})
+
+	t.Run("empty PromptFile is not modified", func(t *testing.T) {
+		t.Parallel()
+		c := &Config{
+			AgentsDir: "/agents",
+			Prompts: PromptsConfig{
+				IssueRefinement: PromptSourceConfig{Prompt: "inline"},
+			},
+		}
+		c.absolutePromptPaths()
+
+		if got := c.Prompts.IssueRefinement.PromptFile; got != "" {
+			t.Errorf("PromptFile should remain empty, got %q", got)
+		}
+	})
+
 }


### PR DESCRIPTION
## Summary

- Adds `Config.absolutePromptPaths()` called from `applyDefaults` to join all relative `PromptFile` fields with `AgentsDir` in-place (absolute paths and empty strings are left unchanged)
- `PromptSourceConfig.Resolve()` and `TaskConfig.Resolve()` now take no parameter — callers no longer need to supply `AgentsDir`
- Removes manual `filepath.Join(cfg.AgentsDir, ...)` from `cmd/agents/main.go` (`resolveSkills`, `resolvePrompts`) and `task.Resolve(s.cfg.AgentsDir)` from `autonomous/scheduler.go`

Closes #26

## Test plan

- [ ] `TestAbsolutePromptPaths` — unit tests for the new normalization function covering relative join, absolute preservation, and empty path passthrough
- [ ] `TestTaskConfigResolve` — updated to call `Resolve()` with no argument
- [ ] `TestLoadAppliesDefaults` — updated assertions to expect joined default paths
- [ ] `TestTaskConfigPromptFileAccepted` — updated to use an explicit `agents_dir` and verify the joined absolute path
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)