### PR TITLE
refactor: replace manual min-clamp guards with built-in max

### DIFF
--- a/cmd/agents/main.go
+++ b/cmd/agents/main.go
@@ -79,9 +79,7 @@ func run() error {
 		for range d.MaxDepth {
 			runBuf *= d.MaxFanout
 		}
-		if runBuf < cfg.Daemon.Processor.EventQueueBuffer {
-			runBuf = cfg.Daemon.Processor.EventQueueBuffer
-		}
+		runBuf = max(runBuf, cfg.Daemon.Processor.EventQueueBuffer)
 		dataChannels := workflow.NewDataChannels(runBuf)
 		engine := workflow.NewEngine(cfg, runners, dataChannels, logger)
 		scheduler.WithDispatcher(engine.Dispatcher())

--- a/internal/workflow/dispatch.go
+++ b/internal/workflow/dispatch.go
@@ -95,10 +95,7 @@ func (s *DispatchDedupStore) Start(ctx context.Context) {
 		return
 	}
 	go func() {
-		tickInterval := s.ttl / 4
-		if tickInterval < time.Second {
-			tickInterval = time.Second
-		}
+		tickInterval := max(s.ttl/4, time.Second)
 		ticker := time.NewTicker(tickInterval)
 		defer ticker.Stop()
 		for {


### PR DESCRIPTION
## Why

Two production code sites use the `if x < y { x = y }` floor-clamp
pattern. Go 1.21 added a built-in `max` function that expresses this
idiom in a single expression. This repo is on Go 1.24, so the built-in
is available.

## What changed

**`cmd/agents/main.go`** — floor `runBuf` to the configured event queue
buffer:
```go
// before
if runBuf < cfg.Daemon.Processor.EventQueueBuffer {
    runBuf = cfg.Daemon.Processor.EventQueueBuffer
}
// after
runBuf = max(runBuf, cfg.Daemon.Processor.EventQueueBuffer)
```

**`internal/workflow/dispatch.go`** — floor the eviction ticker interval
to `time.Second`:
```go
// before
tickInterval := s.ttl / 4
if tickInterval < time.Second {
    tickInterval = time.Second
}
// after
tickInterval := max(s.ttl/4, time.Second)
```

No behaviour change — pure readability improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)