### PR TITLE
test(webhook): merge two requireAPIKey rejection tests into table-driven

### DIFF
--- a/internal/webhook/api_test.go
+++ b/internal/webhook/api_test.go
@@ -627,47 +627,33 @@ func TestRequireAPIKeyBlocksWhenKeyConfigured(t *testing.T) {
 	}
 }
 
-// TestRequireAPIKeyBlocksWrongToken verifies that a wrong Bearer token is
-// rejected with 401.
-func TestRequireAPIKeyBlocksWrongToken(t *testing.T) {
+// TestRequireAPIKeyRejectsInvalidAuth verifies that the middleware rejects
+// requests with a wrong token or an unsupported auth scheme.
+func TestRequireAPIKeyRejectsInvalidAuth(t *testing.T) {
 	t.Parallel()
-	srv, _ := newTestServer(testCfg(nil))
-
-	req := httptest.NewRequest(http.MethodGet, "/api/agents", nil)
-	req.Header.Set("Authorization", "Bearer wrong-token")
-	rec := httptest.NewRecorder()
-	srv.requireAPIKey(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})).ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusUnauthorized {
-		t.Fatalf("want 401 for wrong token, got %d", rec.Code)
+	tests := []struct {
+		name       string
+		authHeader string
+	}{
+		{name: "wrong Bearer token", authHeader: "Bearer wrong-token"},
+		{name: "raw key no scheme", authHeader: testAPIKey},
+		{name: "Basic scheme", authHeader: "Basic " + testAPIKey},
+		{name: "Token scheme", authHeader: "Token " + testAPIKey},
 	}
-}
-
-// TestRequireAPIKeyBlocksNonBearerScheme verifies that the middleware rejects
-// Authorization headers that do not use the Bearer scheme, even when the value
-// happens to be the correct API key.
-func TestRequireAPIKeyBlocksNonBearerScheme(t *testing.T) {
-	t.Parallel()
-	for _, authHeader := range []string{
-		testAPIKey,            // raw key, no scheme
-		"Basic " + testAPIKey, // Basic scheme instead of Bearer
-		"Token " + testAPIKey, // other non-Bearer scheme
-	} {
-		t.Run(authHeader, func(t *testing.T) {
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			srv, _ := newTestServer(testCfg(nil))
 
 			req := httptest.NewRequest(http.MethodGet, "/api/agents", nil)
-			req.Header.Set("Authorization", authHeader)
+			req.Header.Set("Authorization", tc.authHeader)
 			rec := httptest.NewRecorder()
 			srv.requireAPIKey(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 			})).ServeHTTP(rec, req)
 
 			if rec.Code != http.StatusUnauthorized {
-				t.Fatalf("want 401 for non-Bearer auth %q, got %d", authHeader, rec.Code)
+				t.Fatalf("want 401 for auth %q, got %d", tc.authHeader, rec.Code)
 			}
 		})
 	}


### PR DESCRIPTION
## Why

`TestRequireAPIKeyBlocksWrongToken` tested a single case (wrong Bearer token) and `TestRequireAPIKeyBlocksNonBearerScheme` tested three cases (raw key, Basic scheme, Token scheme) in an unnamed `range` loop. Both tests used identical setup, the same endpoint, and the same assertion (`401 Unauthorized`). The only variable was the `Authorization` header value.

Collapsing them into `TestRequireAPIKeyRejectsInvalidAuth` with four named subtests:
- Each rejection scenario is now discoverable by name in test output (`-run TestRequireAPIKeyRejectsInvalidAuth/wrong_Bearer_token`, etc.)
- Eliminates the duplicate boilerplate (server setup, request construction, assertion)
- The unnamed string loop in the old test becomes a proper table with `name` + `authHeader` fields

No behavioral change — all four cases are preserved.