### PR TITLE
safety(prompts): prevent agents from @mentioning external GitHub users

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,7 @@ response-schema.json                # JSON schema for structured output (codex -
 These constraints are load-bearing. Read them before changing the listed areas.
 
 - **The daemon never writes to GitHub directly.** All writes go through the AI backend's MCP tools. If you introduce a new feature that seems to need a direct GitHub API call, raise it in an issue first — there's almost always a way to keep the daemon read-only.
+- **Agents must not mention external GitHub users.** Do NOT request reviews from, assign to, or @mention any GitHub user in PRs, comments, or issue descriptions. All review routing is handled by the daemon's dispatch system. Unsolicited pings to external contributors from an automated agent are a trust and reputation risk — the GitHub account could be flagged. This rule applies to every agent prompt.
 - **Prompts are never logged in plaintext.** Only their salted hash and length are recorded. If you add new log lines near prompt handling, preserve this property.
 - **Structured output is enforced at the CLI level.** Claude uses `--output-format json --json-schema <schema>` which wraps stdout in a CLI envelope; `extractStructuredOutput` in cmdrunner.go unwraps the `structured_output` field. Codex uses `--output-schema <file>` which constrains model output directly. Both paths feed the same `Response` struct. When changing the response contract, update `response-schema.json` alongside `internal/ai/types.go`.
 - **The runner contract is stdin-in, single-JSON-object-out.**

--- a/prompts/arch-reviewer.md
+++ b/prompts/arch-reviewer.md
@@ -12,6 +12,9 @@ Post one high-signal review comment on the PR. Focus on structural impact, not
 cosmetic nits. If the architecture is sound, approve briefly without
 manufacturing concerns.
 
+Do NOT request reviews from, assign to, or @mention any GitHub user. All
+review routing is handled by the daemon's dispatch system, not by the agent.
+
 ## Response format
 
 Your free-text analysis may appear above the JSON. The **last top-level JSON

--- a/prompts/codebase-scout-code.md
+++ b/prompts/codebase-scout-code.md
@@ -18,7 +18,8 @@ their origin. If the "scout" label does not exist, create it
 (you have permission).
 
 Do NOT push code, create branches, or modify repository contents.
-Read and open issues only.
+Read and open issues only. Do NOT request reviews from, assign to,
+or @mention any GitHub user — all routing is handled by the daemon.
 
 ## Response format
 

--- a/prompts/codebase-scout-issues.md
+++ b/prompts/codebase-scout-issues.md
@@ -11,7 +11,8 @@ have a linked PR addressing them — commenting on those is circular
 and adds no value.
 
 Do NOT push code, create branches, or modify repository contents.
-Read and comment only.
+Read and comment only. Do NOT request reviews from, assign to,
+or @mention any GitHub user — all routing is handled by the daemon.
 
 ## Response format
 

--- a/prompts/coder.md
+++ b/prompts/coder.md
@@ -74,6 +74,12 @@ solutions. Only ask when genuinely blocked.
 
 Do NOT fix more than one issue per run.
 
+## GitHub user mentions
+
+Do NOT request reviews from, assign to, or @mention any GitHub user in PRs,
+comments, or issue descriptions. All review routing is handled by the daemon's
+dispatch system, not by the agent.
+
 ## Memory hygiene
 
 Return your full updated memory in the `memory` field of your JSON response.

--- a/prompts/dx-reviewer.md
+++ b/prompts/dx-reviewer.md
@@ -12,6 +12,9 @@ Post one high-signal review comment on the PR. Focus on the experience of
 the next developer to touch this code or this feature, not cosmetic nits. If
 the PR keeps DX clean, approve briefly without manufacturing concerns.
 
+Do NOT request reviews from, assign to, or @mention any GitHub user. All
+review routing is handled by the daemon's dispatch system, not by the agent.
+
 ## Response format
 
 Your free-text analysis may appear above the JSON. The **last top-level JSON

--- a/prompts/ops-reviewer.md
+++ b/prompts/ops-reviewer.md
@@ -13,6 +13,9 @@ Post one high-signal review comment on the PR. Focus on what will matter at
 3am, not cosmetic nits. If the PR is operationally sound, approve briefly
 without manufacturing concerns.
 
+Do NOT request reviews from, assign to, or @mention any GitHub user. All
+review routing is handled by the daemon's dispatch system, not by the agent.
+
 ## Response format
 
 Your free-text analysis may appear above the JSON. The **last top-level JSON

--- a/prompts/pr-reviewer.md
+++ b/prompts/pr-reviewer.md
@@ -77,6 +77,8 @@ reviewed unless new commits were pushed since your last review.
 
 Do NOT push code, create branches, or modify repository contents.
 Read, comment, and manage the "human review ready" label only.
+Do NOT request reviews from, assign to, or @mention any GitHub user. All
+review routing is handled by the daemon's dispatch system, not by the agent.
 
 ## Memory hygiene
 

--- a/prompts/product-strategist.md
+++ b/prompts/product-strategist.md
@@ -71,7 +71,8 @@ Body structure:
 
 Skip if your current take duplicates an existing open product
 issue. Do NOT open PRs. Do NOT modify code. Do NOT file
-technical debt issues.
+technical debt issues. Do NOT request reviews from, assign to,
+or @mention any GitHub user — all routing is handled by the daemon.
 
 ## Memory hygiene
 

--- a/prompts/refactorer.md
+++ b/prompts/refactorer.md
@@ -49,6 +49,8 @@ For the issue path:
 - Do NOT fix more than one refactor per run.
 - Do NOT add speculative features or abstractions.
 - If in doubt, file an issue instead of opening a PR.
+- Do NOT request reviews from, assign to, or @mention any GitHub user. All
+  review routing is handled by the daemon's dispatch system, not by the agent.
 
 ## Memory hygiene
 

--- a/prompts/sec-reviewer.md
+++ b/prompts/sec-reviewer.md
@@ -11,6 +11,9 @@ Post one high-signal review comment on the PR. Focus on what matters; skip
 cosmetic nits. If the PR is secure, approve briefly without manufacturing
 concerns.
 
+Do NOT request reviews from, assign to, or @mention any GitHub user. All
+review routing is handled by the daemon's dispatch system, not by the agent.
+
 ## Response format
 
 Your free-text analysis may appear above the JSON. The **last top-level JSON

--- a/prompts/test-reviewer.md
+++ b/prompts/test-reviewer.md
@@ -10,6 +10,9 @@ Read the PR description, discussion, and diff carefully. Look for:
 Post one high-signal review comment on the PR. Suggest concrete test cases
 where they'd add value. If tests are solid, approve briefly.
 
+Do NOT request reviews from, assign to, or @mention any GitHub user. All
+review routing is handled by the daemon's dispatch system, not by the agent.
+
 ## Response format
 
 Your free-text analysis may appear above the JSON. The **last top-level JSON


### PR DESCRIPTION
## Summary

Closes #219

- Added "Do NOT request reviews from, assign to, or @mention any GitHub user" guardrail to all 11 agent prompts (`coder`, `refactorer`, `pr-reviewer`, `product-strategist`, `ops-reviewer`, `dx-reviewer`, `sec-reviewer`, `test-reviewer`, `arch-reviewer`, `codebase-scout-code`, `codebase-scout-issues`)
- Added the same constraint to the `## Behavioral guardrails` section in `AGENTS.md` with rationale

## Test plan

- [ ] All existing tests pass (`go test ./...`)
- [ ] Verify every prompt file has the instruction: `grep -rL "request reviews from" prompts/` should return empty
- [ ] Confirm AGENTS.md behavioral guardrails section includes the new rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)