### PR TITLE
refactor(config): precompute sorted event kinds list for error messages

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,6 +46,17 @@ var validEventKinds = map[string]struct{}{
 	"push":                                  {},
 }
 
+// validEventKindsSorted is a precomputed, sorted list of validEventKinds keys
+// for use in human-readable error messages.
+var validEventKindsSorted = func() []string {
+	ks := make([]string, 0, len(validEventKinds))
+	for k := range validEventKinds {
+		ks = append(ks, k)
+	}
+	slices.Sort(ks)
+	return ks
+}()
+
 const (
 	defaultHTTPListenAddr          = ":8080"
 	defaultHTTPStatusPath          = "/status"
@@ -610,7 +621,7 @@ func (c *Config) validateRepos() error {
 			if _, ok := c.AgentByName(b.Agent); !ok {
 				return fmt.Errorf("config: repo %q: binding references unknown agent %q", r.Name, b.Agent)
 			}
-			if !b.IsCron() && !b.IsLabel() && len(b.Events) == 0 {
+			if !b.IsCron() && !b.IsLabel() && !b.IsEvent() {
 				return fmt.Errorf("config: repo %q: binding for agent %q has no trigger (set cron, labels, or events)", r.Name, b.Agent)
 			}
 			triggerCount := 0
@@ -628,13 +639,8 @@ func (c *Config) validateRepos() error {
 			}
 			for _, kind := range b.Events {
 				if _, ok := validEventKinds[kind]; !ok {
-					supported := make([]string, 0, len(validEventKinds))
-					for k := range validEventKinds {
-						supported = append(supported, k)
-					}
-					slices.Sort(supported)
 					return fmt.Errorf("config: repo %q: binding for agent %q has unknown event kind %q (supported: %s)",
-						r.Name, b.Agent, kind, strings.Join(supported, ", "))
+						r.Name, b.Agent, kind, strings.Join(validEventKindsSorted, ", "))
 				}
 			}
 		}


### PR DESCRIPTION
## Why

`validateRepos` was rebuilding the supported event kinds list from the
`validEventKinds` map inside the error path of a loop over `b.Events`:

```go
for _, kind := range b.Events {
    if _, ok := validEventKinds[kind]; !ok {
        supported := make([]string, 0, len(validEventKinds))
        for k := range validEventKinds {
            supported = append(supported, k)
        }
        slices.Sort(supported)
        return fmt.Errorf("... (supported: %s)", strings.Join(supported, ", "))
    }
}
```

`validEventKinds` is a constant package-level map that never changes at
runtime, so the sorted key slice can be computed once at package init time
— exactly as `validAIBackendNames` is already a precomputed sorted slice.

## What changed

- Added `validEventKindsSorted []string` computed once via an init-time
  function literal, adjacent to `validEventKinds`.
- Replaced the 5-line inline construction in `validateRepos` with a
  reference to `validEventKindsSorted`.
- Replaced the inconsistent `len(b.Events) == 0` check with `!b.IsEvent()`
  to match the `IsLabel` / `IsCron` methods used in the same block.

No behaviour changed; `go test ./...` passes.