### PR TITLE
feat(proxy): built-in Anthropic↔OpenAI translation proxy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,7 @@ Multi-stage build on `node:22-alpine` so the image includes Claude Code, Codex, 
   - `GET /status` — JSON with uptime, queue depths, agent schedules
   - `POST /webhooks/github` — HMAC-verified webhook receiver
   - `POST /agents/run` — on-demand agent trigger (requires Bearer token)
+  - `POST /v1/messages` — Anthropic↔OpenAI translation proxy (disabled by default; enabled via `daemon.proxy.enabled: true`)
 - Relevant webhook events: `issues.labeled`, `pull_request.labeled`. Trigger label comes from `payload.label.name`.
 - Duplicate webhook suppression via `X-GitHub-Delivery` TTL cache.
 - Workflow execution is stateless in-process. Only autonomous agents persist memory (per-agent, per-repo markdown file under `memory_dir`).

--- a/README.md
+++ b/README.md
@@ -383,10 +383,40 @@ GitHub sends a ping immediately; the daemon will log the delivery.
 | `GET` | `/status` | none | Health check: JSON with uptime, queue depths, agent schedules |
 | `POST` | `/webhooks/github` | `X-Hub-Signature-256` HMAC | GitHub webhook receiver |
 | `POST` | `/agents/run` | `Authorization: Bearer <key>` | On-demand agent trigger |
+| `POST` | `/v1/messages` | none | Anthropic↔OpenAI translation proxy (opt-in via `proxy.enabled`) |
 
 The `/agents/run` body is `{"agent": "<name>", "repo": "owner/repo"}`. It blocks until the agent finishes. If `api_key_env` is not configured the endpoint returns `403 Forbidden`.
 
 Duplicate webhook deliveries are suppressed via `X-GitHub-Delivery` with a TTL cache.
+
+---
+
+## Local / OpenAI-compatible backends
+
+The daemon includes a built-in Anthropic Messages ↔ OpenAI Chat Completions translation proxy. Enable it to run the `claude` CLI against any OpenAI-compatible backend (Ollama, llama.cpp, vLLM, Qwen, etc.) without a separate sidecar.
+
+```yaml
+daemon:
+  proxy:
+    enabled: true
+    path: /v1/messages          # default; configurable
+    upstream:
+      url: http://localhost:8001/v1   # OpenAI-compat base URL
+      model: qwen3                    # model name sent upstream
+      api_key_env: LOCAL_LLM_API_KEY  # optional; omit if not required
+      timeout_seconds: 120
+      extra_body:                     # forwarded verbatim on every request
+        chat_template_kwargs:
+          enable_thinking: false
+```
+
+Then point the Claude CLI at the daemon:
+
+```bash
+ANTHROPIC_BASE_URL=http://localhost:8080 claude -p "Summarise the repo."
+```
+
+The proxy translates text turns, tool use / tool results, system messages, stop reasons, and usage counters. Streaming, vision, and prompt-caching control blocks are not supported in v1.
 
 ---
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -26,6 +26,23 @@ daemon:
 
   memory_dir: /var/lib/agents/memory            # persistent agent memory root
 
+  # Built-in Anthropic↔OpenAI translation proxy (disabled by default).
+  # Enable to run `ANTHROPIC_BASE_URL=http://localhost:8080 claude -p "hi"`
+  # against any OpenAI-compatible backend (llama.cpp, Ollama, vLLM, etc.)
+  # without a separate sidecar like LiteLLM.
+  #
+  # proxy:
+  #   enabled: false
+  #   path: /v1/messages          # path the claude CLI hits
+  #   upstream:
+  #     url: http://ts-vortex:8001/v1   # OpenAI-compat base URL
+  #     model: qwen3                    # model name forwarded upstream
+  #     api_key_env: LOCAL_LLM_API_KEY  # optional; empty if not required
+  #     timeout_seconds: 120
+  #     extra_body:                     # merged into every upstream request
+  #       chat_template_kwargs:
+  #         enable_thinking: false
+
   ai_backends:
     claude:
       command: claude

