### PR TITLE
test(webhook): remove pre-Go 1.22 loop variable capture

### DIFF
--- a/internal/webhook/server_test.go
+++ b/internal/webhook/server_test.go
@@ -280,7 +280,6 @@ func TestHandleAgentsRunReturnsBadRequestOnMissingFields(t *testing.T) {
 		{"empty body", `{}`},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			server := newRunServer(&stubTriggerer{})
 			req := authedRequest(http.MethodPost, "/agents/run", tc.body)


### PR DESCRIPTION
## Why

`tc := tc` inside a `for _, tc := range` loop was necessary before Go 1.22 to prevent the closure from capturing a single shared loop variable. Since Go 1.22, each iteration gets its own variable, so the shadowing assignment is dead code.

This module declares `go 1.24.12`, so the pattern has been obsolete since the module was created.

## What changed

Removed the single `tc := tc` line in `TestHandleAgentsRunReturnsBadRequestOnMissingFields` in `internal/webhook/server_test.go`. No behavioral change.