### PR TITLE
refactor(workflow): extract BuildRoster to eliminate Engine/Scheduler duplicate

### DIFF
--- a/internal/autonomous/scheduler.go
+++ b/internal/autonomous/scheduler.go
@@ -294,7 +294,7 @@ func (s *Scheduler) executeAgentRun(ctx context.Context, repo string, agent conf
 	}
 
 	logger := s.logger.With().Str("repo", repo).Str("agent", agent.Name).Str("backend", backend).Logger()
-	roster := s.buildRoster(repo, agent.Name)
+	roster := workflow.BuildRoster(s.cfg, repo, agent.Name)
 	// runCompleted is set to true once runner.Run returns successfully. The cron
 	// mark should only be rolled back when the autonomous pass itself fails
 	// (prompt rendering, memory lock, or runner error). A post-run failure such
@@ -364,37 +364,6 @@ func (s *Scheduler) executeAgentRun(ctx context.Context, repo string, agent conf
 		}
 	}
 	return err
-}
-
-// buildRoster returns the roster of peer agents for the given repo, excluding
-// the current agent.
-func (s *Scheduler) buildRoster(repoName, currentAgentName string) []ai.RosterEntry {
-	repoDef, ok := s.cfg.RepoByName(repoName)
-	if !ok {
-		return nil
-	}
-	seen := make(map[string]struct{})
-	var roster []ai.RosterEntry
-	for _, b := range repoDef.Use {
-		if !b.IsEnabled() || b.Agent == currentAgentName {
-			continue
-		}
-		if _, dup := seen[b.Agent]; dup {
-			continue
-		}
-		agent, ok := s.cfg.AgentByName(b.Agent)
-		if !ok {
-			continue
-		}
-		seen[b.Agent] = struct{}{}
-		roster = append(roster, ai.RosterEntry{
-			Name:          agent.Name,
-			Description:   agent.Description,
-			Skills:        agent.Skills,
-			AllowDispatch: agent.AllowDispatch,
-		})
-	}
-	return roster
 }
 
 func (s *Scheduler) setRunCtx(ctx context.Context) {

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -233,10 +233,11 @@ func (e *Engine) agentsForEvent(ev Event) []config.AgentDef {
 	return matched
 }
 
-// buildRoster constructs the roster of peer agents for the given repo and
-// agent name. The current agent is excluded.
-func (e *Engine) buildRoster(repoName, currentAgentName string) []ai.RosterEntry {
-	repo, ok := e.cfg.RepoByName(repoName)
+// BuildRoster constructs the roster of peer agents for the given repo and
+// agent name. The current agent is excluded. It is shared with the autonomous
+// scheduler to avoid duplicating the dedup+lookup logic.
+func BuildRoster(cfg *config.Config, repoName, currentAgentName string) []ai.RosterEntry {
+	repo, ok := cfg.RepoByName(repoName)
 	if !ok {
 		return nil
 	}
@@ -249,7 +250,7 @@ func (e *Engine) buildRoster(repoName, currentAgentName string) []ai.RosterEntry
 		if _, dup := seen[b.Agent]; dup {
 			continue
 		}
-		agent, ok := e.cfg.AgentByName(b.Agent)
+		agent, ok := cfg.AgentByName(b.Agent)
 		if !ok {
 			continue
 		}
@@ -302,7 +303,7 @@ func (e *Engine) runAgent(ctx context.Context, ev Event, agent config.AgentDef) 
 	}
 
 	// Build the roster of peer agents for this repo.
-	roster := e.buildRoster(ev.Repo.FullName, agent.Name)
+	roster := BuildRoster(e.cfg, ev.Repo.FullName, agent.Name)
 
 	promptPayload := ev.Payload
 


### PR DESCRIPTION
## Why

`Engine.buildRoster` (in `internal/workflow/engine.go`) and `Scheduler.buildRoster` (in `internal/autonomous/scheduler.go`) contained identical logic:

- same seen-map dedup
- same binding iteration with `IsEnabled` / self-exclusion guard
- same `AgentDef → ai.RosterEntry` projection

Any future change to roster construction (e.g. a new roster field) would have to be applied in two places.

## What changed

- `(e *Engine) buildRoster` is lifted to a package-level `workflow.BuildRoster(cfg, repoName, currentAgentName)`.
- `Engine.runAgent` calls `BuildRoster(e.cfg, …)` instead of the method.
- `Scheduler.buildRoster` is deleted; `Scheduler.executeAgentRun` calls `workflow.BuildRoster(s.cfg, …)`.

`autonomous` already imported `workflow`, so no new import edges are introduced.

## No behaviour change

Pure restructuring; all existing tests continue to cover the shared path.