### PR TITLE
refactor(config): derive log-level error message from validLogLevels slice

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -592,7 +592,7 @@ var validLogLevels = []string{"trace", "debug", "info", "warn", "error", "fatal"
 func (c *Config) validateLogConfig() error {
 	if c.Daemon.Log.Level != "" {
 		if !slices.Contains(validLogLevels, c.Daemon.Log.Level) {
-			return fmt.Errorf("config: invalid log level %q (supported: trace, debug, info, warn, error, fatal, panic, disabled)", c.Daemon.Log.Level)
+			return fmt.Errorf("config: invalid log level %q (supported: %s)", c.Daemon.Log.Level, strings.Join(validLogLevels, ", "))
 		}
 	}
 	switch c.Daemon.Log.Format {


### PR DESCRIPTION
## Why

`validateLogConfig` builds its error message by hardcoding the allowed log levels as a literal string:

```go
return fmt.Errorf("config: invalid log level %q (supported: trace, debug, info, warn, error, fatal, panic, disabled)", c.Daemon.Log.Level)
```

The `validLogLevels` slice six lines above is the authoritative source of that list. Adding a new level to the slice would not automatically update the error message — a silent maintenance trap.

## What changed

Replace the hardcoded string with `strings.Join(validLogLevels, ", ")`, matching the pattern already used by `validAIBackendNames`:

```go
return fmt.Errorf("config: invalid log level %q (supported: %s)", c.Daemon.Log.Level, strings.Join(validLogLevels, ", "))
```

Output is identical; no test changes required.