### PR TITLE
refactor(config): replace isValidBackendName loop with slices.Contains

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -537,12 +538,7 @@ func (c *Config) validateRepos() error {
 }
 
 func isValidBackendName(name string) bool {
-	for _, v := range validAIBackendNames {
-		if v == name {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(validAIBackendNames, name)
 }
 
 func setDefault(dst *string, def string) {


### PR DESCRIPTION
## Why

`isValidBackendName` in `internal/config/config.go` uses a 6-line manual for-loop to search a fixed `[]string` — the exact pattern `slices.Contains` was introduced for in Go 1.21. This project targets Go 1.24, so the stdlib function is already available.

Consistent with the same refactor applied to `containsLabel` in `internal/workflow/engine.go` (PR #123).

## What changed

- Replaced the 6-line manual loop in `isValidBackendName` with `slices.Contains`.
- Added `"slices"` to the import block.
- No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)