--- a/internal/anthropic_proxy/handler.go
+++ b/internal/anthropic_proxy/handler.go
@@ -1,0 +1,167 @@
+package anthropicproxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// UpstreamConfig holds the connection parameters for the OpenAI-compatible upstream.
+type UpstreamConfig struct {
+	URL       string
+	Model     string
+	APIKey    string
+	Timeout   time.Duration
+	ExtraBody map[string]any
+}
+
+// Handler is an HTTP handler that accepts Anthropic Messages API requests,
+// translates them to OpenAI Chat Completions, proxies them to an upstream, and
+// returns the response in Anthropic format.
+type Handler struct {
+	upstream UpstreamConfig
+	client   *http.Client
+	logger   zerolog.Logger
+}
+
+// NewHandler creates a Handler with the given upstream configuration.
+func NewHandler(upstream UpstreamConfig, logger zerolog.Logger) *Handler {
+	return &Handler{
+		upstream: upstream,
+		client:   &http.Client{Timeout: upstream.Timeout},
+		logger:   logger.With().Str("component", "anthropic_proxy").Logger(),
+	}
+}
+
+// ServeHTTP implements http.Handler.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, 4<<20)) // 4 MiB limit
+	if err != nil {
+		h.writeError(w, http.StatusBadRequest, "invalid_request_error", "failed to read request body")
+		return
+	}
+
+	var anthReq MessagesRequest
+	if err := json.Unmarshal(body, &anthReq); err != nil {
+		h.writeError(w, http.StatusBadRequest, "invalid_request_error", "malformed Anthropic request: "+err.Error())
+		return
+	}
+	if anthReq.MaxTokens <= 0 {
+		h.writeError(w, http.StatusBadRequest, "invalid_request_error", "max_tokens is required and must be positive")
+		return
+	}
+	if len(anthReq.Messages) == 0 {
+		h.writeError(w, http.StatusBadRequest, "invalid_request_error", "messages must not be empty")
+		return
+	}
+
+	oaiReq, err := ToOpenAI(anthReq, h.upstream.Model)
+	if err != nil {
+		h.writeError(w, http.StatusBadRequest, "invalid_request_error", "translation to OpenAI format failed: "+err.Error())
+		return
+	}
+
+	reqBody, err := h.marshalWithExtraBody(oaiReq)
+	if err != nil {
+		h.logger.Error().Err(err).Msg("failed to marshal upstream request")
+		h.writeError(w, http.StatusInternalServerError, "api_error", "internal marshalling error")
+		return
+	}
+
+	upstreamURL := h.upstream.URL + "/chat/completions"
+	upstreamReq, err := http.NewRequestWithContext(r.Context(), http.MethodPost, upstreamURL, bytes.NewReader(reqBody))
+	if err != nil {
+		h.logger.Error().Err(err).Msg("failed to build upstream request")
+		h.writeError(w, http.StatusInternalServerError, "api_error", "internal error building upstream request")
+		return
+	}
+	upstreamReq.Header.Set("Content-Type", "application/json")
+	if h.upstream.APIKey != "" {
+		upstreamReq.Header.Set("Authorization", "Bearer "+h.upstream.APIKey)
+	}
+
+	resp, err := h.client.Do(upstreamReq)
+	if err != nil {
+		h.logger.Error().Err(err).Str("url", upstreamURL).Msg("upstream request failed")
+		h.writeError(w, http.StatusBadGateway, "api_error", "upstream request failed: "+err.Error())
+		return
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20)) // 8 MiB limit
+	if err != nil {
+		h.logger.Error().Err(err).Msg("failed to read upstream response")
+		h.writeError(w, http.StatusBadGateway, "api_error", "failed to read upstream response")
+		return
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		h.logger.Error().Int("status", resp.StatusCode).Str("body", truncate(string(respBody), 200)).Msg("upstream error")
+		h.writeError(w, http.StatusBadGateway, "api_error", fmt.Sprintf("upstream returned status %d", resp.StatusCode))
+		return
+	}
+
+	var oaiResp ChatResponse
+	if err := json.Unmarshal(respBody, &oaiResp); err != nil {
+		h.logger.Error().Err(err).Msg("failed to parse upstream response")
+		h.writeError(w, http.StatusBadGateway, "api_error", "failed to parse upstream response")
+		return
+	}
+
+	anthResp, err := ToAnthropic(oaiResp, h.upstream.Model)
+	if err != nil {
+		h.logger.Error().Err(err).Msg("failed to translate upstream response to Anthropic format")
+		h.writeError(w, http.StatusBadGateway, "api_error", "response translation failed: "+err.Error())
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(anthResp)
+}
+
+// marshalWithExtraBody marshals req to JSON and then merges any extra_body
+// fields from the upstream config into the top-level object.
+func (h *Handler) marshalWithExtraBody(req ChatRequest) ([]byte, error) {
+	if len(h.upstream.ExtraBody) == 0 {
+		return json.Marshal(req)
+	}
+	// Round-trip through map[string]any so we can inject extra_body fields.
+	b, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, err
+	}
+	for k, v := range h.upstream.ExtraBody {
+		m[k] = v
+	}
+	return json.Marshal(m)
+}
+
+// writeError writes an Anthropic-shaped error response.
+func (h *Handler) writeError(w http.ResponseWriter, status int, errType, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(AnthropicError{
+		Type: "error",
+		Error: AnthropicErrorInner{
+			Type:    errType,
+			Message: msg,
+		},
+	})
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/internal/anthropic_proxy/handler_test.go
+++ b/internal/anthropic_proxy/handler_test.go
@@ -1,0 +1,204 @@
+package anthropicproxy
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// fakeUpstream returns an httptest.Server that responds with the given status
+// and body. It also captures the last request body and headers for assertions.
+type fakeUpstream struct {
+	*httptest.Server
+	status  int
+	body    string
+	lastReq *http.Request
+	lastBody []byte
+}
+
+func newFakeUpstream(status int, body string) *fakeUpstream {
+	f := &fakeUpstream{status: status, body: body}
+	f.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f.lastReq = r
+		f.lastBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	return f
+}
+
+func newHandler(upstream *fakeUpstream, extraBody map[string]any) *Handler {
+	return NewHandler(UpstreamConfig{
+		URL:       upstream.URL,
+		Model:     "test-model",
+		Timeout:   5 * time.Second,
+		ExtraBody: extraBody,
+	}, zerolog.Nop())
+}
+
+const oaiTextResp = `{
+  "id": "chatcmpl-1",
+  "object": "chat.completion",
+  "model": "test-model",
+  "choices": [{"index":0,"message":{"role":"assistant","content":"Hello!"},"finish_reason":"stop"}],
+  "usage": {"prompt_tokens":5,"completion_tokens":3,"total_tokens":8}
+}`
+
+func TestHandler_TextRequest(t *testing.T) {
+	t.Parallel()
+	up := newFakeUpstream(http.StatusOK, oaiTextResp)
+	defer up.Close()
+
+	h := newHandler(up, nil)
+	body := `{"model":"claude","max_tokens":100,"messages":[{"role":"user","content":"Hello!"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(body))
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	var resp MessagesResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.StopReason != "end_turn" {
+		t.Errorf("stop_reason: got %q, want %q", resp.StopReason, "end_turn")
+	}
+	if len(resp.Content) != 1 || resp.Content[0].Text != "Hello!" {
+		t.Errorf("content: got %+v", resp.Content)
+	}
+}
+
+func TestHandler_TranslationApplied(t *testing.T) {
+	t.Parallel()
+	up := newFakeUpstream(http.StatusOK, oaiTextResp)
+	defer up.Close()
+
+	h := newHandler(up, nil)
+	body := `{
+		"model":"claude","max_tokens":50,
+		"system":"You are a bot.",
+		"messages":[{"role":"user","content":"Hi"}]
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d", w.Code)
+	}
+
+	// Verify the upstream received the translated OpenAI request with system message.
+	var sentReq ChatRequest
+	if err := json.Unmarshal(up.lastBody, &sentReq); err != nil {
+		t.Fatalf("parse upstream body: %v", err)
+	}
+	if len(sentReq.Messages) != 2 {
+		t.Fatalf("upstream messages count: got %d, want 2", len(sentReq.Messages))
+	}
+	if sentReq.Messages[0].Role != "system" || sentReq.Messages[0].Content != "You are a bot." {
+		t.Errorf("upstream[0]: got %+v", sentReq.Messages[0])
+	}
+	if sentReq.Model != "test-model" {
+		t.Errorf("upstream model: got %q, want %q", sentReq.Model, "test-model")
+	}
+}
+
+func TestHandler_ExtraBodyInjected(t *testing.T) {
+	t.Parallel()
+	up := newFakeUpstream(http.StatusOK, oaiTextResp)
+	defer up.Close()
+
+	extra := map[string]any{
+		"chat_template_kwargs": map[string]any{"enable_thinking": false},
+	}
+	h := newHandler(up, extra)
+
+	body := `{"model":"claude","max_tokens":10,"messages":[{"role":"user","content":"hi"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d", w.Code)
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(up.lastBody, &m); err != nil {
+		t.Fatalf("parse upstream body: %v", err)
+	}
+	if _, ok := m["chat_template_kwargs"]; !ok {
+		t.Error("extra_body field 'chat_template_kwargs' not found in upstream request")
+	}
+}
+
+func TestHandler_Upstream500ReturnsBadGateway(t *testing.T) {
+	t.Parallel()
+	up := newFakeUpstream(http.StatusInternalServerError, `{"error":"server error"}`)
+	defer up.Close()
+
+	h := newHandler(up, nil)
+	body := `{"model":"claude","max_tokens":10,"messages":[{"role":"user","content":"hi"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("status: got %d, want 502", w.Code)
+	}
+	var errResp AnthropicError
+	if err := json.NewDecoder(w.Body).Decode(&errResp); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if errResp.Type != "error" {
+		t.Errorf("error type: got %q, want %q", errResp.Type, "error")
+	}
+}
+
+func TestHandler_MalformedRequest(t *testing.T) {
+	t.Parallel()
+	up := newFakeUpstream(http.StatusOK, oaiTextResp)
+	defer up.Close()
+
+	h := newHandler(up, nil)
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`not json`))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status: got %d, want 400", w.Code)
+	}
+	var errResp AnthropicError
+	if err := json.NewDecoder(w.Body).Decode(&errResp); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if errResp.Error.Type != "invalid_request_error" {
+		t.Errorf("error inner type: got %q, want %q", errResp.Error.Type, "invalid_request_error")
+	}
+}
+
+func TestHandler_MissingMaxTokensReturns400(t *testing.T) {
+	t.Parallel()
+	up := newFakeUpstream(http.StatusOK, oaiTextResp)
+	defer up.Close()
+
+	h := newHandler(up, nil)
+	// max_tokens omitted (zero value)
+	body := `{"model":"claude","messages":[{"role":"user","content":"hi"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status: got %d, want 400", w.Code)
+	}
+}

--- a/internal/anthropic_proxy/translate.go
+++ b/internal/anthropic_proxy/translate.go
@@ -70,16 +70,38 @@ func translateAnthropicMessage(msg AnthropicMessage) ([]ChatMessage, error) {
 	}
 }
 
-// translateUserMessage handles role:user Anthropic messages. Tool result blocks
-// are emitted as role:tool messages; remaining text is emitted as role:user.
+// translateUserMessage handles role:user Anthropic messages. Blocks are
+// emitted in their original order: text blocks become role:user messages
+// (consecutive text blocks are merged) and tool_result blocks become
+// role:tool messages, preserving mixed-content ordering.
 func translateUserMessage(text string, blocks []ContentBlock) ([]ChatMessage, error) {
+	// Plain string content (no block array) — emit as-is.
+	if len(blocks) == 0 {
+		if text != "" {
+			return []ChatMessage{{Role: "user", Content: text}}, nil
+		}
+		return []ChatMessage{{Role: "user"}}, nil
+	}
+
 	var out []ChatMessage
+	var pending string
+
+	flushText := func() {
+		if pending != "" {
+			out = append(out, ChatMessage{Role: "user", Content: pending})
+			pending = ""
+		}
+	}
 
 	for _, b := range blocks {
 		switch b.Type {
 		case "text":
-			// accumulated below
+			if pending != "" {
+				pending += "\n"
+			}
+			pending += b.Text
 		case "tool_result":
+			flushText()
 			content, err := toolResultContent(b.Content)
 			if err != nil {
 				return nil, fmt.Errorf("tool_result content: %w", err)
@@ -92,11 +114,11 @@ func translateUserMessage(text string, blocks []ContentBlock) ([]ChatMessage, er
 		}
 	}
 
-	if text != "" {
-		out = append([]ChatMessage{{Role: "user", Content: text}}, out...)
-	} else if len(out) == 0 {
+	flushText()
+
+	if len(out) == 0 {
 		// No text, no tool results — emit an empty user message to preserve turn order.
-		out = append(out, ChatMessage{Role: "user"})
+		return []ChatMessage{{Role: "user"}}, nil
 	}
 
 	return out, nil

--- a/internal/anthropic_proxy/translate.go
+++ b/internal/anthropic_proxy/translate.go
@@ -283,11 +283,14 @@ func toolResultContent(raw json.RawMessage) (string, error) {
 		}
 		var out string
 		for _, b := range blocks {
-			if b.Type == "text" {
+			switch b.Type {
+			case "text":
 				if out != "" {
 					out += "\n"
 				}
 				out += b.Text
+			default:
+				return "", fmt.Errorf("unsupported tool_result content block type %q", b.Type)
 			}
 		}
 		return out, nil

--- a/internal/anthropic_proxy/translate.go
+++ b/internal/anthropic_proxy/translate.go
@@ -128,7 +128,27 @@ func translateUserMessage(text string, blocks []ContentBlock) ([]ChatMessage, er
 
 // translateAssistantMessage handles role:assistant Anthropic messages.
 // Tool use blocks become OpenAI tool_calls; text blocks become the content.
+//
+// OpenAI's message schema places text in content and tool calls in tool_calls,
+// with no provision for interleaved ordering. Mixed turns where a text block
+// follows a tool_use block cannot be represented faithfully, so they are
+// rejected. Turns with leading text followed by tool_use blocks (the common
+// pattern) translate without loss.
 func translateAssistantMessage(text string, blocks []ContentBlock) ([]ChatMessage, error) {
+	// Detect interleaved text-after-tool_use ordering, which cannot be
+	// preserved in the OpenAI message shape.
+	seenToolUse := false
+	for _, b := range blocks {
+		switch b.Type {
+		case "tool_use":
+			seenToolUse = true
+		case "text":
+			if seenToolUse {
+				return nil, fmt.Errorf("unsupported assistant block ordering: text block follows tool_use block")
+			}
+		}
+	}
+
 	msg := ChatMessage{Role: "assistant", Content: text}
 
 	for _, b := range blocks {

--- a/internal/anthropic_proxy/translate.go
+++ b/internal/anthropic_proxy/translate.go
@@ -111,6 +111,8 @@ func translateUserMessage(text string, blocks []ContentBlock) ([]ChatMessage, er
 				ToolCallID: b.ToolUseID,
 				Content:    content,
 			})
+		default:
+			return nil, fmt.Errorf("unsupported user content block type %q", b.Type)
 		}
 	}
 
@@ -130,8 +132,14 @@ func translateAssistantMessage(text string, blocks []ContentBlock) ([]ChatMessag
 	msg := ChatMessage{Role: "assistant", Content: text}
 
 	for _, b := range blocks {
-		if b.Type != "tool_use" {
+		switch b.Type {
+		case "text":
+			// Already captured in the text parameter via parseContent; skip.
 			continue
+		case "tool_use":
+			// Handled below.
+		default:
+			return nil, fmt.Errorf("unsupported assistant content block type %q", b.Type)
 		}
 		args, err := rawJSONToString(b.Input)
 		if err != nil {

--- a/internal/anthropic_proxy/translate.go
+++ b/internal/anthropic_proxy/translate.go
@@ -1,0 +1,317 @@
+package anthropicproxy
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ToOpenAI translates an Anthropic MessagesRequest into an OpenAI ChatRequest
+// using the provided upstream model name. The Anthropic model field is ignored;
+// the caller supplies the model to use upstream.
+//
+// Translation rules (v1 scope):
+//   - Top-level system string → role:system message prepended to messages.
+//   - User/assistant text content → role:user / role:assistant with string content.
+//   - Assistant tool_use blocks → role:assistant with tool_calls.
+//   - User tool_result blocks → role:tool messages (one per block).
+//   - Tools: input_schema → parameters; type set to "function".
+func ToOpenAI(req MessagesRequest, upstreamModel string) (ChatRequest, error) {
+	out := ChatRequest{
+		Model:     upstreamModel,
+		MaxTokens: req.MaxTokens,
+	}
+
+	// System prompt becomes the first message.
+	if req.System != "" {
+		out.Messages = append(out.Messages, ChatMessage{
+			Role:    "system",
+			Content: req.System,
+		})
+	}
+
+	for i, msg := range req.Messages {
+		msgs, err := translateAnthropicMessage(msg)
+		if err != nil {
+			return ChatRequest{}, fmt.Errorf("message[%d]: %w", i, err)
+		}
+		out.Messages = append(out.Messages, msgs...)
+	}
+
+	for _, t := range req.Tools {
+		out.Tools = append(out.Tools, OAITool{
+			Type: "function",
+			Function: OAIFunction{
+				Name:        t.Name,
+				Description: t.Description,
+				Parameters:  t.InputSchema,
+			},
+		})
+	}
+
+	return out, nil
+}
+
+// translateAnthropicMessage converts one Anthropic message into zero or more
+// OpenAI messages. A user message containing tool_result blocks expands into
+// multiple role:tool messages (one per block).
+func translateAnthropicMessage(msg AnthropicMessage) ([]ChatMessage, error) {
+	blocks, text, err := parseContent(msg.Content)
+	if err != nil {
+		return nil, err
+	}
+
+	switch msg.Role {
+	case "user":
+		return translateUserMessage(text, blocks)
+	case "assistant":
+		return translateAssistantMessage(text, blocks)
+	default:
+		return nil, fmt.Errorf("unsupported role %q", msg.Role)
+	}
+}
+
+// translateUserMessage handles role:user Anthropic messages. Tool result blocks
+// are emitted as role:tool messages; remaining text is emitted as role:user.
+func translateUserMessage(text string, blocks []ContentBlock) ([]ChatMessage, error) {
+	var out []ChatMessage
+
+	for _, b := range blocks {
+		switch b.Type {
+		case "text":
+			// accumulated below
+		case "tool_result":
+			content, err := toolResultContent(b.Content)
+			if err != nil {
+				return nil, fmt.Errorf("tool_result content: %w", err)
+			}
+			out = append(out, ChatMessage{
+				Role:       "tool",
+				ToolCallID: b.ToolUseID,
+				Content:    content,
+			})
+		}
+	}
+
+	if text != "" {
+		out = append([]ChatMessage{{Role: "user", Content: text}}, out...)
+	} else if len(out) == 0 {
+		// No text, no tool results — emit an empty user message to preserve turn order.
+		out = append(out, ChatMessage{Role: "user"})
+	}
+
+	return out, nil
+}
+
+// translateAssistantMessage handles role:assistant Anthropic messages.
+// Tool use blocks become OpenAI tool_calls; text blocks become the content.
+func translateAssistantMessage(text string, blocks []ContentBlock) ([]ChatMessage, error) {
+	msg := ChatMessage{Role: "assistant", Content: text}
+
+	for _, b := range blocks {
+		if b.Type != "tool_use" {
+			continue
+		}
+		args, err := rawJSONToString(b.Input)
+		if err != nil {
+			return nil, fmt.Errorf("tool_use input: %w", err)
+		}
+		msg.ToolCalls = append(msg.ToolCalls, ToolCall{
+			ID:   b.ID,
+			Type: "function",
+			Function: ToolCallFunction{
+				Name:      b.Name,
+				Arguments: args,
+			},
+		})
+	}
+
+	return []ChatMessage{msg}, nil
+}
+
+// ToAnthropic translates an OpenAI ChatResponse back to Anthropic MessagesResponse
+// shape. Only the first choice is used. The upstream model name is reflected in
+// the response.
+//
+// Translation rules (v1 scope):
+//   - Text content → type:text content block.
+//   - tool_calls → type:tool_use content blocks; arguments JSON string → input object.
+//   - finish_reason: stop → stop_reason: end_turn.
+//   - finish_reason: length → stop_reason: max_tokens.
+//   - finish_reason: tool_calls → stop_reason: tool_use.
+//   - usage: prompt_tokens/completion_tokens → input_tokens/output_tokens.
+func ToAnthropic(resp ChatResponse, upstreamModel string) (MessagesResponse, error) {
+	out := MessagesResponse{
+		ID:    resp.ID,
+		Type:  "message",
+		Role:  "assistant",
+		Model: upstreamModel,
+		Usage: AnthropicUsage{
+			InputTokens:  resp.Usage.PromptTokens,
+			OutputTokens: resp.Usage.CompletionTokens,
+		},
+	}
+
+	if len(resp.Choices) == 0 {
+		out.StopReason = "end_turn"
+		return out, nil
+	}
+
+	choice := resp.Choices[0]
+	out.StopReason = translateFinishReason(choice.FinishReason)
+
+	if choice.Message.Content != "" {
+		out.Content = append(out.Content, ContentBlock{
+			Type: "text",
+			Text: choice.Message.Content,
+		})
+	}
+
+	for _, tc := range choice.Message.ToolCalls {
+		input, err := stringToRawJSON(tc.Function.Arguments)
+		if err != nil {
+			return MessagesResponse{}, fmt.Errorf("tool_call arguments: %w", err)
+		}
+		out.Content = append(out.Content, ContentBlock{
+			Type:  "tool_use",
+			ID:    tc.ID,
+			Name:  tc.Function.Name,
+			Input: input,
+		})
+	}
+
+	if len(out.Content) == 0 {
+		out.Content = []ContentBlock{}
+	}
+
+	return out, nil
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+// parseContent decodes the Anthropic content field. Content can be a JSON
+// string (returns it as text with no blocks) or a JSON array of ContentBlock.
+// Text blocks in an array are concatenated with newlines.
+func parseContent(raw json.RawMessage) (blocks []ContentBlock, text string, err error) {
+	if len(raw) == 0 {
+		return nil, "", nil
+	}
+
+	// Peek at the first non-whitespace byte to determine type.
+	first := firstNonSpace(raw)
+	switch first {
+	case '"':
+		var s string
+		if err := json.Unmarshal(raw, &s); err != nil {
+			return nil, "", fmt.Errorf("parse string content: %w", err)
+		}
+		return nil, s, nil
+	case '[':
+		if err := json.Unmarshal(raw, &blocks); err != nil {
+			return nil, "", fmt.Errorf("parse content array: %w", err)
+		}
+		for _, b := range blocks {
+			if b.Type == "text" {
+				if text != "" {
+					text += "\n"
+				}
+				text += b.Text
+			}
+		}
+		return blocks, text, nil
+	default:
+		return nil, "", fmt.Errorf("unexpected content type (first byte: %q)", first)
+	}
+}
+
+func firstNonSpace(b []byte) byte {
+	for _, c := range b {
+		if c != ' ' && c != '\t' && c != '\n' && c != '\r' {
+			return c
+		}
+	}
+	return 0
+}
+
+// toolResultContent extracts the string content from a tool_result block.
+// The content field can be a JSON string or an array of content blocks.
+func toolResultContent(raw json.RawMessage) (string, error) {
+	if len(raw) == 0 {
+		return "", nil
+	}
+	first := firstNonSpace(raw)
+	switch first {
+	case '"':
+		var s string
+		if err := json.Unmarshal(raw, &s); err != nil {
+			return "", fmt.Errorf("parse tool_result string: %w", err)
+		}
+		return s, nil
+	case '[':
+		var blocks []ContentBlock
+		if err := json.Unmarshal(raw, &blocks); err != nil {
+			return "", fmt.Errorf("parse tool_result blocks: %w", err)
+		}
+		var out string
+		for _, b := range blocks {
+			if b.Type == "text" {
+				if out != "" {
+					out += "\n"
+				}
+				out += b.Text
+			}
+		}
+		return out, nil
+	default:
+		return "", fmt.Errorf("unexpected tool_result content type (first byte: %q)", first)
+	}
+}
+
+// rawJSONToString marshal a raw JSON value to its string representation.
+// Used to convert Anthropic tool input (raw JSON object) to OpenAI function
+// arguments (JSON-encoded string).
+func rawJSONToString(raw json.RawMessage) (string, error) {
+	if len(raw) == 0 {
+		return "{}", nil
+	}
+	// Validate that the raw JSON is valid before round-tripping.
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return "", fmt.Errorf("invalid tool input JSON: %w", err)
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "", fmt.Errorf("re-marshal tool input: %w", err)
+	}
+	return string(b), nil
+}
+
+// stringToRawJSON parses a JSON string (OpenAI function arguments) into a
+// raw JSON value (Anthropic tool input).
+func stringToRawJSON(s string) (json.RawMessage, error) {
+	if s == "" {
+		return json.RawMessage("{}"), nil
+	}
+	var v any
+	if err := json.Unmarshal([]byte(s), &v); err != nil {
+		return nil, fmt.Errorf("parse function arguments: %w", err)
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshal function arguments: %w", err)
+	}
+	return json.RawMessage(b), nil
+}
+
+// translateFinishReason maps an OpenAI finish_reason to an Anthropic stop_reason.
+func translateFinishReason(reason string) string {
+	switch reason {
+	case "stop":
+		return "end_turn"
+	case "length":
+		return "max_tokens"
+	case "tool_calls":
+		return "tool_use"
+	default:
+		return "end_turn"
+	}
+}

--- a/internal/anthropic_proxy/translate_test.go
+++ b/internal/anthropic_proxy/translate_test.go
@@ -412,6 +412,44 @@ func jsonBlocks(blocks []ContentBlock) json.RawMessage {
 	return json.RawMessage(b)
 }
 
+// TestToOpenAI_UnsupportedUserBlock verifies that a user turn containing an
+// unsupported content block type (e.g. "image") returns a translation error
+// rather than silently dropping the block.
+func TestToOpenAI_UnsupportedUserBlock(t *testing.T) {
+	t.Parallel()
+	req := MessagesRequest{
+		Messages: []AnthropicMessage{
+			{
+				Role:    "user",
+				Content: jsonBlocks([]ContentBlock{{Type: "image", Text: ""}}),
+			},
+		},
+	}
+	_, err := ToOpenAI(req, "gpt-4")
+	if err == nil {
+		t.Fatal("expected error for unsupported user block type, got nil")
+	}
+}
+
+// TestToOpenAI_UnsupportedAssistantBlock verifies that an assistant turn
+// containing an unsupported content block type (e.g. "thinking") returns a
+// translation error rather than silently dropping the block.
+func TestToOpenAI_UnsupportedAssistantBlock(t *testing.T) {
+	t.Parallel()
+	req := MessagesRequest{
+		Messages: []AnthropicMessage{
+			{
+				Role:    "assistant",
+				Content: jsonBlocks([]ContentBlock{{Type: "thinking", Text: "some chain of thought"}}),
+			},
+		},
+	}
+	_, err := ToOpenAI(req, "gpt-4")
+	if err == nil {
+		t.Fatal("expected error for unsupported assistant block type, got nil")
+	}
+}
+
 func assertMsg(t *testing.T, msg ChatMessage, role, content string, toolCalls []ToolCall) {
 	t.Helper()
 	if msg.Role != role {

--- a/internal/anthropic_proxy/translate_test.go
+++ b/internal/anthropic_proxy/translate_test.go
@@ -450,6 +450,30 @@ func TestToOpenAI_UnsupportedAssistantBlock(t *testing.T) {
 	}
 }
 
+// TestToOpenAI_UnsupportedToolResultBlock verifies that a tool_result whose
+// content array contains an unsupported nested block type (e.g. "image")
+// returns a translation error rather than silently dropping the block and
+// producing lossy/partial text content.
+func TestToOpenAI_UnsupportedToolResultBlock(t *testing.T) {
+	t.Parallel()
+	// tool_result with a content array that includes an image block.
+	toolResultContent := json.RawMessage(`[{"type":"image","source":{"type":"base64","media_type":"image/png","data":"abc"}}]`)
+	req := MessagesRequest{
+		Messages: []AnthropicMessage{
+			{
+				Role: "user",
+				Content: jsonBlocks([]ContentBlock{
+					{Type: "tool_result", ToolUseID: "tc_1", Content: toolResultContent},
+				}),
+			},
+		},
+	}
+	_, err := ToOpenAI(req, "gpt-4")
+	if err == nil {
+		t.Fatal("expected error for unsupported tool_result nested block type, got nil")
+	}
+}
+
 func assertMsg(t *testing.T, msg ChatMessage, role, content string, toolCalls []ToolCall) {
 	t.Helper()
 	if msg.Role != role {

--- a/internal/anthropic_proxy/translate_test.go
+++ b/internal/anthropic_proxy/translate_test.go
@@ -1,0 +1,388 @@
+package anthropicproxy
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// ── ToOpenAI ──────────────────────────────────────────────────────────────────
+
+func TestToOpenAI_TextOnly(t *testing.T) {
+	t.Parallel()
+	req := MessagesRequest{
+		Model:     "claude-3-5-sonnet-20241022",
+		MaxTokens: 100,
+		Messages: []AnthropicMessage{
+			{Role: "user", Content: jsonStr("Hello!")},
+			{Role: "assistant", Content: jsonStr("Hi there!")},
+		},
+	}
+
+	got, err := ToOpenAI(req, "qwen")
+	if err != nil {
+		t.Fatalf("ToOpenAI: %v", err)
+	}
+	if got.Model != "qwen" {
+		t.Errorf("model: got %q, want %q", got.Model, "qwen")
+	}
+	if got.MaxTokens != 100 {
+		t.Errorf("max_tokens: got %d, want 100", got.MaxTokens)
+	}
+	if len(got.Messages) != 2 {
+		t.Fatalf("message count: got %d, want 2", len(got.Messages))
+	}
+	assertMsg(t, got.Messages[0], "user", "Hello!", nil)
+	assertMsg(t, got.Messages[1], "assistant", "Hi there!", nil)
+}
+
+func TestToOpenAI_SystemMessage(t *testing.T) {
+	t.Parallel()
+	req := MessagesRequest{
+		Model:     "claude",
+		MaxTokens: 50,
+		System:    "You are a helpful assistant.",
+		Messages: []AnthropicMessage{
+			{Role: "user", Content: jsonStr("Hi")},
+		},
+	}
+
+	got, err := ToOpenAI(req, "llama")
+	if err != nil {
+		t.Fatalf("ToOpenAI: %v", err)
+	}
+	if len(got.Messages) != 2 {
+		t.Fatalf("message count: got %d, want 2", len(got.Messages))
+	}
+	assertMsg(t, got.Messages[0], "system", "You are a helpful assistant.", nil)
+	assertMsg(t, got.Messages[1], "user", "Hi", nil)
+}
+
+func TestToOpenAI_ToolUse(t *testing.T) {
+	t.Parallel()
+	toolInput := json.RawMessage(`{"location":"Paris","unit":"celsius"}`)
+	req := MessagesRequest{
+		MaxTokens: 200,
+		Messages: []AnthropicMessage{
+			{Role: "user", Content: jsonStr("What's the weather in Paris?")},
+			{
+				Role: "assistant",
+				Content: jsonBlocks([]ContentBlock{
+					{Type: "tool_use", ID: "tu_001", Name: "get_weather", Input: toolInput},
+				}),
+			},
+		},
+	}
+
+	got, err := ToOpenAI(req, "qwen")
+	if err != nil {
+		t.Fatalf("ToOpenAI: %v", err)
+	}
+	if len(got.Messages) != 2 {
+		t.Fatalf("message count: got %d, want 2", len(got.Messages))
+	}
+	asst := got.Messages[1]
+	if asst.Role != "assistant" {
+		t.Errorf("role: got %q, want %q", asst.Role, "assistant")
+	}
+	if len(asst.ToolCalls) != 1 {
+		t.Fatalf("tool_calls count: got %d, want 1", len(asst.ToolCalls))
+	}
+	tc := asst.ToolCalls[0]
+	if tc.ID != "tu_001" {
+		t.Errorf("tool_call id: got %q, want %q", tc.ID, "tu_001")
+	}
+	if tc.Function.Name != "get_weather" {
+		t.Errorf("function name: got %q, want %q", tc.Function.Name, "get_weather")
+	}
+	if tc.Function.Arguments != `{"location":"Paris","unit":"celsius"}` {
+		t.Errorf("function arguments: got %q, want canonical JSON", tc.Function.Arguments)
+	}
+}
+
+func TestToOpenAI_ToolResult(t *testing.T) {
+	t.Parallel()
+	req := MessagesRequest{
+		MaxTokens: 200,
+		Messages: []AnthropicMessage{
+			{
+				Role: "user",
+				Content: jsonBlocks([]ContentBlock{
+					{
+						Type:      "tool_result",
+						ToolUseID: "tu_001",
+						Content:   json.RawMessage(`"22°C, partly cloudy"`),
+					},
+				}),
+			},
+		},
+	}
+
+	got, err := ToOpenAI(req, "qwen")
+	if err != nil {
+		t.Fatalf("ToOpenAI: %v", err)
+	}
+	if len(got.Messages) != 1 {
+		t.Fatalf("message count: got %d, want 1", len(got.Messages))
+	}
+	toolMsg := got.Messages[0]
+	if toolMsg.Role != "tool" {
+		t.Errorf("role: got %q, want %q", toolMsg.Role, "tool")
+	}
+	if toolMsg.ToolCallID != "tu_001" {
+		t.Errorf("tool_call_id: got %q, want %q", toolMsg.ToolCallID, "tu_001")
+	}
+	if toolMsg.Content != "22°C, partly cloudy" {
+		t.Errorf("content: got %q, want %q", toolMsg.Content, "22°C, partly cloudy")
+	}
+}
+
+func TestToOpenAI_MultiTurnWithTools(t *testing.T) {
+	t.Parallel()
+	toolInput := json.RawMessage(`{"q":"go channels"}`)
+	req := MessagesRequest{
+		MaxTokens: 500,
+		System:    "You are a coding assistant.",
+		Messages: []AnthropicMessage{
+			{Role: "user", Content: jsonStr("Search for Go channels docs.")},
+			{
+				Role: "assistant",
+				Content: jsonBlocks([]ContentBlock{
+					{Type: "text", Text: "Let me search for that."},
+					{Type: "tool_use", ID: "tc_1", Name: "search", Input: toolInput},
+				}),
+			},
+			{
+				Role: "user",
+				Content: jsonBlocks([]ContentBlock{
+					{Type: "tool_result", ToolUseID: "tc_1", Content: json.RawMessage(`"Go channels are..."`)}},
+				),
+			},
+			{Role: "assistant", Content: jsonStr("Based on the search results...")},
+		},
+	}
+
+	got, err := ToOpenAI(req, "qwen")
+	if err != nil {
+		t.Fatalf("ToOpenAI: %v", err)
+	}
+	// system + 4 anthropic messages, but tool_result expands to role:tool message
+	// system, user, assistant(tool_calls), tool, assistant
+	if len(got.Messages) != 5 {
+		t.Fatalf("message count: got %d, want 5: %+v", len(got.Messages), got.Messages)
+	}
+	if got.Messages[0].Role != "system" {
+		t.Errorf("[0] role: got %q", got.Messages[0].Role)
+	}
+	if got.Messages[1].Role != "user" {
+		t.Errorf("[1] role: got %q", got.Messages[1].Role)
+	}
+	if got.Messages[2].Role != "assistant" || len(got.Messages[2].ToolCalls) == 0 {
+		t.Errorf("[2] expected assistant with tool_calls, got role=%q tool_calls=%v", got.Messages[2].Role, got.Messages[2].ToolCalls)
+	}
+	if got.Messages[3].Role != "tool" {
+		t.Errorf("[3] role: got %q, want %q", got.Messages[3].Role, "tool")
+	}
+	if got.Messages[4].Role != "assistant" {
+		t.Errorf("[4] role: got %q", got.Messages[4].Role)
+	}
+}
+
+func TestToOpenAI_ToolDefinitions(t *testing.T) {
+	t.Parallel()
+	schema := json.RawMessage(`{"type":"object","properties":{"q":{"type":"string"}},"required":["q"]}`)
+	req := MessagesRequest{
+		MaxTokens: 100,
+		Messages:  []AnthropicMessage{{Role: "user", Content: jsonStr("hi")}},
+		Tools: []AnthropicTool{
+			{Name: "search", Description: "Search the web", InputSchema: schema},
+		},
+	}
+
+	got, err := ToOpenAI(req, "qwen")
+	if err != nil {
+		t.Fatalf("ToOpenAI: %v", err)
+	}
+	if len(got.Tools) != 1 {
+		t.Fatalf("tools count: got %d, want 1", len(got.Tools))
+	}
+	tool := got.Tools[0]
+	if tool.Type != "function" {
+		t.Errorf("tool type: got %q, want %q", tool.Type, "function")
+	}
+	if tool.Function.Name != "search" {
+		t.Errorf("tool name: got %q, want %q", tool.Function.Name, "search")
+	}
+	if tool.Function.Description != "Search the web" {
+		t.Errorf("tool description: got %q", tool.Function.Description)
+	}
+	if string(tool.Function.Parameters) != string(schema) {
+		t.Errorf("parameters: got %s, want %s", tool.Function.Parameters, schema)
+	}
+}
+
+// ── ToAnthropic ───────────────────────────────────────────────────────────────
+
+func TestToAnthropic_TextOnly(t *testing.T) {
+	t.Parallel()
+	resp := ChatResponse{
+		ID:    "chatcmpl-abc",
+		Model: "qwen",
+		Choices: []Choice{
+			{
+				Index:        0,
+				FinishReason: "stop",
+				Message:      ChatMessage{Role: "assistant", Content: "Hello!"},
+			},
+		},
+		Usage: OAIUsage{PromptTokens: 10, CompletionTokens: 5},
+	}
+
+	got, err := ToAnthropic(resp, "qwen")
+	if err != nil {
+		t.Fatalf("ToAnthropic: %v", err)
+	}
+	if got.StopReason != "end_turn" {
+		t.Errorf("stop_reason: got %q, want %q", got.StopReason, "end_turn")
+	}
+	if len(got.Content) != 1 || got.Content[0].Type != "text" || got.Content[0].Text != "Hello!" {
+		t.Errorf("content: got %+v", got.Content)
+	}
+	if got.Usage.InputTokens != 10 || got.Usage.OutputTokens != 5 {
+		t.Errorf("usage: got %+v", got.Usage)
+	}
+	if got.Model != "qwen" {
+		t.Errorf("model: got %q", got.Model)
+	}
+}
+
+func TestToAnthropic_ToolCalls(t *testing.T) {
+	t.Parallel()
+	resp := ChatResponse{
+		ID: "chatcmpl-xyz",
+		Choices: []Choice{
+			{
+				FinishReason: "tool_calls",
+				Message: ChatMessage{
+					Role: "assistant",
+					ToolCalls: []ToolCall{
+						{
+							ID:   "call_1",
+							Type: "function",
+							Function: ToolCallFunction{
+								Name:      "get_weather",
+								Arguments: `{"location":"Tokyo"}`,
+							},
+						},
+					},
+				},
+			},
+		},
+		Usage: OAIUsage{PromptTokens: 20, CompletionTokens: 15},
+	}
+
+	got, err := ToAnthropic(resp, "qwen")
+	if err != nil {
+		t.Fatalf("ToAnthropic: %v", err)
+	}
+	if got.StopReason != "tool_use" {
+		t.Errorf("stop_reason: got %q, want %q", got.StopReason, "tool_use")
+	}
+	if len(got.Content) != 1 {
+		t.Fatalf("content count: got %d, want 1", len(got.Content))
+	}
+	block := got.Content[0]
+	if block.Type != "tool_use" || block.ID != "call_1" || block.Name != "get_weather" {
+		t.Errorf("tool_use block: %+v", block)
+	}
+	if string(block.Input) != `{"location":"Tokyo"}` {
+		t.Errorf("input: got %s, want %s", block.Input, `{"location":"Tokyo"}`)
+	}
+}
+
+func TestToAnthropic_StopReasonTable(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		finishReason string
+		wantStop     string
+	}{
+		{"stop", "end_turn"},
+		{"length", "max_tokens"},
+		{"tool_calls", "tool_use"},
+		{"content_filter", "end_turn"}, // unknown → end_turn
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.finishReason, func(t *testing.T) {
+			t.Parallel()
+			resp := ChatResponse{
+				Choices: []Choice{
+					{FinishReason: tc.finishReason, Message: ChatMessage{Role: "assistant", Content: "ok"}},
+				},
+			}
+			got, err := ToAnthropic(resp, "m")
+			if err != nil {
+				t.Fatalf("ToAnthropic: %v", err)
+			}
+			if got.StopReason != tc.wantStop {
+				t.Errorf("finish_reason %q: got stop_reason %q, want %q", tc.finishReason, got.StopReason, tc.wantStop)
+			}
+		})
+	}
+}
+
+func TestToAnthropic_UsageCounters(t *testing.T) {
+	t.Parallel()
+	resp := ChatResponse{
+		Choices: []Choice{
+			{FinishReason: "stop", Message: ChatMessage{Role: "assistant", Content: "done"}},
+		},
+		Usage: OAIUsage{PromptTokens: 100, CompletionTokens: 42, TotalTokens: 142},
+	}
+	got, err := ToAnthropic(resp, "m")
+	if err != nil {
+		t.Fatalf("ToAnthropic: %v", err)
+	}
+	if got.Usage.InputTokens != 100 {
+		t.Errorf("input_tokens: got %d, want 100", got.Usage.InputTokens)
+	}
+	if got.Usage.OutputTokens != 42 {
+		t.Errorf("output_tokens: got %d, want 42", got.Usage.OutputTokens)
+	}
+}
+
+func TestToAnthropic_EmptyChoices(t *testing.T) {
+	t.Parallel()
+	resp := ChatResponse{}
+	got, err := ToAnthropic(resp, "m")
+	if err != nil {
+		t.Fatalf("ToAnthropic: %v", err)
+	}
+	if got.StopReason != "end_turn" {
+		t.Errorf("stop_reason: got %q, want %q", got.StopReason, "end_turn")
+	}
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func jsonStr(s string) json.RawMessage {
+	b, _ := json.Marshal(s)
+	return json.RawMessage(b)
+}
+
+func jsonBlocks(blocks []ContentBlock) json.RawMessage {
+	b, _ := json.Marshal(blocks)
+	return json.RawMessage(b)
+}
+
+func assertMsg(t *testing.T, msg ChatMessage, role, content string, toolCalls []ToolCall) {
+	t.Helper()
+	if msg.Role != role {
+		t.Errorf("role: got %q, want %q", msg.Role, role)
+	}
+	if msg.Content != content {
+		t.Errorf("content: got %q, want %q", msg.Content, content)
+	}
+	if len(toolCalls) == 0 && len(msg.ToolCalls) != 0 {
+		t.Errorf("expected no tool_calls, got %d", len(msg.ToolCalls))
+	}
+}

--- a/internal/anthropic_proxy/translate_test.go
+++ b/internal/anthropic_proxy/translate_test.go
@@ -187,6 +187,44 @@ func TestToOpenAI_MultiTurnWithTools(t *testing.T) {
 	}
 }
 
+func TestToOpenAI_MixedUserTurnOrder(t *testing.T) {
+	t.Parallel()
+	// A user turn with [tool_result, text] must produce [role:tool, role:user],
+	// not [role:user, role:tool] as the old "prepend text" logic did.
+	req := MessagesRequest{
+		MaxTokens: 100,
+		Messages: []AnthropicMessage{
+			{
+				Role: "user",
+				Content: jsonBlocks([]ContentBlock{
+					{Type: "tool_result", ToolUseID: "tc_1", Content: json.RawMessage(`"result text"`)},
+					{Type: "text", Text: "Follow-up question."},
+				}),
+			},
+		},
+	}
+
+	got, err := ToOpenAI(req, "qwen")
+	if err != nil {
+		t.Fatalf("ToOpenAI: %v", err)
+	}
+	if len(got.Messages) != 2 {
+		t.Fatalf("message count: got %d, want 2: %+v", len(got.Messages), got.Messages)
+	}
+	if got.Messages[0].Role != "tool" {
+		t.Errorf("[0] role: got %q, want %q", got.Messages[0].Role, "tool")
+	}
+	if got.Messages[0].ToolCallID != "tc_1" {
+		t.Errorf("[0] tool_call_id: got %q, want %q", got.Messages[0].ToolCallID, "tc_1")
+	}
+	if got.Messages[1].Role != "user" {
+		t.Errorf("[1] role: got %q, want %q", got.Messages[1].Role, "user")
+	}
+	if got.Messages[1].Content != "Follow-up question." {
+		t.Errorf("[1] content: got %q", got.Messages[1].Content)
+	}
+}
+
 func TestToOpenAI_ToolDefinitions(t *testing.T) {
 	t.Parallel()
 	schema := json.RawMessage(`{"type":"object","properties":{"q":{"type":"string"}},"required":["q"]}`)

--- a/internal/anthropic_proxy/translate_test.go
+++ b/internal/anthropic_proxy/translate_test.go
@@ -450,6 +450,64 @@ func TestToOpenAI_UnsupportedAssistantBlock(t *testing.T) {
 	}
 }
 
+// TestToOpenAI_InterleavedAssistantBlocks verifies that an assistant turn with
+// a text block following a tool_use block is rejected. OpenAI's message schema
+// cannot represent this ordering without data loss, so the proxy must fail fast
+// rather than silently reorder the content.
+func TestToOpenAI_InterleavedAssistantBlocks(t *testing.T) {
+	t.Parallel()
+	toolInput := json.RawMessage(`{"key":"val"}`)
+	// Pattern: text("before"), tool_use(A), text("after") — trailing text after tool_use.
+	req := MessagesRequest{
+		Messages: []AnthropicMessage{
+			{
+				Role: "assistant",
+				Content: jsonBlocks([]ContentBlock{
+					{Type: "text", Text: "before"},
+					{Type: "tool_use", ID: "tu_1", Name: "my_tool", Input: toolInput},
+					{Type: "text", Text: "after"},
+				}),
+			},
+		},
+	}
+	_, err := ToOpenAI(req, "gpt-4")
+	if err == nil {
+		t.Fatal("expected error for interleaved text/tool_use ordering, got nil")
+	}
+}
+
+// TestToOpenAI_LeadingTextThenToolUseIsValid verifies that the common pattern
+// of text-then-tool_use (non-interleaved) translates without error.
+func TestToOpenAI_LeadingTextThenToolUseIsValid(t *testing.T) {
+	t.Parallel()
+	toolInput := json.RawMessage(`{}`)
+	req := MessagesRequest{
+		Messages: []AnthropicMessage{
+			{
+				Role: "assistant",
+				Content: jsonBlocks([]ContentBlock{
+					{Type: "text", Text: "Let me call the tool."},
+					{Type: "tool_use", ID: "tu_1", Name: "do_it", Input: toolInput},
+				}),
+			},
+		},
+	}
+	got, err := ToOpenAI(req, "gpt-4")
+	if err != nil {
+		t.Fatalf("unexpected error for valid text-then-tool_use turn: %v", err)
+	}
+	if len(got.Messages) != 1 {
+		t.Fatalf("message count: got %d, want 1", len(got.Messages))
+	}
+	msg := got.Messages[0]
+	if msg.Content != "Let me call the tool." {
+		t.Errorf("content: got %q, want %q", msg.Content, "Let me call the tool.")
+	}
+	if len(msg.ToolCalls) != 1 {
+		t.Errorf("tool_calls count: got %d, want 1", len(msg.ToolCalls))
+	}
+}
+
 // TestToOpenAI_UnsupportedToolResultBlock verifies that a tool_result whose
 // content array contains an unsupported nested block type (e.g. "image")
 // returns a translation error rather than silently dropping the block and

--- a/internal/anthropic_proxy/types.go
+++ b/internal/anthropic_proxy/types.go
@@ -1,0 +1,149 @@
+// Package anthropicproxy provides a translation layer between the Anthropic
+// Messages API and OpenAI Chat Completions API, plus an HTTP handler that
+// accepts Anthropic-format requests and proxies them to any OpenAI-compatible
+// upstream.
+//
+// Only non-streaming text and tool-use turns are covered (v1 scope). Streaming,
+// vision, prompt-caching control blocks, and extended thinking are out of scope.
+package anthropicproxy
+
+import "encoding/json"
+
+// ── Anthropic Messages API ────────────────────────────────────────────────────
+
+// MessagesRequest is the body of POST /v1/messages (Anthropic format).
+type MessagesRequest struct {
+	Model     string              `json:"model"`
+	MaxTokens int                 `json:"max_tokens"`
+	System    string              `json:"system,omitempty"`
+	Messages  []AnthropicMessage  `json:"messages"`
+	Tools     []AnthropicTool     `json:"tools,omitempty"`
+}
+
+// AnthropicMessage is a single turn in the Anthropic message array.
+// Content is either a JSON string or a JSON array of ContentBlock.
+type AnthropicMessage struct {
+	Role    string          `json:"role"`
+	Content json.RawMessage `json:"content"`
+}
+
+// ContentBlock is one element of the content array in an AnthropicMessage.
+type ContentBlock struct {
+	Type string `json:"type"`
+
+	// type == "text"
+	Text string `json:"text,omitempty"`
+
+	// type == "tool_use"
+	ID    string          `json:"id,omitempty"`
+	Name  string          `json:"name,omitempty"`
+	Input json.RawMessage `json:"input,omitempty"`
+
+	// type == "tool_result"
+	ToolUseID string          `json:"tool_use_id,omitempty"`
+	Content   json.RawMessage `json:"content,omitempty"` // string or array
+}
+
+// AnthropicTool describes a tool available to the model (Anthropic format).
+type AnthropicTool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	InputSchema json.RawMessage `json:"input_schema"`
+}
+
+// MessagesResponse is the Anthropic-format response returned to the client.
+type MessagesResponse struct {
+	ID           string         `json:"id"`
+	Type         string         `json:"type"`
+	Role         string         `json:"role"`
+	Content      []ContentBlock `json:"content"`
+	Model        string         `json:"model"`
+	StopReason   string         `json:"stop_reason"`
+	StopSequence *string        `json:"stop_sequence"`
+	Usage        AnthropicUsage `json:"usage"`
+}
+
+// AnthropicUsage carries token counts in the Anthropic response shape.
+type AnthropicUsage struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+}
+
+// AnthropicError is the Anthropic-format error body returned to the client.
+type AnthropicError struct {
+	Type  string              `json:"type"`
+	Error AnthropicErrorInner `json:"error"`
+}
+
+// AnthropicErrorInner holds the error type and human-readable message.
+type AnthropicErrorInner struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+}
+
+// ── OpenAI Chat Completions API ───────────────────────────────────────────────
+
+// ChatRequest is the body sent to the OpenAI-compatible upstream.
+type ChatRequest struct {
+	Model     string        `json:"model"`
+	MaxTokens int           `json:"max_tokens"`
+	Messages  []ChatMessage `json:"messages"`
+	Tools     []OAITool     `json:"tools,omitempty"`
+}
+
+// ChatMessage is one message in the OpenAI messages array.
+type ChatMessage struct {
+	Role       string     `json:"role"`
+	Content    string     `json:"content,omitempty"`
+	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string     `json:"tool_call_id,omitempty"`
+}
+
+// ToolCall is one function call inside an assistant ChatMessage.
+type ToolCall struct {
+	ID       string           `json:"id"`
+	Type     string           `json:"type"` // always "function"
+	Function ToolCallFunction `json:"function"`
+}
+
+// ToolCallFunction holds the function name and its JSON-encoded arguments.
+type ToolCallFunction struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"` // JSON string (not raw JSON)
+}
+
+// OAITool is a tool definition in the OpenAI format.
+type OAITool struct {
+	Type     string      `json:"type"` // always "function"
+	Function OAIFunction `json:"function"`
+}
+
+// OAIFunction is the function definition inside an OAITool.
+type OAIFunction struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Parameters  json.RawMessage `json:"parameters"`
+}
+
+// ChatResponse is the response from the OpenAI-compatible upstream.
+type ChatResponse struct {
+	ID      string   `json:"id"`
+	Object  string   `json:"object"`
+	Model   string   `json:"model"`
+	Choices []Choice `json:"choices"`
+	Usage   OAIUsage `json:"usage"`
+}
+
+// Choice is one generation choice in the OpenAI response.
+type Choice struct {
+	Index        int         `json:"index"`
+	Message      ChatMessage `json:"message"`
+	FinishReason string      `json:"finish_reason"`
+}
+
+// OAIUsage carries token counts in the OpenAI response shape.
+type OAIUsage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,6 +65,9 @@ const (
 	defaultMaxPromptChars   = 12000
 
 	defaultMemoryDir = "/var/lib/agents/memory"
+
+	defaultProxyPath           = "/v1/messages"
+	defaultProxyTimeoutSeconds = 120
 )
 
 // Config is the root configuration loaded from YAML.
