### PR TITLE
refactor(logging): hoist default writer before switch to remove duplication

### DIFF
--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -25,14 +25,13 @@ func NewLogger(cfg config.LogConfig) zerolog.Logger {
 	zerolog.SetGlobalLevel(level)
 
 	var formatErr error
-	var writer io.Writer
+	var writer io.Writer = zerolog.ConsoleWriter{Out: os.Stdout}
 	switch strings.ToLower(strings.TrimSpace(cfg.Format)) {
 	case "json":
 		writer = os.Stdout
 	case "text", "":
-		writer = zerolog.ConsoleWriter{Out: os.Stdout}
+		// default writer already set
 	default:
-		writer = zerolog.ConsoleWriter{Out: os.Stdout}
 		formatErr = fmt.Errorf("unknown log format %q", cfg.Format)
 	}
 


### PR DESCRIPTION
## Why

`NewLogger` had the same `zerolog.ConsoleWriter{Out: os.Stdout}` struct
literal assigned in two separate switch arms:

```go
case "text", "":
    writer = zerolog.ConsoleWriter{Out: os.Stdout}
default:
    writer = zerolog.ConsoleWriter{Out: os.Stdout}   // duplicate
    formatErr = fmt.Errorf(...)
```

## What changed

Initialise `writer` to `zerolog.ConsoleWriter{Out: os.Stdout}` before
the switch, making it the canonical default. The `"text"/""`  arm
becomes an explicit no-op comment and the `default` arm only sets
`formatErr` — behaviour is identical, duplication is gone.

```go
var writer io.Writer = zerolog.ConsoleWriter{Out: os.Stdout}
switch ... {
case "json":
    writer = os.Stdout
case "text", "":
    // default writer already set
default:
    formatErr = fmt.Errorf("unknown log format %q", cfg.Format)
}
```

No behaviour change. No other files touched.