### PR TITLE
test(config): remove dead tc := tc loop capture in TestProxyValidationErrors

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -991,7 +991,6 @@ func TestProxyValidationErrors(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			path := writeConfig(t, proxyYAML(tc.block))


### PR DESCRIPTION
## Why

`TestProxyValidationErrors` in `internal/config/config_test.go` contains
a `tc := tc` loop-variable capture idiom that was necessary before Go 1.22
to pin the loop variable in closures. Since Go 1.22 each loop iteration
creates a fresh variable automatically, so the shadowing assignment is dead
code.

This is the same fix that was applied in #116, #136, and #142 for other
locations in the test suite. One instance was missed when the test was
first introduced.

## What changed

Deleted the single `tc := tc` line inside the `for _, tc := range tests`
loop in `TestProxyValidationErrors`. No logic changed.