### PR TITLE
test(proxy): remove dead lastReq field from fakeUpstream

### DIFF
--- a/internal/anthropic_proxy/handler_test.go
+++ b/internal/anthropic_proxy/handler_test.go
@@ -13,19 +13,17 @@ import (
 )
 
 // fakeUpstream returns an httptest.Server that responds with the given status
-// and body. It also captures the last request body and headers for assertions.
+// and body. It also captures the last request body for assertions.
 type fakeUpstream struct {
 	*httptest.Server
-	status  int
-	body    string
-	lastReq *http.Request
+	status   int
+	body     string
 	lastBody []byte
 }
 
 func newFakeUpstream(status int, body string) *fakeUpstream {
 	f := &fakeUpstream{status: status, body: body}
 	f.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		f.lastReq = r
 		f.lastBody, _ = io.ReadAll(r.Body)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(status)


### PR DESCRIPTION
## Why

`fakeUpstream.lastReq` was assigned in the `httptest.Server` closure (`f.lastReq = r`) but never accessed in any test assertion. It is pure dead code.

## What changed

- Removed the `lastReq *http.Request` field from the `fakeUpstream` struct.
- Removed the `f.lastReq = r` write in the capture closure.
- Updated the comment to drop the now-stale mention of "headers".

No test logic or assertion is changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)