### PR TITLE
fix(store): errors.Is for sql.ErrNoRows in loadDaemon

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -20,6 +20,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"embed"
+	"errors"
 	"fmt"
 	"io/fs"
 	"sort"
@@ -360,7 +361,7 @@ func Load(db *sql.DB) (*config.Config, error) {
 func loadDaemon(db *sql.DB, cfg *config.Config) error {
 	var value string
 	err := db.QueryRow("SELECT value FROM config WHERE key='daemon'").Scan(&value)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return fmt.Errorf("store load: daemon config not found in database (did you run --import?)")
 	}
 	if err != nil {


### PR DESCRIPTION
## What

In `loadDaemon`, replace:

```go
if err == sql.ErrNoRows {
```

with:

```go
if errors.Is(err, sql.ErrNoRows) {
```

## Why

`sql.ErrNoRows` is a sentinel value. Direct `==` comparison works today
because it isn't wrapped here, but the rest of the codebase (main.go,
autonomous/memory.go, autonomous/scheduler.go) consistently uses
`errors.Is` for all sentinel checks. This was the sole inconsistent
site; aligning it removes a gotcha if the error ever travels through a
`fmt.Errorf("%w", ...)` wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)