### PR TITLE
refactor(workflow): use dispatchStoreKey in webhook run marker methods

### DIFF
--- a/internal/workflow/dispatch.go
+++ b/internal/workflow/dispatch.go
@@ -219,7 +219,7 @@ func (s *DispatchDedupStore) AbandonClaim(target, repo string, number int) {
 // Callers must follow with FinalizeWebhookRun (success) or AbandonWebhookRun
 // (failure) to release the marker.
 func (s *DispatchDedupStore) MarkWebhookRunInFlight(agent, repo string, number int) {
-	key := fmt.Sprintf("%s\x00%s\x00%d", agent, repo, number)
+	key := dispatchStoreKey(agent, repo, number)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.webhookRefCounts[key]++
@@ -231,7 +231,7 @@ func (s *DispatchDedupStore) MarkWebhookRunInFlight(agent, repo string, number i
 // duplicates until the dedup_window_seconds elapses. Once the refcount reaches
 // zero, the evict() loop is free to remove the entry when expiresAt passes.
 func (s *DispatchDedupStore) FinalizeWebhookRun(agent, repo string, number int) {
-	key := fmt.Sprintf("%s\x00%s\x00%d", agent, repo, number)
+	key := dispatchStoreKey(agent, repo, number)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.webhookRefCounts[key] <= 1 {
@@ -247,7 +247,7 @@ func (s *DispatchDedupStore) FinalizeWebhookRun(agent, repo string, number int) 
 // by the error and panic paths in fanOut so that a retry or a subsequent event
 // for the same item can claim the slot and attempt the run again.
 func (s *DispatchDedupStore) AbandonWebhookRun(agent, repo string, number int) {
-	key := fmt.Sprintf("%s\x00%s\x00%d", agent, repo, number)
+	key := dispatchStoreKey(agent, repo, number)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.webhookRefCounts[key] <= 1 {


### PR DESCRIPTION
## Why

`MarkWebhookRunInFlight`, `FinalizeWebhookRun`, and `AbandonWebhookRun` were inlining the dispatch key format directly:

```go
key := fmt.Sprintf("%s\x00%s\x00%d", agent, repo, number)
```

All other methods in the same file (`SeenOrAdd`, `SeesPendingOrCommitted`, `TryClaim`, `CommitClaim`, `AbandonClaim`, `TryClaimForDispatch`) already call the `dispatchStoreKey` helper. These three were left behind when the helper was extracted in #157.

## What

Replace the three inline `fmt.Sprintf` calls with `dispatchStoreKey(agent, repo, number)`. Pure mechanical substitution — the key format is identical, so behaviour is unchanged.

## Test plan
- [x] `go test ./...` passes