### PR TITLE
refactor(config): derive log-format validation from validLogFormats slice

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -588,6 +588,7 @@ func (c *Config) validateDispatchConfig() error {
 }
 
 var validLogLevels = []string{"trace", "debug", "info", "warn", "error", "fatal", "panic", "disabled"}
+var validLogFormats = []string{"json", "text"}
 
 func (c *Config) validateLogConfig() error {
 	if c.Daemon.Log.Level != "" {
@@ -595,11 +596,8 @@ func (c *Config) validateLogConfig() error {
 			return fmt.Errorf("config: invalid log level %q (supported: trace, debug, info, warn, error, fatal, panic, disabled)", c.Daemon.Log.Level)
 		}
 	}
-	switch c.Daemon.Log.Format {
-	case "json", "text", "":
-		// valid
-	default:
-		return fmt.Errorf("config: unknown log format %q (supported: json, text)", c.Daemon.Log.Format)
+	if c.Daemon.Log.Format != "" && !slices.Contains(validLogFormats, c.Daemon.Log.Format) {
+		return fmt.Errorf("config: unknown log format %q (supported: %s)", c.Daemon.Log.Format, strings.Join(validLogFormats, ", "))
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- Extracts `validLogFormats = []string{"json", "text"}` to replace the hardcoded switch/case in `validateLogConfig`
- Makes format validation symmetric with level validation (which already uses `validLogLevels` + `slices.Contains`)
- Adding a new log format now requires updating only one place instead of two

Relates to the same pattern addressed for log levels in #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)