### PR TITLE
test(config): remove pre-Go 1.22 loop variable captures

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -495,7 +495,6 @@ func TestLoadAcceptsValidLogLevels(t *testing.T) {
 
 	levels := []string{"trace", "debug", "info", "warn", "error", "fatal", "panic", "disabled", "DEBUG", "INFO", "", "\"  debug  \""}
 	for _, level := range levels {
-		level := level
 		t.Run("level="+level, func(t *testing.T) {
 			path := writeConfig(t, logLevelYAML(level))
 			if _, err := Load(path); err != nil {
@@ -543,7 +542,6 @@ func TestLoadAcceptsValidLogFormats(t *testing.T) {
 
 	formats := []string{"json", "text", "JSON", "TEXT", "", "\"  json  \""}
 	for _, format := range formats {
-		format := format
 		t.Run("format="+format, func(t *testing.T) {
 			path := writeConfig(t, logFormatYAML(format))
 			if _, err := Load(path); err != nil {


### PR DESCRIPTION
## Why

`TestLoadAcceptsValidLogLevels` (line 499) and `TestLoadAcceptsValidLogFormats` (line 546) in `internal/config/config_test.go` both contain `level := level` / `format := format` shadow assignments inside their `for` loops. These were the pre-Go 1.22 workaround for per-iteration variable capture in goroutines/closures.

Go 1.22 changed loop variable semantics so each iteration gets its own copy — the shadow is a no-op and dead code. The project is on Go 1.24 (go.mod). This is the same cleanup applied to `internal/webhook/server_test.go` in #111.

## What

- Remove `level := level` from `TestLoadAcceptsValidLogLevels`.
- Remove `format := format` from `TestLoadAcceptsValidLogFormats`.

No behaviour change. CI (`go test ./... -race`) will confirm.