### PR TITLE
refactor: replace pre-1.22 counter loops with for range N

### DIFF
--- a/cmd/agents/main.go
+++ b/cmd/agents/main.go
@@ -74,7 +74,7 @@ func run() error {
 		// would cause PushEvent to silently drop later hops.
 		d := cfg.Daemon.Processor.Dispatch
 		runBuf := 1
-		for i := 0; i < d.MaxDepth; i++ {
+		for range d.MaxDepth {
 			runBuf *= d.MaxFanout
 		}
 		if runBuf < cfg.Daemon.Processor.EventQueueBuffer {

--- a/internal/workflow/data_channels_test.go
+++ b/internal/workflow/data_channels_test.go
@@ -30,7 +30,7 @@ func TestConcurrentPushAndCloseDoesNotPanic(t *testing.T) {
 
 	// Spawn writers that push continuously until they get ErrQueueClosed or
 	// the channel buffer fills up.
-	for i := 0; i < 8; i++ {
+	for range 8 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()


### PR DESCRIPTION
## Why

Two loops iterate a fixed number of times but never use the loop
variable `i`:

- `cmd/agents/main.go` — buffer-size calculation that multiplies
  `MaxFanout` exactly `MaxDepth` times
- `internal/workflow/data_channels_test.go` — spawns 8 concurrent
  goroutines

Go 1.22 added `for range N` for exactly this pattern (integer range).
The rest of the codebase already uses it in `processor.go`,
`dispatch_test.go`, `scheduler_test.go`, and `engine_test.go`. These
two were the only remaining pre-1.22 style counter loops where the
index is unused.

## Change

```diff
-for i := 0; i < d.MaxDepth; i++ {
+for range d.MaxDepth {
```

```diff
-for i := 0; i < 8; i++ {
+for range 8 {
```

No behaviour change — `for range N` is exactly equivalent to
`for i := 0; i < N; i++` when `i` is unused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)