### PR TITLE
refactor(autonomous): replace bound-check loop with slices.ContainsFunc

### DIFF
--- a/internal/autonomous/scheduler.go
+++ b/internal/autonomous/scheduler.go
@@ -3,6 +3,7 @@ package autonomous
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -224,14 +225,9 @@ func (s *Scheduler) TriggerAgent(ctx context.Context, agentName, repo string) er
 	}
 	// The agent must actually be bound to this repo (any trigger kind is
 	// sufficient for on-demand execution).
-	bound := false
-	for _, b := range repoDef.Use {
-		if b.Agent == agentName && b.IsEnabled() {
-			bound = true
-			break
-		}
-	}
-	if !bound {
+	if !slices.ContainsFunc(repoDef.Use, func(b config.Binding) bool {
+		return b.Agent == agentName && b.IsEnabled()
+	}) {
 		return fmt.Errorf("agent %q is not bound to repo %q", agentName, repo)
 	}
 	return s.executeAgentRun(ctx, repoDef.Name, agent)


### PR DESCRIPTION
## Why

`TriggerAgent` contains a classic bool-flag loop that checks whether any enabled binding in `repoDef.Use` references the requested agent:

```go
bound := false
for _, b := range repoDef.Use {
    if b.Agent == agentName && b.IsEnabled() {
        bound = true
        break
    }
}
if !bound {
    return fmt.Errorf(...)
}
```

This is the same pattern already removed from `engine.go` (#123) and `config.go` (#125). `slices.ContainsFunc` expresses the same predicate directly, eliminating the auxiliary variable and the early-return loop.

## Change

`internal/autonomous/scheduler.go` — replace the 6-line loop with a single `slices.ContainsFunc` guard; add `"slices"` to the import block.

No behaviour change.