### PR TITLE
test(ai): add t.Parallel() to TestExtractJSON and its subtests

### DIFF
--- a/internal/ai/cmdrunner_test.go
+++ b/internal/ai/cmdrunner_test.go
@@ -50,6 +50,8 @@ func TestBuildCommandEnvDaemonNumber(t *testing.T) {
 }
 
 func TestExtractJSON(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		input   string
@@ -131,6 +133,7 @@ func TestExtractJSON(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := extractJSON([]byte(tt.input))
 			if tt.wantErr {
 				if err == nil {


### PR DESCRIPTION
## Why

`TestExtractJSON` is a 13-case table-driven test for a pure function
(`extractJSON` takes `[]byte`, returns `([]byte, error)`, touches no
shared state). It was the only table-driven test in the `ai` package
without `t.Parallel()` — `TestBuildCommandEnvDaemonNumber` next to it
already uses it for both the outer test and its subtests.

## What

- Add `t.Parallel()` to `TestExtractJSON` (outer).
- Add `t.Parallel()` to each subtest closure.

No logic changes. CI (`go test ./... -race`) will validate correctness.