### PR TITLE
refactor(ai): replace manual sort.Strings key loop with slices.Sorted(maps.Keys(...))

### DIFF
--- a/internal/ai/prompt.go
+++ b/internal/ai/prompt.go
@@ -2,8 +2,9 @@ package ai
 
 import (
 	"fmt"
+	"maps"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/eloylp/agents/internal/config"
@@ -82,12 +83,7 @@ func renderRuntimeContext(ctx PromptContext) string {
 	}
 	if len(ctx.Payload) > 0 {
 		// Sort keys for deterministic output.
-		keys := make([]string, 0, len(ctx.Payload))
-		for k := range ctx.Payload {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-		for _, k := range keys {
+		for _, k := range slices.Sorted(maps.Keys(ctx.Payload)) {
 			v := ctx.Payload[k]
 			if s, ok := v.(string); ok && strings.Contains(s, "\n") {
 				fmt.Fprintf(&b, "%s:\n", k)


### PR DESCRIPTION
## Why

`renderRuntimeContext` in `internal/ai/prompt.go` was collecting map keys
into a slice, calling `sort.Strings`, then ranging over the result — a
four-step pattern for a sorted-key iteration:

```go
keys := make([]string, 0, len(ctx.Payload))
for k := range ctx.Payload {
    keys = append(keys, k)
}
sort.Strings(keys)
for _, k := range keys {
```

Go 1.23 added `maps.Keys` (returns `iter.Seq[K]`) and `slices.Sorted`
(collects + sorts an iterator) to the standard library. Since the module
targets Go 1.24, these are available and collapse the four lines to one:

```go
for _, k := range slices.Sorted(maps.Keys(ctx.Payload)) {
```

This drops the now-unused `"sort"` import and is consistent with `slices`
already used throughout the codebase (e.g. `slices.ContainsFunc`,
`slices.Sort`, `slices.Contains` in config, engine, scheduler).

## Change

- `internal/ai/prompt.go`: replace manual key-collection + `sort.Strings`
  with `slices.Sorted(maps.Keys(ctx.Payload))`; swap `"sort"` import for
  `"maps"` + `"slices"`

No behaviour change — output order is identical (both sort ascending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)