### PR TITLE
test: remove two stray pre-Go 1.22 loop captures

### DIFF
--- a/internal/anthropic_proxy/translate_test.go
+++ b/internal/anthropic_proxy/translate_test.go
@@ -349,7 +349,6 @@ func TestToAnthropic_StopReasonTable(t *testing.T) {
 		{"content_filter", "end_turn"}, // unknown → end_turn
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.finishReason, func(t *testing.T) {
 			t.Parallel()
 			resp := ChatResponse{

--- a/internal/webhook/server_test.go
+++ b/internal/webhook/server_test.go
@@ -223,7 +223,6 @@ func TestHandleIssuesEventDropsPRLabeledAction(t *testing.T) {
 func TestHandleIssuesEventDropsPRLifecycleActions(t *testing.T) {
 	t.Parallel()
 	for _, action := range []string{"opened", "edited", "reopened", "closed"} {
-		action := action
 		t.Run(action, func(t *testing.T) {
 			t.Parallel()
 			server, dc := newTestServer(testCfg(nil))


### PR DESCRIPTION
## Why

`#136` swept out pre-Go 1.22 loop-capture self-assignments from several test files, but two instances were missed:

- `tc := tc` in `TestToAnthropic_StopReasonTable` (`internal/anthropic_proxy/translate_test.go:352`)
- `action := action` in `TestHandleIssuesEventDropsPRLifecycleActions` (`internal/webhook/server_test.go:226`)

Since Go 1.22 each range iteration has its own copy of the loop variable, so these self-assignments are dead code. The subtests already call `t.Parallel()` and work correctly without them.

## Change

Two one-line deletions; no logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)