### PR TITLE
test: remove loop variable captures re-introduced by #129

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -257,7 +257,6 @@ func TestLoadRejectsBindingWithMixedTriggers(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			repo := fmt.Sprintf(`
@@ -294,7 +293,6 @@ repos:
 func TestLoadAcceptsValidEventKinds(t *testing.T) {
 	t.Setenv("TEST_SECRET", "s3cret")
 	for kind := range validEventKinds {
-		kind := kind
 		t.Run(kind, func(t *testing.T) {
 			t.Parallel()
 			repo := fmt.Sprintf(`

--- a/internal/webhook/server_test.go
+++ b/internal/webhook/server_test.go
@@ -306,7 +306,6 @@ func TestHandlePullRequestClosedPayloadIncludesMerged(t *testing.T) {
 		{name: "non-merged close", merged: false, deliveryID: "d-pr-closed-ordinary"},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			server, dc := newTestServer(testCfg(nil))
@@ -500,7 +499,6 @@ func TestHandlePushIgnoresNonBranchRefs(t *testing.T) {
 		{name: "notes ref", ref: "refs/notes/commits", sha: "abc123"},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			server, dc := newTestServer(testCfg(nil))


### PR DESCRIPTION
## Why

PRs #111 and #116 deleted the pre-Go 1.22 `tc := tc` / `kind := kind`
loop-variable captures that became dead code once Go 1.22 made loop
variables per-iteration.

PR #129 (feat(workflow): support broader GitHub event types) added new
table-driven subtests in two files and inadvertently re-introduced four
of those same no-op captures:

| File | Line | Symbol |
|------|------|--------|
| `internal/config/config_test.go` | 260 | `tc := tc` |
| `internal/config/config_test.go` | 297 | `kind := kind` |
| `internal/webhook/server_test.go` | 309 | `tc := tc` |
| `internal/webhook/server_test.go` | 503 | `tc := tc` |

## What changed

Deleted the four redundant self-assignments. No logic changed;
`go test ./...` passes.