### PR TITLE
test(webhook): collapse 3 auth-rejection tests into table-driven

### DIFF
--- a/internal/webhook/server_test.go
+++ b/internal/webhook/server_test.go
@@ -624,12 +624,13 @@ func TestHandleAgentsRunAuthRejections(t *testing.T) {
 			t.Parallel()
 			cfg := testCfg(tc.mutateCfg)
 			server := NewServer(cfg, NewDeliveryStore(time.Hour), workflow.NewDataChannels(1), nil, nil, zerolog.Nop())
+			handler := server.requireAPIKey(http.HandlerFunc(server.handleAgentsRun))
 			req := httptest.NewRequest(http.MethodPost, "/agents/run", strings.NewReader(`{"agent":"a","repo":"r"}`))
 			if tc.authHeader != "" {
 				req.Header.Set("Authorization", tc.authHeader)
 			}
 			rr := httptest.NewRecorder()
-			server.handleAgentsRun(rr, req)
+			handler.ServeHTTP(rr, req)
 			if rr.Code != tc.wantStatus {
 				t.Fatalf("got %d, want %d", rr.Code, tc.wantStatus)
 			}

--- a/internal/webhook/server_test.go
+++ b/internal/webhook/server_test.go
@@ -613,6 +613,21 @@ func TestHandleAgentsRunAuthRejections(t *testing.T) {
 			wantStatus: http.StatusUnauthorized,
 		},
 		{
+			name:       "raw key no scheme",
+			authHeader: testAPIKey,
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "Basic scheme",
+			authHeader: "Basic " + testAPIKey,
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "Token scheme",
+			authHeader: "Token " + testAPIKey,
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
 			name:       "no api key configured",
 			mutateCfg:  func(c *config.Config) { c.Daemon.HTTP.APIKey = "" },
 			authHeader: "Bearer something",

--- a/internal/webhook/server_test.go
+++ b/internal/webhook/server_test.go
@@ -595,67 +595,45 @@ func TestHandleAgentsRunEnqueuesEvent(t *testing.T) {
 	}
 }
 
-func TestHandleAgentsRunRejectsNoAuth(t *testing.T) {
+func TestHandleAgentsRunAuthRejections(t *testing.T) {
 	t.Parallel()
-	server := newRunServer()
-	handler := server.requireAPIKey(http.HandlerFunc(server.handleAgentsRun))
-	req := httptest.NewRequest(http.MethodPost, "/agents/run", strings.NewReader(`{"agent":"a","repo":"r"}`))
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
-	if rr.Code != http.StatusUnauthorized {
-		t.Fatalf("got %d, want %d", rr.Code, http.StatusUnauthorized)
-	}
-}
-
-func TestHandleAgentsRunRejectsWrongToken(t *testing.T) {
-	t.Parallel()
-	server := newRunServer()
-	handler := server.requireAPIKey(http.HandlerFunc(server.handleAgentsRun))
-	req := httptest.NewRequest(http.MethodPost, "/agents/run", strings.NewReader(`{"agent":"a","repo":"r"}`))
-	req.Header.Set("Authorization", "Bearer wrong-key")
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
-	if rr.Code != http.StatusUnauthorized {
-		t.Fatalf("got %d, want %d", rr.Code, http.StatusUnauthorized)
-	}
-}
-
-func TestHandleAgentsRunBlocksNonBearerScheme(t *testing.T) {
-	t.Parallel()
-	server := newRunServer()
-	handler := server.requireAPIKey(http.HandlerFunc(server.handleAgentsRun))
-	tests := []struct {
-		name   string
-		header string
+	cases := []struct {
+		name       string
+		mutateCfg  func(*config.Config)
+		authHeader string
+		wantStatus int
 	}{
-		{"raw key", testAPIKey},
-		{"Basic scheme", "Basic " + testAPIKey},
-		{"Token scheme", "Token " + testAPIKey},
+		{
+			name:       "no auth header",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "wrong token",
+			authHeader: "Bearer wrong-key",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "no api key configured",
+			mutateCfg:  func(c *config.Config) { c.Daemon.HTTP.APIKey = "" },
+			authHeader: "Bearer something",
+			wantStatus: http.StatusForbidden,
+		},
 	}
-	for _, tc := range tests {
+	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+			cfg := testCfg(tc.mutateCfg)
+			server := NewServer(cfg, NewDeliveryStore(time.Hour), workflow.NewDataChannels(1), nil, nil, zerolog.Nop())
 			req := httptest.NewRequest(http.MethodPost, "/agents/run", strings.NewReader(`{"agent":"a","repo":"r"}`))
-			req.Header.Set("Authorization", tc.header)
+			if tc.authHeader != "" {
+				req.Header.Set("Authorization", tc.authHeader)
+			}
 			rr := httptest.NewRecorder()
-			handler.ServeHTTP(rr, req)
-			if rr.Code != http.StatusUnauthorized {
-				t.Fatalf("scheme %q: got %d, want %d", tc.header, rr.Code, http.StatusUnauthorized)
+			server.handleAgentsRun(rr, req)
+			if rr.Code != tc.wantStatus {
+				t.Fatalf("got %d, want %d", rr.Code, tc.wantStatus)
 			}
 		})
-	}
-}
-
-func TestHandleAgentsRunReturnsForbiddenWhenNoAPIKeyConfigured(t *testing.T) {
-	t.Parallel()
-	cfg := testCfg(func(c *config.Config) { c.Daemon.HTTP.APIKey = "" })
-	server := NewServer(cfg, NewDeliveryStore(time.Hour), workflow.NewDataChannels(1), nil, nil, zerolog.Nop())
-	req := httptest.NewRequest(http.MethodPost, "/agents/run", strings.NewReader(`{"agent":"a","repo":"r"}`))
-	req.Header.Set("Authorization", "Bearer something")
-	rr := httptest.NewRecorder()
-	server.handleAgentsRun(rr, req)
-	if rr.Code != http.StatusForbidden {
-		t.Fatalf("got %d, want %d", rr.Code, http.StatusForbidden)
 	}
 }
 


### PR DESCRIPTION
## Why

`TestHandleAgentsRunRejectsNoAuth`, `TestHandleAgentsRunRejectsWrongToken`, and `TestHandleAgentsRunReturnsForbiddenWhenNoAPIKeyConfigured` are structurally identical: each creates a server, fires a POST to `/agents/run` with a specific auth credential, and asserts one HTTP status code. The only differences are the `Authorization` header value and the expected status.

Collapsing them into a single `TestHandleAgentsRunAuthRejections` table makes the three covered scenarios visible at a glance and removes ~30 lines of boilerplate while preserving full coverage.

## Changes

- Replaced three flat test functions with one table-driven `TestHandleAgentsRunAuthRejections`
- Each of the three original scenarios becomes a named parallel subtest
- No behavioral change — all assertions are identical to the originals

## Test plan

- [ ] `go test ./internal/webhook/... -race` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)