### PR TITLE
test(ai): replace manual prefix check with strings.HasPrefix

### DIFF
--- a/internal/ai/cmdrunner_test.go
+++ b/internal/ai/cmdrunner_test.go
@@ -2,6 +2,7 @@ package ai
 
 import (
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -33,7 +34,7 @@ func TestBuildCommandEnvDaemonNumber(t *testing.T) {
 				Number:   tc.number,
 			})
 			hasNumber := slices.ContainsFunc(env, func(e string) bool {
-				return len(e) >= len("AI_DAEMON_NUMBER=") && e[:len("AI_DAEMON_NUMBER=")] == "AI_DAEMON_NUMBER="
+				return strings.HasPrefix(e, "AI_DAEMON_NUMBER=")
 			})
 			if hasNumber != tc.wantNumberVar {
 				t.Errorf("AI_DAEMON_NUMBER present=%v, want present=%v (env=%v)", hasNumber, tc.wantNumberVar, env)


### PR DESCRIPTION
## Why

`TestBuildCommandEnvDaemonNumber` in `internal/ai/cmdrunner_test.go` checked for the `AI_DAEMON_NUMBER=` prefix using manual length arithmetic:

```go
len(e) >= len("AI_DAEMON_NUMBER=") && e[:len("AI_DAEMON_NUMBER=")] == "AI_DAEMON_NUMBER="
```

This is `strings.HasPrefix` written by hand. The stdlib function is shorter, immediately recognisable, and less error-prone (no off-by-one risk, no duplicated string literal).

## What changed

- Added `"strings"` to the import block in `cmdrunner_test.go`.
- Replaced the manual length+slice check with `strings.HasPrefix(e, "AI_DAEMON_NUMBER=")`.

No behaviour change.