### PR TITLE
refactor(config): deduplicate resolveBackend into config.ResolveBackend

### DIFF
--- a/internal/autonomous/scheduler.go
+++ b/internal/autonomous/scheduler.go
@@ -238,7 +238,7 @@ func (s *Scheduler) TriggerAgent(ctx context.Context, agentName, repo string) er
 }
 
 func (s *Scheduler) executeAgentRun(ctx context.Context, repo string, agent config.AgentDef) error {
-	backend := s.resolveBackend(agent.Backend)
+	backend := s.cfg.ResolveBackend(agent.Backend)
 	if backend == "" {
 		return fmt.Errorf("no configured backend for agent %q (configured: %q)", agent.Name, agent.Backend)
 	}
@@ -269,20 +269,6 @@ func (s *Scheduler) executeAgentRun(ctx context.Context, repo string, agent conf
 		logger.Info().Int("artifacts_stored", len(resp.Artifacts)).Msg("autonomous pass completed")
 		return nil
 	})
-}
-
-// resolveBackend returns the concrete backend name for the given agent
-// configuration value. "auto" or empty resolves to the default configured
-// backend; an explicit name is returned as-is if it's configured.
-func (s *Scheduler) resolveBackend(configured string) string {
-	configured = strings.ToLower(strings.TrimSpace(configured))
-	if configured == "" || configured == "auto" {
-		return s.cfg.DefaultBackend()
-	}
-	if _, ok := s.cfg.Daemon.AIBackends[configured]; !ok {
-		return ""
-	}
-	return configured
 }
 
 func (s *Scheduler) setRunCtx(ctx context.Context) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -228,6 +228,21 @@ func (c *Config) DefaultBackend() string {
 	return ""
 }
 
+// ResolveBackend returns the concrete backend name for the given agent
+// configuration value. "auto" or empty resolves to the default configured
+// backend; an explicit name is returned as-is if it is present in
+// ai_backends. Returns "" if the name is explicit but not configured.
+func (c *Config) ResolveBackend(configured string) string {
+	configured = strings.ToLower(strings.TrimSpace(configured))
+	if configured == "" || configured == "auto" {
+		return c.DefaultBackend()
+	}
+	if _, ok := c.Daemon.AIBackends[configured]; !ok {
+		return ""
+	}
+	return configured
+}
+
 // ─── internal: defaults, normalization, secrets, prompt loading, validation ──
 
 func (c *Config) applyDefaults() {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -307,6 +307,32 @@ func TestDefaultBackendPrefersFirstConfigured(t *testing.T) {
 	}
 }
 
+func TestResolveBackend(t *testing.T) {
+	t.Parallel()
+	cfg := &Config{
+		Daemon: DaemonConfig{
+			AIBackends: map[string]AIBackendConfig{
+				"claude": {Command: "claude"},
+			},
+		},
+	}
+	cases := []struct {
+		configured string
+		want       string
+	}{
+		{"", "claude"},
+		{"auto", "claude"},
+		{"claude", "claude"},
+		{"codex", ""},  // not in ai_backends
+		{"CLAUDE", "claude"}, // case-folded
+	}
+	for _, tc := range cases {
+		if got := cfg.ResolveBackend(tc.configured); got != tc.want {
+			t.Errorf("ResolveBackend(%q): got %q, want %q", tc.configured, got, tc.want)
+		}
+	}
+}
+
 func TestConfigExampleYAMLLoads(t *testing.T) {
 	t.Setenv("GITHUB_WEBHOOK_SECRET", "s3cret")
 	t.Setenv("AGENTS_API_KEY", "apikey")

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -121,7 +121,7 @@ func (e *Engine) agentsForLabel(repoName, label string) []config.AgentDef {
 }
 
 func (e *Engine) runAgent(ctx context.Context, repo string, number int, agent config.AgentDef, kind string) error {
-	backend := e.resolveBackend(agent.Backend)
+	backend := e.cfg.ResolveBackend(agent.Backend)
 	if backend == "" {
 		return fmt.Errorf("agent %q: no runner available for backend %q", agent.Name, agent.Backend)
 	}
@@ -151,17 +151,6 @@ func (e *Engine) runAgent(ctx context.Context, repo string, number int, agent co
 	}
 	logger.Info().Int("artifacts_stored", len(resp.Artifacts)).Msg("agent run completed")
 	return nil
-}
-
-func (e *Engine) resolveBackend(configured string) string {
-	configured = strings.ToLower(strings.TrimSpace(configured))
-	if configured == "" || configured == "auto" {
-		return e.cfg.DefaultBackend()
-	}
-	if _, ok := e.cfg.Daemon.AIBackends[configured]; !ok {
-		return ""
-	}
-	return configured
 }
 
 func containsLabel(labels []string, target string) bool {


### PR DESCRIPTION
## Why

`autonomous.Scheduler` and `workflow.Engine` each had a private `resolveBackend` method with identical bodies (14 lines each). The logic — normalise the configured name, fall back to `DefaultBackend()` for `auto`/empty, validate against `Daemon.AIBackends` — only touches `*config.Config` data, so it naturally belongs there.

## What changed

- Added `(*Config).ResolveBackend(configured string) string` in `internal/config/config.go`, right next to `DefaultBackend`.
- Removed the two private copies in `autonomous/scheduler.go` and `workflow/engine.go`; callers updated to `cfg.ResolveBackend(...)`.
- Added a table-driven test in `config_test.go` covering: empty string, `"auto"`, explicit-present, explicit-missing, and case-folded input.

## Behaviour

No behaviour change. The semantics are identical to the removed copies.