### PR TITLE
test(config): collapse 3 dispatch-wiring error tests into table-driven

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -638,41 +638,37 @@ repos:
 `, agentBlock)
 }
 
-func TestDispatchCanDispatchUnknownAgentRejected(t *testing.T) {
-	t.Setenv("TEST_SECRET", "s3cret")
-	yaml := dispatchYAML(`
+func TestDispatchWiringValidationErrors(t *testing.T) {
+	cases := []struct {
+		name   string
+		agents string
+		errMsg string
+	}{
+		{
+			name: "unknown agent in can_dispatch",
+			agents: `
   - name: coder
     backend: claude
     skills: [architect]
     prompt: "Write code."
     can_dispatch: [nonexistent-agent]
-`)
-	path := writeConfig(t, yaml)
-	_, err := Load(path)
-	if err == nil || !strings.Contains(err.Error(), "unknown agent") {
-		t.Fatalf("expected unknown-agent error, got %v", err)
-	}
-}
-
-func TestDispatchCanDispatchSelfRejected(t *testing.T) {
-	t.Setenv("TEST_SECRET", "s3cret")
-	yaml := dispatchYAML(`
+`,
+			errMsg: "unknown agent",
+		},
+		{
+			name: "can_dispatch includes self",
+			agents: `
   - name: coder
     backend: claude
     skills: [architect]
     prompt: "Write code."
     can_dispatch: [coder]
-`)
-	path := writeConfig(t, yaml)
-	_, err := Load(path)
-	if err == nil || !strings.Contains(err.Error(), "itself") {
-		t.Fatalf("expected self-reference error, got %v", err)
-	}
-}
-
-func TestDispatchTargetRequiresDescription(t *testing.T) {
-	t.Setenv("TEST_SECRET", "s3cret")
-	yaml := dispatchYAML(`
+`,
+			errMsg: "itself",
+		},
+		{
+			name: "dispatch target missing description",
+			agents: `
   - name: coder
     backend: claude
     skills: [architect]
@@ -683,12 +679,22 @@ func TestDispatchTargetRequiresDescription(t *testing.T) {
     skills: [architect]
     prompt: "Review PRs."
     allow_dispatch: true
-    # description intentionally omitted
-`)
-	path := writeConfig(t, yaml)
-	_, err := Load(path)
-	if err == nil || !strings.Contains(err.Error(), "description") {
-		t.Fatalf("expected description-required error, got %v", err)
+`,
+			errMsg: "description",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("TEST_SECRET", "s3cret")
+			path := writeConfig(t, dispatchYAML(tc.agents))
+			_, err := Load(path)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.errMsg)
+			}
+			if !strings.Contains(err.Error(), tc.errMsg) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.errMsg)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Why

`TestDispatchCanDispatchUnknownAgentRejected`, `TestDispatchCanDispatchSelfRejected`, and `TestDispatchTargetRequiresDescription` are structurally identical: each sets the env var, builds a `dispatchYAML` block, loads the config, and asserts a specific error substring. Three functions with identical skeletons that differ only in the YAML and the expected error string — a textbook table-driven candidate.

## What changed

Replaced the three flat tests with a single `TestDispatchWiringValidationErrors` table-driven test. The logic is equivalent; the three cases preserve the same YAML inputs and error-string assertions.

## Notes

- Uses `t.Setenv` inside each subtest (not the parent), consistent with the existing `TestDispatchConfigValidationRejectsNonPositiveValues` pattern in the same file.
- No subtests are parallelised because `t.Setenv` and `t.Parallel()` are mutually exclusive.