### PR TITLE
test(workflow): add t.Parallel() to DataChannels tests

### DIFF
--- a/internal/workflow/data_channels_test.go
+++ b/internal/workflow/data_channels_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestPushAfterCloseReturnsErrQueueClosed(t *testing.T) {
+	t.Parallel()
 	dc := NewDataChannels(4, 4)
 	dc.Close()
 
@@ -19,12 +20,14 @@ func TestPushAfterCloseReturnsErrQueueClosed(t *testing.T) {
 }
 
 func TestDoubleCloseDoesNotPanic(t *testing.T) {
+	t.Parallel()
 	dc := NewDataChannels(4, 4)
 	dc.Close()
 	dc.Close() // must not panic
 }
 
 func TestConcurrentPushAndCloseDoesNotPanic(t *testing.T) {
+	t.Parallel()
 	dc := NewDataChannels(64, 64)
 	var wg sync.WaitGroup
 


### PR DESCRIPTION
## Why

`TestPushAfterCloseReturnsErrQueueClosed`, `TestDoubleCloseDoesNotPanic`, and `TestConcurrentPushAndCloseDoesNotPanic` each construct their own `DataChannels` instance via `NewDataChannels` and hold no shared state. Adding `t.Parallel()` lets the test scheduler run them concurrently, improves race-detector coverage, and keeps the file consistent with the rest of the test suite.

No logic changes — pure test scheduling.