@@ -87,6 +90,28 @@ type DaemonConfig struct {
 	Processor  ProcessorConfig            `yaml:"processor"`
 	MemoryDir  string                     `yaml:"memory_dir"`
 	AIBackends map[string]AIBackendConfig `yaml:"ai_backends"`
+	Proxy      ProxyConfig                `yaml:"proxy"`
+}
+
+// ProxyConfig controls the built-in Anthropic↔OpenAI translation proxy.
+// When Enabled is false (the default) no additional route is mounted.
+type ProxyConfig struct {
+	Enabled  bool              `yaml:"enabled"`
+	Path     string            `yaml:"path"`
+	Upstream ProxyUpstreamConfig `yaml:"upstream"`
+}
+
+// ProxyUpstreamConfig describes the OpenAI-compatible endpoint the proxy
+// forwards requests to.
+type ProxyUpstreamConfig struct {
+	URL            string         `yaml:"url"`
+	Model          string         `yaml:"model"`
+	APIKeyEnv      string         `yaml:"api_key_env"`
+	TimeoutSeconds int            `yaml:"timeout_seconds"`
+	ExtraBody      map[string]any `yaml:"extra_body"`
+
+	// APIKey is resolved from APIKeyEnv at load time and is not present in YAML.
+	APIKey string `yaml:"-"`
 }
 
 // LogConfig controls daemon logging output.
