### PR TITLE
test(webhook): remove dead loop-variable captures in api_test.go

### DIFF
--- a/internal/webhook/api_test.go
+++ b/internal/webhook/api_test.go
@@ -609,7 +609,6 @@ func TestHandleAPIDispatchesZeroWhenNoProvider(t *testing.T) {
 func TestRequireAPIKeyBlocksWhenKeyConfigured(t *testing.T) {
 	t.Parallel()
 	for _, path := range []string{"/api/agents", "/api/config", "/api/dispatches"} {
-		path := path
 		t.Run(path, func(t *testing.T) {
 			t.Parallel()
 			srv, _ := newTestServer(testCfg(nil)) // testCfg sets APIKey = testAPIKey
@@ -651,11 +650,10 @@ func TestRequireAPIKeyBlocksWrongToken(t *testing.T) {
 func TestRequireAPIKeyBlocksNonBearerScheme(t *testing.T) {
 	t.Parallel()
 	for _, authHeader := range []string{
-		testAPIKey,                   // raw key, no scheme
-		"Basic " + testAPIKey,        // Basic scheme instead of Bearer
-		"Token " + testAPIKey,        // other non-Bearer scheme
+		testAPIKey,            // raw key, no scheme
+		"Basic " + testAPIKey, // Basic scheme instead of Bearer
+		"Token " + testAPIKey, // other non-Bearer scheme
 	} {
-		authHeader := authHeader
 		t.Run(authHeader, func(t *testing.T) {
 			t.Parallel()
 			srv, _ := newTestServer(testCfg(nil))


### PR DESCRIPTION
## Why

Go 1.22 changed loop semantics so each iteration gets its own copy of the loop variable. The module declares `go 1.24.12`, so the classic pre-1.22 shadow assignments:

```go
path := path          // inside TestRequireAPIKeyBlocksWhenKeyConfigured
authHeader := authHeader  // inside TestRequireAPIKeyBlocksNonBearerScheme
```

are no longer needed — the closure inside `t.Run` already captures the per-iteration value. The same fixup has been applied to `server_test.go`, `config_test.go`, and `translate_test.go` in earlier PRs (#136, #142, #161); `api_test.go` was missed.

## Changes

- `TestRequireAPIKeyBlocksWhenKeyConfigured`: remove `path := path`
- `TestRequireAPIKeyBlocksNonBearerScheme`: remove `authHeader := authHeader`

No behaviour change; test logic is identical.