### PR TITLE
feat(store,webhook): Phase 2 write API — CRUD endpoints + live config reload

### DIFF
--- a/cmd/agents/main.go
+++ b/cmd/agents/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"flag"
 	"fmt"
@@ -53,9 +54,12 @@ func run() error {
 	runRepo := flag.String("repo", "", "repo to target when using --run-agent (e.g. owner/repo)")
 	flag.Parse()
 
-	cfg, err := loadConfig(*configPath, *dbPath, *importPath)
+	cfg, db, err := loadConfig(*configPath, *dbPath, *importPath)
 	if err != nil {
 		return err
+	}
+	if db != nil {
+		defer db.Close()
 	}
 
 	logger := logging.NewLogger(cfg.Daemon.Log)
@@ -125,6 +129,9 @@ func run() error {
 	server.WithUI(ui.FS)
 	server.WithObserve(obs)
 	server.WithRuntimeState(obs)
+	if db != nil {
+		server.WithStore(db)
+	}
 
 	group, groupCtx := errgroup.WithContext(ctx)
 	deliveryStore.Start(groupCtx)
@@ -188,28 +195,33 @@ func setupScheduler(cfg *config.Config, runners map[string]ai.Runner, logger zer
 //   - If importPath is also set, the YAML at importPath is parsed and written
 //     into the database before loading.
 //   - The config is then read from the database.
+//   - The returned *sql.DB is kept open for the lifetime of the daemon so that
+//     write API endpoints can use it. The caller is responsible for Close.
 //
-// When dbPath is empty, configPath is used (default behaviour).
-func loadConfig(configPath, dbPath, importPath string) (*config.Config, error) {
+// When dbPath is empty, configPath is used (default behaviour) and nil is
+// returned for the DB.
+func loadConfig(configPath, dbPath, importPath string) (*config.Config, *sql.DB, error) {
 	if importPath != "" && dbPath == "" {
-		return nil, fmt.Errorf("--import requires --db")
+		return nil, nil, fmt.Errorf("--import requires --db")
 	}
 	if dbPath == "" {
-		return config.Load(configPath)
+		cfg, err := config.Load(configPath)
+		return cfg, nil, err
 	}
 	db, err := store.Open(dbPath)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	defer db.Close()
 
 	if importPath != "" {
 		yamlCfg, err := config.Load(importPath)
 		if err != nil {
-			return nil, fmt.Errorf("import: load YAML: %w", err)
+			db.Close()
+			return nil, nil, fmt.Errorf("import: load YAML: %w", err)
 		}
 		if err := store.Import(db, yamlCfg); err != nil {
-			return nil, fmt.Errorf("import: write to database: %w", err)
+			db.Close()
+			return nil, nil, fmt.Errorf("import: write to database: %w", err)
 		}
 		// Count from the source config so the message reflects exactly what
 		// was written, not a potentially stale whole-table count.
@@ -222,7 +234,12 @@ func loadConfig(configPath, dbPath, importPath string) (*config.Config, error) {
 			len(yamlCfg.Agents), len(yamlCfg.Repos), nBindings)
 	}
 
-	return store.LoadAndValidate(db)
+	cfg, err := store.LoadAndValidate(db)
+	if err != nil {
+		db.Close()
+		return nil, nil, err
+	}
+	return cfg, db, nil
 }
 
 // schedulerStatusAdapter adapts *autonomous.Scheduler to webhook.StatusProvider,

--- a/cmd/agents/main.go
+++ b/cmd/agents/main.go
@@ -131,6 +131,11 @@ func run() error {
 	server.WithRuntimeState(obs)
 	if db != nil {
 		server.WithStore(db)
+		// Propagate write-API config reloads to the engine and scheduler so that
+		// new repos, agents, and bindings take effect without a restart.
+		// Note: new cron bindings and backend changes require a restart.
+		server.WithConfigObserver(engine)
+		server.WithConfigObserver(scheduler)
 	}
 
 	group, groupCtx := errgroup.WithContext(ctx)

--- a/internal/autonomous/scheduler.go
+++ b/internal/autonomous/scheduler.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/robfig/cron/v3"
@@ -71,7 +72,7 @@ type lastRunRecord struct {
 // Scheduler wires cron-triggered agent bindings from the config into the
 // robfig/cron engine.
 type Scheduler struct {
-	cfg          *config.Config
+	cfgPtr       atomic.Pointer[config.Config]
 	runners      map[string]ai.Runner
 	memories     *MemoryStore
 	cron         *cron.Cron
@@ -83,6 +84,21 @@ type Scheduler struct {
 	lastRuns     map[string]lastRunRecord // key: "name\x00repo"
 	dispatcher   *workflow.Dispatcher    // nil when dispatch is not configured
 	traceRec     workflow.TraceRecorder  // nil when tracing is not configured
+}
+
+// cfg returns the current effective configuration. All scheduler methods must
+// call this instead of reading the field directly so live reloads are visible.
+func (s *Scheduler) cfg() *config.Config {
+	return s.cfgPtr.Load()
+}
+
+// UpdateConfig atomically replaces the scheduler's config so that the next
+// agent execution uses updated agent definitions, backends, and skills.
+// Cron bindings that were registered at startup will use the new config on
+// their next firing. New cron bindings added after startup are not
+// automatically scheduled; a daemon restart is required for those.
+func (s *Scheduler) UpdateConfig(cfg *config.Config) {
+	s.cfgPtr.Store(cfg)
 }
 
 // WithDispatcher attaches a Dispatcher to the Scheduler so that dispatch
@@ -110,13 +126,13 @@ func NewScheduler(cfg *config.Config, runners map[string]ai.Runner, memories *Me
 		cron.WithChain(cron.SkipIfStillRunning(cronLogger)),
 	)
 	s := &Scheduler{
-		cfg:      cfg,
 		runners:  runners,
 		memories: memories,
 		cron:     c,
 		logger:   logger.With().Str("component", "autonomous_scheduler").Logger(),
 		lastRuns: make(map[string]lastRunRecord),
 	}
+	s.cfgPtr.Store(cfg)
 	if err := s.registerJobs(); err != nil {
 		return nil, err
 	}
@@ -140,7 +156,7 @@ func (s *Scheduler) Run(ctx context.Context) error {
 }
 
 func (s *Scheduler) registerJobs() error {
-	for _, repo := range s.cfg.Repos {
+	for _, repo := range s.cfg().Repos {
 		if !repo.Enabled {
 			continue
 		}
@@ -148,7 +164,7 @@ func (s *Scheduler) registerJobs() error {
 			if !binding.IsEnabled() || !binding.IsCron() {
 				continue
 			}
-			agent, ok := s.cfg.AgentByName(binding.Agent)
+			agent, ok := s.cfg().AgentByName(binding.Agent)
 			if !ok {
 				// Validation at config load should have caught this; defensive.
 				return fmt.Errorf("binding references unknown agent %q on repo %q", binding.Agent, repo.Name)
@@ -247,11 +263,11 @@ func (s *Scheduler) AgentStatuses() []AgentStatus {
 // the run itself fails.
 func (s *Scheduler) TriggerAgent(ctx context.Context, agentName, repo string) error {
 	agentName = strings.ToLower(strings.TrimSpace(agentName))
-	repoDef, ok := s.cfg.RepoByName(repo)
+	repoDef, ok := s.cfg().RepoByName(repo)
 	if !ok || !repoDef.Enabled {
 		return fmt.Errorf("repo %q is disabled or not found", repo)
 	}
-	agent, ok := s.cfg.AgentByName(agentName)
+	agent, ok := s.cfg().AgentByName(agentName)
 	if !ok {
 		return fmt.Errorf("agent %q not found", agentName)
 	}
@@ -283,7 +299,7 @@ func (s *Scheduler) executeAgentRun(ctx context.Context, repo string, agent conf
 	// Resolve backend and runner. If either fails, roll back the cron mark
 	// written above so that subsequent dispatches are not spuriously suppressed
 	// for the full dedup_window_seconds.
-	backend := s.cfg.ResolveBackend(agent.Backend)
+	backend := s.cfg().ResolveBackend(agent.Backend)
 	if backend == "" {
 		if s.dispatcher != nil {
 			s.dispatcher.RollbackAutonomousRun(agent.Name, repo)
@@ -299,7 +315,7 @@ func (s *Scheduler) executeAgentRun(ctx context.Context, repo string, agent conf
 	}
 
 	logger := s.logger.With().Str("repo", repo).Str("agent", agent.Name).Str("backend", backend).Logger()
-	roster := workflow.BuildRoster(s.cfg, repo, agent.Name)
+	roster := workflow.BuildRoster(s.cfg(), repo, agent.Name)
 	// runCompleted is set to true once runner.Run returns successfully. The cron
 	// mark should only be rolled back when the autonomous pass itself fails
 	// (prompt rendering, memory lock, or runner error). A post-run failure such
@@ -307,7 +323,7 @@ func (s *Scheduler) executeAgentRun(ctx context.Context, repo string, agent conf
 	// already committed, so the dedup window must remain in force.
 	runCompleted := false
 	err := s.memories.WithLock(agent.Name, repo, func(memoryPath string, memory string) error {
-		rendered, err := ai.RenderAgentPrompt(agent, s.cfg.Skills, ai.PromptContext{
+		rendered, err := ai.RenderAgentPrompt(agent, s.cfg().Skills, ai.PromptContext{
 			Repo:       repo,
 			Backend:    backend,
 			Memory:     memory,

--- a/internal/autonomous/scheduler.go
+++ b/internal/autonomous/scheduler.go
@@ -169,7 +169,7 @@ func (s *Scheduler) registerJobs() error {
 				// Validation at config load should have caught this; defensive.
 				return fmt.Errorf("binding references unknown agent %q on repo %q", binding.Agent, repo.Name)
 			}
-			job := s.makeCronJob(repo.Name, agent)
+			job := s.makeCronJob(repo.Name, agent.Name, binding.Cron)
 			id, err := s.cron.AddFunc(binding.Cron, job)
 			if err != nil {
 				return fmt.Errorf("schedule agent %q for repo %q: %w", agent.Name, repo.Name, err)
@@ -187,10 +187,39 @@ func (s *Scheduler) registerJobs() error {
 	return nil
 }
 
-func (s *Scheduler) makeCronJob(repo string, agent config.AgentDef) func() {
+// makeCronJob returns a closure registered with the cron engine for the given
+// (repo, agentName, cronExpr) triple. On every firing the closure re-resolves
+// the repo definition, the binding, and the agent definition from the live
+// config (via s.cfg()) so that write-API updates to agent prompts, backends,
+// AllowPRs, and binding enabled state are picked up without a daemon restart.
+// If the repo is disabled, the binding has been removed/disabled, or the agent
+// no longer exists in the live config the firing is silently skipped.
+func (s *Scheduler) makeCronJob(repo, agentName, cronExpr string) func() {
 	return func() {
 		ctx := s.currentRunCtx()
 		if ctx.Err() != nil {
+			return
+		}
+		// Re-resolve from the live config so that write-API mutations are
+		// visible on the next cron tick without requiring a restart.
+		repoDef, ok := s.cfg().RepoByName(repo)
+		if !ok || !repoDef.Enabled {
+			s.logger.Info().Str("repo", repo).Str("agent", agentName).
+				Msg("autonomous run skipped: repo disabled or removed from config")
+			return
+		}
+		bound := slices.ContainsFunc(repoDef.Use, func(b config.Binding) bool {
+			return b.Agent == agentName && b.IsEnabled() && b.IsCron() && b.Cron == cronExpr
+		})
+		if !bound {
+			s.logger.Info().Str("repo", repo).Str("agent", agentName).
+				Msg("autonomous run skipped: binding disabled or removed from config")
+			return
+		}
+		agent, ok := s.cfg().AgentByName(agentName)
+		if !ok {
+			s.logger.Error().Str("repo", repo).Str("agent", agentName).
+				Msg("autonomous run skipped: agent not found in live config")
 			return
 		}
 		status := "success"
@@ -203,11 +232,11 @@ func (s *Scheduler) makeCronJob(repo string, agent config.AgentDef) func() {
 				// agent pass ran.
 				status = "skipped"
 			default:
-				s.logger.Error().Str("repo", repo).Str("agent", agent.Name).Err(err).Msg("autonomous agent run completed with errors")
+				s.logger.Error().Str("repo", repo).Str("agent", agentName).Err(err).Msg("autonomous agent run completed with errors")
 				status = "error"
 			}
 		}
-		s.recordLastRun(agent.Name, repo, time.Now(), status)
+		s.recordLastRun(agentName, repo, time.Now(), status)
 	}
 }
 

--- a/internal/autonomous/scheduler_test.go
+++ b/internal/autonomous/scheduler_test.go
@@ -1060,6 +1060,116 @@ func TestSchedulerCronMarkBlocksDispatchDuringInFlightRun(t *testing.T) {
 	}
 }
 
+// TestSchedulerCronJobPicksUpLiveConfigOnEachFiring verifies that when the
+// scheduler's config is updated via UpdateConfig, the next cron firing uses the
+// new agent definition (prompt, AllowPRs, etc.) rather than the startup snapshot.
+func TestSchedulerCronJobPicksUpLiveConfigOnEachFiring(t *testing.T) {
+	t.Parallel()
+	runner := &promptCapturingRunner{}
+	cfg := baseCfg(nil)
+	s, err := NewScheduler(cfg, map[string]ai.Runner{"claude": runner}, NewMemoryStore(t.TempDir()), zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewScheduler: %v", err)
+	}
+
+	wrappedJob := s.cron.Entry(s.agentEntries[0].cronID).WrappedJob
+	s.setRunCtx(context.Background())
+
+	// First firing uses the initial prompt.
+	wrappedJob.Run()
+
+	// Update the live config with a different agent prompt.
+	updated := *cfg
+	updated.Agents = []config.AgentDef{
+		{Name: "reviewer", Backend: "claude", Skills: []string{"architect"}, Prompt: "Updated live-reload prompt."},
+	}
+	s.UpdateConfig(&updated)
+
+	// Second firing must use the updated prompt.
+	wrappedJob.Run()
+
+	runner.mu.Lock()
+	prompts := runner.prompts
+	runner.mu.Unlock()
+
+	if len(prompts) != 2 {
+		t.Fatalf("expected 2 prompts, got %d", len(prompts))
+	}
+	if !strings.Contains(prompts[0], "Review PRs.") {
+		t.Errorf("first firing: expected initial prompt, got: %q", prompts[0])
+	}
+	if !strings.Contains(prompts[1], "Updated live-reload prompt.") {
+		t.Errorf("second firing: expected updated prompt, got: %q", prompts[1])
+	}
+}
+
+// TestSchedulerCronJobSkipsDisabledBindingAfterLiveReload verifies that when a
+// binding is disabled via UpdateConfig, the next cron firing is a no-op.
+func TestSchedulerCronJobSkipsDisabledBindingAfterLiveReload(t *testing.T) {
+	t.Parallel()
+	runner := &stubRunner{}
+	cfg := baseCfg(nil)
+	s, err := NewScheduler(cfg, map[string]ai.Runner{"claude": runner}, NewMemoryStore(t.TempDir()), zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewScheduler: %v", err)
+	}
+
+	wrappedJob := s.cron.Entry(s.agentEntries[0].cronID).WrappedJob
+	s.setRunCtx(context.Background())
+
+	// First firing runs normally.
+	wrappedJob.Run()
+
+	// Disable the binding in the live config.
+	f := false
+	updated := *cfg
+	updated.Repos = []config.RepoDef{{
+		Name:    "owner/repo",
+		Enabled: true,
+		Use:     []config.Binding{{Agent: "reviewer", Cron: "* * * * *", Enabled: &f}},
+	}}
+	s.UpdateConfig(&updated)
+
+	// Second firing must be skipped.
+	wrappedJob.Run()
+
+	runner.mu.Lock()
+	calls := runner.calls
+	runner.mu.Unlock()
+	if calls != 1 {
+		t.Errorf("expected 1 runner call (second skipped after disable), got %d", calls)
+	}
+}
+
+// TestSchedulerCronJobSkipsDisabledRepoAfterLiveReload verifies that when a
+// repo is disabled via UpdateConfig, the next cron firing is a no-op.
+func TestSchedulerCronJobSkipsDisabledRepoAfterLiveReload(t *testing.T) {
+	t.Parallel()
+	runner := &stubRunner{}
+	cfg := baseCfg(nil)
+	s, err := NewScheduler(cfg, map[string]ai.Runner{"claude": runner}, NewMemoryStore(t.TempDir()), zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewScheduler: %v", err)
+	}
+
+	wrappedJob := s.cron.Entry(s.agentEntries[0].cronID).WrappedJob
+	s.setRunCtx(context.Background())
+
+	// Disable the repo in the live config.
+	updated := *cfg
+	updated.Repos = []config.RepoDef{{Name: "owner/repo", Enabled: false}}
+	s.UpdateConfig(&updated)
+
+	wrappedJob.Run()
+
+	runner.mu.Lock()
+	calls := runner.calls
+	runner.mu.Unlock()
+	if calls != 0 {
+		t.Errorf("expected 0 runner calls for disabled repo, got %d", calls)
+	}
+}
+
 // TestCronDispatchCrossNamespaceRaceOnlyOneWins is a regression test for the
 // TOCTOU race identified after the initial dispatch-dedup implementation. The
 // old code used two separate operations:

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -40,6 +40,10 @@ func Open(path string) (*sql.DB, error) {
 	if err != nil {
 		return nil, fmt.Errorf("store: open %s: %w", path, err)
 	}
+	// SQLite is single-writer; a pool size of 1 ensures that the
+	// PRAGMA foreign_keys=ON issued below applies to the one connection
+	// that the pool will ever use.
+	db.SetMaxOpenConns(1)
 	// Use WAL mode for better concurrent read performance.
 	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
 		db.Close()
@@ -639,5 +643,184 @@ func LoadAndValidate(db *sql.DB) (*config.Config, error) {
 		return nil, err
 	}
 	return config.FinishLoad(cfg)
+}
+
+// ── Write API ───────────────────────────────────────────────────────────────
+//
+// Each Put* function performs an FK-safe upsert using INSERT … ON CONFLICT DO
+// UPDATE rather than INSERT OR REPLACE (which deletes + re-inserts the row and
+// would violate FK constraints on child tables such as bindings).
+//
+// Each Delete* function removes the named row. Callers must remove FK-dependent
+// children (e.g. bindings) before deleting a repo or agent.
+
+// PutAgent creates or updates an agent definition in the database. The agent
+// record is upserted in-place, so any bindings that reference it are preserved.
+func PutAgent(db *sql.DB, a config.AgentDef) error {
+	skills, err := json.Marshal(a.Skills)
+	if err != nil {
+		return fmt.Errorf("store put agent %s: marshal skills: %w", a.Name, err)
+	}
+	canDispatch, err := json.Marshal(a.CanDispatch)
+	if err != nil {
+		return fmt.Errorf("store put agent %s: marshal can_dispatch: %w", a.Name, err)
+	}
+	_, err = db.Exec(`
+		INSERT INTO agents(name,backend,skills,prompt,allow_prs,allow_dispatch,can_dispatch,description)
+		VALUES (?,?,?,?,?,?,?,?)
+		ON CONFLICT(name) DO UPDATE SET
+		  backend=excluded.backend,
+		  skills=excluded.skills,
+		  prompt=excluded.prompt,
+		  allow_prs=excluded.allow_prs,
+		  allow_dispatch=excluded.allow_dispatch,
+		  can_dispatch=excluded.can_dispatch,
+		  description=excluded.description`,
+		a.Name, a.Backend, string(skills), a.Prompt,
+		boolToInt(a.AllowPRs), boolToInt(a.AllowDispatch),
+		string(canDispatch), a.Description,
+	)
+	if err != nil {
+		return fmt.Errorf("store put agent %s: %w", a.Name, err)
+	}
+	return nil
+}
+
+// DeleteAgent removes an agent by name. All bindings that reference this agent
+// must be deleted first; otherwise a FK violation is returned.
+func DeleteAgent(db *sql.DB, name string) error {
+	_, err := db.Exec("DELETE FROM agents WHERE name=?", name)
+	if err != nil {
+		return fmt.Errorf("store delete agent %s: %w", name, err)
+	}
+	return nil
+}
+
+// PutSkill creates or updates a skill definition.
+func PutSkill(db *sql.DB, name string, s config.SkillDef) error {
+	_, err := db.Exec(`
+		INSERT INTO skills(name,prompt) VALUES (?,?)
+		ON CONFLICT(name) DO UPDATE SET prompt=excluded.prompt`,
+		name, s.Prompt,
+	)
+	if err != nil {
+		return fmt.Errorf("store put skill %s: %w", name, err)
+	}
+	return nil
+}
+
+// DeleteSkill removes a skill by name.
+func DeleteSkill(db *sql.DB, name string) error {
+	_, err := db.Exec("DELETE FROM skills WHERE name=?", name)
+	if err != nil {
+		return fmt.Errorf("store delete skill %s: %w", name, err)
+	}
+	return nil
+}
+
+// PutBackend creates or updates an AI backend definition.
+func PutBackend(db *sql.DB, name string, b config.AIBackendConfig) error {
+	args, err := json.Marshal(b.Args)
+	if err != nil {
+		return fmt.Errorf("store put backend %s: marshal args: %w", name, err)
+	}
+	env, err := json.Marshal(b.Env)
+	if err != nil {
+		return fmt.Errorf("store put backend %s: marshal env: %w", name, err)
+	}
+	_, err = db.Exec(`
+		INSERT INTO backends(name,command,args,env,timeout_seconds,max_prompt_chars,redaction_salt_env)
+		VALUES (?,?,?,?,?,?,?)
+		ON CONFLICT(name) DO UPDATE SET
+		  command=excluded.command,
+		  args=excluded.args,
+		  env=excluded.env,
+		  timeout_seconds=excluded.timeout_seconds,
+		  max_prompt_chars=excluded.max_prompt_chars,
+		  redaction_salt_env=excluded.redaction_salt_env`,
+		name, b.Command, string(args), string(env),
+		b.TimeoutSeconds, b.MaxPromptChars, b.RedactionSaltEnv,
+	)
+	if err != nil {
+		return fmt.Errorf("store put backend %s: %w", name, err)
+	}
+	return nil
+}
+
+// DeleteBackend removes a backend by name.
+func DeleteBackend(db *sql.DB, name string) error {
+	_, err := db.Exec("DELETE FROM backends WHERE name=?", name)
+	if err != nil {
+		return fmt.Errorf("store delete backend %s: %w", name, err)
+	}
+	return nil
+}
+
+// PutRepo creates or updates a repo definition. Bindings are not touched by
+// this call; use PutBinding / DeleteBinding to manage them.
+func PutRepo(db *sql.DB, r config.RepoDef) error {
+	_, err := db.Exec(`
+		INSERT INTO repos(name,enabled) VALUES (?,?)
+		ON CONFLICT(name) DO UPDATE SET enabled=excluded.enabled`,
+		r.Name, boolToInt(r.Enabled),
+	)
+	if err != nil {
+		return fmt.Errorf("store put repo %s: %w", r.Name, err)
+	}
+	return nil
+}
+
+// DeleteRepo removes a repo and all of its bindings.
+func DeleteRepo(db *sql.DB, name string) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("store delete repo %s: begin: %w", name, err)
+	}
+	defer tx.Rollback()
+	if _, err := tx.Exec("DELETE FROM bindings WHERE repo=?", name); err != nil {
+		return fmt.Errorf("store delete repo %s: delete bindings: %w", name, err)
+	}
+	if _, err := tx.Exec("DELETE FROM repos WHERE name=?", name); err != nil {
+		return fmt.Errorf("store delete repo %s: %w", name, err)
+	}
+	return tx.Commit()
+}
+
+// PutBinding appends a new binding to a repo. It returns the auto-assigned row
+// ID so callers can reference the new binding in subsequent delete calls.
+func PutBinding(db *sql.DB, repo string, b config.Binding) (int64, error) {
+	labels, err := json.Marshal(b.Labels)
+	if err != nil {
+		return 0, fmt.Errorf("store put binding: marshal labels: %w", err)
+	}
+	events, err := json.Marshal(b.Events)
+	if err != nil {
+		return 0, fmt.Errorf("store put binding: marshal events: %w", err)
+	}
+	enabled := 1
+	if b.Enabled != nil && !*b.Enabled {
+		enabled = 0
+	}
+	res, err := db.Exec(`
+		INSERT INTO bindings(repo,agent,labels,events,cron,enabled) VALUES (?,?,?,?,?,?)`,
+		repo, b.Agent, string(labels), string(events), b.Cron, enabled,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("store put binding repo=%s agent=%s: %w", repo, b.Agent, err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("store put binding: last insert id: %w", err)
+	}
+	return id, nil
+}
+
+// DeleteBinding removes a single binding row by its primary-key ID.
+func DeleteBinding(db *sql.DB, id int64) error {
+	_, err := db.Exec("DELETE FROM bindings WHERE id=?", id)
+	if err != nil {
+		return fmt.Errorf("store delete binding %d: %w", id, err)
+	}
+	return nil
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -815,11 +815,20 @@ func PutBinding(db *sql.DB, repo string, b config.Binding) (int64, error) {
 	return id, nil
 }
 
-// DeleteBinding removes a single binding row by its primary-key ID.
-func DeleteBinding(db *sql.DB, id int64) error {
-	_, err := db.Exec("DELETE FROM bindings WHERE id=?", id)
+// DeleteBinding removes a single binding row by its primary-key ID, scoped to
+// the given repo. Returns sql.ErrNoRows if no binding with that id belongs to
+// that repo, preventing cross-repo deletion.
+func DeleteBinding(db *sql.DB, repo string, id int64) error {
+	res, err := db.Exec("DELETE FROM bindings WHERE id=? AND repo=?", id, repo)
 	if err != nil {
 		return fmt.Errorf("store delete binding %d: %w", id, err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("store delete binding %d: rows affected: %w", id, err)
+	}
+	if n == 0 {
+		return sql.ErrNoRows
 	}
 	return nil
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -337,3 +337,250 @@ func TestLoadEmptyDatabase(t *testing.T) {
 		t.Fatal("expected error loading from empty database, got nil")
 	}
 }
+
+// ── Write API ──────────────────────────────────────────────────────────────
+
+// TestPutDeleteAgent exercises the PutAgent / DeleteAgent round-trip. An agent
+// written by PutAgent appears in Load results and is gone after DeleteAgent.
+func TestPutDeleteAgent(t *testing.T) {
+	t.Parallel()
+	db, cleanup := openTestDB(t)
+	defer cleanup()
+
+	// Prime the database so daemon config is present (Load requires it).
+	if err := store.Import(db, minimalCfg()); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+
+	// Update an existing agent in-place (no FK violation even with bindings).
+	updated := config.AgentDef{
+		Name:    "coder",
+		Backend: "claude",
+		Skills:  []string{"testing"},
+		Prompt:  "Updated prompt.",
+	}
+	if err := store.PutAgent(db, updated); err != nil {
+		t.Fatalf("PutAgent: %v", err)
+	}
+
+	out, err := store.Load(db)
+	if err != nil {
+		t.Fatalf("load after put: %v", err)
+	}
+	var found config.AgentDef
+	for _, a := range out.Agents {
+		if a.Name == "coder" {
+			found = a
+		}
+	}
+	if found.Prompt != "Updated prompt." {
+		t.Errorf("updated prompt: got %q, want %q", found.Prompt, "Updated prompt.")
+	}
+	// Bindings must survive the in-place update.
+	if len(out.Repos[0].Use) != 3 {
+		t.Errorf("bindings after update: got %d, want 3", len(out.Repos[0].Use))
+	}
+
+	// Add a new agent with no bindings so it is safe to delete.
+	fresh := config.AgentDef{Name: "temp", Backend: "claude", Prompt: "Temporary."}
+	if err := store.PutAgent(db, fresh); err != nil {
+		t.Fatalf("PutAgent new: %v", err)
+	}
+	if err := store.DeleteAgent(db, "temp"); err != nil {
+		t.Fatalf("DeleteAgent: %v", err)
+	}
+	out2, err := store.Load(db)
+	if err != nil {
+		t.Fatalf("load after delete: %v", err)
+	}
+	for _, a := range out2.Agents {
+		if a.Name == "temp" {
+			t.Error("deleted agent still present in load result")
+		}
+	}
+}
+
+// TestPutDeleteSkill exercises the skill write path.
+func TestPutDeleteSkill(t *testing.T) {
+	t.Parallel()
+	db, cleanup := openTestDB(t)
+	defer cleanup()
+
+	if err := store.Import(db, minimalCfg()); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+
+	// Update existing skill.
+	if err := store.PutSkill(db, "architect", config.SkillDef{Prompt: "New architect prompt."}); err != nil {
+		t.Fatalf("PutSkill update: %v", err)
+	}
+	out, err := store.Load(db)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if out.Skills["architect"].Prompt != "New architect prompt." {
+		t.Errorf("skill prompt: got %q", out.Skills["architect"].Prompt)
+	}
+
+	// Add then delete a new skill.
+	if err := store.PutSkill(db, "temp-skill", config.SkillDef{Prompt: "Temp."}); err != nil {
+		t.Fatalf("PutSkill new: %v", err)
+	}
+	if err := store.DeleteSkill(db, "temp-skill"); err != nil {
+		t.Fatalf("DeleteSkill: %v", err)
+	}
+	out2, err := store.Load(db)
+	if err != nil {
+		t.Fatalf("load after delete: %v", err)
+	}
+	if _, ok := out2.Skills["temp-skill"]; ok {
+		t.Error("deleted skill still present")
+	}
+}
+
+// TestPutDeleteBackend exercises the backend write path.
+func TestPutDeleteBackend(t *testing.T) {
+	t.Parallel()
+	db, cleanup := openTestDB(t)
+	defer cleanup()
+
+	if err := store.Import(db, minimalCfg()); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+
+	newBackend := config.AIBackendConfig{
+		Command:        "codex",
+		Args:           []string{"--model", "gpt-4"},
+		Env:            map[string]string{"OPENAI_API_KEY": "x"},
+		TimeoutSeconds: 300,
+		MaxPromptChars: 8000,
+	}
+	if err := store.PutBackend(db, "codex", newBackend); err != nil {
+		t.Fatalf("PutBackend: %v", err)
+	}
+	out, err := store.Load(db)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if b, ok := out.Daemon.AIBackends["codex"]; !ok {
+		t.Error("codex backend not found after put")
+	} else if b.Command != "codex" {
+		t.Errorf("backend command: got %q", b.Command)
+	}
+
+	if err := store.DeleteBackend(db, "codex"); err != nil {
+		t.Fatalf("DeleteBackend: %v", err)
+	}
+	out2, err := store.Load(db)
+	if err != nil {
+		t.Fatalf("load after delete: %v", err)
+	}
+	if _, ok := out2.Daemon.AIBackends["codex"]; ok {
+		t.Error("deleted backend still present")
+	}
+}
+
+// TestPutDeleteRepo exercises repo creation and deletion. DeleteRepo must
+// cascade-delete its bindings.
+func TestPutDeleteRepo(t *testing.T) {
+	t.Parallel()
+	db, cleanup := openTestDB(t)
+	defer cleanup()
+
+	if err := store.Import(db, minimalCfg()); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+
+	// Add a new repo.
+	newRepo := config.RepoDef{Name: "owner/other", Enabled: true}
+	if err := store.PutRepo(db, newRepo); err != nil {
+		t.Fatalf("PutRepo: %v", err)
+	}
+	out, err := store.Load(db)
+	if err != nil {
+		t.Fatalf("load after put: %v", err)
+	}
+	var foundRepo bool
+	for _, r := range out.Repos {
+		if r.Name == "owner/other" {
+			foundRepo = true
+		}
+	}
+	if !foundRepo {
+		t.Error("new repo not found after put")
+	}
+
+	// Toggle the original repo disabled.
+	if err := store.PutRepo(db, config.RepoDef{Name: "owner/repo", Enabled: false}); err != nil {
+		t.Fatalf("PutRepo update: %v", err)
+	}
+	out2, err := store.Load(db)
+	if err != nil {
+		t.Fatalf("load after update: %v", err)
+	}
+	for _, r := range out2.Repos {
+		if r.Name == "owner/repo" && r.Enabled {
+			t.Error("repo should be disabled after update")
+		}
+	}
+
+	// DeleteRepo must also remove its bindings.
+	if err := store.DeleteRepo(db, "owner/repo"); err != nil {
+		t.Fatalf("DeleteRepo: %v", err)
+	}
+	out3, err := store.Load(db)
+	if err != nil {
+		t.Fatalf("load after delete: %v", err)
+	}
+	for _, r := range out3.Repos {
+		if r.Name == "owner/repo" {
+			t.Error("deleted repo still present")
+		}
+	}
+	counts, _ := store.CountFrom(db)
+	if counts.Bindings != 0 {
+		t.Errorf("bindings not cascade-deleted: got %d", counts.Bindings)
+	}
+}
+
+// TestPutDeleteBinding exercises adding and removing individual bindings.
+func TestPutDeleteBinding(t *testing.T) {
+	t.Parallel()
+	db, cleanup := openTestDB(t)
+	defer cleanup()
+
+	if err := store.Import(db, minimalCfg()); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+
+	b := config.Binding{
+		Agent:  "pr-reviewer",
+		Events: []string{"pull_request.opened"},
+	}
+	id, err := store.PutBinding(db, "owner/repo", b)
+	if err != nil {
+		t.Fatalf("PutBinding: %v", err)
+	}
+	if id == 0 {
+		t.Error("PutBinding returned zero ID")
+	}
+
+	out, err := store.Load(db)
+	if err != nil {
+		t.Fatalf("load after put: %v", err)
+	}
+	if len(out.Repos[0].Use) != 4 {
+		t.Errorf("bindings after add: got %d, want 4", len(out.Repos[0].Use))
+	}
+
+	if err := store.DeleteBinding(db, id); err != nil {
+		t.Fatalf("DeleteBinding: %v", err)
+	}
+	out2, err := store.Load(db)
+	if err != nil {
+		t.Fatalf("load after delete: %v", err)
+	}
+	if len(out2.Repos[0].Use) != 3 {
+		t.Errorf("bindings after delete: got %d, want 3", len(out2.Repos[0].Use))
+	}
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2,6 +2,7 @@ package store_test
 
 import (
 	"database/sql"
+	"errors"
 	"path/filepath"
 	"testing"
 
@@ -573,7 +574,7 @@ func TestPutDeleteBinding(t *testing.T) {
 		t.Errorf("bindings after add: got %d, want 4", len(out.Repos[0].Use))
 	}
 
-	if err := store.DeleteBinding(db, id); err != nil {
+	if err := store.DeleteBinding(db, "owner/repo", id); err != nil {
 		t.Fatalf("DeleteBinding: %v", err)
 	}
 	out2, err := store.Load(db)
@@ -582,5 +583,51 @@ func TestPutDeleteBinding(t *testing.T) {
 	}
 	if len(out2.Repos[0].Use) != 3 {
 		t.Errorf("bindings after delete: got %d, want 3", len(out2.Repos[0].Use))
+	}
+}
+
+// TestDeleteBindingCrossRepo verifies that DeleteBinding scopes the delete to
+// the given repo and returns sql.ErrNoRows when the binding belongs to a
+// different repo.
+func TestDeleteBindingCrossRepo(t *testing.T) {
+	t.Parallel()
+	db, cleanup := openTestDB(t)
+	defer cleanup()
+
+	if err := store.Import(db, minimalCfg()); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+
+	// Add a second repo and a binding under it.
+	if err := store.PutRepo(db, config.RepoDef{Name: "owner/other", Enabled: true}); err != nil {
+		t.Fatalf("PutRepo: %v", err)
+	}
+	id, err := store.PutBinding(db, "owner/other", config.Binding{
+		Agent:  "pr-reviewer",
+		Events: []string{"push"},
+	})
+	if err != nil {
+		t.Fatalf("PutBinding: %v", err)
+	}
+
+	// Attempt to delete via the wrong repo — must fail with sql.ErrNoRows.
+	err = store.DeleteBinding(db, "owner/repo", id)
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("cross-repo delete: want sql.ErrNoRows, got %v", err)
+	}
+
+	// The binding in owner/other must still be present.
+	out, err := store.Load(db)
+	if err != nil {
+		t.Fatalf("load after failed delete: %v", err)
+	}
+	found := false
+	for _, r := range out.Repos {
+		if r.Name == "owner/other" && len(r.Use) == 1 {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("binding was deleted despite wrong-repo attempt")
 	}
 }

--- a/internal/webhook/api.go
+++ b/internal/webhook/api.go
@@ -59,8 +59,8 @@ func (s *Server) handleAPIAgents(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	// Build one entry per configured agent.
-	agents := make([]apiAgentJSON, 0, len(s.cfg.Agents))
-	for _, a := range s.cfg.Agents {
+	agents := make([]apiAgentJSON, 0, len(s.cfg().Agents))
+	for _, a := range s.cfg().Agents {
 		currentStatus := "idle"
 		if s.runtimeState != nil && s.runtimeState.IsRunning(a.Name) {
 			currentStatus = "running"
@@ -79,7 +79,7 @@ func (s *Server) handleAPIAgents(w http.ResponseWriter, _ *http.Request) {
 		// Collect bindings from all repos that reference this agent.
 		// Disabled repos are excluded entirely — they are not active in the
 		// runtime, so they should not appear in the fleet snapshot.
-		for _, repo := range s.cfg.Repos {
+		for _, repo := range s.cfg().Repos {
 			if !repo.Enabled {
 				continue
 			}
@@ -240,7 +240,7 @@ const redacted = "[redacted]"
 // secret values replaced by "[redacted]". Env-var names are preserved so
 // operators can identify which environment variable holds a given secret.
 func (s *Server) handleAPIConfig(w http.ResponseWriter, _ *http.Request) {
-	cfg := s.cfg
+	cfg := s.cfg()
 
 	httpCfg := apiHTTPConfigJSON{
 		ListenAddr:             cfg.Daemon.HTTP.ListenAddr,
@@ -506,7 +506,7 @@ func (s *Server) handleAPIGraph(w http.ResponseWriter, _ *http.Request) {
 	// Seed the node set from the full configured fleet so that agents with no
 	// dispatch history still appear in the graph (issue #151: "Nodes = agents").
 	seen := make(map[string]struct{})
-	for _, a := range s.cfg.Agents {
+	for _, a := range s.cfg().Agents {
 		seen[a.Name] = struct{}{}
 	}
 	// Include any edge endpoints not already covered by the current config
@@ -560,7 +560,7 @@ func (s *Server) handleAPIMemory(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	memDir := s.cfg.Daemon.MemoryDir
+	memDir := s.cfg().Daemon.MemoryDir
 	if memDir == "" {
 		http.Error(w, "memory_dir not configured", http.StatusNotFound)
 		return

--- a/internal/webhook/api_write.go
+++ b/internal/webhook/api_write.go
@@ -1,0 +1,307 @@
+package webhook
+
+// api_write.go contains the CRUD mutation handlers for the write API.
+// These endpoints are only registered when the server is started with a SQLite
+// database (--db flag). After each successful write the server reloads its
+// in-memory config from the database so that subsequent GET requests reflect
+// the change without a restart.
+//
+// All write endpoints require the same bearer-token auth as POST /agents/run.
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+
+	"github.com/gorilla/mux"
+
+	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/store"
+)
+
+// maxWriteBodyBytes caps request bodies for write endpoints.
+const maxWriteBodyBytes = 1 << 20 // 1 MiB
+
+// ── /api/agents ─────────────────────────────────────────────────────────────
+
+// putAgentRequest is the wire shape for PUT /api/agents.
+type putAgentRequest struct {
+	Name          string   `json:"name"`
+	Backend       string   `json:"backend"`
+	Skills        []string `json:"skills"`
+	Prompt        string   `json:"prompt"`
+	AllowPRs      bool     `json:"allow_prs"`
+	AllowDispatch bool     `json:"allow_dispatch"`
+	CanDispatch   []string `json:"can_dispatch"`
+	Description   string   `json:"description"`
+}
+
+// handlePutAgent handles PUT /api/agents — creates or updates an agent.
+func (s *Server) handlePutAgent(w http.ResponseWriter, r *http.Request) {
+	var req putAgentRequest
+	if err := decodeBody(r, &req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if req.Name == "" {
+		http.Error(w, "name is required", http.StatusBadRequest)
+		return
+	}
+	a := config.AgentDef{
+		Name:          req.Name,
+		Backend:       req.Backend,
+		Skills:        req.Skills,
+		Prompt:        req.Prompt,
+		AllowPRs:      req.AllowPRs,
+		AllowDispatch: req.AllowDispatch,
+		CanDispatch:   req.CanDispatch,
+		Description:   req.Description,
+	}
+	if err := store.PutAgent(s.db, a); err != nil {
+		s.logger.Error().Err(err).Str("agent", req.Name).Msg("put agent")
+		http.Error(w, "failed to save agent", http.StatusInternalServerError)
+		return
+	}
+	if err := s.reloadConfig(); err != nil {
+		s.logger.Error().Err(err).Msg("reload config after put agent")
+		// Non-fatal: the DB write succeeded; the in-memory view may be stale
+		// until next restart, but the data is persisted.
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleDeleteAgent handles DELETE /api/agents/{name}.
+func (s *Server) handleDeleteAgent(w http.ResponseWriter, r *http.Request) {
+	name := mux.Vars(r)["name"]
+	if err := store.DeleteAgent(s.db, name); err != nil {
+		s.logger.Error().Err(err).Str("agent", name).Msg("delete agent")
+		http.Error(w, "failed to delete agent", http.StatusInternalServerError)
+		return
+	}
+	if err := s.reloadConfig(); err != nil {
+		s.logger.Error().Err(err).Msg("reload config after delete agent")
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ── /api/skills ─────────────────────────────────────────────────────────────
+
+type putSkillRequest struct {
+	Name   string `json:"name"`
+	Prompt string `json:"prompt"`
+}
+
+// handlePutSkill handles PUT /api/skills — creates or updates a skill.
+func (s *Server) handlePutSkill(w http.ResponseWriter, r *http.Request) {
+	var req putSkillRequest
+	if err := decodeBody(r, &req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if req.Name == "" {
+		http.Error(w, "name is required", http.StatusBadRequest)
+		return
+	}
+	if err := store.PutSkill(s.db, req.Name, config.SkillDef{Prompt: req.Prompt}); err != nil {
+		s.logger.Error().Err(err).Str("skill", req.Name).Msg("put skill")
+		http.Error(w, "failed to save skill", http.StatusInternalServerError)
+		return
+	}
+	if err := s.reloadConfig(); err != nil {
+		s.logger.Error().Err(err).Msg("reload config after put skill")
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleDeleteSkill handles DELETE /api/skills/{name}.
+func (s *Server) handleDeleteSkill(w http.ResponseWriter, r *http.Request) {
+	name := mux.Vars(r)["name"]
+	if err := store.DeleteSkill(s.db, name); err != nil {
+		s.logger.Error().Err(err).Str("skill", name).Msg("delete skill")
+		http.Error(w, "failed to delete skill", http.StatusInternalServerError)
+		return
+	}
+	if err := s.reloadConfig(); err != nil {
+		s.logger.Error().Err(err).Msg("reload config after delete skill")
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ── /api/backends ────────────────────────────────────────────────────────────
+
+type putBackendRequest struct {
+	Name             string            `json:"name"`
+	Command          string            `json:"command"`
+	Args             []string          `json:"args"`
+	Env              map[string]string `json:"env"`
+	TimeoutSeconds   int               `json:"timeout_seconds"`
+	MaxPromptChars   int               `json:"max_prompt_chars"`
+	RedactionSaltEnv string            `json:"redaction_salt_env"`
+}
+
+// handlePutBackend handles PUT /api/backends — creates or updates a backend.
+func (s *Server) handlePutBackend(w http.ResponseWriter, r *http.Request) {
+	var req putBackendRequest
+	if err := decodeBody(r, &req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if req.Name == "" {
+		http.Error(w, "name is required", http.StatusBadRequest)
+		return
+	}
+	b := config.AIBackendConfig{
+		Command:          req.Command,
+		Args:             req.Args,
+		Env:              req.Env,
+		TimeoutSeconds:   req.TimeoutSeconds,
+		MaxPromptChars:   req.MaxPromptChars,
+		RedactionSaltEnv: req.RedactionSaltEnv,
+	}
+	if err := store.PutBackend(s.db, req.Name, b); err != nil {
+		s.logger.Error().Err(err).Str("backend", req.Name).Msg("put backend")
+		http.Error(w, "failed to save backend", http.StatusInternalServerError)
+		return
+	}
+	if err := s.reloadConfig(); err != nil {
+		s.logger.Error().Err(err).Msg("reload config after put backend")
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleDeleteBackend handles DELETE /api/backends/{name}.
+func (s *Server) handleDeleteBackend(w http.ResponseWriter, r *http.Request) {
+	name := mux.Vars(r)["name"]
+	if err := store.DeleteBackend(s.db, name); err != nil {
+		s.logger.Error().Err(err).Str("backend", name).Msg("delete backend")
+		http.Error(w, "failed to delete backend", http.StatusInternalServerError)
+		return
+	}
+	if err := s.reloadConfig(); err != nil {
+		s.logger.Error().Err(err).Msg("reload config after delete backend")
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ── /api/repos ───────────────────────────────────────────────────────────────
+
+type putRepoRequest struct {
+	Name    string `json:"name"`
+	Enabled bool   `json:"enabled"`
+}
+
+// handlePutRepo handles PUT /api/repos — creates or updates a repo.
+// Bindings are managed separately via the /api/repos/{name}/bindings endpoints.
+func (s *Server) handlePutRepo(w http.ResponseWriter, r *http.Request) {
+	var req putRepoRequest
+	if err := decodeBody(r, &req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if req.Name == "" {
+		http.Error(w, "name is required", http.StatusBadRequest)
+		return
+	}
+	repo := config.RepoDef{Name: req.Name, Enabled: req.Enabled}
+	if err := store.PutRepo(s.db, repo); err != nil {
+		s.logger.Error().Err(err).Str("repo", req.Name).Msg("put repo")
+		http.Error(w, "failed to save repo", http.StatusInternalServerError)
+		return
+	}
+	if err := s.reloadConfig(); err != nil {
+		s.logger.Error().Err(err).Msg("reload config after put repo")
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleDeleteRepo handles DELETE /api/repos/{name}.
+// This also deletes all bindings for that repo.
+func (s *Server) handleDeleteRepo(w http.ResponseWriter, r *http.Request) {
+	name := mux.Vars(r)["name"]
+	if err := store.DeleteRepo(s.db, name); err != nil {
+		s.logger.Error().Err(err).Str("repo", name).Msg("delete repo")
+		http.Error(w, "failed to delete repo", http.StatusInternalServerError)
+		return
+	}
+	if err := s.reloadConfig(); err != nil {
+		s.logger.Error().Err(err).Msg("reload config after delete repo")
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ── /api/repos/{name}/bindings ───────────────────────────────────────────────
+
+type putBindingRequest struct {
+	Agent   string   `json:"agent"`
+	Labels  []string `json:"labels"`
+	Events  []string `json:"events"`
+	Cron    string   `json:"cron"`
+	Enabled *bool    `json:"enabled"`
+}
+
+type putBindingResponse struct {
+	ID int64 `json:"id"`
+}
+
+// handlePutBinding handles POST /api/repos/{name}/bindings — adds a binding.
+func (s *Server) handlePutBinding(w http.ResponseWriter, r *http.Request) {
+	repo := mux.Vars(r)["name"]
+	var req putBindingRequest
+	if err := decodeBody(r, &req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if req.Agent == "" {
+		http.Error(w, "agent is required", http.StatusBadRequest)
+		return
+	}
+	b := config.Binding{
+		Agent:   req.Agent,
+		Labels:  req.Labels,
+		Events:  req.Events,
+		Cron:    req.Cron,
+		Enabled: req.Enabled,
+	}
+	id, err := store.PutBinding(s.db, repo, b)
+	if err != nil {
+		s.logger.Error().Err(err).Str("repo", repo).Str("agent", req.Agent).Msg("put binding")
+		http.Error(w, "failed to save binding", http.StatusInternalServerError)
+		return
+	}
+	if err := s.reloadConfig(); err != nil {
+		s.logger.Error().Err(err).Msg("reload config after put binding")
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(putBindingResponse{ID: id})
+}
+
+// handleDeleteBinding handles DELETE /api/repos/{name}/bindings/{id}.
+func (s *Server) handleDeleteBinding(w http.ResponseWriter, r *http.Request) {
+	idStr := mux.Vars(r)["id"]
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		http.Error(w, "invalid binding id", http.StatusBadRequest)
+		return
+	}
+	if err := store.DeleteBinding(s.db, id); err != nil {
+		s.logger.Error().Err(err).Int64("id", id).Msg("delete binding")
+		http.Error(w, "failed to delete binding", http.StatusInternalServerError)
+		return
+	}
+	if err := s.reloadConfig(); err != nil {
+		s.logger.Error().Err(err).Msg("reload config after delete binding")
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+// decodeBody reads and JSON-decodes a request body, enforcing a 1 MiB size cap.
+func decodeBody(r *http.Request, dst any) error {
+	if err := json.NewDecoder(io.LimitReader(r.Body, maxWriteBodyBytes)).Decode(dst); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/webhook/api_write.go
+++ b/internal/webhook/api_write.go
@@ -9,7 +9,9 @@ package webhook
 // All write endpoints require the same bearer-token auth as POST /agents/run.
 
 import (
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"strconv"
@@ -278,15 +280,22 @@ func (s *Server) handlePutBinding(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleDeleteBinding handles DELETE /api/repos/{name}/bindings/{id}.
+// The binding must belong to the named repo; a mismatch returns 404.
 func (s *Server) handleDeleteBinding(w http.ResponseWriter, r *http.Request) {
-	idStr := mux.Vars(r)["id"]
+	vars := mux.Vars(r)
+	repo := vars["name"]
+	idStr := vars["id"]
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
 		http.Error(w, "invalid binding id", http.StatusBadRequest)
 		return
 	}
-	if err := store.DeleteBinding(s.db, id); err != nil {
-		s.logger.Error().Err(err).Int64("id", id).Msg("delete binding")
+	if err := store.DeleteBinding(s.db, repo, id); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			http.Error(w, "binding not found", http.StatusNotFound)
+			return
+		}
+		s.logger.Error().Err(err).Str("repo", repo).Int64("id", id).Msg("delete binding")
 		http.Error(w, "failed to delete binding", http.StatusInternalServerError)
 		return
 	}

--- a/internal/webhook/api_write.go
+++ b/internal/webhook/api_write.go
@@ -67,8 +67,8 @@ func (s *Server) handlePutAgent(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := s.reloadConfig(); err != nil {
 		s.logger.Error().Err(err).Msg("reload config after put agent")
-		// Non-fatal: the DB write succeeded; the in-memory view may be stale
-		// until next restart, but the data is persisted.
+		http.Error(w, "failed to reload config", http.StatusInternalServerError)
+		return
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -83,6 +83,8 @@ func (s *Server) handleDeleteAgent(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := s.reloadConfig(); err != nil {
 		s.logger.Error().Err(err).Msg("reload config after delete agent")
+		http.Error(w, "failed to reload config", http.StatusInternalServerError)
+		return
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -112,6 +114,8 @@ func (s *Server) handlePutSkill(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := s.reloadConfig(); err != nil {
 		s.logger.Error().Err(err).Msg("reload config after put skill")
+		http.Error(w, "failed to reload config", http.StatusInternalServerError)
+		return
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -126,6 +130,8 @@ func (s *Server) handleDeleteSkill(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := s.reloadConfig(); err != nil {
 		s.logger.Error().Err(err).Msg("reload config after delete skill")
+		http.Error(w, "failed to reload config", http.StatusInternalServerError)
+		return
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -168,6 +174,8 @@ func (s *Server) handlePutBackend(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := s.reloadConfig(); err != nil {
 		s.logger.Error().Err(err).Msg("reload config after put backend")
+		http.Error(w, "failed to reload config", http.StatusInternalServerError)
+		return
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -182,6 +190,8 @@ func (s *Server) handleDeleteBackend(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := s.reloadConfig(); err != nil {
 		s.logger.Error().Err(err).Msg("reload config after delete backend")
+		http.Error(w, "failed to reload config", http.StatusInternalServerError)
+		return
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -190,7 +200,10 @@ func (s *Server) handleDeleteBackend(w http.ResponseWriter, r *http.Request) {
 
 type putRepoRequest struct {
 	Name    string `json:"name"`
-	Enabled bool   `json:"enabled"`
+	// Enabled defaults to true when omitted, matching the config model where
+	// repos are enabled by default. Use a pointer so an explicit false is
+	// distinguishable from an absent field.
+	Enabled *bool `json:"enabled"`
 }
 
 // handlePutRepo handles PUT /api/repos — creates or updates a repo.
@@ -205,7 +218,11 @@ func (s *Server) handlePutRepo(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "name is required", http.StatusBadRequest)
 		return
 	}
-	repo := config.RepoDef{Name: req.Name, Enabled: req.Enabled}
+	enabled := true // repos are enabled by default; explicit false overrides
+	if req.Enabled != nil {
+		enabled = *req.Enabled
+	}
+	repo := config.RepoDef{Name: req.Name, Enabled: enabled}
 	if err := store.PutRepo(s.db, repo); err != nil {
 		s.logger.Error().Err(err).Str("repo", req.Name).Msg("put repo")
 		http.Error(w, "failed to save repo", http.StatusInternalServerError)
@@ -213,6 +230,8 @@ func (s *Server) handlePutRepo(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := s.reloadConfig(); err != nil {
 		s.logger.Error().Err(err).Msg("reload config after put repo")
+		http.Error(w, "failed to reload config", http.StatusInternalServerError)
+		return
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -228,6 +247,8 @@ func (s *Server) handleDeleteRepo(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := s.reloadConfig(); err != nil {
 		s.logger.Error().Err(err).Msg("reload config after delete repo")
+		http.Error(w, "failed to reload config", http.StatusInternalServerError)
+		return
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -273,6 +294,8 @@ func (s *Server) handlePutBinding(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := s.reloadConfig(); err != nil {
 		s.logger.Error().Err(err).Msg("reload config after put binding")
+		http.Error(w, "failed to reload config", http.StatusInternalServerError)
+		return
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
@@ -301,6 +324,8 @@ func (s *Server) handleDeleteBinding(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := s.reloadConfig(); err != nil {
 		s.logger.Error().Err(err).Msg("reload config after delete binding")
+		http.Error(w, "failed to reload config", http.StatusInternalServerError)
+		return
 	}
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/webhook/api_write_test.go
+++ b/internal/webhook/api_write_test.go
@@ -3,6 +3,7 @@ package webhook
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -288,25 +289,53 @@ func TestHandleDeleteBackend(t *testing.T) {
 
 func TestHandlePutRepo(t *testing.T) {
 	t.Parallel()
-	srv, cleanup := openWriteTestServer(t)
-	defer cleanup()
-
-	req := postJSON(t, http.MethodPut, "/api/repos",
-		putRepoRequest{Name: "owner/new-repo", Enabled: true})
-	rec := httptest.NewRecorder()
-	srv.handlePutRepo(rec, req)
-
-	if rec.Code != http.StatusNoContent {
-		t.Fatalf("want 204, got %d: %s", rec.Code, rec.Body.String())
+	tests := []struct {
+		name      string
+		req       putRepoRequest
+		wantEnabled bool
+	}{
+		{
+			name:        "explicit enabled=true",
+			req:         putRepoRequest{Name: "owner/new-repo", Enabled: boolPtr(true)},
+			wantEnabled: true,
+		},
+		{
+			name:        "explicit enabled=false",
+			req:         putRepoRequest{Name: "owner/disabled-repo", Enabled: boolPtr(false)},
+			wantEnabled: false,
+		},
+		{
+			name:        "omitted enabled defaults to true",
+			req:         putRepoRequest{Name: "owner/default-repo"},
+			wantEnabled: true,
+		},
 	}
-	found := false
-	for _, r := range srv.cfg().Repos {
-		if r.Name == "owner/new-repo" && r.Enabled {
-			found = true
-		}
-	}
-	if !found {
-		t.Error("new repo not visible in live config")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv, cleanup := openWriteTestServer(t)
+			defer cleanup()
+
+			req := postJSON(t, http.MethodPut, "/api/repos", tc.req)
+			rec := httptest.NewRecorder()
+			srv.handlePutRepo(rec, req)
+
+			if rec.Code != http.StatusNoContent {
+				t.Fatalf("want 204, got %d: %s", rec.Code, rec.Body.String())
+			}
+			found := false
+			for _, r := range srv.cfg().Repos {
+				if r.Name == tc.req.Name {
+					if r.Enabled != tc.wantEnabled {
+						t.Errorf("repo %q: enabled=%v, want %v", tc.req.Name, r.Enabled, tc.wantEnabled)
+					}
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("repo %q not visible in live config", tc.req.Name)
+			}
+		})
 	}
 }
 
@@ -317,7 +346,7 @@ func TestHandleDeleteRepo(t *testing.T) {
 
 	// Add then delete.
 	addReq := postJSON(t, http.MethodPut, "/api/repos",
-		putRepoRequest{Name: "owner/tmp", Enabled: true})
+		putRepoRequest{Name: "owner/tmp", Enabled: boolPtr(true)})
 	srv.handlePutRepo(httptest.NewRecorder(), addReq)
 
 	req := httptest.NewRequest(http.MethodDelete, "/api/repos/owner/tmp", nil)
@@ -452,7 +481,7 @@ func TestHandleDeleteBindingCrossRepo(t *testing.T) {
 
 	// First add a second repo so we have two repos in the DB.
 	putRepoReq := postJSON(t, http.MethodPut, "/api/repos",
-		putRepoRequest{Name: "owner/other-repo", Enabled: true})
+		putRepoRequest{Name: "owner/other-repo", Enabled: boolPtr(true)})
 	srv.handlePutRepo(httptest.NewRecorder(), putRepoReq)
 
 	// Add a binding to owner/repo.
@@ -507,4 +536,80 @@ func muxVars(r *http.Request, vars map[string]string) *http.Request {
 // intStr converts an int64 to a decimal string.
 func intStr(n int64) string {
 	return strconv.FormatInt(n, 10)
+}
+
+// boolPtr returns a pointer to the given bool value.
+func boolPtr(b bool) *bool { return &b }
+
+// TestHandleMutationReloadFailureReturns500 verifies that when reloadConfig
+// fails after a successful DB write, the handler returns 500 rather than
+// the success status code. The DB write is preserved (idempotent on retry).
+func TestHandleMutationReloadFailureReturns500(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		handler func(srv *Server, rec *httptest.ResponseRecorder)
+		wantCode int
+	}{
+		{
+			name:     "put agent",
+			wantCode: http.StatusNoContent,
+			handler: func(srv *Server, rec *httptest.ResponseRecorder) {
+				req := postJSON(t, http.MethodPut, "/api/agents",
+					putAgentRequest{Name: "reloader", Backend: "claude", Prompt: "x"})
+				srv.handlePutAgent(rec, req)
+			},
+		},
+		{
+			name:     "put skill",
+			wantCode: http.StatusNoContent,
+			handler: func(srv *Server, rec *httptest.ResponseRecorder) {
+				req := postJSON(t, http.MethodPut, "/api/skills",
+					putSkillRequest{Name: "s", Prompt: "x"})
+				srv.handlePutSkill(rec, req)
+			},
+		},
+		{
+			name:     "put repo",
+			wantCode: http.StatusNoContent,
+			handler: func(srv *Server, rec *httptest.ResponseRecorder) {
+				req := postJSON(t, http.MethodPut, "/api/repos",
+					putRepoRequest{Name: "owner/r"})
+				srv.handlePutRepo(rec, req)
+			},
+		},
+		{
+			name:     "put binding",
+			wantCode: http.StatusCreated,
+			handler: func(srv *Server, rec *httptest.ResponseRecorder) {
+				req := postJSON(t, http.MethodPost, "/api/repos/owner~repo/bindings",
+					putBindingRequest{Agent: "coder", Events: []string{"push"}})
+				req = muxVars(req, map[string]string{"name": "owner/repo"})
+				srv.handlePutBinding(rec, req)
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name+" succeeds normally", func(t *testing.T) {
+			t.Parallel()
+			srv, cleanup := openWriteTestServer(t)
+			defer cleanup()
+			rec := httptest.NewRecorder()
+			tc.handler(srv, rec)
+			if rec.Code != tc.wantCode {
+				t.Fatalf("want %d, got %d: %s", tc.wantCode, rec.Code, rec.Body.String())
+			}
+		})
+		t.Run(tc.name+" reload failure returns 500", func(t *testing.T) {
+			t.Parallel()
+			srv, cleanup := openWriteTestServer(t)
+			defer cleanup()
+			srv.testReloadHook = func() error { return errors.New("simulated reload failure") }
+			rec := httptest.NewRecorder()
+			tc.handler(srv, rec)
+			if rec.Code != http.StatusInternalServerError {
+				t.Fatalf("want 500, got %d: %s", rec.Code, rec.Body.String())
+			}
+		})
+	}
 }

--- a/internal/webhook/api_write_test.go
+++ b/internal/webhook/api_write_test.go
@@ -1,0 +1,456 @@
+package webhook
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/rs/zerolog"
+
+	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/store"
+	"github.com/eloylp/agents/internal/workflow"
+)
+
+// openWriteTestServer creates a Server wired to a fresh in-memory SQLite DB
+// pre-loaded with minimalStore config. It returns the server and a cleanup func.
+func openWriteTestServer(t *testing.T) (*Server, func()) {
+	t.Helper()
+	dir := t.TempDir()
+	db, err := store.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+
+	// Seed the DB with the minimal fleet so daemon config is present.
+	seed := minimalStoreCfg()
+	if err := store.Import(db, seed); err != nil {
+		db.Close()
+		t.Fatalf("import seed: %v", err)
+	}
+
+	// Use store.Load (not LoadAndValidate) to avoid env-var resolution in tests.
+	// Set secrets directly so the server has a valid webhook secret and API key.
+	cfg, err := store.Load(db)
+	if err != nil {
+		db.Close()
+		t.Fatalf("load: %v", err)
+	}
+	cfg.Daemon.HTTP.WebhookSecret = "test-webhook-secret"
+	cfg.Daemon.HTTP.APIKey = testAPIKey
+
+	dc := workflow.NewDataChannels(1)
+	srv := NewServer(cfg, NewDeliveryStore(0), dc, nil, nil, zerolog.Nop())
+	srv.WithStore(db)
+	return srv, func() { db.Close() }
+}
+
+// minimalStoreCfg returns a *config.Config that is valid enough for
+// store.Import — it has daemon settings, one backend, one agent, and one repo
+// with no bindings. No validation is run (LoadAndValidate handles that).
+func minimalStoreCfg() *config.Config {
+	return &config.Config{
+		Daemon: config.DaemonConfig{
+			Log: config.LogConfig{Level: "info", Format: "text"},
+			HTTP: config.HTTPConfig{
+				ListenAddr:             ":0",
+				StatusPath:             "/status",
+				WebhookPath:            "/webhooks/github",
+				AgentsRunPath:          "/agents/run",
+				WebhookSecretEnv:       "GITHUB_WEBHOOK_SECRET",
+				WebhookSecret:          "secret",
+				APIKey:                 testAPIKey,
+				ReadTimeoutSeconds:     15,
+				WriteTimeoutSeconds:    15,
+				IdleTimeoutSeconds:     60,
+				MaxBodyBytes:           1 << 20,
+				DeliveryTTLSeconds:     3600,
+				ShutdownTimeoutSeconds: 15,
+			},
+			Processor: config.ProcessorConfig{
+				EventQueueBuffer:    256,
+				MaxConcurrentAgents: 4,
+				Dispatch: config.DispatchConfig{
+					MaxDepth:           3,
+					MaxFanout:          4,
+					DedupWindowSeconds: 300,
+				},
+			},
+			MemoryDir: "/var/lib/agents/memory",
+			AIBackends: map[string]config.AIBackendConfig{
+				"claude": {
+					Command:        "claude",
+					Args:           []string{"-p"},
+					Env:            map[string]string{},
+					TimeoutSeconds: 600,
+					MaxPromptChars: 12000,
+				},
+			},
+		},
+		Agents: []config.AgentDef{
+			{Name: "coder", Backend: "claude", Prompt: "Write code."},
+		},
+		Repos: []config.RepoDef{
+			{Name: "owner/repo", Enabled: true},
+		},
+	}
+}
+
+// authHeader returns the Bearer auth header for the test API key.
+func authHeader() string { return "Bearer " + testAPIKey }
+
+// postJSON builds a request with a JSON body.
+func postJSON(t *testing.T, method, path string, body any) *http.Request {
+	t.Helper()
+	data, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	req := httptest.NewRequest(method, path, bytes.NewReader(data))
+	req.Header.Set("Authorization", authHeader())
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+// ── /api/agents ─────────────────────────────────────────────────────────────
+
+func TestHandlePutAgent(t *testing.T) {
+	t.Parallel()
+	srv, cleanup := openWriteTestServer(t)
+	defer cleanup()
+
+	body := putAgentRequest{
+		Name:    "reviewer",
+		Backend: "claude",
+		Prompt:  "Review PRs carefully.",
+	}
+	req := postJSON(t, http.MethodPut, "/api/agents", body)
+	rec := httptest.NewRecorder()
+	srv.handlePutAgent(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("want 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+	// Verify the config was refreshed.
+	found := false
+	for _, a := range srv.cfg().Agents {
+		if a.Name == "reviewer" && a.Prompt == "Review PRs carefully." {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("put agent not visible in live config")
+	}
+}
+
+func TestHandlePutAgentMissingName(t *testing.T) {
+	t.Parallel()
+	srv, cleanup := openWriteTestServer(t)
+	defer cleanup()
+
+	req := postJSON(t, http.MethodPut, "/api/agents", putAgentRequest{Backend: "claude"})
+	rec := httptest.NewRecorder()
+	srv.handlePutAgent(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", rec.Code)
+	}
+}
+
+func TestHandleDeleteAgent(t *testing.T) {
+	t.Parallel()
+	srv, cleanup := openWriteTestServer(t)
+	defer cleanup()
+
+	// First add an agent with no bindings so deletion is safe.
+	addReq := postJSON(t, http.MethodPut, "/api/agents",
+		putAgentRequest{Name: "temp", Backend: "claude", Prompt: "Temp."})
+	srv.handlePutAgent(httptest.NewRecorder(), addReq)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/agents/temp", nil)
+	req.Header.Set("Authorization", authHeader())
+	rec := httptest.NewRecorder()
+
+	// Inject mux vars.
+	req = muxVars(req, map[string]string{"name": "temp"})
+	srv.handleDeleteAgent(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("want 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+	for _, a := range srv.cfg().Agents {
+		if a.Name == "temp" {
+			t.Error("deleted agent still visible in live config")
+		}
+	}
+}
+
+// ── /api/skills ─────────────────────────────────────────────────────────────
+
+func TestHandlePutSkill(t *testing.T) {
+	t.Parallel()
+	srv, cleanup := openWriteTestServer(t)
+	defer cleanup()
+
+	req := postJSON(t, http.MethodPut, "/api/skills",
+		putSkillRequest{Name: "security", Prompt: "Think about security."})
+	rec := httptest.NewRecorder()
+	srv.handlePutSkill(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("want 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if srv.cfg().Skills["security"].Prompt != "Think about security." {
+		t.Error("skill not visible in live config after put")
+	}
+}
+
+func TestHandleDeleteSkill(t *testing.T) {
+	t.Parallel()
+	srv, cleanup := openWriteTestServer(t)
+	defer cleanup()
+
+	// Seed a skill to delete.
+	seedReq := postJSON(t, http.MethodPut, "/api/skills",
+		putSkillRequest{Name: "temp-skill", Prompt: "Temp."})
+	srv.handlePutSkill(httptest.NewRecorder(), seedReq)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/skills/temp-skill", nil)
+	req.Header.Set("Authorization", authHeader())
+	req = muxVars(req, map[string]string{"name": "temp-skill"})
+	rec := httptest.NewRecorder()
+	srv.handleDeleteSkill(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("want 204, got %d", rec.Code)
+	}
+	if _, ok := srv.cfg().Skills["temp-skill"]; ok {
+		t.Error("deleted skill still visible in live config")
+	}
+}
+
+// ── /api/backends ────────────────────────────────────────────────────────────
+
+func TestHandlePutBackend(t *testing.T) {
+	t.Parallel()
+	srv, cleanup := openWriteTestServer(t)
+	defer cleanup()
+
+	req := postJSON(t, http.MethodPut, "/api/backends", putBackendRequest{
+		Name:           "codex",
+		Command:        "codex",
+		Args:           []string{"--model", "gpt-4"},
+		Env:            map[string]string{},
+		TimeoutSeconds: 300,
+		MaxPromptChars: 8000,
+	})
+	rec := httptest.NewRecorder()
+	srv.handlePutBackend(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("want 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if _, ok := srv.cfg().Daemon.AIBackends["codex"]; !ok {
+		t.Error("backend not visible in live config after put")
+	}
+}
+
+func TestHandleDeleteBackend(t *testing.T) {
+	t.Parallel()
+	srv, cleanup := openWriteTestServer(t)
+	defer cleanup()
+
+	addReq := postJSON(t, http.MethodPut, "/api/backends", putBackendRequest{
+		Name: "extra", Command: "extra", Env: map[string]string{}, TimeoutSeconds: 60,
+	})
+	srv.handlePutBackend(httptest.NewRecorder(), addReq)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/backends/extra", nil)
+	req.Header.Set("Authorization", authHeader())
+	req = muxVars(req, map[string]string{"name": "extra"})
+	rec := httptest.NewRecorder()
+	srv.handleDeleteBackend(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("want 204, got %d", rec.Code)
+	}
+	if _, ok := srv.cfg().Daemon.AIBackends["extra"]; ok {
+		t.Error("deleted backend still present in live config")
+	}
+}
+
+// ── /api/repos ───────────────────────────────────────────────────────────────
+
+func TestHandlePutRepo(t *testing.T) {
+	t.Parallel()
+	srv, cleanup := openWriteTestServer(t)
+	defer cleanup()
+
+	req := postJSON(t, http.MethodPut, "/api/repos",
+		putRepoRequest{Name: "owner/new-repo", Enabled: true})
+	rec := httptest.NewRecorder()
+	srv.handlePutRepo(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("want 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+	found := false
+	for _, r := range srv.cfg().Repos {
+		if r.Name == "owner/new-repo" && r.Enabled {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("new repo not visible in live config")
+	}
+}
+
+func TestHandleDeleteRepo(t *testing.T) {
+	t.Parallel()
+	srv, cleanup := openWriteTestServer(t)
+	defer cleanup()
+
+	// Add then delete.
+	addReq := postJSON(t, http.MethodPut, "/api/repos",
+		putRepoRequest{Name: "owner/tmp", Enabled: true})
+	srv.handlePutRepo(httptest.NewRecorder(), addReq)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/repos/owner/tmp", nil)
+	req.Header.Set("Authorization", authHeader())
+	req = muxVars(req, map[string]string{"name": "owner/tmp"})
+	rec := httptest.NewRecorder()
+	srv.handleDeleteRepo(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("want 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+	for _, r := range srv.cfg().Repos {
+		if r.Name == "owner/tmp" {
+			t.Error("deleted repo still visible in live config")
+		}
+	}
+}
+
+// ── /api/repos/{name}/bindings ───────────────────────────────────────────────
+
+func TestHandlePutBinding(t *testing.T) {
+	t.Parallel()
+	srv, cleanup := openWriteTestServer(t)
+	defer cleanup()
+
+	req := postJSON(t, http.MethodPost, "/api/repos/owner~repo/bindings",
+		putBindingRequest{Agent: "coder", Events: []string{"push"}})
+	req = muxVars(req, map[string]string{"name": "owner/repo"})
+	rec := httptest.NewRecorder()
+	srv.handlePutBinding(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("want 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp putBindingResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.ID == 0 {
+		t.Error("want non-zero binding ID in response")
+	}
+	// Verify it is visible in the reloaded config.
+	found := false
+	for _, r := range srv.cfg().Repos {
+		if r.Name == "owner/repo" {
+			for _, b := range r.Use {
+				if b.Agent == "coder" && len(b.Events) == 1 && b.Events[0] == "push" {
+					found = true
+				}
+			}
+		}
+	}
+	if !found {
+		t.Error("new binding not visible in live config")
+	}
+}
+
+func TestHandleDeleteBinding(t *testing.T) {
+	t.Parallel()
+	srv, cleanup := openWriteTestServer(t)
+	defer cleanup()
+
+	// Add a binding to get its ID.
+	addReq := postJSON(t, http.MethodPost, "/api/repos/owner~repo/bindings",
+		putBindingRequest{Agent: "coder", Cron: "0 * * * *"})
+	addReq = muxVars(addReq, map[string]string{"name": "owner/repo"})
+	addRec := httptest.NewRecorder()
+	srv.handlePutBinding(addRec, addReq)
+	if addRec.Code != http.StatusCreated {
+		t.Fatalf("add binding: want 201, got %d", addRec.Code)
+	}
+	var addResp putBindingResponse
+	if err := json.NewDecoder(addRec.Body).Decode(&addResp); err != nil {
+		t.Fatalf("decode add response: %v", err)
+	}
+
+	beforeCount := 0
+	for _, r := range srv.cfg().Repos {
+		if r.Name == "owner/repo" {
+			beforeCount = len(r.Use)
+		}
+	}
+
+	// Now delete it.
+	delPath := "/api/repos/owner~repo/bindings/" + intStr(addResp.ID)
+	req := httptest.NewRequest(http.MethodDelete, delPath, nil)
+	req.Header.Set("Authorization", authHeader())
+	req = muxVars(req, map[string]string{
+		"name": "owner/repo",
+		"id":   intStr(addResp.ID),
+	})
+	rec := httptest.NewRecorder()
+	srv.handleDeleteBinding(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("want 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+	afterCount := 0
+	for _, r := range srv.cfg().Repos {
+		if r.Name == "owner/repo" {
+			afterCount = len(r.Use)
+		}
+	}
+	if afterCount != beforeCount-1 {
+		t.Errorf("binding count: want %d, got %d", beforeCount-1, afterCount)
+	}
+}
+
+func TestHandleDeleteBindingInvalidID(t *testing.T) {
+	t.Parallel()
+	srv, cleanup := openWriteTestServer(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/repos/owner~repo/bindings/bad", nil)
+	req.Header.Set("Authorization", authHeader())
+	req = muxVars(req, map[string]string{"name": "owner/repo", "id": "bad"})
+	rec := httptest.NewRecorder()
+	srv.handleDeleteBinding(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", rec.Code)
+	}
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+// muxVars injects gorilla/mux route variables into a request for unit testing
+// handlers that call mux.Vars(r).
+func muxVars(r *http.Request, vars map[string]string) *http.Request {
+	return mux.SetURLVars(r, vars)
+}
+
+// intStr converts an int64 to a decimal string.
+func intStr(n int64) string {
+	return strconv.FormatInt(n, 10)
+}

--- a/internal/webhook/api_write_test.go
+++ b/internal/webhook/api_write_test.go
@@ -442,6 +442,60 @@ func TestHandleDeleteBindingInvalidID(t *testing.T) {
 	}
 }
 
+// TestHandleDeleteBindingCrossRepo verifies that a binding can only be deleted
+// through its own repo's endpoint — trying to delete via a different repo's
+// path must return 404, not silently succeed.
+func TestHandleDeleteBindingCrossRepo(t *testing.T) {
+	t.Parallel()
+	srv, cleanup := openWriteTestServer(t)
+	defer cleanup()
+
+	// First add a second repo so we have two repos in the DB.
+	putRepoReq := postJSON(t, http.MethodPut, "/api/repos",
+		putRepoRequest{Name: "owner/other-repo", Enabled: true})
+	srv.handlePutRepo(httptest.NewRecorder(), putRepoReq)
+
+	// Add a binding to owner/repo.
+	addReq := postJSON(t, http.MethodPost, "/api/repos/owner~repo/bindings",
+		putBindingRequest{Agent: "coder", Cron: "0 * * * *"})
+	addReq = muxVars(addReq, map[string]string{"name": "owner/repo"})
+	addRec := httptest.NewRecorder()
+	srv.handlePutBinding(addRec, addReq)
+	if addRec.Code != http.StatusCreated {
+		t.Fatalf("add binding: want 201, got %d", addRec.Code)
+	}
+	var addResp putBindingResponse
+	if err := json.NewDecoder(addRec.Body).Decode(&addResp); err != nil {
+		t.Fatalf("decode add response: %v", err)
+	}
+
+	// Try to delete that binding via owner/other-repo — must return 404.
+	delPath := "/api/repos/owner~other-repo/bindings/" + intStr(addResp.ID)
+	req := httptest.NewRequest(http.MethodDelete, delPath, nil)
+	req.Header.Set("Authorization", authHeader())
+	req = muxVars(req, map[string]string{
+		"name": "owner/other-repo",
+		"id":   intStr(addResp.ID),
+	})
+	rec := httptest.NewRecorder()
+	srv.handleDeleteBinding(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("cross-repo delete: want 404, got %d", rec.Code)
+	}
+
+	// Verify the binding still exists under the correct repo.
+	found := false
+	for _, r := range srv.cfg().Repos {
+		if r.Name == "owner/repo" {
+			found = len(r.Use) > 0
+		}
+	}
+	if !found {
+		t.Error("binding was deleted despite cross-repo attempt")
+	}
+}
+
 // ── helpers ──────────────────────────────────────────────────────────────────
 
 // muxVars injects gorilla/mux route variables into a request for unit testing

--- a/internal/webhook/server.go
+++ b/internal/webhook/server.go
@@ -86,6 +86,10 @@ type Server struct {
 	proxy         *anthropicproxy.Handler
 	uiFS          fs.FS          // optional; when set, /ui/ serves these static files
 	observeStore  *observe.Store // optional; when set, enables observability endpoints
+
+	// testReloadHook is an optional override injected by tests to simulate
+	// reloadConfig failures. When non-nil it replaces the real reload logic.
+	testReloadHook func() error
 }
 
 // cfg returns the current effective configuration. All request handlers must
@@ -138,6 +142,9 @@ func (s *Server) WithConfigObserver(o ConfigObserver) {
 // notified so that execution components (Engine, Scheduler) pick up the new
 // routing and agent definitions on their next operation.
 func (s *Server) reloadConfig() error {
+	if s.testReloadHook != nil {
+		return s.testReloadHook()
+	}
 	raw, err := store.Load(s.db)
 	if err != nil {
 		return err

--- a/internal/webhook/server.go
+++ b/internal/webhook/server.go
@@ -5,6 +5,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"crypto/subtle"
+	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -12,6 +13,7 @@ import (
 	"io/fs"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -20,6 +22,7 @@ import (
 	anthropicproxy "github.com/eloylp/agents/internal/anthropic_proxy"
 	"github.com/eloylp/agents/internal/config"
 	"github.com/eloylp/agents/internal/observe"
+	"github.com/eloylp/agents/internal/store"
 	"github.com/eloylp/agents/internal/workflow"
 )
 
@@ -59,7 +62,11 @@ type EventQueue interface {
 }
 
 type Server struct {
-	cfg           *config.Config
+	// cfgPtr holds the current effective config as an atomic pointer so that
+	// write-API handlers can swap it after persisting a change without holding
+	// a coarse lock across all request handlers.
+	cfgPtr        atomic.Pointer[config.Config]
+	db            *sql.DB        // non-nil only when --db is used; enables write API
 	delivery      *DeliveryStore
 	logger        zerolog.Logger
 	channels      EventQueue
@@ -70,6 +77,12 @@ type Server struct {
 	proxy         *anthropicproxy.Handler
 	uiFS          fs.FS          // optional; when set, /ui/ serves these static files
 	observeStore  *observe.Store // optional; when set, enables observability endpoints
+}
+
+// cfg returns the current effective configuration. All request handlers must
+// call this instead of accessing the underlying pointer directly.
+func (s *Server) cfg() *config.Config {
+	return s.cfgPtr.Load()
 }
 
 // WithUI attaches an fs.FS containing the pre-built static UI assets to the
@@ -92,9 +105,35 @@ func (s *Server) WithRuntimeState(rsp RuntimeStateProvider) {
 	s.runtimeState = rsp
 }
 
-func NewServer(cfg *config.Config, delivery *DeliveryStore, channels EventQueue, provider StatusProvider, dispatchStats DispatchStatsProvider, logger zerolog.Logger) *Server {
+// WithStore attaches a SQLite database to the server. When set, the server
+// registers CRUD write endpoints under /api/ so the fleet can be managed
+// without restarting the daemon.
+func (s *Server) WithStore(db *sql.DB) {
+	s.db = db
+}
+
+// reloadConfig reloads the structural config from the SQLite database and
+// atomically replaces the server's config pointer. Resolved runtime secrets
+// (webhook secret, API key, proxy API key) are not stored in the database —
+// they are carried forward from the current live config so they remain valid
+// without requiring a re-read of environment variables.
+func (s *Server) reloadConfig() error {
+	cfg, err := store.Load(s.db)
+	if err != nil {
+		return err
+	}
+	// Preserve secrets that were resolved from env vars at startup; they cannot
+	// change at runtime and are not stored in SQLite.
+	live := s.cfgPtr.Load()
+	cfg.Daemon.HTTP.WebhookSecret = live.Daemon.HTTP.WebhookSecret
+	cfg.Daemon.HTTP.APIKey = live.Daemon.HTTP.APIKey
+	cfg.Daemon.Proxy.Upstream.APIKey = live.Daemon.Proxy.Upstream.APIKey
+	s.cfgPtr.Store(cfg)
+	return nil
+}
+
+func NewServer(initialCfg *config.Config, delivery *DeliveryStore, channels EventQueue, provider StatusProvider, dispatchStats DispatchStatsProvider, logger zerolog.Logger) *Server {
 	s := &Server{
-		cfg:           cfg,
 		delivery:      delivery,
 		logger:        logger.With().Str("component", "webhook_server").Logger(),
 		channels:      channels,
@@ -102,8 +141,9 @@ func NewServer(cfg *config.Config, delivery *DeliveryStore, channels EventQueue,
 		dispatchStats: dispatchStats,
 		startTime:     time.Now(),
 	}
-	if cfg.Daemon.Proxy.Enabled {
-		up := cfg.Daemon.Proxy.Upstream
+	s.cfgPtr.Store(initialCfg)
+	if initialCfg.Daemon.Proxy.Enabled {
+		up := initialCfg.Daemon.Proxy.Upstream
 		s.proxy = anthropicproxy.NewHandler(anthropicproxy.UpstreamConfig{
 			URL:       up.URL,
 			Model:     up.Model,
@@ -125,7 +165,7 @@ func (s *Server) buildHandler() http.Handler {
 	// deadline and is still set in Run(). SSE handlers clear that write
 	// deadline for themselves via http.ResponseController.SetWriteDeadline so
 	// they can stream indefinitely; see serveSSEWithInterval in api.go.
-	writeTimeout := time.Duration(s.cfg.Daemon.HTTP.WriteTimeoutSeconds) * time.Second
+	writeTimeout := time.Duration(s.cfg().Daemon.HTTP.WriteTimeoutSeconds) * time.Second
 	withTimeout := func(h http.Handler) http.Handler {
 		if writeTimeout <= 0 {
 			return h
@@ -134,9 +174,9 @@ func (s *Server) buildHandler() http.Handler {
 	}
 
 	router := mux.NewRouter()
-	router.Handle(s.cfg.Daemon.HTTP.StatusPath, withTimeout(http.HandlerFunc(s.handleStatus))).Methods(http.MethodGet)
-	router.Handle(s.cfg.Daemon.HTTP.WebhookPath, withTimeout(http.HandlerFunc(s.handleGitHubWebhook))).Methods(http.MethodPost)
-	router.Handle(s.cfg.Daemon.HTTP.AgentsRunPath, withTimeout(s.requireAPIKey(http.HandlerFunc(s.handleAgentsRun)))).Methods(http.MethodPost)
+	router.Handle(s.cfg().Daemon.HTTP.StatusPath, withTimeout(http.HandlerFunc(s.handleStatus))).Methods(http.MethodGet)
+	router.Handle(s.cfg().Daemon.HTTP.WebhookPath, withTimeout(http.HandlerFunc(s.handleGitHubWebhook))).Methods(http.MethodPost)
+	router.Handle(s.cfg().Daemon.HTTP.AgentsRunPath, withTimeout(s.requireAPIKey(http.HandlerFunc(s.handleAgentsRun)))).Methods(http.MethodPost)
 	router.Handle("/api/run", withTimeout(http.HandlerFunc(s.handleAgentsRun))).Methods(http.MethodPost)
 
 	// Observability API — read-only endpoints served unauthenticated at the
@@ -163,6 +203,25 @@ func (s *Server) buildHandler() http.Handler {
 		router.HandleFunc("/api/memory/stream", s.handleAPIMemoryStream)           // SSE — no timeout
 	}
 
+	// Write API — only registered when a SQLite database is attached via
+	// WithStore. These endpoints mutate the DB and refresh the server's live
+	// config view; they require the same bearer-token as /agents/run.
+	if s.db != nil {
+		mustWrite := func(h http.Handler) http.Handler {
+			return withTimeout(s.requireAPIKey(h))
+		}
+		router.Handle("/api/agents", mustWrite(http.HandlerFunc(s.handlePutAgent))).Methods(http.MethodPut)
+		router.Handle("/api/agents/{name}", mustWrite(http.HandlerFunc(s.handleDeleteAgent))).Methods(http.MethodDelete)
+		router.Handle("/api/skills", mustWrite(http.HandlerFunc(s.handlePutSkill))).Methods(http.MethodPut)
+		router.Handle("/api/skills/{name}", mustWrite(http.HandlerFunc(s.handleDeleteSkill))).Methods(http.MethodDelete)
+		router.Handle("/api/backends", mustWrite(http.HandlerFunc(s.handlePutBackend))).Methods(http.MethodPut)
+		router.Handle("/api/backends/{name}", mustWrite(http.HandlerFunc(s.handleDeleteBackend))).Methods(http.MethodDelete)
+		router.Handle("/api/repos", mustWrite(http.HandlerFunc(s.handlePutRepo))).Methods(http.MethodPut)
+		router.Handle("/api/repos/{name}", mustWrite(http.HandlerFunc(s.handleDeleteRepo))).Methods(http.MethodDelete)
+		router.Handle("/api/repos/{name}/bindings", mustWrite(http.HandlerFunc(s.handlePutBinding))).Methods(http.MethodPost)
+		router.Handle("/api/repos/{name}/bindings/{id}", mustWrite(http.HandlerFunc(s.handleDeleteBinding))).Methods(http.MethodDelete)
+	}
+
 	// Static UI: served from the embedded dist/ tree when a UI FS is provided.
 	// Unauthenticated — same reasoning as the /api/* routes above.
 	if s.uiFS != nil {
@@ -183,10 +242,10 @@ func (s *Server) buildHandler() http.Handler {
 		// deadline; wrapping it with http.TimeoutHandler would impose a hard
 		// cap shorter than the configured LLM inference timeout and break long
 		// completions.
-		router.Handle(s.cfg.Daemon.Proxy.Path, s.proxy).Methods(http.MethodPost)
+		router.Handle(s.cfg().Daemon.Proxy.Path, s.proxy).Methods(http.MethodPost)
 		// /v1/models is a lightweight stub — wrap it with the standard timeout.
 		router.Handle("/v1/models", withTimeout(http.HandlerFunc(s.proxy.ModelsHandler))).Methods(http.MethodGet)
-		s.logger.Info().Str("path", s.cfg.Daemon.Proxy.Path).Str("upstream", s.cfg.Daemon.Proxy.Upstream.URL).Msg("anthropic proxy enabled")
+		s.logger.Info().Str("path", s.cfg().Daemon.Proxy.Path).Str("upstream", s.cfg().Daemon.Proxy.Upstream.URL).Msg("anthropic proxy enabled")
 	}
 	return router
 }
@@ -195,11 +254,11 @@ func (s *Server) Run(ctx context.Context) error {
 	router := s.buildHandler()
 
 	srv := &http.Server{
-		Addr:         s.cfg.Daemon.HTTP.ListenAddr,
+		Addr:         s.cfg().Daemon.HTTP.ListenAddr,
 		Handler:      router,
-		ReadTimeout:  time.Duration(s.cfg.Daemon.HTTP.ReadTimeoutSeconds) * time.Second,
-		WriteTimeout: time.Duration(s.cfg.Daemon.HTTP.WriteTimeoutSeconds) * time.Second,
-		IdleTimeout:  time.Duration(s.cfg.Daemon.HTTP.IdleTimeoutSeconds) * time.Second,
+		ReadTimeout:  time.Duration(s.cfg().Daemon.HTTP.ReadTimeoutSeconds) * time.Second,
+		WriteTimeout: time.Duration(s.cfg().Daemon.HTTP.WriteTimeoutSeconds) * time.Second,
+		IdleTimeout:  time.Duration(s.cfg().Daemon.HTTP.IdleTimeoutSeconds) * time.Second,
 	}
 
 	// A background goroutine watches for ctx cancellation and triggers HTTP
@@ -208,14 +267,14 @@ func (s *Server) Run(ctx context.Context) error {
 	errCh := make(chan error, 1)
 	go func() {
 		<-ctx.Done()
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Duration(s.cfg.Daemon.HTTP.ShutdownTimeoutSeconds)*time.Second)
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Duration(s.cfg().Daemon.HTTP.ShutdownTimeoutSeconds)*time.Second)
 		defer cancel()
 		errCh <- srv.Shutdown(shutdownCtx)
 	}()
 
-	logEvent := s.logger.Info().Str("addr", s.cfg.Daemon.HTTP.ListenAddr).Str("status_path", s.cfg.Daemon.HTTP.StatusPath).Str("webhook_path", s.cfg.Daemon.HTTP.WebhookPath).Str("agents_run_path", s.cfg.Daemon.HTTP.AgentsRunPath)
+	logEvent := s.logger.Info().Str("addr", s.cfg().Daemon.HTTP.ListenAddr).Str("status_path", s.cfg().Daemon.HTTP.StatusPath).Str("webhook_path", s.cfg().Daemon.HTTP.WebhookPath).Str("agents_run_path", s.cfg().Daemon.HTTP.AgentsRunPath)
 	if s.proxy != nil {
-		logEvent = logEvent.Str("proxy_path", s.cfg.Daemon.Proxy.Path)
+		logEvent = logEvent.Str("proxy_path", s.cfg().Daemon.Proxy.Path)
 	}
 	logEvent.Msg("starting webhook server")
 	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
@@ -230,7 +289,7 @@ func (s *Server) Run(ctx context.Context) error {
 // operators that rely solely on network-level access control.
 func (s *Server) requireAPIKey(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if s.cfg.Daemon.HTTP.APIKey != "" {
+		if s.cfg().Daemon.HTTP.APIKey != "" {
 			authHeader := r.Header.Get("Authorization")
 			const prefix = "Bearer "
 			if !strings.HasPrefix(authHeader, prefix) {
@@ -238,7 +297,7 @@ func (s *Server) requireAPIKey(next http.Handler) http.Handler {
 				return
 			}
 			token := authHeader[len(prefix):]
-			if subtle.ConstantTimeCompare([]byte(token), []byte(s.cfg.Daemon.HTTP.APIKey)) != 1 {
+			if subtle.ConstantTimeCompare([]byte(token), []byte(s.cfg().Daemon.HTTP.APIKey)) != 1 {
 				http.Error(w, "unauthorized", http.StatusUnauthorized)
 				return
 			}
@@ -292,12 +351,12 @@ type agentsRunRequest struct {
 }
 
 func (s *Server) handleAgentsRun(w http.ResponseWriter, r *http.Request) {
-	if s.cfg.Daemon.HTTP.APIKey == "" {
+	if s.cfg().Daemon.HTTP.APIKey == "" {
 		http.Error(w, "endpoint disabled: no API key configured", http.StatusForbidden)
 		return
 	}
 	var req agentsRunRequest
-	if err := json.NewDecoder(io.LimitReader(r.Body, s.cfg.Daemon.HTTP.MaxBodyBytes)).Decode(&req); err != nil {
+	if err := json.NewDecoder(io.LimitReader(r.Body, s.cfg().Daemon.HTTP.MaxBodyBytes)).Decode(&req); err != nil {
 		http.Error(w, "invalid request body", http.StatusBadRequest)
 		return
 	}
@@ -306,7 +365,7 @@ func (s *Server) handleAgentsRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	repo, ok := s.cfg.RepoByName(req.Repo)
+	repo, ok := s.cfg().RepoByName(req.Repo)
 	if !ok || !repo.Enabled {
 		http.Error(w, "repo not found or disabled", http.StatusNotFound)
 		return
@@ -346,12 +405,12 @@ func (s *Server) handleGitHubWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, s.cfg.Daemon.HTTP.MaxBodyBytes))
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, s.cfg().Daemon.HTTP.MaxBodyBytes))
 	if err != nil {
 		http.Error(w, "invalid body", http.StatusBadRequest)
 		return
 	}
-	if !verifySignature(body, s.cfg.Daemon.HTTP.WebhookSecret, r.Header.Get("X-Hub-Signature-256")) {
+	if !verifySignature(body, s.cfg().Daemon.HTTP.WebhookSecret, r.Header.Get("X-Hub-Signature-256")) {
 		http.Error(w, "invalid signature", http.StatusUnauthorized)
 		return
 	}
@@ -440,7 +499,7 @@ func (s *Server) handleIssuesEvent(ctx context.Context, w http.ResponseWriter, b
 		return
 	}
 
-	repo, ok := s.cfg.RepoByName(payload.Repository.FullName)
+	repo, ok := s.cfg().RepoByName(payload.Repository.FullName)
 	if !ok || !repo.Enabled {
 		w.WriteHeader(http.StatusAccepted)
 		return
@@ -502,7 +561,7 @@ func (s *Server) handlePullRequestEvent(ctx context.Context, w http.ResponseWrit
 		return
 	}
 
-	repo, ok := s.cfg.RepoByName(payload.Repository.FullName)
+	repo, ok := s.cfg().RepoByName(payload.Repository.FullName)
 	if !ok || !repo.Enabled {
 		w.WriteHeader(http.StatusAccepted)
 		return
@@ -569,7 +628,7 @@ func (s *Server) handleIssueCommentEvent(ctx context.Context, w http.ResponseWri
 		return
 	}
 
-	repo, ok := s.cfg.RepoByName(payload.Repository.FullName)
+	repo, ok := s.cfg().RepoByName(payload.Repository.FullName)
 	if !ok || !repo.Enabled {
 		w.WriteHeader(http.StatusAccepted)
 		return
@@ -607,7 +666,7 @@ func (s *Server) handlePullRequestReviewEvent(ctx context.Context, w http.Respon
 		return
 	}
 
-	repo, ok := s.cfg.RepoByName(payload.Repository.FullName)
+	repo, ok := s.cfg().RepoByName(payload.Repository.FullName)
 	if !ok || !repo.Enabled {
 		w.WriteHeader(http.StatusAccepted)
 		return
@@ -646,7 +705,7 @@ func (s *Server) handlePullRequestReviewCommentEvent(ctx context.Context, w http
 		return
 	}
 
-	repo, ok := s.cfg.RepoByName(payload.Repository.FullName)
+	repo, ok := s.cfg().RepoByName(payload.Repository.FullName)
 	if !ok || !repo.Enabled {
 		w.WriteHeader(http.StatusAccepted)
 		return
@@ -678,7 +737,7 @@ func (s *Server) handlePushEvent(ctx context.Context, w http.ResponseWriter, bod
 		return
 	}
 
-	repo, ok := s.cfg.RepoByName(payload.Repository.FullName)
+	repo, ok := s.cfg().RepoByName(payload.Repository.FullName)
 	if !ok || !repo.Enabled {
 		w.WriteHeader(http.StatusAccepted)
 		return

--- a/internal/webhook/server.go
+++ b/internal/webhook/server.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"net/http"
@@ -61,12 +62,20 @@ type EventQueue interface {
 	QueueStats() workflow.QueueStat
 }
 
+// ConfigObserver is notified after every successful reloadConfig call so that
+// execution components can pick up the new config without a daemon restart.
+// Implementations must be safe for concurrent use.
+type ConfigObserver interface {
+	UpdateConfig(*config.Config)
+}
+
 type Server struct {
 	// cfgPtr holds the current effective config as an atomic pointer so that
 	// write-API handlers can swap it after persisting a change without holding
 	// a coarse lock across all request handlers.
 	cfgPtr        atomic.Pointer[config.Config]
-	db            *sql.DB        // non-nil only when --db is used; enables write API
+	db            *sql.DB          // non-nil only when --db is used; enables write API
+	observers     []ConfigObserver // notified after every successful reloadConfig
 	delivery      *DeliveryStore
 	logger        zerolog.Logger
 	channels      EventQueue
@@ -112,23 +121,42 @@ func (s *Server) WithStore(db *sql.DB) {
 	s.db = db
 }
 
-// reloadConfig reloads the structural config from the SQLite database and
+// WithConfigObserver registers a component that should receive config updates
+// after every successful write-API mutation. Multiple observers are supported;
+// each is called synchronously in the order registered.
+func (s *Server) WithConfigObserver(o ConfigObserver) {
+	s.observers = append(s.observers, o)
+}
+
+// reloadConfig reloads the structural config from the SQLite database, applies
+// defaults, normalisation, and validation via config.FinishLoad, then
 // atomically replaces the server's config pointer. Resolved runtime secrets
 // (webhook secret, API key, proxy API key) are not stored in the database —
 // they are carried forward from the current live config so they remain valid
 // without requiring a re-read of environment variables.
+// After the server's pointer is updated every registered ConfigObserver is
+// notified so that execution components (Engine, Scheduler) pick up the new
+// routing and agent definitions on their next operation.
 func (s *Server) reloadConfig() error {
-	cfg, err := store.Load(s.db)
+	raw, err := store.Load(s.db)
 	if err != nil {
 		return err
 	}
-	// Preserve secrets that were resolved from env vars at startup; they cannot
-	// change at runtime and are not stored in SQLite.
+	// Copy runtime secrets into the freshly-loaded config BEFORE FinishLoad so
+	// that resolveSecrets (which only sets a field when it is empty) leaves them
+	// intact and validate does not fail on a missing webhook secret.
 	live := s.cfgPtr.Load()
-	cfg.Daemon.HTTP.WebhookSecret = live.Daemon.HTTP.WebhookSecret
-	cfg.Daemon.HTTP.APIKey = live.Daemon.HTTP.APIKey
-	cfg.Daemon.Proxy.Upstream.APIKey = live.Daemon.Proxy.Upstream.APIKey
+	raw.Daemon.HTTP.WebhookSecret = live.Daemon.HTTP.WebhookSecret
+	raw.Daemon.HTTP.APIKey = live.Daemon.HTTP.APIKey
+	raw.Daemon.Proxy.Upstream.APIKey = live.Daemon.Proxy.Upstream.APIKey
+	cfg, err := config.FinishLoad(raw)
+	if err != nil {
+		return fmt.Errorf("reload config: %w", err)
+	}
 	s.cfgPtr.Store(cfg)
+	for _, o := range s.observers {
+		o.UpdateConfig(cfg)
+	}
 	return nil
 }
 

--- a/internal/workflow/dispatch.go
+++ b/internal/workflow/dispatch.go
@@ -410,6 +410,7 @@ func (s *DispatchDedupStore) TryClaimForDispatch(agent, repo string, number int,
 // dedup safety limits.
 type Dispatcher struct {
 	cfg      config.DispatchConfig
+	agentsMu sync.RWMutex
 	agents   map[string]config.AgentDef // all agents by name (lower-cased)
 	dedup    *DispatchDedupStore
 	counters dispatchCounters
@@ -428,6 +429,14 @@ func NewDispatcher(cfg config.DispatchConfig, agents map[string]config.AgentDef,
 		queue:  queue,
 		logger: logger.With().Str("component", "dispatcher").Logger(),
 	}
+}
+
+// UpdateAgents atomically replaces the agent map used for opt-in checks.
+// Safe to call concurrently with ProcessDispatches.
+func (d *Dispatcher) UpdateAgents(agents map[string]config.AgentDef) {
+	d.agentsMu.Lock()
+	d.agents = agents
+	d.agentsMu.Unlock()
 }
 
 // WithGraphRecorder attaches an optional recorder called on each successfully
@@ -487,7 +496,9 @@ func (d *Dispatcher) ProcessDispatches(
 		}
 
 		// Opt-in check: target must have allow_dispatch: true.
+		d.agentsMu.RLock()
 		target, ok := d.agents[req.Agent]
+		d.agentsMu.RUnlock()
 		if !ok || !target.AllowDispatch {
 			logBase.Warn().Msg("dispatch dropped: target has allow_dispatch: false")
 			d.counters.droppedNoOptin.Add(1)

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -48,7 +48,7 @@ type GraphRecorder interface {
 // Agent resolution, backend selection, and prompt composition all happen here;
 // the runners just execute the resulting prompt.
 type Engine struct {
-	cfg           *config.Config
+	cfgPtr        atomic.Pointer[config.Config]
 	runners       map[string]ai.Runner
 	dispatcher    *Dispatcher
 	maxConcurrent int
@@ -59,6 +59,26 @@ type Engine struct {
 	runsDeduped   atomic.Int64
 }
 
+// cfg returns the current effective configuration. All engine methods must
+// call this instead of reading the field directly so live reloads are visible.
+func (e *Engine) cfg() *config.Config {
+	return e.cfgPtr.Load()
+}
+
+// UpdateConfig atomically replaces the engine's config and updates the
+// dispatcher's agent map so that the next event uses new routing definitions.
+// It is safe to call concurrently with HandleEvent.
+func (e *Engine) UpdateConfig(cfg *config.Config) {
+	e.cfgPtr.Store(cfg)
+	if e.dispatcher != nil {
+		agentMap := make(map[string]config.AgentDef, len(cfg.Agents))
+		for _, a := range cfg.Agents {
+			agentMap[a.Name] = a
+		}
+		e.dispatcher.UpdateAgents(agentMap)
+	}
+}
+
 // NewEngine builds an Engine. queue may be nil, in which case dispatch
 // requests from agent responses are validated and logged but not enqueued.
 func NewEngine(cfg *config.Config, runners map[string]ai.Runner, queue EventEnqueuer, logger zerolog.Logger) *Engine {
@@ -67,11 +87,11 @@ func NewEngine(cfg *config.Config, runners map[string]ai.Runner, queue EventEnqu
 		max = 4
 	}
 	eng := &Engine{
-		cfg:           cfg,
 		runners:       runners,
 		maxConcurrent: max,
 		logger:        logger.With().Str("component", "workflow_engine").Logger(),
 	}
+	eng.cfgPtr.Store(cfg)
 	if queue != nil {
 		agentMap := make(map[string]config.AgentDef, len(cfg.Agents))
 		for _, a := range cfg.Agents {
@@ -164,7 +184,7 @@ func (e *Engine) handleDispatchEvent(ctx context.Context, ev Event) error {
 		return fmt.Errorf("agent.dispatch event missing target_agent in payload")
 	}
 
-	repo, ok := e.cfg.RepoByName(ev.Repo.FullName)
+	repo, ok := e.cfg().RepoByName(ev.Repo.FullName)
 	if !ok || !repo.Enabled {
 		e.logger.Warn().Str("repo", ev.Repo.FullName).Msg("dispatch event for disabled or unknown repo, skipping")
 		return nil
@@ -177,7 +197,7 @@ func (e *Engine) handleDispatchEvent(ctx context.Context, ev Event) error {
 		return fmt.Errorf("dispatch: target agent %q is not bound to repo %q", targetName, ev.Repo.FullName)
 	}
 
-	agent, ok := e.cfg.AgentByName(targetName)
+	agent, ok := e.cfg().AgentByName(targetName)
 	if !ok {
 		return fmt.Errorf("dispatch: target agent %q not found", targetName)
 	}
@@ -325,7 +345,7 @@ func (e *Engine) fanOut(ctx context.Context, ev Event) error {
 // payload label is in the binding's Labels slice. An event binding matches
 // when ev.Kind appears in the binding's Events slice.
 func (e *Engine) agentsForEvent(ev Event) []config.AgentDef {
-	repo, ok := e.cfg.RepoByName(ev.Repo.FullName)
+	repo, ok := e.cfg().RepoByName(ev.Repo.FullName)
 	if !ok || !repo.Enabled {
 		return nil
 	}
@@ -357,7 +377,7 @@ func (e *Engine) agentsForEvent(ev Event) []config.AgentDef {
 		if _, dup := seen[b.Agent]; dup {
 			continue
 		}
-		agent, ok := e.cfg.AgentByName(b.Agent)
+		agent, ok := e.cfg().AgentByName(b.Agent)
 		if !ok {
 			continue
 		}
@@ -418,7 +438,7 @@ func extractDispatchContext(ev Event) (rootEventID string, depth int) {
 }
 
 func (e *Engine) runAgent(ctx context.Context, ev Event, agent config.AgentDef) error {
-	backend := e.cfg.ResolveBackend(agent.Backend)
+	backend := e.cfg().ResolveBackend(agent.Backend)
 	if backend == "" {
 		return fmt.Errorf("agent %q: no runner available for backend %q", agent.Name, agent.Backend)
 	}
@@ -438,11 +458,11 @@ func (e *Engine) runAgent(ctx context.Context, ev Event, agent config.AgentDef) 
 	}
 
 	// Build the roster of peer agents for this repo.
-	roster := BuildRoster(e.cfg, ev.Repo.FullName, agent.Name)
+	roster := BuildRoster(e.cfg(), ev.Repo.FullName, agent.Name)
 
 	promptPayload := ev.Payload
 
-	rendered, err := ai.RenderAgentPrompt(agent, e.cfg.Skills, ai.PromptContext{
+	rendered, err := ai.RenderAgentPrompt(agent, e.cfg().Skills, ai.PromptContext{
 		Repo:          ev.Repo.FullName,
 		Number:        ev.Number,
 		Backend:       backend,


### PR DESCRIPTION
## Summary

Implements Phase 2 of #188: a complete write API for managing fleet entities (agents, skills, backends, repos, bindings) at runtime over HTTP, backed by the Phase 1 SQLite store. The daemon's in-memory config view updates atomically after every write — no restart required.

**Based on** #204 (Phase 1 — must merge first).

### What changed

- **`internal/store`** — FK-safe `Put*` / `Delete*` helpers for all five entity types. `SetMaxOpenConns(1)` ensures `PRAGMA foreign_keys=ON` is honoured on every pooled connection.
- **`internal/webhook/server.go`** — `s.cfg` replaced by `atomic.Pointer[config.Config]` + `cfg()` accessor; `WithStore(db)` activates the write routes; `reloadConfig()` refreshes the live config after each mutation while preserving runtime secrets.
- **`internal/webhook/api_write.go`** — ten new endpoints (`PUT`/`DELETE` on agents, skills, backends, repos; `POST`/`DELETE` on bindings), all bearer-token gated, all reloading live config on success.
- **`cmd/agents/main.go`** — `loadConfig` now returns `(*config.Config, *sql.DB, error)`; the DB stays open for the daemon's lifetime.

### Write endpoints (only active with `--db`)

| Method | Path | Action |
|---|---|---|
| `PUT` | `/api/agents` | Create or update agent |
| `DELETE` | `/api/agents/{name}` | Delete agent |
| `PUT` | `/api/skills` | Create or update skill |
| `DELETE` | `/api/skills/{name}` | Delete skill |
| `PUT` | `/api/backends` | Create or update backend |
| `DELETE` | `/api/backends/{name}` | Delete backend |
| `PUT` | `/api/repos` | Create or update repo |
| `DELETE` | `/api/repos/{name}` | Delete repo (cascades bindings) |
| `POST` | `/api/repos/{name}/bindings` | Add binding; returns `{"id": N}` |
| `DELETE` | `/api/repos/{name}/bindings/{id}` | Delete binding by ID |

## Test plan

- [ ] `go test ./internal/store/... ./internal/webhook/... -count=1` — all new store and handler tests pass
- [ ] `go test ./... -count=1` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)