### PR TITLE
refactor(proxy): replace one-caller joinNonEmpty helper with strings.Join + slices.DeleteFunc

### DIFF
--- a/internal/anthropic_proxy/translate.go
+++ b/internal/anthropic_proxy/translate.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"slices"
+	"strings"
 )
 
 // ToOpenAI translates an Anthropic MessagesRequest into an OpenAI ChatRequest
@@ -270,24 +272,10 @@ func systemToString(raw json.RawMessage) (string, error) {
 			}
 			parts = append(parts, b.Text)
 		}
-		return joinNonEmpty(parts, "\n\n"), nil
+		return strings.Join(slices.DeleteFunc(parts, func(s string) bool { return s == "" }), "\n\n"), nil
 	default:
 		return "", fmt.Errorf("system must be a string or an array of content blocks")
 	}
-}
-
-func joinNonEmpty(parts []string, sep string) string {
-	var out string
-	for _, p := range parts {
-		if p == "" {
-			continue
-		}
-		if out != "" {
-			out += sep
-		}
-		out += p
-	}
-	return out
 }
 
 // ── helpers ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Why

`joinNonEmpty` in `internal/anthropic_proxy/translate.go` was a 12-line custom loop with a single call site (`systemToString`). It reimplemented what the stdlib already provides: filter a slice then join it.

## What changed

Removed `joinNonEmpty` and replaced its one call site with:

```go
strings.Join(slices.DeleteFunc(parts, func(s string) bool { return s == "" }), "\n\n")
```

No behaviour change — `slices.DeleteFunc` filters in the same order, and `strings.Join` produces identical output.

## Scope

- 1 file touched (`internal/anthropic_proxy/translate.go`)
- 3 lines added, 15 deleted (net −12)