@@ -293,6 +318,10 @@ func (c *Config) applyDefaults() {
 	setDefaultInt(&c.Daemon.Processor.EventQueueBuffer, defaultEventQueueBufferSize)
 	setDefaultInt(&c.Daemon.Processor.MaxConcurrentAgents, defaultMaxConcurrentAgents)
 
+	// daemon.proxy defaults (only applied when proxy is enabled or path is set)
+	setDefault(&c.Daemon.Proxy.Path, defaultProxyPath)
+	setDefaultInt(&c.Daemon.Proxy.Upstream.TimeoutSeconds, defaultProxyTimeoutSeconds)
+
 	// daemon.ai_backends defaults
 	for name, backend := range c.Daemon.AIBackends {
 		if backend.TimeoutSeconds == 0 {
@@ -375,6 +404,9 @@ func (c *Config) resolveSecrets() {
 	if c.Daemon.HTTP.APIKey == "" && c.Daemon.HTTP.APIKeyEnv != "" {
 		c.Daemon.HTTP.APIKey = os.Getenv(c.Daemon.HTTP.APIKeyEnv)
 	}
+	if c.Daemon.Proxy.Upstream.APIKey == "" && c.Daemon.Proxy.Upstream.APIKeyEnv != "" {
+		c.Daemon.Proxy.Upstream.APIKey = os.Getenv(c.Daemon.Proxy.Upstream.APIKeyEnv)
+	}
 }
 
 // loadPromptFiles reads any prompt_file references in skills and agents,
@@ -443,7 +475,30 @@ func (c *Config) validate() error {
 	if err := c.validateAgents(); err != nil {
 		return err
 	}
+	if err := c.validateProxy(); err != nil {
+		return err
+	}
 	return c.validateRepos()
+}
+
+func (c *Config) validateProxy() error {
+	p := c.Daemon.Proxy
+	if !p.Enabled {
+		return nil
+	}
+	if p.Upstream.URL == "" {
+		return errors.New("config: proxy.upstream.url is required when proxy.enabled is true")
+	}
+	if p.Upstream.Model == "" {
+		return errors.New("config: proxy.upstream.model is required when proxy.enabled is true")
+	}
+	if !strings.HasPrefix(p.Path, "/") {
+		return fmt.Errorf("config: proxy.path must start with '/', got %q", p.Path)
+	}
+	if p.Upstream.TimeoutSeconds <= 0 {
+		return fmt.Errorf("config: proxy.upstream.timeout_seconds must be positive, got %d", p.Upstream.TimeoutSeconds)
+	}
+	return nil
 }
 
 var validLogLevels = map[string]struct{}{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -498,6 +498,12 @@ func (c *Config) validateProxy() error {
 	if p.Upstream.TimeoutSeconds <= 0 {
 		return fmt.Errorf("config: proxy.upstream.timeout_seconds must be positive, got %d", p.Upstream.TimeoutSeconds)
 	}
+	// When an api_key_env is configured, the variable must resolve at startup so
+	// that a missing or mis-spelled env var fails fast rather than producing
+	// silent 401/403 errors against a protected upstream at request time.
+	if p.Upstream.APIKeyEnv != "" && p.Upstream.APIKey == "" {
+		return fmt.Errorf("config: proxy.upstream.api_key_env %q is set but the environment variable is empty or unset", p.Upstream.APIKeyEnv)
+	}
 	return nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -607,3 +607,152 @@ func TestLoadAcceptsValidLogFormats(t *testing.T) {
 		})
 	}
 }
+
+// ── proxy config ───────────────────────────────────────────────────────────────
+
+func proxyYAML(proxyBlock string) string {
+	return fmt.Sprintf(`
+daemon:
+  http:
+    webhook_secret_env: TEST_SECRET
+  ai_backends:
+    claude:
+      command: claude
+      args: ["-p"]
+  proxy:
+%s
+
+agents:
+  - name: reviewer
+    backend: claude
+    prompt: "You review PRs."
+
+repos:
+  - name: "owner/repo"
+    enabled: true
+    use:
+      - agent: reviewer
+        labels: ["ai:review"]
+`, proxyBlock)
+}
+
+func TestProxyDisabledByDefault(t *testing.T) {
+	t.Setenv("TEST_SECRET", "s3cret")
+	path := writeConfig(t, minimalYAML(""))
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Daemon.Proxy.Enabled {
+		t.Error("proxy should be disabled by default")
+	}
+}
+
+func TestProxyDefaultsApplied(t *testing.T) {
+	t.Setenv("TEST_SECRET", "s3cret")
+	path := writeConfig(t, minimalYAML(""))
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Daemon.Proxy.Path != defaultProxyPath {
+		t.Errorf("proxy path default: got %q, want %q", cfg.Daemon.Proxy.Path, defaultProxyPath)
+	}
+	if cfg.Daemon.Proxy.Upstream.TimeoutSeconds != defaultProxyTimeoutSeconds {
+		t.Errorf("proxy timeout default: got %d, want %d", cfg.Daemon.Proxy.Upstream.TimeoutSeconds, defaultProxyTimeoutSeconds)
+	}
+}
+
+func TestProxyValidConfigLoads(t *testing.T) {
+	t.Setenv("TEST_SECRET", "s3cret")
+	t.Setenv("LLM_KEY", "key-abc")
+	block := `
+    enabled: true
+    upstream:
+      url: http://localhost:8001/v1
+      model: qwen
+      api_key_env: LLM_KEY
+      timeout_seconds: 60`
+	path := writeConfig(t, proxyYAML(block))
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.Daemon.Proxy.Enabled {
+		t.Error("proxy not enabled")
+	}
+	if cfg.Daemon.Proxy.Upstream.URL != "http://localhost:8001/v1" {
+		t.Errorf("upstream url: got %q", cfg.Daemon.Proxy.Upstream.URL)
+	}
+	if cfg.Daemon.Proxy.Upstream.Model != "qwen" {
+		t.Errorf("upstream model: got %q", cfg.Daemon.Proxy.Upstream.Model)
+	}
+	if cfg.Daemon.Proxy.Upstream.APIKey != "key-abc" {
+		t.Errorf("upstream api key not resolved: got %q", cfg.Daemon.Proxy.Upstream.APIKey)
+	}
+	if cfg.Daemon.Proxy.Upstream.TimeoutSeconds != 60 {
+		t.Errorf("upstream timeout: got %d", cfg.Daemon.Proxy.Upstream.TimeoutSeconds)
+	}
+}
+
+func TestProxyValidationErrors(t *testing.T) {
+	t.Setenv("TEST_SECRET", "s3cret")
+
+	tests := []struct {
+		name       string
+		block      string
+		wantErrMsg string
+	}{
+		{
+			name: "missing url",
+			block: `
+    enabled: true
+    upstream:
+      model: qwen`,
+			wantErrMsg: "config: proxy.upstream.url is required when proxy.enabled is true",
+		},
+		{
+			name: "missing model",
+			block: `
+    enabled: true
+    upstream:
+      url: http://localhost:8001/v1`,
+			wantErrMsg: "config: proxy.upstream.model is required when proxy.enabled is true",
+		},
+		{
+			name: "path without slash",
+			block: `
+    enabled: true
+    path: v1/messages
+    upstream:
+      url: http://localhost:8001/v1
+      model: qwen`,
+			wantErrMsg: `config: proxy.path must start with '/', got "v1/messages"`,
+		},
+		{
+			name: "non-positive timeout",
+			block: `
+    enabled: true
+    upstream:
+      url: http://localhost:8001/v1
+      model: qwen
+      timeout_seconds: -1`,
+			wantErrMsg: "config: proxy.upstream.timeout_seconds must be positive, got -1",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path := writeConfig(t, proxyYAML(tc.block))
+			_, err := Load(path)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if err.Error() != tc.wantErrMsg {
+				t.Errorf("error: got %q, want %q", err.Error(), tc.wantErrMsg)
+			}
+		})
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -739,6 +739,16 @@ func TestProxyValidationErrors(t *testing.T) {
       timeout_seconds: -1`,
 			wantErrMsg: "config: proxy.upstream.timeout_seconds must be positive, got -1",
 		},
+		{
+			name: "api_key_env set but variable unset",
+			block: `
+    enabled: true
+    upstream:
+      url: http://localhost:8001/v1
+      model: qwen
+      api_key_env: MISSING_LLM_KEY`,
+			wantErrMsg: `config: proxy.upstream.api_key_env "MISSING_LLM_KEY" is set but the environment variable is empty or unset`,
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/webhook/server.go
+++ b/internal/webhook/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/rs/zerolog"
 
+	"github.com/eloylp/agents/internal/anthropic_proxy"
 	"github.com/eloylp/agents/internal/config"
 	"github.com/eloylp/agents/internal/workflow"
 )
@@ -54,10 +55,11 @@ type Server struct {
 	provider  StatusProvider
 	startTime time.Time
 	triggerer AgentTriggerer
+	proxy     *anthropicproxy.Handler
 }
 
 func NewServer(cfg *config.Config, delivery *DeliveryStore, channels EventQueue, provider StatusProvider, logger zerolog.Logger, triggerer AgentTriggerer) *Server {
-	return &Server{
+	s := &Server{
 		cfg:       cfg,
 		delivery:  delivery,
 		logger:    logger.With().Str("component", "webhook_server").Logger(),
@@ -66,6 +68,17 @@ func NewServer(cfg *config.Config, delivery *DeliveryStore, channels EventQueue,
 		startTime: time.Now(),
 		triggerer: triggerer,
 	}
+	if cfg.Daemon.Proxy.Enabled {
+		up := cfg.Daemon.Proxy.Upstream
+		s.proxy = anthropicproxy.NewHandler(anthropicproxy.UpstreamConfig{
+			URL:       up.URL,
+			Model:     up.Model,
+			APIKey:    up.APIKey,
+			Timeout:   time.Duration(up.TimeoutSeconds) * time.Second,
+			ExtraBody: up.ExtraBody,
+		}, logger)
+	}
+	return s
 }
 
 func (s *Server) Run(ctx context.Context) error {
@@ -73,6 +86,10 @@ func (s *Server) Run(ctx context.Context) error {
 	router.HandleFunc(s.cfg.Daemon.HTTP.StatusPath, s.handleStatus).Methods(http.MethodGet)
 	router.HandleFunc(s.cfg.Daemon.HTTP.WebhookPath, s.handleGitHubWebhook).Methods(http.MethodPost)
 	router.HandleFunc(s.cfg.Daemon.HTTP.AgentsRunPath, s.handleAgentsRun).Methods(http.MethodPost)
+	if s.proxy != nil {
+		router.Handle(s.cfg.Daemon.Proxy.Path, s.proxy).Methods(http.MethodPost)
+		s.logger.Info().Str("path", s.cfg.Daemon.Proxy.Path).Str("upstream", s.cfg.Daemon.Proxy.Upstream.URL).Msg("anthropic proxy enabled")
+	}
 
 	srv := &http.Server{
 		Addr:         s.cfg.Daemon.HTTP.ListenAddr,
@@ -93,7 +110,11 @@ func (s *Server) Run(ctx context.Context) error {
 		errCh <- srv.Shutdown(shutdownCtx)
 	}()
 
-	s.logger.Info().Str("addr", s.cfg.Daemon.HTTP.ListenAddr).Str("status_path", s.cfg.Daemon.HTTP.StatusPath).Str("webhook_path", s.cfg.Daemon.HTTP.WebhookPath).Str("agents_run_path", s.cfg.Daemon.HTTP.AgentsRunPath).Msg("starting webhook server")
+	logEvent := s.logger.Info().Str("addr", s.cfg.Daemon.HTTP.ListenAddr).Str("status_path", s.cfg.Daemon.HTTP.StatusPath).Str("webhook_path", s.cfg.Daemon.HTTP.WebhookPath).Str("agents_run_path", s.cfg.Daemon.HTTP.AgentsRunPath)
+	if s.proxy != nil {
+		logEvent = logEvent.Str("proxy_path", s.cfg.Daemon.Proxy.Path)
+	}
+	logEvent.Msg("starting webhook server")
 	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return err
 	}


### PR DESCRIPTION
## Summary

- New package `internal/anthropic_proxy/` with pure translation functions (`ToOpenAI`, `ToAnthropic`) and an HTTP handler. Covers text turns, tool use/result blocks, system messages, stop-reason mapping, and usage counters.
- Config: `daemon.proxy` section (disabled by default). Validated at load time — URL and model required when enabled, path must start with `/`, timeout must be positive, API key resolved from env.
- Server: `NewServer` builds and mounts the proxy handler when `proxy.enabled: true`.
- Docs: README "Local / OpenAI-compatible backends" section, CLAUDE.md HTTP endpoint list, `config.example.yaml` commented proxy block.

## Test plan

- [ ] `go test ./... -race` green
- [ ] `TestToOpenAI_*` and `TestToAnthropic_*` cover text, system, tool use, tool result, multi-turn, stop reasons, and usage counters
- [ ] `TestHandler_*` covers happy path, translation applied, extra_body injection, upstream 500 → 502, malformed request → 400, missing max_tokens → 400
- [ ] `TestProxy*` config tests cover defaults, valid load with api_key_env resolution, and validation errors (missing url, missing model, bad path, non-positive timeout)

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)