### PR TITLE
test(config): hoist Setenv and add t.Parallel to dispatch-validation subtests

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -732,6 +732,7 @@ func TestDispatchValidConfigAccepted(t *testing.T) {
 }
 
 func TestDispatchConfigValidationRejectsNonPositiveValues(t *testing.T) {
+	t.Setenv("TEST_SECRET", "s3cret")
 	cases := []struct {
 		name   string
 		yaml   string
@@ -815,7 +816,7 @@ repos:
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("TEST_SECRET", "s3cret")
+			t.Parallel()
 			path := writeConfig(t, tc.yaml)
 			_, err := Load(path)
 			if err == nil {


### PR DESCRIPTION
## Why

`TestDispatchConfigValidationRejectsNonPositiveValues` is a table-driven test
with three subtests. Each subtest called `t.Setenv` but never `t.Parallel()`,
so the three cases ran sequentially even though they are fully independent.

## What

Follow the pattern already established by `TestLoadRejectsInvalidLogLevel` in
the same file:

- Hoist the shared `t.Setenv("TEST_SECRET", "s3cret")` to the outer function.
- Replace the per-subtest `t.Setenv` call with `t.Parallel()`.

The outer function is intentionally left non-parallel (having `t.Setenv` at
the outer level makes it unsuitable for `t.Parallel()`), but the three subtests
can now run concurrently and will surface data races under `-race`.

## Change

Two lines changed in one file; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)