### PR TITLE
refactor(store): sort.Slice → slices.SortFunc in migrate

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -22,7 +22,7 @@ import (
 	"embed"
 	"fmt"
 	"io/fs"
-	"sort"
+	"slices"
 	"strings"
 
 	_ "modernc.org/sqlite" // register the sqlite3 driver
@@ -72,8 +72,8 @@ func migrate(db *sql.DB) error {
 	if err != nil {
 		return fmt.Errorf("store: read migrations dir: %w", err)
 	}
-	sort.Slice(entries, func(i, j int) bool {
-		return entries[i].Name() < entries[j].Name()
+	slices.SortFunc(entries, func(a, b fs.DirEntry) int {
+		return strings.Compare(a.Name(), b.Name())
 	})
 
 	for _, entry := range entries {


### PR DESCRIPTION
## Why

`sort.Slice` in `internal/store/store.go` was the only remaining use of the `"sort"` package in the file. The rest of the codebase uses the `slices` package (introduced in Go 1.21) for collection operations consistently.

`sort.Slice` uses an index-based comparator — a footgun that can silently capture the wrong slice if refactored. `slices.SortFunc` takes a typed comparator (`func(a, b fs.DirEntry) int`) that is harder to misuse and more self-documenting.

## What

In `migrate`, replace:

```go
sort.Slice(entries, func(i, j int) bool {
    return entries[i].Name() < entries[j].Name()
})
```

with:

```go
slices.SortFunc(entries, func(a, b fs.DirEntry) int {
    return strings.Compare(a.Name(), b.Name())
})
```

Drop the `"sort"` import, add `"slices"`. `"strings"` was already imported.

## Test plan
- [x] `go test ./...` passes (all packages green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)