### PR TITLE
test: add missing t.Parallel() to 3 independent tests

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -282,6 +282,7 @@ repos:
 }
 
 func TestBindingIsEnabledDefaultsTrue(t *testing.T) {
+	t.Parallel()
 	var b Binding
 	if !b.IsEnabled() {
 		t.Errorf("expected enabled by default")
@@ -294,6 +295,7 @@ func TestBindingIsEnabledDefaultsTrue(t *testing.T) {
 }
 
 func TestDefaultBackendPrefersFirstConfigured(t *testing.T) {
+	t.Parallel()
 	cfg := &Config{
 		Daemon: DaemonConfig{
 			AIBackends: map[string]AIBackendConfig{

--- a/internal/workflow/processor_test.go
+++ b/internal/workflow/processor_test.go
@@ -83,6 +83,7 @@ func TestProcessorProcessingCtxReturnsDrainContextWithDeadline(t *testing.T) {
 }
 
 func TestProcessorRunDrainsQueuesOnCancellation(t *testing.T) {
+	t.Parallel()
 	dataChannels := NewDataChannels(4, 4)
 	handler := &stubProcessorHandler{}
 	processor := NewProcessor(dataChannels, handler, 1, time.Second, zerolog.Nop())


### PR DESCRIPTION
## Why

Three tests were missing `t.Parallel()` despite having no shared state, no env-var dependencies, and no globals:

- `TestProcessorRunDrainsQueuesOnCancellation` (`internal/workflow/processor_test.go`) — creates its own local `DataChannels` and `Processor`; involves goroutines and a context-cancel flow, so parallel execution is especially useful for the race detector.
- `TestBindingIsEnabledDefaultsTrue` (`internal/config/config_test.go`) — pure zero-value struct test.
- `TestDefaultBackendPrefersFirstConfigured` (`internal/config/config_test.go`) — constructs a local `Config` value, no I/O.

Adding `t.Parallel()` lets the race detector catch hidden races earlier and reduces total suite wall time. No logic changes.

## What changed

Added one `t.Parallel()` call to each of the three tests listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)