### PR TITLE
fix(config): restore path/filepath import removed by PR #86

### DIFF
--- a/internal/autonomous/scheduler.go
+++ b/internal/autonomous/scheduler.go
@@ -240,7 +240,7 @@ func (s *Scheduler) TriggerAgent(ctx context.Context, agentName, repo string) er
 
 func (s *Scheduler) executeAgentRun(ctx context.Context, repo string, agent config.AutonomousAgentConfig) error {
 	logger := s.logger.With().Str("repo", repo).Str("agent", agent.Name).Logger()
-	backend := s.resolveBackend(agent.Backend)
+	backend := s.cfg.ResolveBackend(agent.Backend)
 	if backend == "" {
 		return fmt.Errorf("no configured backend for autonomous agent run (configured: %q)", agent.Backend)
 	}
@@ -267,10 +267,6 @@ func (s *Scheduler) executeAgentRun(ctx context.Context, repo string, agent conf
 		}
 		return nil
 	})
-}
-
-func (s *Scheduler) resolveBackend(configured string) string {
-	return s.cfg.ResolveBackend(configured)
 }
 
 func (s *Scheduler) setRunCtx(ctx context.Context) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"gopkg.in/yaml.v3"


### PR DESCRIPTION
## Summary

- PR #86 removed `path/filepath` from `internal/config/config.go` when deleting `PromptSourceConfig.Resolve()`, but `TaskConfig.Resolve()` (added in PR #96, commit `e21e9ab`) also calls `filepath.IsAbs` and `filepath.Join`
- This left the entire `config` package failing to compile on main
- Also inlines `Scheduler.resolveBackend` — a one-liner passthrough to `s.cfg.ResolveBackend` called in exactly one place, adding no meaning

## Why it matters

`go build ./...` and `go test ./...` both fail on the current `main` branch. Every PR rebasing on `main` inherits the broken build until this is fixed.

## Test plan

- [x] `go test ./...` passes after the change
- [x] `go build ./...` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)