### PR TITLE
refactor(workflow): replace containsLabel loop with slices.ContainsFunc

### DIFF
--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 
@@ -155,10 +156,7 @@ func (e *Engine) runAgent(ctx context.Context, repo string, number int, agent co
 
 func containsLabel(labels []string, target string) bool {
 	target = strings.ToLower(strings.TrimSpace(target))
-	for _, l := range labels {
-		if strings.ToLower(strings.TrimSpace(l)) == target {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(labels, func(l string) bool {
+		return strings.ToLower(strings.TrimSpace(l)) == target
+	})
 }


### PR DESCRIPTION
## Why

`containsLabel` in `internal/workflow/engine.go` uses a manual for-loop to search a `[]string` with a predicate — the exact pattern `slices.ContainsFunc` was introduced for in Go 1.21. This project targets Go 1.24, so the stdlib function is already available.

## What changed

- Replaced the 5-line manual loop with `slices.ContainsFunc` and a one-line predicate.
- Added `"slices"` to the import block.
- `"strings"` is kept — `strings.ToLower` / `strings.TrimSpace` are still used inside the predicate and elsewhere in the file.
- No behaviour change: the normalisation (trim + lower) is preserved inside the predicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)