### PR TITLE
test(config): hoist Setenv and add t.Parallel to dispatch-wiring subtests

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -643,6 +643,7 @@ repos:
 }
 
 func TestDispatchWiringValidationErrors(t *testing.T) {
+	t.Setenv("TEST_SECRET", "s3cret")
 	cases := []struct {
 		name   string
 		agents string
@@ -689,7 +690,7 @@ func TestDispatchWiringValidationErrors(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("TEST_SECRET", "s3cret")
+			t.Parallel()
 			path := writeConfig(t, dispatchYAML(tc.agents))
 			_, err := Load(path)
 			if err == nil {

--- a/internal/webhook/api_test.go
+++ b/internal/webhook/api_test.go
@@ -609,7 +609,6 @@ func TestHandleAPIDispatchesZeroWhenNoProvider(t *testing.T) {
 func TestRequireAPIKeyBlocksWhenKeyConfigured(t *testing.T) {
 	t.Parallel()
 	for _, path := range []string{"/api/agents", "/api/config", "/api/dispatches"} {
-		path := path
 		t.Run(path, func(t *testing.T) {
 			t.Parallel()
 			srv, _ := newTestServer(testCfg(nil)) // testCfg sets APIKey = testAPIKey
@@ -651,11 +650,10 @@ func TestRequireAPIKeyBlocksWrongToken(t *testing.T) {
 func TestRequireAPIKeyBlocksNonBearerScheme(t *testing.T) {
 	t.Parallel()
 	for _, authHeader := range []string{
-		testAPIKey,                   // raw key, no scheme
-		"Basic " + testAPIKey,        // Basic scheme instead of Bearer
-		"Token " + testAPIKey,        // other non-Bearer scheme
+		testAPIKey,            // raw key, no scheme
+		"Basic " + testAPIKey, // Basic scheme instead of Bearer
+		"Token " + testAPIKey, // other non-Bearer scheme
 	} {
-		authHeader := authHeader
 		t.Run(authHeader, func(t *testing.T) {
 			t.Parallel()
 			srv, _ := newTestServer(testCfg(nil))


### PR DESCRIPTION
## Why

`TestDispatchWiringValidationErrors` sets `TEST_SECRET` inside each subtest but never calls `t.Parallel()`, so the three cases run sequentially even though they are fully independent:

```go
for _, tc := range cases {
    t.Run(tc.name, func(t *testing.T) {
        t.Setenv("TEST_SECRET", "s3cret")   // per-subtest; blocks parallelism
        path := writeConfig(t, dispatchYAML(tc.agents))
        ...
    })
}
```

This is the same pattern fixed for `TestDispatchConfigValidationRejectsNonPositiveValues` in #186.

## What changed

- Hoist `t.Setenv("TEST_SECRET", "s3cret")` to the outer function.
- Replace the per-subtest `t.Setenv` call with `t.Parallel()`.

The three subtests can now run concurrently and will surface data races under `-race`. No behaviour change.