### PR TITLE
test(autonomous): collapse 3 TriggerAgent rejection tests into table-driven

### DIFF
--- a/internal/autonomous/scheduler_test.go
+++ b/internal/autonomous/scheduler_test.go
@@ -155,44 +155,47 @@ func TestTriggerAgentRunsSynchronously(t *testing.T) {
 	}
 }
 
-func TestTriggerAgentRejectsUnboundAgent(t *testing.T) {
+func TestTriggerAgentRejections(t *testing.T) {
 	t.Parallel()
-	cfg := baseCfg(func(c *config.Config) {
-		c.Agents = append(c.Agents, config.AgentDef{Name: "orphan", Backend: "claude", Prompt: "x"})
-	})
-	s, err := NewScheduler(cfg, map[string]ai.Runner{"claude": &stubRunner{}}, NewMemoryStore(t.TempDir()), zerolog.Nop())
-	if err != nil {
-		t.Fatalf("NewScheduler: %v", err)
+	cases := []struct {
+		name      string
+		mutateCfg func(*config.Config)
+		agent     string
+		wantErr   string
+	}{
+		{
+			name: "unbound agent",
+			mutateCfg: func(c *config.Config) {
+				c.Agents = append(c.Agents, config.AgentDef{Name: "orphan", Backend: "claude", Prompt: "x"})
+			},
+			agent:   "orphan",
+			wantErr: "not bound",
+		},
+		{
+			name:    "unknown agent",
+			agent:   "ghost",
+			wantErr: "not found",
+		},
+		{
+			name:      "disabled repo",
+			mutateCfg: func(c *config.Config) { c.Repos[0].Enabled = false },
+			agent:     "reviewer",
+			wantErr:   "disabled",
+		},
 	}
-	err = s.TriggerAgent(context.Background(), "orphan", "owner/repo")
-	if err == nil || !strings.Contains(err.Error(), "not bound") {
-		t.Errorf("expected not-bound error, got %v", err)
-	}
-}
-
-func TestTriggerAgentRejectsUnknownAgent(t *testing.T) {
-	t.Parallel()
-	cfg := baseCfg(nil)
-	s, err := NewScheduler(cfg, map[string]ai.Runner{"claude": &stubRunner{}}, NewMemoryStore(t.TempDir()), zerolog.Nop())
-	if err != nil {
-		t.Fatalf("NewScheduler: %v", err)
-	}
-	err = s.TriggerAgent(context.Background(), "ghost", "owner/repo")
-	if err == nil || !strings.Contains(err.Error(), "not found") {
-		t.Errorf("expected not-found error, got %v", err)
-	}
-}
-
-func TestTriggerAgentRejectsDisabledRepo(t *testing.T) {
-	t.Parallel()
-	cfg := baseCfg(func(c *config.Config) { c.Repos[0].Enabled = false })
-	s, err := NewScheduler(cfg, map[string]ai.Runner{"claude": &stubRunner{}}, NewMemoryStore(t.TempDir()), zerolog.Nop())
-	if err != nil {
-		t.Fatalf("NewScheduler: %v", err)
-	}
-	err = s.TriggerAgent(context.Background(), "reviewer", "owner/repo")
-	if err == nil || !strings.Contains(err.Error(), "disabled") {
-		t.Errorf("expected disabled error, got %v", err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := baseCfg(tc.mutateCfg)
+			s, err := NewScheduler(cfg, map[string]ai.Runner{"claude": &stubRunner{}}, NewMemoryStore(t.TempDir()), zerolog.Nop())
+			if err != nil {
+				t.Fatalf("NewScheduler: %v", err)
+			}
+			err = s.TriggerAgent(context.Background(), tc.agent, "owner/repo")
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("expected error containing %q, got %v", tc.wantErr, err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Why

`TestTriggerAgentRejectsUnboundAgent`, `TestTriggerAgentRejectsUnknownAgent`, and `TestTriggerAgentRejectsDisabledRepo` are structurally identical: each creates a scheduler with a minor config mutation, calls `TriggerAgent`, and asserts a specific error substring. Three functions with the same skeleton that differ only in the config mutation, the agent name, and the expected error string — a textbook table-driven candidate.

## What changed

Replaced the three flat tests with a single `TestTriggerAgentRejections` table-driven test. The logic is equivalent; all three cases preserve the same config mutations, agent names, and error-string assertions.

## Notes

- Each subtest has `t.Parallel()` — safe because none use `t.Setenv`.
- No behaviour change.