### PR TITLE
refactor(workflow): replace containsStr helper with slices.Contains

### DIFF
--- a/internal/workflow/dispatch.go
+++ b/internal/workflow/dispatch.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -409,7 +410,7 @@ func (d *Dispatcher) ProcessDispatches(
 		}
 
 		// Whitelist check: originator's CanDispatch must include the target.
-		if !containsStr(originator.CanDispatch, req.Agent) {
+		if !slices.Contains(originator.CanDispatch, req.Agent) {
 			logBase.Warn().Msg("dispatch dropped: target not in originator's can_dispatch whitelist")
 			d.counters.droppedNoWhitelist.Add(1)
 			continue
@@ -552,16 +553,6 @@ func (d *Dispatcher) FinalizeAutonomousRun(agentName, repo string) {
 // Stats returns a snapshot of the current dispatch counters.
 func (d *Dispatcher) Stats() DispatchStats {
 	return d.counters.snapshot()
-}
-
-// containsStr reports whether slice contains s.
-func containsStr(slice []string, s string) bool {
-	for _, v := range slice {
-		if v == s {
-			return true
-		}
-	}
-	return false
 }
 
 // sanitizeName lowercases and trims a name for safe comparison.


### PR DESCRIPTION
## Why

`containsStr` in `internal/workflow/dispatch.go` was a private helper that exactly reimplements `slices.Contains` from the stdlib. It had a single call site and added no value over the stdlib function.

## What changed

- Added `slices` to the import block.
- Replaced the one `containsStr(...)` call with `slices.Contains(...)` directly.
- Deleted the now-unused `containsStr` helper (9 lines gone).

No behaviour change.