### PR TITLE
refactor(autonomous): replace manual map copy with maps.Clone

### DIFF
--- a/internal/autonomous/scheduler.go
+++ b/internal/autonomous/scheduler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 	"sync"
@@ -197,10 +198,7 @@ func (s *Scheduler) recordLastRun(name, repo string, at time.Time, status string
 // AgentStatuses returns the current scheduling state for all registered bindings.
 func (s *Scheduler) AgentStatuses() []AgentStatus {
 	s.lastRunsMu.RLock()
-	runs := make(map[string]lastRunRecord, len(s.lastRuns))
-	for k, v := range s.lastRuns {
-		runs[k] = v
-	}
+	runs := maps.Clone(s.lastRuns)
 	s.lastRunsMu.RUnlock()
 
 	entries := s.cron.Entries()


### PR DESCRIPTION
## Why

`AgentStatuses` takes a read-lock on `lastRunsMu`, copies `s.lastRuns` into a local map, then releases the lock. The copy used an explicit `make` + `range` loop:

```go
runs := make(map[string]lastRunRecord, len(s.lastRuns))
for k, v := range s.lastRuns {
    runs[k] = v
}
```

`maps.Clone` (stdlib since Go 1.21) does exactly this in one line and makes the intent — shallow copy — obvious at a glance.

## Change

- Add `"maps"` import to `internal/autonomous/scheduler.go`
- Replace the 4-line copy loop with `runs := maps.Clone(s.lastRuns)`

No behaviour change; the resulting map is identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)