### PR TITLE
test(store): replace returned cleanup func with t.Cleanup in openTestDB

### DIFF
--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -100,7 +100,7 @@ func minimalCfg() *config.Config {
 	}
 }
 
-func openTestDB(t *testing.T) (*sql.DB, func()) {
+func openTestDB(t *testing.T) *sql.DB {
 	t.Helper()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.db")
@@ -108,7 +108,8 @@ func openTestDB(t *testing.T) (*sql.DB, func()) {
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	return db, func() { db.Close() }
+	t.Cleanup(func() { db.Close() })
+	return db
 }
 
 // TestOpenAndMigrate verifies that Open creates a new database and applies all
@@ -138,8 +139,7 @@ func TestOpenAndMigrate(t *testing.T) {
 // original on all fields that are persisted.
 func TestImportLoad(t *testing.T) {
 	t.Parallel()
-	db, cleanup := openTestDB(t)
-	defer cleanup()
+	db := openTestDB(t)
 
 	in := minimalCfg()
 	if err := store.Import(db, in); err != nil {
@@ -266,8 +266,7 @@ func TestImportLoad(t *testing.T) {
 // does not fail and does not duplicate rows.
 func TestImportIsIdempotent(t *testing.T) {
 	t.Parallel()
-	db, cleanup := openTestDB(t)
-	defer cleanup()
+	db := openTestDB(t)
 
 	in := minimalCfg()
 	if err := store.Import(db, in); err != nil {
@@ -293,8 +292,7 @@ func TestImportIsIdempotent(t *testing.T) {
 // import.
 func TestCountFrom(t *testing.T) {
 	t.Parallel()
-	db, cleanup := openTestDB(t)
-	defer cleanup()
+	db := openTestDB(t)
 
 	if err := store.Import(db, minimalCfg()); err != nil {
 		t.Fatalf("import: %v", err)
@@ -329,8 +327,7 @@ func TestCountFrom(t *testing.T) {
 // a descriptive error rather than a zero-value Config.
 func TestLoadEmptyDatabase(t *testing.T) {
 	t.Parallel()
-	db, cleanup := openTestDB(t)
-	defer cleanup()
+	db := openTestDB(t)
 
 	_, err := store.Load(db)
 	if err == nil {


### PR DESCRIPTION
## Why

`openTestDB` was returning a `(*sql.DB, func())` pair that each caller had to spread across two lines and remember to `defer`:

```go
db, cleanup := openTestDB(t)
defer cleanup()
```

`t.Cleanup` registered inside the helper is the modern Go idiom for this pattern. It:
- guarantees cleanup runs at test end **including on `t.Fatal` paths** (the deferred func does too, but it's easy to forget that `defer` fires on `Fatal` in Go — `t.Cleanup` makes the intent explicit)
- removes per-caller boilerplate entirely

## What

- `openTestDB` now registers `t.Cleanup(func() { db.Close() })` internally and returns only `*sql.DB`
- All four call sites simplified from two lines to one

## Test plan
- [x] `go test ./internal/store/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)