### PR TITLE
test(autonomous): add t.Parallel() to MemoryStore tests

### DIFF
--- a/internal/autonomous/memory_test.go
+++ b/internal/autonomous/memory_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestMemoryStoreCreatesPerRepoMemory(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	store := NewMemoryStore(dir)
 	var capturedPath string
@@ -48,6 +49,7 @@ func TestMemoryStoreCreatesPerRepoMemory(t *testing.T) {
 }
 
 func TestMemoryStoreRejectsPathEscapes(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	store := NewMemoryStore(dir)
 	var path string


### PR DESCRIPTION
## Why

`TestMemoryStoreCreatesPerRepoMemory` and `TestMemoryStoreRejectsPathEscapes` are pure unit tests for a stateless function. Each test creates its own isolated directory via `t.TempDir()`, writes and reads only within that directory, and touches no env vars or global state. They are safe to run in parallel.

`scheduler_test.go` in the same package already calls `t.Parallel()` on all its tests — these two were the only outliers in `autonomous`.

## What

- Add `t.Parallel()` to `TestMemoryStoreCreatesPerRepoMemory`.
- Add `t.Parallel()` to `TestMemoryStoreRejectsPathEscapes`.

No logic changes.