### PR TITLE
feat(ai): SQLite-backed agent memory via structured response

### DIFF
--- a/cmd/agents/main.go
+++ b/cmd/agents/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"flag"
 	"fmt"
@@ -53,9 +54,12 @@ func run() error {
 	runRepo := flag.String("repo", "", "repo to target when using --run-agent (e.g. owner/repo)")
 	flag.Parse()
 
-	cfg, err := loadConfig(*configPath, *dbPath, *importPath)
+	cfg, db, err := loadConfig(*configPath, *dbPath, *importPath)
 	if err != nil {
 		return err
+	}
+	if db != nil {
+		defer db.Close()
 	}
 
 	logger := logging.NewLogger(cfg.Daemon.Log)
@@ -64,6 +68,9 @@ func run() error {
 	scheduler, err := setupScheduler(cfg, runners, logger)
 	if err != nil {
 		return err
+	}
+	if db != nil {
+		scheduler.WithDB(db)
 	}
 
 	// --run-agent mode: execute one agent pass synchronously and exit.
@@ -188,28 +195,34 @@ func setupScheduler(cfg *config.Config, runners map[string]ai.Runner, logger zer
 //   - If importPath is also set, the YAML at importPath is parsed and written
 //     into the database before loading.
 //   - The config is then read from the database.
+//   - The open *sql.DB is returned so the caller can pass it to subsystems
+//     (e.g. the scheduler for SQLite-backed memory). The caller owns the DB
+//     and must close it when done.
 //
-// When dbPath is empty, configPath is used (default behaviour).
-func loadConfig(configPath, dbPath, importPath string) (*config.Config, error) {
+// When dbPath is empty, configPath is used (default behaviour) and the
+// returned *sql.DB is nil.
+func loadConfig(configPath, dbPath, importPath string) (*config.Config, *sql.DB, error) {
 	if importPath != "" && dbPath == "" {
-		return nil, fmt.Errorf("--import requires --db")
+		return nil, nil, fmt.Errorf("--import requires --db")
 	}
 	if dbPath == "" {
-		return config.Load(configPath)
+		cfg, err := config.Load(configPath)
+		return cfg, nil, err
 	}
 	db, err := store.Open(dbPath)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	defer db.Close()
 
 	if importPath != "" {
 		yamlCfg, err := config.Load(importPath)
 		if err != nil {
-			return nil, fmt.Errorf("import: load YAML: %w", err)
+			db.Close()
+			return nil, nil, fmt.Errorf("import: load YAML: %w", err)
 		}
 		if err := store.Import(db, yamlCfg); err != nil {
-			return nil, fmt.Errorf("import: write to database: %w", err)
+			db.Close()
+			return nil, nil, fmt.Errorf("import: write to database: %w", err)
 		}
 		// Count from the source config so the message reflects exactly what
 		// was written, not a potentially stale whole-table count.
@@ -222,7 +235,12 @@ func loadConfig(configPath, dbPath, importPath string) (*config.Config, error) {
 			len(yamlCfg.Agents), len(yamlCfg.Repos), nBindings)
 	}
 
-	return store.LoadAndValidate(db)
+	cfg, err := store.LoadAndValidate(db)
+	if err != nil {
+		db.Close()
+		return nil, nil, err
+	}
+	return cfg, db, nil
 }
 
 // schedulerStatusAdapter adapts *autonomous.Scheduler to webhook.StatusProvider,

--- a/internal/ai/prompt.go
+++ b/internal/ai/prompt.go
@@ -27,7 +27,13 @@ type PromptContext struct {
 	Number     int    // issue or PR number, 0 for runs with no GitHub item
 	Backend    string // resolved backend name (claude, codex, ...)
 	Memory     string // existing memory snapshot for autonomous runs
-	MemoryPath string // path the agent should update after the run
+	MemoryPath string // path the agent should update after the run (file-based memory only)
+	// ShowMemory controls whether existing memory is injected into the prompt.
+	// Set to true by the scheduler for autonomous runs. For SQLite-backed memory
+	// (MemoryPath == "") the agent is expected to return updated memory in the
+	// `memory` response field. For file-backed memory (MemoryPath != "") the
+	// agent writes to the file directly.
+	ShowMemory bool
 	EventKind  string         // e.g. "issues.labeled", "push" — empty for autonomous runs
 	Actor      string         // GitHub login that triggered the event; empty for autonomous runs
 	Payload    map[string]any // kind-specific event fields; nil for autonomous runs
@@ -131,7 +137,17 @@ func renderRuntimeContext(ctx PromptContext) string {
 		}
 	}
 	if ctx.MemoryPath != "" {
+		// File-based memory (YAML-only mode): tell the agent where to write.
 		fmt.Fprintf(&b, "Memory file: %s\n", ctx.MemoryPath)
+		mem := strings.TrimSpace(ctx.Memory)
+		if mem == "" {
+			b.WriteString("Existing memory: (empty)\n")
+		} else {
+			fmt.Fprintf(&b, "Existing memory:\n%s\n", mem)
+		}
+	} else if ctx.ShowMemory {
+		// SQLite-based memory (--db mode): inject existing content only — the
+		// agent returns updated memory in the `memory` response field.
 		mem := strings.TrimSpace(ctx.Memory)
 		if mem == "" {
 			b.WriteString("Existing memory: (empty)\n")

--- a/internal/ai/prompt_test.go
+++ b/internal/ai/prompt_test.go
@@ -348,3 +348,57 @@ func TestRenderAgentPromptTotalContentPreserved(t *testing.T) {
 		}
 	}
 }
+
+// TestRenderAgentPromptSQLiteMemory verifies that setting ShowMemory=true
+// (SQLite path) injects the memory content without a "Memory file:" line.
+func TestRenderAgentPromptSQLiteMemory(t *testing.T) {
+	t.Parallel()
+	agent := config.AgentDef{
+		Name:   "coder",
+		Prompt: "Do your job.",
+	}
+	usr := renderUser(t, agent, nil, ai.PromptContext{
+		Repo:       "owner/repo",
+		ShowMemory: true,
+		Memory:     "## Prior work\n- fixed #42\n",
+	})
+	if strings.Contains(usr, "Memory file:") {
+		t.Errorf("SQLite path must not include 'Memory file:' line; User:\n%s", usr)
+	}
+	if !strings.Contains(usr, "fixed #42") {
+		t.Errorf("missing memory content in User:\n%s", usr)
+	}
+}
+
+// TestRenderAgentPromptSQLiteMemoryEmpty verifies that ShowMemory=true with
+// no prior memory renders "(empty)" rather than omitting the section.
+func TestRenderAgentPromptSQLiteMemoryEmpty(t *testing.T) {
+	t.Parallel()
+	agent := config.AgentDef{Prompt: "Go."}
+	usr := renderUser(t, agent, nil, ai.PromptContext{
+		Repo:       "owner/repo",
+		ShowMemory: true,
+	})
+	if !strings.Contains(usr, "Existing memory: (empty)") {
+		t.Errorf("expected explicit empty signal in User:\n%s", usr)
+	}
+}
+
+// TestRenderAgentPromptNoMemoryWithoutShowMemory verifies that event-driven
+// runs (ShowMemory=false, MemoryPath="") do not expose memory in the prompt.
+func TestRenderAgentPromptNoMemoryWithoutShowMemory(t *testing.T) {
+	t.Parallel()
+	agent := config.AgentDef{Prompt: "Go."}
+	// Simulate an event-driven run: Repo is set but ShowMemory is false and
+	// MemoryPath is empty. The Memory field should be ignored entirely.
+	usr := renderUser(t, agent, nil, ai.PromptContext{
+		Repo:   "owner/repo",
+		Memory: "should not appear",
+	})
+	if strings.Contains(usr, "should not appear") {
+		t.Errorf("memory must not be injected for event-driven runs; User:\n%s", usr)
+	}
+	if strings.Contains(usr, "Existing memory") {
+		t.Errorf("memory section must not appear for event-driven runs; User:\n%s", usr)
+	}
+}

--- a/internal/ai/types.go
+++ b/internal/ai/types.go
@@ -44,4 +44,9 @@ type Response struct {
 	Artifacts []Artifact        `json:"artifacts"`
 	Summary   string            `json:"summary"`
 	Dispatch  []DispatchRequest `json:"dispatch,omitempty"`
+	// Memory is the agent's full updated memory state for autonomous runs.
+	// When non-empty the daemon writes it back to the memory store, replacing
+	// the previous content entirely. An empty string leaves the stored memory
+	// unchanged. Only meaningful for autonomous runs; event-driven runs ignore it.
+	Memory string `json:"memory,omitempty"`
 }

--- a/internal/autonomous/scheduler.go
+++ b/internal/autonomous/scheduler.go
@@ -2,6 +2,7 @@ package autonomous
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"maps"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/eloylp/agents/internal/ai"
 	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/store"
 	"github.com/eloylp/agents/internal/workflow"
 )
 
@@ -74,6 +76,7 @@ type Scheduler struct {
 	cfg          *config.Config
 	runners      map[string]ai.Runner
 	memories     *MemoryStore
+	db           *sql.DB                // nil when SQLite memory is not in use
 	cron         *cron.Cron
 	logger       zerolog.Logger
 	ctxMu        sync.RWMutex
@@ -83,6 +86,15 @@ type Scheduler struct {
 	lastRuns     map[string]lastRunRecord // key: "name\x00repo"
 	dispatcher   *workflow.Dispatcher    // nil when dispatch is not configured
 	traceRec     workflow.TraceRecorder  // nil when tracing is not configured
+}
+
+// WithDB attaches a SQLite database to the Scheduler. When set, autonomous
+// agent runs read and write memory via the store package (GetMemory/SetMemory)
+// instead of the file-based MemoryStore. The scheduler sets ShowMemory=true
+// and MemoryPath="" in every PromptContext so the agent knows to return
+// updated memory in the `memory` response field.
+func (s *Scheduler) WithDB(db *sql.DB) {
+	s.db = db
 }
 
 // WithDispatcher attaches a Dispatcher to the Scheduler so that dispatch
@@ -306,12 +318,17 @@ func (s *Scheduler) executeAgentRun(ctx context.Context, repo string, agent conf
 	// as a dispatch enqueue error must NOT clear the mark — the autonomous pass
 	// already committed, so the dedup window must remain in force.
 	runCompleted := false
-	err := s.memories.WithLock(agent.Name, repo, func(memoryPath string, memory string) error {
+
+	// doRun performs the prompt render, agent execution, and post-run memory
+	// update. It is called either inside memories.WithLock (file-based path) or
+	// directly with the SQLite-fetched memory (--db path).
+	doRun := func(memoryPath string, memory string) error {
 		rendered, err := ai.RenderAgentPrompt(agent, s.cfg.Skills, ai.PromptContext{
 			Repo:       repo,
 			Backend:    backend,
 			Memory:     memory,
 			MemoryPath: memoryPath,
+			ShowMemory: memoryPath == "",
 			Roster:     roster,
 		})
 		if err != nil {
@@ -352,6 +369,12 @@ func (s *Scheduler) executeAgentRun(ctx context.Context, repo string, agent conf
 			return fmt.Errorf("agent run: %w", err)
 		}
 		runCompleted = true
+		// Persist updated memory when using the SQLite path.
+		if s.db != nil && resp.Memory != "" {
+			if merr := store.SetMemory(s.db, agent.Name, repo, resp.Memory); merr != nil {
+				logger.Error().Err(merr).Msg("failed to persist agent memory")
+			}
+		}
 		logger.Info().Int("artifacts_stored", len(resp.Artifacts)).Int("dispatch_requests", len(resp.Dispatch)).Msg("autonomous pass completed")
 		if s.dispatcher != nil && len(resp.Dispatch) > 0 {
 			// Synthesize a minimal event to carry repo context into the dispatcher.
@@ -375,7 +398,23 @@ func (s *Scheduler) executeAgentRun(ctx context.Context, repo string, agent conf
 			}
 		}
 		return nil
-	})
+	}
+
+	var err error
+	if s.db != nil {
+		// SQLite-backed memory path: fetch memory outside the file lock, run,
+		// then write back in doRun if the agent returned non-empty memory.
+		mem, merr := store.GetMemory(s.db, agent.Name, repo)
+		if merr != nil {
+			if s.dispatcher != nil {
+				s.dispatcher.RollbackAutonomousRun(agent.Name, repo)
+			}
+			return fmt.Errorf("get memory: %w", merr)
+		}
+		err = doRun("", mem)
+	} else {
+		err = s.memories.WithLock(agent.Name, repo, doRun)
+	}
 	if s.dispatcher != nil {
 		if err != nil && !runCompleted {
 			// Roll back the cron mark only when the autonomous pass itself failed

--- a/internal/store/migrations/002_memory.sql
+++ b/internal/store/migrations/002_memory.sql
@@ -1,0 +1,12 @@
+-- Phase 2: agent memory stored in SQLite.
+-- Each (agent, repo) pair has a single text blob that the agent can overwrite
+-- in full via the `memory` field of its structured response. The updated_at
+-- column records the last write time for UI display and future TTL cleanup.
+
+CREATE TABLE IF NOT EXISTS memory (
+    agent      TEXT NOT NULL,
+    repo       TEXT NOT NULL,
+    content    TEXT NOT NULL DEFAULT '',
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (agent, repo)
+);

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -20,6 +20,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"embed"
+	"errors"
 	"fmt"
 	"io/fs"
 	"sort"
@@ -639,5 +640,41 @@ func LoadAndValidate(db *sql.DB) (*config.Config, error) {
 		return nil, err
 	}
 	return config.FinishLoad(cfg)
+}
+
+// ── Memory API ──────────────────────────────────────────────────────────────
+
+// GetMemory returns the stored memory blob for the given (agent, repo) pair.
+// Returns an empty string (not an error) when no memory has been written yet.
+func GetMemory(db *sql.DB, agent, repo string) (string, error) {
+	var content string
+	err := db.QueryRow(
+		"SELECT content FROM memory WHERE agent=? AND repo=?", agent, repo,
+	).Scan(&content)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("store get memory agent=%s repo=%s: %w", agent, repo, err)
+	}
+	return content, nil
+}
+
+// SetMemory writes (upserts) the memory blob for the given (agent, repo) pair.
+// Passing an empty string clears the memory but keeps the row; callers that
+// want a full delete should call DeleteMemory instead.
+func SetMemory(db *sql.DB, agent, repo, content string) error {
+	_, err := db.Exec(`
+		INSERT INTO memory(agent,repo,content,updated_at)
+		VALUES (?,?,?,datetime('now'))
+		ON CONFLICT(agent,repo) DO UPDATE SET
+		  content=excluded.content,
+		  updated_at=excluded.updated_at`,
+		agent, repo, content,
+	)
+	if err != nil {
+		return fmt.Errorf("store set memory agent=%s repo=%s: %w", agent, repo, err)
+	}
+	return nil
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -337,3 +337,95 @@ func TestLoadEmptyDatabase(t *testing.T) {
 		t.Fatal("expected error loading from empty database, got nil")
 	}
 }
+
+// TestGetMemoryEmpty verifies that GetMemory returns an empty string (not an
+// error) when no memory has been written yet for the given (agent, repo) pair.
+func TestGetMemoryEmpty(t *testing.T) {
+	t.Parallel()
+	db, cleanup := openTestDB(t)
+	defer cleanup()
+
+	got, err := store.GetMemory(db, "coder", "owner/repo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected empty string, got %q", got)
+	}
+}
+
+// TestSetAndGetMemory verifies the full write→read round-trip.
+func TestSetAndGetMemory(t *testing.T) {
+	t.Parallel()
+	db, cleanup := openTestDB(t)
+	defer cleanup()
+
+	const (
+		agent   = "coder"
+		repo    = "owner/repo"
+		content = "## Notes\n- remember foo\n"
+	)
+
+	if err := store.SetMemory(db, agent, repo, content); err != nil {
+		t.Fatalf("SetMemory: %v", err)
+	}
+
+	got, err := store.GetMemory(db, agent, repo)
+	if err != nil {
+		t.Fatalf("GetMemory: %v", err)
+	}
+	if got != content {
+		t.Errorf("GetMemory = %q, want %q", got, content)
+	}
+}
+
+// TestSetMemoryUpsert verifies that a second SetMemory call overwrites the
+// previous content rather than appending or failing.
+func TestSetMemoryUpsert(t *testing.T) {
+	t.Parallel()
+	db, cleanup := openTestDB(t)
+	defer cleanup()
+
+	const agent, repo = "coder", "owner/repo"
+	if err := store.SetMemory(db, agent, repo, "first"); err != nil {
+		t.Fatalf("first SetMemory: %v", err)
+	}
+	if err := store.SetMemory(db, agent, repo, "second"); err != nil {
+		t.Fatalf("second SetMemory: %v", err)
+	}
+	got, err := store.GetMemory(db, agent, repo)
+	if err != nil {
+		t.Fatalf("GetMemory: %v", err)
+	}
+	if got != "second" {
+		t.Errorf("GetMemory after upsert = %q, want %q", got, "second")
+	}
+}
+
+// TestMemoryIsolatedByAgentAndRepo verifies that memory entries are scoped to
+// the (agent, repo) pair: writing for one pair must not affect another.
+func TestMemoryIsolatedByAgentAndRepo(t *testing.T) {
+	t.Parallel()
+	db, cleanup := openTestDB(t)
+	defer cleanup()
+
+	cases := []struct{ agent, repo, content string }{
+		{"coder", "owner/repo-a", "mem-a"},
+		{"coder", "owner/repo-b", "mem-b"},
+		{"reviewer", "owner/repo-a", "mem-c"},
+	}
+	for _, c := range cases {
+		if err := store.SetMemory(db, c.agent, c.repo, c.content); err != nil {
+			t.Fatalf("SetMemory(%s,%s): %v", c.agent, c.repo, err)
+		}
+	}
+	for _, c := range cases {
+		got, err := store.GetMemory(db, c.agent, c.repo)
+		if err != nil {
+			t.Fatalf("GetMemory(%s,%s): %v", c.agent, c.repo, err)
+		}
+		if got != c.content {
+			t.Errorf("GetMemory(%s,%s) = %q, want %q", c.agent, c.repo, got, c.content)
+		}
+	}
+}

--- a/response-schema.json
+++ b/response-schema.json
@@ -33,6 +33,10 @@
         "additionalProperties": false
       },
       "description": "Agents to invoke next via the reactive dispatch system"
+    },
+    "memory": {
+      "type": "string",
+      "description": "Full updated memory state for autonomous runs (full overwrite). Empty string leaves stored memory unchanged."
     }
   },
   "required": ["summary", "artifacts", "dispatch"],


### PR DESCRIPTION
## Summary

Closes #203

Implements end-to-end SQLite-backed agent memory for database-backed (`--db`) deployments, so operators no longer need a separate filesystem `memory_dir` when using the database path.

- **`store/migrations/002_memory.sql`**: new `memory` table keyed by `(agent, repo)` with a text blob and `updated_at` timestamp
- **`store`**: `GetMemory` / `SetMemory` helpers with upsert semantics
- **`ai.Response`**: new optional `memory` field — agents return their full updated memory here instead of writing to a file
- **`ai.PromptContext`**: new `ShowMemory bool` flag controls whether existing memory is injected; only set for autonomous runs, never for event-driven runs (fixes the previous condition that could leak memory into event runs)
- **`response-schema.json`**: adds optional `"memory"` property
- **`autonomous.Scheduler`**: `WithDB(*sql.DB)` — when set, reads memory via `store.GetMemory` before each run and persists `resp.Memory` via `store.SetMemory` after a successful run; file-based path is unchanged
- **`cmd/agents/main.go`**: `loadConfig` now returns the open `*sql.DB` (caller owns lifetime); scheduler receives it via `WithDB`

## Test plan

- [ ] `store`: `TestGetMemoryEmpty`, `TestSetAndGetMemory`, `TestSetMemoryUpsert`, `TestMemoryIsolatedByAgentAndRepo`
- [ ] `ai`: `TestRenderAgentPromptSQLiteMemory`, `TestRenderAgentPromptSQLiteMemoryEmpty`, `TestRenderAgentPromptNoMemoryWithoutShowMemory`
- [ ] All existing tests continue to pass (`go test ./... -count=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)