### PR TITLE
test(webhook): fold empty-agent bad-request case into existing table

### DIFF
--- a/internal/webhook/server_test.go
+++ b/internal/webhook/server_test.go
@@ -680,6 +680,7 @@ func TestHandleAgentsRunReturnsBadRequestOnMissingFields(t *testing.T) {
 		{"missing agent", `{"repo":"owner/repo"}`},
 		{"missing repo", `{"agent":"coder"}`},
 		{"empty body", `{}`},
+		{"empty agent", `{"agent":""}`},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -703,17 +704,6 @@ func TestHandleAgentsRunReturnsNotFoundForUnknownRepo(t *testing.T) {
 	server.handleAgentsRun(rr, req)
 	if rr.Code != http.StatusNotFound {
 		t.Fatalf("got %d, want %d", rr.Code, http.StatusNotFound)
-	}
-}
-
-func TestHandleAgentsRunReturnsBadRequestForMissingFields(t *testing.T) {
-	t.Parallel()
-	server := newRunServer()
-	req := authedRequest(http.MethodPost, "/agents/run", `{"agent":""}`)
-	rr := httptest.NewRecorder()
-	server.handleAgentsRun(rr, req)
-	if rr.Code != http.StatusBadRequest {
-		t.Fatalf("got %d, want %d: %s", rr.Code, http.StatusBadRequest, rr.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Why

`TestHandleAgentsRunReturnsBadRequestForMissingFields` tests `{"agent":""}` producing a 400 response — which is the same handler, same assertion, and same code path as the three rows already in `TestHandleAgentsRunReturnsBadRequestOnMissingFields`.

Having two test functions that cover the same behavior under confusingly similar names increases maintenance cost without adding coverage.

## What changed

- Added `{"empty agent", \`{"agent":""}\`}` as a fourth row to the existing table in `TestHandleAgentsRunReturnsBadRequestOnMissingFields`.
- Deleted the now-redundant `TestHandleAgentsRunReturnsBadRequestForMissingFields`.

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)