### PR TITLE
feat(ui): replace comma-separated inputs with badge pickers from DB

### DIFF
--- a/internal/ui/src/app/page.tsx
+++ b/internal/ui/src/app/page.tsx
@@ -4,6 +4,7 @@ import Card from '@/components/Card'
 import StatusBadge from '@/components/StatusBadge'
 import Modal from '@/components/Modal'
 import Link from 'next/link'
+import BadgePicker from '@/components/BadgePicker'
 
 interface Binding {
   repo: string
@@ -102,11 +103,13 @@ const emptyForm: StoreAgent = {
 }
 
 function AgentForm({
-  initial, isNew, backends, onSave, onCancel, saving, error,
+  initial, isNew, backends, skillNames, agentNames, onSave, onCancel, saving, error,
 }: {
   initial: StoreAgent
   isNew: boolean
   backends: string[]
+  skillNames: string[]
+  agentNames: string[]
   onSave: (a: StoreAgent) => void
   onCancel: () => void
   saving: boolean
@@ -138,13 +141,8 @@ function AgentForm({
         </select>
       </div>
       <div>
-        <label style={labelStyle}>Skills (comma-separated)</label>
-        <input
-          style={inputStyle}
-          value={form.skills.join(', ')}
-          onChange={e => set('skills', e.target.value.split(',').map(s => s.trim()).filter(Boolean))}
-          placeholder="architect, testing, security"
-        />
+        <label style={labelStyle}>Skills</label>
+        <BadgePicker options={skillNames} selected={form.skills} onChange={v => set('skills', v)} placeholder="Add skill…" />
       </div>
       <div>
         <label style={labelStyle}>Description</label>
@@ -160,13 +158,8 @@ function AgentForm({
         />
       </div>
       <div>
-        <label style={labelStyle}>Can dispatch (comma-separated agent names)</label>
-        <input
-          style={inputStyle}
-          value={form.can_dispatch.join(', ')}
-          onChange={e => set('can_dispatch', e.target.value.split(',').map(s => s.trim()).filter(Boolean))}
-          placeholder="pr-reviewer, sec-reviewer"
-        />
+        <label style={labelStyle}>Can dispatch</label>
+        <BadgePicker options={agentNames.filter(n => n !== form.name)} selected={form.can_dispatch} onChange={v => set('can_dispatch', v)} placeholder="Add agent…" />
       </div>
       <div style={{ display: 'flex', gap: '1.5rem' }}>
         <label style={{ fontSize: '0.85rem', color: '#1e293b', display: 'flex', alignItems: 'center', gap: '0.4rem', cursor: 'pointer' }}>
@@ -271,6 +264,8 @@ export default function FleetPage() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
   const [backendNames, setBackendNames] = useState<string[]>([])
+  const [skillNames, setSkillNames] = useState<string[]>([])
+  const [agentNames, setAgentNames] = useState<string[]>([])
 
   const [modal, setModal] = useState<'create' | 'edit' | 'delete' | null>(null)
   const [selected, setSelected] = useState<StoreAgent>(emptyForm)
@@ -294,6 +289,14 @@ export default function FleetPage() {
     fetch('/api/store/backends')
       .then(r => r.ok ? r.json() : [])
       .then((data: { name: string }[]) => setBackendNames(data.map(b => b.name)))
+      .catch(() => { /* store not configured — no-op */ })
+    fetch('/api/store/skills')
+      .then(r => r.ok ? r.json() : [])
+      .then((data: { name: string }[]) => setSkillNames(data.map(s => s.name)))
+      .catch(() => { /* store not configured — no-op */ })
+    fetch('/api/store/agents')
+      .then(r => r.ok ? r.json() : [])
+      .then((data: { name: string }[]) => setAgentNames(data.map(a => a.name)))
       .catch(() => { /* store not configured — no-op */ })
   }, [])
 
@@ -424,6 +427,8 @@ export default function FleetPage() {
             initial={selected}
             isNew={modal === 'create'}
             backends={backendNames}
+            skillNames={skillNames}
+            agentNames={agentNames}
             onSave={saveAgent}
             onCancel={() => setModal(null)}
             saving={saving}

--- a/internal/ui/src/app/repos/page.tsx
+++ b/internal/ui/src/app/repos/page.tsx
@@ -2,6 +2,7 @@
 import { useState, useEffect } from 'react'
 import Card from '@/components/Card'
 import Modal from '@/components/Modal'
+import BadgePicker from '@/components/BadgePicker'
 
 interface Binding {
   agent: string
@@ -28,6 +29,15 @@ type AgentGroup = {
 
 const emptyTrigger: TriggerBinding = { labels: [], events: [], cron: '', enabled: true }
 const emptyRepo: Repo = { name: '', enabled: true, bindings: [] }
+
+const SUPPORTED_EVENTS = [
+  'issues.labeled', 'issues.opened', 'issues.edited', 'issues.reopened', 'issues.closed',
+  'pull_request.labeled', 'pull_request.opened', 'pull_request.synchronize',
+  'pull_request.ready_for_review', 'pull_request.closed',
+  'issue_comment.created',
+  'pull_request_review.submitted', 'pull_request_review_comment.created',
+  'push',
+]
 
 function bindingsToGroups(bindings: Binding[]): AgentGroup[] {
   const groups: AgentGroup[] = []
@@ -139,11 +149,11 @@ function TriggerEditor({ trigger, onChange, onRemove }: {
           />
         )}
         {triggerType === 'events' && (
-          <input
-            style={inputStyle}
-            value={(trigger.events ?? []).join(', ')}
-            onChange={e => onChange({ ...trigger, events: e.target.value.split(',').map(s => s.trim()).filter(Boolean) })}
-            placeholder="pull_request.opened, push"
+          <BadgePicker
+            options={SUPPORTED_EVENTS}
+            selected={trigger.events ?? []}
+            onChange={v => onChange({ ...trigger, events: v })}
+            placeholder="Add event…"
           />
         )}
         {triggerType === 'cron' && (
@@ -177,8 +187,9 @@ function TriggerEditor({ trigger, onChange, onRemove }: {
 }
 
 // AgentBindingGroup shows all trigger bindings for one agent.
-function AgentBindingGroup({ group, onChange, onAddTrigger, onRemoveTrigger }: {
+function AgentBindingGroup({ group, agentNames, onChange, onAddTrigger, onRemoveTrigger }: {
   group: AgentGroup
+  agentNames: string[]
   onChange: (g: AgentGroup) => void
   onAddTrigger: () => void
   onRemoveTrigger: (i: number) => void
@@ -193,12 +204,23 @@ function AgentBindingGroup({ group, onChange, onAddTrigger, onRemoveTrigger }: {
     <div style={{ border: '1px solid #bfdbfe', borderRadius: '8px', padding: '0.75rem', marginBottom: '0.65rem', background: '#fafcff' }}>
       <div style={{ marginBottom: '0.5rem' }}>
         <label style={labelStyle}>Agent</label>
-        <input
-          style={{ ...inputStyle, fontWeight: 600 }}
-          value={group.agent}
-          onChange={e => onChange({ ...group, agent: e.target.value })}
-          placeholder="agent-name"
-        />
+        {agentNames.length > 0 ? (
+          <select
+            style={{ ...inputStyle, fontWeight: 600 }}
+            value={group.agent}
+            onChange={e => onChange({ ...group, agent: e.target.value })}
+          >
+            <option value="">Select agent…</option>
+            {agentNames.map(n => <option key={n} value={n}>{n}</option>)}
+          </select>
+        ) : (
+          <input
+            style={{ ...inputStyle, fontWeight: 600 }}
+            value={group.agent}
+            onChange={e => onChange({ ...group, agent: e.target.value })}
+            placeholder="agent-name"
+          />
+        )}
       </div>
       {group.triggers.map((t, i) => (
         <TriggerEditor key={i} trigger={t} onChange={t2 => updateTrigger(i, t2)} onRemove={() => onRemoveTrigger(i)} />
@@ -213,9 +235,10 @@ function AgentBindingGroup({ group, onChange, onAddTrigger, onRemoveTrigger }: {
   )
 }
 
-function RepoForm({ initial, isNew, onSave, onCancel, saving, error }: {
+function RepoForm({ initial, isNew, agentNames, onSave, onCancel, saving, error }: {
   initial: Repo
   isNew: boolean
+  agentNames: string[]
   onSave: (r: Repo) => void
   onCancel: () => void
   saving: boolean
@@ -287,6 +310,7 @@ function RepoForm({ initial, isNew, onSave, onCancel, saving, error }: {
           <AgentBindingGroup
             key={gi}
             group={g}
+            agentNames={agentNames}
             onChange={ng => updateGroup(gi, ng)}
             onAddTrigger={() => addTrigger(gi)}
             onRemoveTrigger={ti => removeTrigger(gi, ti)}
@@ -321,6 +345,7 @@ export default function ReposPage() {
   const [deleteTarget, setDeleteTarget] = useState('')
   const [saving, setSaving] = useState(false)
   const [saveError, setSaveError] = useState('')
+  const [agentNames, setAgentNames] = useState<string[]>([])
 
   const load = () => {
     setLoading(true)
@@ -330,7 +355,13 @@ export default function ReposPage() {
       .catch(e => { setError(String(e)); setLoading(false) })
   }
 
-  useEffect(() => { load() }, [])
+  useEffect(() => {
+    load()
+    fetch('/api/store/agents')
+      .then(r => r.ok ? r.json() : [])
+      .then((data: { name: string }[]) => setAgentNames(data.map(a => a.name)))
+      .catch(() => { /* store not configured — no-op */ })
+  }, [])
 
   const openCreate = () => {
     setSaveError('')
@@ -475,6 +506,7 @@ export default function ReposPage() {
           <RepoForm
             initial={selected}
             isNew={modal === 'create'}
+            agentNames={agentNames}
             onSave={saveRepo}
             onCancel={() => setModal(null)}
             saving={saving}

--- a/internal/ui/src/components/BadgePicker.tsx
+++ b/internal/ui/src/components/BadgePicker.tsx
@@ -1,0 +1,113 @@
+import React from 'react'
+
+const chipStyle: React.CSSProperties = {
+  background: '#1e3a5f',
+  borderRadius: '4px',
+  padding: '2px 6px',
+  fontSize: '0.75rem',
+  color: '#93c5fd',
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '4px',
+  border: '1px solid #1d4ed8',
+}
+
+const removeStyle: React.CSSProperties = {
+  background: 'none',
+  border: 'none',
+  color: '#93c5fd',
+  cursor: 'pointer',
+  fontSize: '0.7rem',
+  padding: '0',
+  lineHeight: 1,
+}
+
+const selectStyle: React.CSSProperties = {
+  width: '100%',
+  padding: '6px 8px',
+  border: '1px solid #bfdbfe',
+  borderRadius: '6px',
+  fontSize: '0.85rem',
+  fontFamily: 'inherit',
+  background: '#f8fafc',
+  color: '#1e293b',
+}
+
+/**
+ * BadgePicker — multi-select chip picker backed by a known options list.
+ *
+ * Selected values render as removable chips. The dropdown only shows
+ * options not yet selected. When all options are selected the dropdown
+ * is hidden. Falls back to a plain text field when no options are loaded
+ * (e.g. store not configured or endpoint returned empty).
+ */
+export default function BadgePicker({
+  options,
+  selected,
+  onChange,
+  placeholder = 'Add…',
+  freeText = false,
+}: {
+  options: string[]
+  selected: string[]
+  onChange: (v: string[]) => void
+  placeholder?: string
+  /** When true, show an extra free-text input alongside the picker. */
+  freeText?: boolean
+}) {
+  const [text, setText] = React.useState('')
+  const available = options.filter(o => !selected.includes(o))
+
+  const remove = (v: string) => onChange(selected.filter(s => s !== v))
+  const add = (v: string) => { if (v && !selected.includes(v)) onChange([...selected, v]) }
+
+  const commitText = () => {
+    const val = text.trim()
+    if (val) { add(val); setText('') }
+  }
+
+  return (
+    <div>
+      {selected.length > 0 && (
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px', marginBottom: '6px' }}>
+          {selected.map(v => (
+            <span key={v} style={chipStyle}>
+              {v}
+              <button style={removeStyle} onClick={() => remove(v)} title={`Remove ${v}`}>✕</button>
+            </span>
+          ))}
+        </div>
+      )}
+      {available.length > 0 && (
+        <select
+          value=""
+          onChange={e => { if (e.target.value) add(e.target.value) }}
+          style={selectStyle}
+        >
+          <option value="">{placeholder}</option>
+          {available.map(o => <option key={o} value={o}>{o}</option>)}
+        </select>
+      )}
+      {freeText && (
+        <div style={{ display: 'flex', gap: '6px', marginTop: available.length > 0 ? '6px' : '0' }}>
+          <input
+            style={{ ...selectStyle, flex: 1 }}
+            value={text}
+            onChange={e => setText(e.target.value)}
+            onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); commitText() } }}
+            placeholder="Type and press Enter…"
+          />
+          <button
+            onClick={commitText}
+            style={{ padding: '6px 10px', border: '1px solid #bfdbfe', borderRadius: '6px', background: '#eff6ff', cursor: 'pointer', fontSize: '0.8rem', color: '#2563eb' }}
+          >
+            Add
+          </button>
+        </div>
+      )}
+      {options.length === 0 && !freeText && (
+        <p style={{ color: '#94a3b8', fontSize: '0.78rem', margin: '4px 0 0' }}>No options available (store not configured).</p>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds reusable `BadgePicker` component: selected values as removable chips, dropdown shows remaining options
- Agent editor: **Skills** → multi-select picker from `/api/store/skills`
- Agent editor: **Can dispatch** → multi-select picker from `/api/store/agents` (self excluded)
- Repo binding: **Events** → multi-select picker from `SUPPORTED_EVENTS` constant
- Repo binding: **Agent** → dropdown from `/api/store/agents` (falls back to text input if store unavailable)

Supersedes #231 (rebased on current main after dist gitignore, auth removal, repos restructure).

Closes #229

## Test plan

- [ ] Agent editor → Skills shows dropdown of DB skills; chips add/remove
- [ ] Can dispatch excludes the agent being edited
- [ ] Repo binding → Events shows supported event kinds as chips
- [ ] Repo binding → Agent shows dropdown of known agents
- [ ] With no `--db`: pickers degrade gracefully (empty options)

🤖 Generated with [Claude Code](https://claude.com/claude-code)