### PR TITLE
refactor(config): replace validEventKindsSorted IIFE with slices.Sorted(maps.Keys)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -48,14 +49,7 @@ var validEventKinds = map[string]struct{}{
 
 // validEventKindsSorted is a precomputed, sorted list of validEventKinds keys
 // for use in human-readable error messages.
-var validEventKindsSorted = func() []string {
-	ks := make([]string, 0, len(validEventKinds))
-	for k := range validEventKinds {
-		ks = append(ks, k)
-	}
-	slices.Sort(ks)
-	return ks
-}()
+var validEventKindsSorted = slices.Sorted(maps.Keys(validEventKinds))
 
 const (
 	defaultHTTPListenAddr          = ":8080"


### PR DESCRIPTION
## Why

`validEventKindsSorted` is initialized via a 7-line immediately-invoked
function expression that manually builds a slice from map keys, sorts it,
and returns it:

```go
var validEventKindsSorted = func() []string {
    ks := make([]string, 0, len(validEventKinds))
    for k := range validEventKinds {
        ks = append(ks, k)
    }
    slices.Sort(ks)
    return ks
}()
```

This is the same pattern that was replaced in `internal/ai/prompt.go` (#141)
with the stdlib one-liner `slices.Sorted(maps.Keys(…))`, available since
Go 1.23.

## What changed

- Import `maps` (already used in `internal/ai/prompt.go`).
- Replace the 7-line IIFE with `slices.Sorted(maps.Keys(validEventKinds))`.

No behaviour change: the result is still a sorted `[]string` of
`validEventKinds` map keys used in human-readable validation error messages.