### PR TITLE
fix(store): set busy_timeout=5000 to prevent SQLITE_BUSY under concurrent writes

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -58,6 +58,14 @@ func Open(path string) (*sql.DB, error) {
 		db.Close()
 		return nil, fmt.Errorf("store: enable foreign keys: %w", err)
 	}
+	// Retry for up to 5 s when another goroutine holds a write lock instead of
+	// returning SQLITE_BUSY immediately. The observe store records spans,
+	// events, and dispatches on concurrent goroutines, so without a timeout
+	// those writes race and one of them can fail with "database is locked".
+	if _, err := db.Exec("PRAGMA busy_timeout=5000"); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("store: set busy timeout: %w", err)
+	}
 	if err := migrate(db); err != nil {
 		db.Close()
 		return nil, err


### PR DESCRIPTION
## Why

`internal/observe` tests were failing intermittently with:

```
observe: persist trace s2: database is locked (5) (SQLITE_BUSY)
--- FAIL: TestStoreTracesByRootEventID
    observe_test.go:582: want 1 span for root-B, got 0
```

`observe.Store.RecordSpan`, `RecordEvent`, and `RecordDispatch` all persist to SQLite on fire-and-forget goroutines. When multiple goroutines race to write to the same database, SQLite returns `SQLITE_BUSY` immediately — because `store.Open` never set a `busy_timeout`.

## What

Add `PRAGMA busy_timeout=5000` in `store.Open`. SQLite will now spin-wait up to 5 seconds for a held write lock to release before surfacing the error. The concurrent write windows these goroutines compete over are orders-of-magnitude shorter than 5 s, so in practice this eliminates the race entirely.

## Test plan

- [ ] `go test ./internal/observe/... -race -count=5` — no more `SQLITE_BUSY` failures
- [ ] `go test ./... -race` — full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)