### PR TITLE
refactor(workflow): replace manual bound-check loop with slices.ContainsFunc

### DIFF
--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -122,14 +122,9 @@ func (e *Engine) handleDispatchEvent(ctx context.Context, ev Event) error {
 	}
 
 	// Target must be bound to this repo (any trigger kind is sufficient).
-	bound := false
-	for _, b := range repo.Use {
-		if b.Agent == targetName && b.IsEnabled() {
-			bound = true
-			break
-		}
-	}
-	if !bound {
+	if !slices.ContainsFunc(repo.Use, func(b config.Binding) bool {
+		return b.Agent == targetName && b.IsEnabled()
+	}) {
 		return fmt.Errorf("dispatch: target agent %q is not bound to repo %q", targetName, ev.Repo.FullName)
 	}
 


### PR DESCRIPTION
## Why

`handleDispatchEvent` in `engine.go` contained a manual `for`/`break` loop to
check whether a target agent is bound to a repo:

```go
bound := false
for _, b := range repo.Use {
    if b.Agent == targetName && b.IsEnabled() {
        bound = true
        break
    }
}
if !bound {
```

This is the identical pattern that was already replaced by `slices.ContainsFunc`
in `TriggerAgent` (PR #127). That refactor was missed here because
`handleDispatchEvent` sits in the engine package rather than the scheduler.

## What

Replace the loop with the same `slices.ContainsFunc` call used in `TriggerAgent`:

```go
if !slices.ContainsFunc(repo.Use, func(b config.Binding) bool {
    return b.Agent == targetName && b.IsEnabled()
}) {
```

`slices` is already imported; no new imports required. Behavior is identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)