### PR TITLE
refactor(config): collapse setDefaultInt/setDefaultInt64 into one generic

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -355,7 +355,7 @@ func (c *Config) applyDefaults() {
 	setDefaultInt(&c.Daemon.HTTP.ReadTimeoutSeconds, defaultHTTPReadTimeoutSeconds)
 	setDefaultInt(&c.Daemon.HTTP.WriteTimeoutSeconds, defaultHTTPWriteTimeoutSeconds)
 	setDefaultInt(&c.Daemon.HTTP.IdleTimeoutSeconds, defaultHTTPIdleTimeoutSeconds)
-	setDefaultInt64(&c.Daemon.HTTP.MaxBodyBytes, defaultHTTPMaxBodyBytes)
+	setDefaultInt(&c.Daemon.HTTP.MaxBodyBytes, defaultHTTPMaxBodyBytes)
 	setDefaultInt(&c.Daemon.HTTP.DeliveryTTLSeconds, defaultDeliveryTTLSeconds)
 	setDefaultInt(&c.Daemon.HTTP.ShutdownTimeoutSeconds, defaultHTTPShutdownSeconds)
 
@@ -765,13 +765,7 @@ func setDefault(dst *string, def string) {
 	}
 }
 
-func setDefaultInt(dst *int, def int) {
-	if *dst == 0 {
-		*dst = def
-	}
-}
-
-func setDefaultInt64(dst *int64, def int64) {
+func setDefaultInt[T int | int64](dst *T, def T) {
 	if *dst == 0 {
 		*dst = def
 	}


### PR DESCRIPTION
## Why

`setDefaultInt` and `setDefaultInt64` were identical functions that differed only in their type. The duplication was purely mechanical — there was no behavioural difference, no reason to keep two copies.

## What

Replace both functions with a single generic helper using a type constraint:

```go
// before: two identical bodies
func setDefaultInt(dst *int, def int)         { if *dst == 0 { *dst = def } }
func setDefaultInt64(dst *int64, def int64)   { if *dst == 0 { *dst = def } }

// after: one function, Go infers T at each call site
func setDefaultInt[T int | int64](dst *T, def T) { if *dst == 0 { *dst = def } }
```

The single call to `setDefaultInt64` (for `MaxBodyBytes int64`) is updated to `setDefaultInt`; Go type inference resolves `T = int64` from the pointer argument.

No behaviour change. The project requires Go 1.24 which has full generics support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)