### PR TITLE
test(ai): use t.Run subtests in TestNormalizeTokenSanitizesForFilesystemUse

### DIFF
--- a/internal/ai/prompt_test.go
+++ b/internal/ai/prompt_test.go
@@ -262,16 +262,19 @@ func TestRenderAgentPromptDispatchContextOmittedWhenNotDispatched(t *testing.T) 
 func TestNormalizeTokenSanitizesForFilesystemUse(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		in, want string
+		name, in, want string
 	}{
-		{"Architect", "architect"},
-		{"  Foo Bar  ", "foo bar"},
-		{"../evil", "evil"},
-		{"a/b/c", "a_b_c"},
+		{"lowercase", "Architect", "architect"},
+		{"trim_spaces", "  Foo Bar  ", "foo bar"},
+		{"strip_dotdot", "../evil", "evil"},
+		{"slash_to_underscore", "a/b/c", "a_b_c"},
 	}
 	for _, tt := range tests {
-		if got := ai.NormalizeToken(tt.in); got != tt.want {
-			t.Errorf("NormalizeToken(%q) = %q, want %q", tt.in, got, tt.want)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := ai.NormalizeToken(tt.in); got != tt.want {
+				t.Errorf("NormalizeToken(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Why

`TestNormalizeTokenSanitizesForFilesystemUse` had four input variations but iterated them with a bare `for` loop:

```go
for _, tt := range tests {
    if got := ai.NormalizeToken(tt.in); got != tt.want {
        t.Errorf("NormalizeToken(%q) = %q, want %q", tt.in, got, tt.want)
    }
}
```

When a case fails the output shows the raw input/want strings but no case name, making it harder to identify which scenario broke at a glance.

## What changed

Each iteration is now wrapped in `t.Run(tt.name, ...)` with `t.Parallel()` inside:

- `go test -v` names each run: `/lowercase`, `/trim_spaces`, `/strip_dotdot`, `/slash_to_underscore`
- A failure immediately names the broken scenario
- All four cases run concurrently, consistent with the rest of the file

No logic changes — only the test structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)