### PR TITLE
refactor(scheduler): extract appendLogKV helper from zerologCronLogger

### DIFF
--- a/internal/autonomous/scheduler.go
+++ b/internal/autonomous/scheduler.go
@@ -31,19 +31,21 @@ type zerologCronLogger struct {
 }
 
 func (z zerologCronLogger) Info(msg string, keysAndValues ...interface{}) {
-	e := z.logger.Info()
-	for i := 0; i+1 < len(keysAndValues); i += 2 {
-		e = e.Interface(fmt.Sprintf("%v", keysAndValues[i]), keysAndValues[i+1])
-	}
-	e.Msg(msg)
+	appendLogKV(z.logger.Info(), keysAndValues).Msg(msg)
 }
 
 func (z zerologCronLogger) Error(err error, msg string, keysAndValues ...interface{}) {
-	e := z.logger.Error().Err(err)
+	appendLogKV(z.logger.Error().Err(err), keysAndValues).Msg(msg)
+}
+
+// appendLogKV attaches key-value pairs to a zerolog event. keysAndValues is a
+// flat alternating slice of [key, value, key, value, …]; odd-length tails are
+// silently ignored, matching cron.Logger convention.
+func appendLogKV(e *zerolog.Event, keysAndValues []interface{}) *zerolog.Event {
 	for i := 0; i+1 < len(keysAndValues); i += 2 {
 		e = e.Interface(fmt.Sprintf("%v", keysAndValues[i]), keysAndValues[i+1])
 	}
-	e.Msg(msg)
+	return e
 }
 
 // AgentStatus is the runtime state of a single registered autonomous binding.


### PR DESCRIPTION
## Why

`zerologCronLogger.Info` and `zerologCronLogger.Error` each contained an identical 3-line loop that iterates a flat `[key, value, key, value, …]` slice and attaches each pair to a zerolog event:

```go
for i := 0; i+1 < len(keysAndValues); i += 2 {
    e = e.Interface(fmt.Sprintf("%v", keysAndValues[i]), keysAndValues[i+1])
}
```

The loop was copy-pasted verbatim; any future change (e.g. switching from `Interface` to a typed logger) would need to be made twice.

## What

Extract the duplicated loop into a package-private `appendLogKV` helper. Both methods collapse to a single chained expression:

```go
func (z zerologCronLogger) Info(msg string, keysAndValues ...interface{}) {
    appendLogKV(z.logger.Info(), keysAndValues).Msg(msg)
}

func (z zerologCronLogger) Error(err error, msg string, keysAndValues ...interface{}) {
    appendLogKV(z.logger.Error().Err(err), keysAndValues).Msg(msg)
}
```

No behaviour change. Tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)