### PR TITLE
refactor: merge non-AI-label enqueue tests into table

### DIFF
--- a/internal/webhook/server_test.go
+++ b/internal/webhook/server_test.go
@@ -163,46 +163,54 @@ func TestHandleIssuesOpenedEnqueuesEvent(t *testing.T) {
 	}
 }
 
-func TestHandleWebhookNonAILabelEnqueues(t *testing.T) {
+// TestHandleNonAILabelEnqueues verifies that non-AI labels are enqueued for both
+// pull_request.labeled and issues.labeled so that event-based bindings
+// (events: ["pull_request.labeled"] / events: ["issues.labeled"]) can match
+// them. Label-based bindings are filtered later by the engine via agentsForEvent.
+func TestHandleNonAILabelEnqueues(t *testing.T) {
 	t.Parallel()
-	server, dc := newTestServer(testCfg(nil))
-
-	// Non-AI labels on pull_request.labeled must be enqueued so that
-	// event-based bindings (events: ["pull_request.labeled"]) can match them.
-	// Label-based bindings are still filtered by the engine via agentsForEvent.
-	body := `{"action":"labeled","label":{"name":"bug"},"repository":{"full_name":"owner/repo"},"pull_request":{"number":2},"sender":{"login":"dev"}}`
-	rr := httptest.NewRecorder()
-	server.handleGitHubWebhook(rr, webhookRequest(t, "pull_request", "delivery-non-ai", body))
-	if rr.Code != http.StatusAccepted {
-		t.Fatalf("got %d, want %d", rr.Code, http.StatusAccepted)
+	cases := []struct {
+		name      string
+		event     string
+		delivery  string
+		body      string
+		wantKind  string
+		wantLabel string
+	}{
+		{
+			name:      "pull_request.labeled",
+			event:     "pull_request",
+			delivery:  "delivery-non-ai",
+			body:      `{"action":"labeled","label":{"name":"bug"},"repository":{"full_name":"owner/repo"},"pull_request":{"number":2},"sender":{"login":"dev"}}`,
+			wantKind:  "pull_request.labeled",
+			wantLabel: "bug",
+		},
+		{
+			name:      "issues.labeled",
+			event:     "issues",
+			delivery:  "delivery-issue-non-ai",
+			body:      `{"action":"labeled","label":{"name":"enhancement"},"repository":{"full_name":"owner/repo"},"issue":{"number":9},"sender":{"login":"dev"}}`,
+			wantKind:  "issues.labeled",
+			wantLabel: "enhancement",
+		},
 	}
-	ev := drainEvent(t, dc)
-	if ev.Kind != "pull_request.labeled" {
-		t.Errorf("kind: got %q, want %q", ev.Kind, "pull_request.labeled")
-	}
-	if ev.Payload["label"] != "bug" {
-		t.Errorf("payload label: got %v", ev.Payload["label"])
-	}
-}
-
-func TestHandleIssuesLabeledNonAILabelEnqueues(t *testing.T) {
-	t.Parallel()
-	server, dc := newTestServer(testCfg(nil))
-
-	// Non-AI labels on issues.labeled must be enqueued so that
-	// event-based bindings (events: ["issues.labeled"]) can match them.
-	body := `{"action":"labeled","label":{"name":"enhancement"},"repository":{"full_name":"owner/repo"},"issue":{"number":9},"sender":{"login":"dev"}}`
-	rr := httptest.NewRecorder()
-	server.handleGitHubWebhook(rr, webhookRequest(t, "issues", "delivery-issue-non-ai", body))
-	if rr.Code != http.StatusAccepted {
-		t.Fatalf("got %d, want %d", rr.Code, http.StatusAccepted)
-	}
-	ev := drainEvent(t, dc)
-	if ev.Kind != "issues.labeled" {
-		t.Errorf("kind: got %q, want %q", ev.Kind, "issues.labeled")
-	}
-	if ev.Payload["label"] != "enhancement" {
-		t.Errorf("payload label: got %v", ev.Payload["label"])
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			server, dc := newTestServer(testCfg(nil))
+			rr := httptest.NewRecorder()
+			server.handleGitHubWebhook(rr, webhookRequest(t, tc.event, tc.delivery, tc.body))
+			if rr.Code != http.StatusAccepted {
+				t.Fatalf("got %d, want %d", rr.Code, http.StatusAccepted)
+			}
+			ev := drainEvent(t, dc)
+			if ev.Kind != tc.wantKind {
+				t.Errorf("kind: got %q, want %q", ev.Kind, tc.wantKind)
+			}
+			if ev.Payload["label"] != tc.wantLabel {
+				t.Errorf("payload label: got %v, want %q", ev.Payload["label"], tc.wantLabel)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- `TestHandleWebhookNonAILabelEnqueues` and `TestHandleIssuesLabeledNonAILabelEnqueues` had identical structure — same setup, same assertions — differing only in event type, delivery ID, JSON body, expected kind, and expected label.
- Merged into `TestHandleNonAILabelEnqueues` with two table rows.
- All assertions and `t.Parallel()` on both outer and subtests preserved.

## Test plan

- [ ] CI passes (`go test ./internal/webhook/... -race`)
- [ ] `TestHandleNonAILabelEnqueues/pull_request.labeled` covers the old `TestHandleWebhookNonAILabelEnqueues`
- [ ] `TestHandleNonAILabelEnqueues/issues.labeled` covers the old `TestHandleIssuesLabeledNonAILabelEnqueues`

🤖 Generated with [Claude Code](https://claude.com/claude-code)