### PR TITLE
refactor(config): convert validLogLevels map to slice for consistency

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -507,14 +507,11 @@ func (c *Config) validateProxy() error {
 	return nil
 }
 
-var validLogLevels = map[string]struct{}{
-	"trace": {}, "debug": {}, "info": {}, "warn": {},
-	"error": {}, "fatal": {}, "panic": {}, "disabled": {},
-}
+var validLogLevels = []string{"trace", "debug", "info", "warn", "error", "fatal", "panic", "disabled"}
 
 func (c *Config) validateLogConfig() error {
 	if c.Daemon.Log.Level != "" {
-		if _, ok := validLogLevels[c.Daemon.Log.Level]; !ok {
+		if !slices.Contains(validLogLevels, c.Daemon.Log.Level) {
 			return fmt.Errorf("config: invalid log level %q (supported: trace, debug, info, warn, error, fatal, panic, disabled)", c.Daemon.Log.Level)
 		}
 	}


### PR DESCRIPTION
## Why

`validAIBackendNames` is already a `[]string` checked with `slices.Contains`.
`validLogLevels` was the odd one out: a `map[string]struct{}` used solely for
membership testing. The map buys nothing here — 8 fixed strings, called once at
startup validation.

## What changed

`internal/config/config.go`:
- `var validLogLevels = map[string]struct{}{...}` → `[]string{...}`
- `if _, ok := validLogLevels[level]; !ok` → `if !slices.Contains(validLogLevels, level)`

No imports added or removed — `slices` is already in use in this file.
No behavior change; all existing tests pass.