### PR TITLE
refactor: replace make+copy slice cloning with slices.Clone

### DIFF
--- a/internal/ai/prompt.go
+++ b/internal/ai/prompt.go
@@ -142,8 +142,7 @@ func renderRuntimeContext(ctx PromptContext) string {
 	if len(ctx.Roster) > 0 {
 		b.WriteString("\n## Available experts\n\n")
 		// Sort roster by name for deterministic output.
-		roster := make([]RosterEntry, len(ctx.Roster))
-		copy(roster, ctx.Roster)
+		roster := slices.Clone(ctx.Roster)
 		slices.SortFunc(roster, func(a, b RosterEntry) int {
 			return strings.Compare(a.Name, b.Name)
 		})

--- a/internal/observe/observe.go
+++ b/internal/observe/observe.go
@@ -9,6 +9,7 @@ package observe
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -219,8 +220,7 @@ func (g *InteractionGraph) Edges() []Edge {
 	out := make([]Edge, 0, len(g.edges))
 	for _, e := range g.edges {
 		cp := *e
-		cp.Dispatches = make([]DispatchRecord, len(e.Dispatches))
-		copy(cp.Dispatches, e.Dispatches)
+		cp.Dispatches = slices.Clone(e.Dispatches)
 		out = append(out, cp)
 	}
 	return out


### PR DESCRIPTION
## Why

Two sites used the manual `make([]T, len(s)) + copy(dst, src)` idiom to clone a slice before sorting or snapshotting it. `slices.Clone` is the stdlib spelling for exactly this operation — it is shorter, immediately recognisable, and consistent with the `maps.Clone` call already used elsewhere in the codebase (e.g. #177).

## What changed

- `internal/ai/prompt.go` — roster copy before `slices.SortFunc`
- `internal/observe/observe.go` — `Dispatches` copy in `Edges()` snapshot; adds `slices` to the import block

No behaviour change. Both call sites guard against nil/empty inputs before reaching the cloning line.