### PR TITLE
test(observe): simplify extractSSEData with strings.CutPrefix

### DIFF
--- a/internal/observe/observe_test.go
+++ b/internal/observe/observe_test.go
@@ -361,16 +361,11 @@ func TestWatchMemoryDirNoOpOnEmptyDir(t *testing.T) {
 	}
 }
 
-// extractSSEData strips the "data: " prefix and trailing "\n\n" added by
+// extractSSEData strips the "data: " prefix and trailing newlines added by
 // sseData so the payload can be unmarshalled as JSON.
 func extractSSEData(raw []byte) []byte {
-	const prefix = "data: "
-	s := string(raw)
-	if len(s) > len(prefix) && s[:len(prefix)] == prefix {
-		s = s[len(prefix):]
-	}
-	s = strings.TrimRight(s, "\n")
-	return []byte(s)
+	s, _ := strings.CutPrefix(string(raw), "data: ")
+	return []byte(strings.TrimRight(s, "\n"))
 }
 
 // ─── ActiveRuns ──────────────────────────────────────────────────────────────
@@ -528,12 +523,9 @@ func TestStoreRecordEventSSEUsesLowercaseJSON(t *testing.T) {
 		t.Fatal("want SSE message, got nothing")
 	}
 
-	// Strip the "data: " prefix and trailing "\n\n", then unmarshal into a raw
-	// map so we can inspect the actual JSON key names.
-	raw := strings.TrimPrefix(string(msg), "data: ")
-	raw = strings.TrimSuffix(raw, "\n\n")
+	// Strip the SSE framing and unmarshal into a raw map to inspect key names.
 	var fields map[string]any
-	if err := json.Unmarshal([]byte(raw), &fields); err != nil {
+	if err := json.Unmarshal(extractSSEData(msg), &fields); err != nil {
 		t.Fatalf("unmarshal SSE payload: %v", err)
 	}
 

--- a/internal/observe/observe_test.go
+++ b/internal/observe/observe_test.go
@@ -368,6 +368,29 @@ func extractSSEData(raw []byte) []byte {
 	return []byte(strings.TrimRight(s, "\n"))
 }
 
+func TestExtractSSEData(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   []byte
+		want []byte
+	}{
+		{"normal SSE frame", []byte("data: {\"k\":\"v\"}\n\n"), []byte("{\"k\":\"v\"}")},
+		{"prefix-only returns empty", []byte("data: "), []byte("")},
+		{"no prefix unchanged", []byte("something else"), []byte("something else")},
+		{"trailing newlines stripped", []byte("data: payload\n\n"), []byte("payload")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := extractSSEData(tc.in)
+			if string(got) != string(tc.want) {
+				t.Errorf("extractSSEData(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
 // ─── ActiveRuns ──────────────────────────────────────────────────────────────
 
 func TestActiveRunsStartFinishIsRunning(t *testing.T) {


### PR DESCRIPTION
## Why

`extractSSEData` in `observe_test.go` stripped the `\"data: \"` SSE prefix with a manual bounds-check pattern (`len(s) > len(prefix) && s[:len(prefix)] == prefix`). Go 1.20 added `strings.CutPrefix` which does exactly this, eliminating the boilerplate.

A second, separate inline extraction in `TestStoreRecordEventSSEUsesLowercaseJSON` was doing the same job with `strings.TrimPrefix` + `strings.TrimSuffix` — replaced with a call to `extractSSEData` to remove the duplication.

## Changes

- `extractSSEData`: 7 lines → 2 lines using `strings.CutPrefix`
- `TestStoreRecordEventSSEUsesLowercaseJSON`: inline stripping removed, replaced with `extractSSEData(msg)`

No behavior change. Both before and after: if the prefix is present it is stripped; if absent the input is returned as-is.