### PR TITLE
refactor(main): replace manual struct copy with direct type conversion

### DIFF
--- a/cmd/agents/main.go
+++ b/cmd/agents/main.go
@@ -333,13 +333,7 @@ func (a schedulerStatusAdapter) AgentStatuses() []webhook.AgentStatus {
 	raw := a.s.AgentStatuses()
 	out := make([]webhook.AgentStatus, len(raw))
 	for i, s := range raw {
-		out[i] = webhook.AgentStatus{
-			Name:       s.Name,
-			Repo:       s.Repo,
-			LastRun:    s.LastRun,
-			NextRun:    s.NextRun,
-			LastStatus: s.LastStatus,
-		}
+		out[i] = webhook.AgentStatus(s)
 	}
 	return out
 }


### PR DESCRIPTION
## Why

`schedulerStatusAdapter.AgentStatuses` copied five fields one-by-one from
`autonomous.AgentStatus` into `webhook.AgentStatus`:

```go
out[i] = webhook.AgentStatus{
    Name:       s.Name,
    Repo:       s.Repo,
    LastRun:    s.LastRun,
    NextRun:    s.NextRun,
    LastStatus: s.LastStatus,
}
```

The two types are structurally identical — same field names, same field
types, same order. The only difference is that `webhook.AgentStatus`
carries JSON struct tags. Per the Go spec (§Conversions), struct types
are convertible when their underlying types are identical *ignoring tags*,
so a direct type conversion is valid and removes the boilerplate entirely:

```go
out[i] = webhook.AgentStatus(s)
```

If a field is ever added to one type without the other, this line will
produce a compile error, which is a better guard than a silent omission in
a struct literal.

## Change

- `cmd/agents/main.go`: 7 lines → 1 line in `AgentStatuses`.

No behaviour change. `go test ./...` passes.