### PR TITLE
config: define backendAuto constant to eliminate scattered "auto" literals

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,11 @@ import (
 // Adding a new backend only requires updating this slice.
 var validAIBackendNames = []string{"claude", "codex"}
 
+// backendAuto is the sentinel token that means "use the default configured
+// backend". It is accepted in autonomous_agents[].backend and in
+// ResolveBackend; it is never a valid backend name in ai_backends.
+const backendAuto = "auto"
+
 const (
 	defaultHTTPListenAddr          = ":8080"
 	defaultHTTPStatusPath          = "/status"
@@ -293,7 +298,7 @@ func (c *Config) normalizeAutonomousAgents() {
 			a.Description = strings.TrimSpace(a.Description)
 			a.Backend = strings.ToLower(strings.TrimSpace(a.Backend))
 			if a.Backend == "" {
-				a.Backend = "auto"
+				a.Backend = backendAuto
 			}
 			for k := range a.Skills {
 				a.Skills[k] = strings.ToLower(strings.TrimSpace(a.Skills[k]))
@@ -480,7 +485,7 @@ func (c *Config) validateAutonomousAgents(skillNames map[string]struct{}) error 
 			if agent.Cron == "" {
 				return fmt.Errorf("config: autonomous agent cron required for repo %s", repo.Repo)
 			}
-			validBackend := agent.Backend == "auto"
+			validBackend := agent.Backend == backendAuto
 			for _, n := range validAIBackendNames {
 				if agent.Backend == n {
 					validBackend = true
@@ -488,7 +493,7 @@ func (c *Config) validateAutonomousAgents(skillNames map[string]struct{}) error 
 				}
 			}
 			if !validBackend {
-				return fmt.Errorf("config: autonomous agent backend %q for repo %s must be one of auto, %s", agent.Backend, repo.Repo, strings.Join(validAIBackendNames, ", "))
+				return fmt.Errorf("config: autonomous agent backend %q for repo %s must be one of %s, %s", agent.Backend, repo.Repo, backendAuto, strings.Join(validAIBackendNames, ", "))
 			}
 			if len(agent.Skills) == 0 {
 				return fmt.Errorf("config: autonomous agent %q for repo %s must reference at least one skill", agent.Name, repo.Repo)
@@ -582,7 +587,7 @@ func (c *Config) DefaultConfiguredBackend() string {
 // match any configured backend returns "" so the caller can skip the event.
 func (c *Config) ResolveBackend(raw string) string {
 	normalized := strings.ToLower(strings.TrimSpace(raw))
-	if normalized == "" || normalized == "auto" {
+	if normalized == "" || normalized == backendAuto {
 		return c.DefaultConfiguredBackend()
 	}
 	if _, ok := c.AIBackends[normalized]; !ok {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -116,7 +116,7 @@ autonomous_agents:
 	if len(cfg.AutonomousAgents) != 1 || len(cfg.AutonomousAgents[0].Agents) != 1 {
 		t.Fatalf("expected one autonomous agent configured")
 	}
-	if got := cfg.AutonomousAgents[0].Agents[0].Backend; got != "auto" {
+	if got := cfg.AutonomousAgents[0].Agents[0].Backend; got != backendAuto {
 		t.Fatalf("expected autonomous backend default auto, got %q", got)
 	}
 }
@@ -150,7 +150,7 @@ func TestResolveBackend(t *testing.T) {
 		want  string
 	}{
 		{"empty falls back to default", "", "claude"},
-		{"auto falls back to default", "auto", "claude"},
+		{"auto falls back to default", backendAuto, "claude"},
 		{"AUTO case-insensitive", "AUTO", "claude"},
 		{"explicit claude", "claude", "claude"},
 		{"explicit codex", "codex", "codex"},


### PR DESCRIPTION
## Summary

- Defines `backendAuto = "auto"` as a package-level constant in `internal/config/config.go`
- Replaces the three scattered `"auto"` string literals in `normalizeAutonomousAgents`, `validateAutonomousAgents`, and `ResolveBackend` with the constant
- Updates two test expectations to use `backendAuto` so they stay in sync with the canonical value

## Context

PR #99 (`fix/25-backend-allowlist-single-source`) already extracted `validAIBackendNames` as the single source of truth for backend names and unified `resolveBackend` into `Config.ResolveBackend`. The remaining scatter from issue #31 was the `"auto"` sentinel appearing in three separate code locations with no shared definition. This PR closes that gap.

Adding a new backend now only requires updating `validAIBackendNames`. The `"auto"` sentinel behavior is defined once in `backendAuto` and referenced by the constant.

Closes #31

## Test plan

- [x] `go test ./... -count=1` passes (no -race, cgo unavailable in build environment)
- [x] Existing `ResolveBackend` tests updated to use `backendAuto` constant
- [x] Backend default normalization test updated to use `backendAuto` constant