### PR TITLE
test(workflow): collapse AllowPRs no-PR guard tests into table-driven

### DIFF
--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -358,41 +358,42 @@ func TestHandleEventPRReviewEventBindingRuns(t *testing.T) {
 	}
 }
 
-func TestEngineAllowPRsFalseInjectsNoPRGuard(t *testing.T) {
+func TestEngineAllowPRsNoPRGuard(t *testing.T) {
 	t.Parallel()
-	// When allow_prs is false (default), the engine must prepend the no-PR
-	// instruction to the system prompt — matching the autonomous scheduler path.
-	e, runner := newTestEngine(func(c *config.Config) {
-		c.Agents[0].AllowPRs = false
-	})
-	ev := labelEvent("issues.labeled", "owner/repo", "ai:review:arch-reviewer", 1)
-	if err := e.HandleEvent(context.Background(), ev); err != nil {
-		t.Fatalf("HandleEvent: %v", err)
+	const noPRGuard = "Do not open or create pull requests under any circumstances."
+	tests := []struct {
+		name        string
+		allowPRs    bool
+		wantGuard   bool
+	}{
+		{
+			name:      "guard prepended when allow_prs=false",
+			allowPRs:  false,
+			wantGuard: true,
+		},
+		{
+			name:      "guard absent when allow_prs=true",
+			allowPRs:  true,
+			wantGuard: false,
+		},
 	}
-	if runner.callCount() != 1 {
-		t.Fatalf("expected 1 run, got %d", runner.callCount())
-	}
-	const want = "Do not open or create pull requests under any circumstances."
-	if !strings.HasPrefix(runner.lastSystem(), want) {
-		t.Errorf("system prompt must start with no-PR guard\ngot: %q", runner.lastSystem())
-	}
-}
-
-func TestEngineAllowPRsTrueOmitsNoPRGuard(t *testing.T) {
-	t.Parallel()
-	// When allow_prs is true the guard must NOT be prepended.
-	e, runner := newTestEngine(func(c *config.Config) {
-		c.Agents[0].AllowPRs = true
-	})
-	ev := labelEvent("issues.labeled", "owner/repo", "ai:review:arch-reviewer", 1)
-	if err := e.HandleEvent(context.Background(), ev); err != nil {
-		t.Fatalf("HandleEvent: %v", err)
-	}
-	if runner.callCount() != 1 {
-		t.Fatalf("expected 1 run, got %d", runner.callCount())
-	}
-	const noPR = "Do not open or create pull requests under any circumstances."
-	if strings.HasPrefix(runner.lastSystem(), noPR) {
-		t.Errorf("system prompt must NOT contain no-PR guard when allow_prs=true\ngot: %q", runner.lastSystem())
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			e, runner := newTestEngine(func(c *config.Config) {
+				c.Agents[0].AllowPRs = tc.allowPRs
+			})
+			ev := labelEvent("issues.labeled", "owner/repo", "ai:review:arch-reviewer", 1)
+			if err := e.HandleEvent(context.Background(), ev); err != nil {
+				t.Fatalf("HandleEvent: %v", err)
+			}
+			if runner.callCount() != 1 {
+				t.Fatalf("expected 1 run, got %d", runner.callCount())
+			}
+			hasGuard := strings.HasPrefix(runner.lastSystem(), noPRGuard)
+			if hasGuard != tc.wantGuard {
+				t.Errorf("no-PR guard present=%v, want %v\nsystem: %q", hasGuard, tc.wantGuard, runner.lastSystem())
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Why

`TestEngineAllowPRsFalseInjectsNoPRGuard` and `TestEngineAllowPRsTrueOmitsNoPRGuard`
are structurally identical: same engine setup, same label event, same runner
call-count check. They differ only in the `AllowPRs` flag value and whether the
assertion expects the guard to be present or absent. Two separate top-level
functions for two values of a boolean is a clear table opportunity.

## What

Collapse both into a single `TestEngineAllowPRsNoPRGuard` with a
`{name, allowPRs, wantGuard}` table and parallel subtests.  Coverage is
unchanged; the unified assertion `hasGuard != tc.wantGuard` is symmetric and
equally clear in both directions.