### PR TITLE
test(workflow): remove dead anchor variables from dispatch_test.go

### DIFF
--- a/internal/workflow/dispatch_test.go
+++ b/internal/workflow/dispatch_test.go
@@ -686,14 +686,13 @@ func TestPostRunDispatchSuppressedWithinDedupWindow(t *testing.T) {
 		t.Error("expected dispatch suppressed: cron mark still active within dedup window")
 	}
 
-	// After the TTL expires the dispatch must succeed.
-	futureNow := now.Add(3 * time.Second)
+	// After the TTL expires the dispatch must succeed. The expiry is simulated
+	// by creating a fresh dedup store (no cron mark) rather than advancing a
+	// real clock.
 	d2 := NewDispatcher(cfg, agents, NewDispatchDedupStore(2), q, zerolog.Nop())
-	// No cron mark written — simulates the window having expired.
 	d2.ProcessDispatches(context.Background(), originator, ev, "root-2", 0, "", []ai.DispatchRequest{
 		{Agent: "coder", Reason: "dispatch after window expired"},
 	})
-	_ = futureNow // anchor variable for clarity
 	if len(q.popped()) != 1 {
 		t.Error("expected dispatch enqueued: dedup window has expired")
 	}
@@ -884,13 +883,11 @@ func TestFinalizeAutonomousRunKeepsTTLBlocksDispatchWithinWindow(t *testing.T) {
 	// check the dispatch namespace (not the cron namespace), so the mark never
 	// blocks repeated autonomous runs.
 	q3 := &fakeQueue{}
-	agentDef := config.AgentDef{Name: "coder", AllowDispatch: true}
 	d3 := NewDispatcher(cfg, agents, dedup, q3, zerolog.Nop())
 	if !d3.TryMarkAutonomousRun("coder", "owner/repo", now) {
 		t.Error("expected second cron run to proceed: cron marks must not suppress other cron runs")
 	}
 	d3.FinalizeAutonomousRun("coder", "owner/repo")
-	_ = agentDef
 }
 
 // TestSuccessfulCronRunRefcountIsZeroAfterFinalize verifies that


### PR DESCRIPTION
## Why

Two variables in `dispatch_test.go` are assigned but never passed to any
function — they exist only so the compiler does not complain:

- **`futureNow`** in `TestPostRunDispatchSuppressedWithinDedupWindow`  
  The "TTL expired" scenario is simulated by constructing a fresh
  `DispatchDedupStore` (no cron mark), not by advancing a real clock.
  The computed timestamp `now.Add(3 * time.Second)` is never used.

- **`agentDef`** in `TestFinalizeAutonomousRunKeepsTTLBlocksDispatchWithinWindow`  
  The second cron-run assertion calls `TryMarkAutonomousRun` with a
  literal string; the `config.AgentDef` struct was never consumed.

Keeping anchor variables alive with `_ = var` comments suggests the
variable is providing some value — these don't.

## What changed

- Remove both dead variables and their `_ = var` guards.
- Improve the comment around the `futureNow` block to explain how
  TTL expiry is actually simulated (fresh store, not time advance).
- No behaviour change; only the test source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)