### PR TITLE
refactor(ai): replace manual string comparator with strings.Compare

### DIFF
--- a/internal/ai/prompt.go
+++ b/internal/ai/prompt.go
@@ -137,14 +137,8 @@ func renderRuntimeContext(ctx PromptContext) string {
 		roster := make([]RosterEntry, len(ctx.Roster))
 		copy(roster, ctx.Roster)
 		slices.SortFunc(roster, func(a, b RosterEntry) int {
-				if a.Name < b.Name {
-					return -1
-				}
-				if a.Name > b.Name {
-					return 1
-				}
-				return 0
-			})
+			return strings.Compare(a.Name, b.Name)
+		})
 		for _, r := range roster {
 			fmt.Fprintf(&b, "- **%s**", r.Name)
 			if r.Description != "" {


### PR DESCRIPTION
## Why

`renderRuntimeContext` in `internal/ai/prompt.go` sorts the roster copy
with a hand-written three-way comparator:

```go
slices.SortFunc(roster, func(a, b RosterEntry) int {
    if a.Name < b.Name {
        return -1
    }
    if a.Name > b.Name {
        return 1
    }
    return 0
})
```

This is exactly what `strings.Compare` already does. The custom
if-chain adds 6 lines of noise with no benefit.

## What changed

Replace the three-branch comparator with a single `strings.Compare` call.
`strings` was already imported; no new dependencies are added.

## No behaviour change

Pure simplification; all existing tests continue to cover the path.