### PR TITLE
test(webhook): table-driven SSE stream handler tests

### DIFF
--- a/internal/webhook/api_test.go
+++ b/internal/webhook/api_test.go
@@ -1,6 +1,7 @@
 package webhook
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -767,6 +768,99 @@ func TestHandleAPIEventsSinceFilter(t *testing.T) {
 	}
 }
 
+// ── SSE stream handlers ─────────────────────────────────────────────────────
+
+// TestHandleSSEStreams verifies the three SSE stream handlers
+// (events/stream, traces/stream, memory/stream) using a table-driven approach.
+//
+// Each sub-test:
+//  1. Connects a subscriber (sseCapture) via the handler goroutine.
+//  2. Reads the immediate ": connected\n\n" heartbeat and checks headers.
+//  3. Publishes one message to the hub and verifies it arrives at the client.
+//  4. Cancels the request context to stop the handler cleanly.
+func TestHandleSSEStreams(t *testing.T) {
+	t.Parallel()
+
+	cfg := testCfg(nil)
+	srv, _ := newTestServer(cfg)
+	obs := newTestObserve()
+	srv.WithObserve(obs)
+
+	tests := []struct {
+		name    string
+		handler func(http.ResponseWriter, *http.Request)
+		publish func(msg []byte)
+		msg     string
+	}{
+		{
+			name:    "events/stream",
+			handler: srv.handleAPIEventsStream,
+			publish: obs.EventsSSE.Publish,
+			msg:     `data: {"id":"ev1"}` + "\n\n",
+		},
+		{
+			name:    "traces/stream",
+			handler: srv.handleAPITracesStream,
+			publish: obs.TracesSSE.Publish,
+			msg:     `data: {"span_id":"sp1"}` + "\n\n",
+		},
+		{
+			name:    "memory/stream",
+			handler: srv.handleAPIMemoryStream,
+			publish: obs.MemorySSE.Publish,
+			msg:     `data: {"agent":"coder","repo":"owner_repo"}` + "\n\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			cap := newSSECapture()
+			req := httptest.NewRequest(http.MethodGet, "/api/"+tc.name, nil).WithContext(ctx)
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				tc.handler(cap, req)
+			}()
+
+			// The handler sends ": connected\n\n" before entering the select
+			// loop, so it must arrive before any published message.
+			heartbeat := mustReadSSEMsg(t, cap.writes, 2*time.Second)
+			if heartbeat != ": connected\n\n" {
+				t.Fatalf("want heartbeat %q, got %q", ": connected\n\n", heartbeat)
+			}
+
+			// Verify SSE-required headers were set before the first write.
+			if got := cap.Header().Get("Content-Type"); got != "text/event-stream" {
+				t.Errorf("Content-Type: want %q, got %q", "text/event-stream", got)
+			}
+			if got := cap.Header().Get("Cache-Control"); got != "no-cache" {
+				t.Errorf("Cache-Control: want %q, got %q", "no-cache", got)
+			}
+
+			// Publish a message and confirm the handler fans it out.
+			tc.publish([]byte(tc.msg))
+			got := mustReadSSEMsg(t, cap.writes, 2*time.Second)
+			if got != tc.msg {
+				t.Errorf("published %q but received %q", tc.msg, got)
+			}
+
+			// Cancel the context; the handler must exit promptly.
+			cancel()
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+				t.Error("handler did not exit after context cancellation")
+			}
+		})
+	}
+}
+
 // ── /api/traces ────────────────────────────────────────────────────────────
 
 func TestHandleAPITracesReturnsStoredSpans(t *testing.T) {
@@ -1122,4 +1216,42 @@ func (p *stubDispatchProvider) DispatchStats() workflow.DispatchStats { return p
 // newTestObserve creates an observe.Store for tests.
 func newTestObserve() *observe.Store {
 	return observe.NewStore()
+}
+
+// sseCapture is a minimal http.ResponseWriter + http.Flusher that forwards
+// each Write call to a buffered channel. This lets test goroutines receive SSE
+// frames without races on a shared bytes.Buffer: the handler goroutine sends,
+// the test goroutine receives.
+type sseCapture struct {
+	header http.Header
+	writes chan []byte
+}
+
+func newSSECapture() *sseCapture {
+	return &sseCapture{
+		header: make(http.Header),
+		writes: make(chan []byte, 32),
+	}
+}
+
+func (c *sseCapture) Header() http.Header { return c.header }
+func (c *sseCapture) WriteHeader(_ int)   {}
+func (c *sseCapture) Write(b []byte) (int, error) {
+	cp := make([]byte, len(b))
+	copy(cp, b)
+	c.writes <- cp
+	return len(b), nil
+}
+func (c *sseCapture) Flush() {} // satisfies http.Flusher
+
+// mustReadSSEMsg drains one message from ch within timeout or fails the test.
+func mustReadSSEMsg(t *testing.T, ch <-chan []byte, timeout time.Duration) string {
+	t.Helper()
+	select {
+	case msg := <-ch:
+		return string(msg)
+	case <-time.After(timeout):
+		t.Fatal("timed out waiting for SSE message")
+		return ""
+	}
 }


### PR DESCRIPTION
## Why

The three SSE stream handlers added in #151's backend work
(`handleAPIEventsStream`, `handleAPITracesStream`, `handleAPIMemoryStream`)
had no HTTP-level test coverage. The non-streaming endpoints were all tested,
but the `serveSSE` fan-out path was only exercised by the `SSEHub` unit tests
in `observe_test.go`, not by a real HTTP handler test.

## What

Adds `TestHandleSSEStreams` — a table-driven test that exercises all three
stream handlers with identical assertions:

1. **Heartbeat** — the handler must emit `": connected\n\n"` immediately after
   subscribing, before any published message.
2. **Headers** — `Content-Type: text/event-stream` and `Cache-Control: no-cache`
   must be set before the first write.
3. **Fan-out** — a message published to the hub arrives at the subscriber.
4. **Clean shutdown** — context cancellation causes the handler to exit promptly.

New helpers added to the test file:

- `sseCapture`: a channel-backed `http.ResponseWriter` + `http.Flusher` that
  forwards each `Write` call to a buffered channel, avoiding data races on a
  shared `bytes.Buffer` between the handler goroutine and the test goroutine.
- `mustReadSSEMsg`: reads one frame from the channel with a deadline.

No production code changes.

## Test plan

- [x] `TestHandleSSEStreams/events/stream` — heartbeat, headers, message delivery
- [x] `TestHandleSSEStreams/traces/stream` — heartbeat, headers, message delivery
- [x] `TestHandleSSEStreams/memory/stream` — heartbeat, headers, message delivery
- [x] `go test ./... -race` passes

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)