### PR TITLE
feat(traces): Level 2 tool-loop transcript viewer per span

### DIFF
--- a/cmd/agents/main.go
+++ b/cmd/agents/main.go
@@ -133,6 +133,7 @@ func run() error {
 	engine.WithTraceRecorder(obs)
 	engine.WithGraphRecorder(obs)
 	engine.WithRunTracker(obs.ActiveRuns)
+	engine.WithStepRecorder(obs)
 	scheduler.WithTraceRecorder(obs)
 
 	deliveryStore := webhook.NewDeliveryStore(time.Duration(cfg.Daemon.HTTP.DeliveryTTLSeconds) * time.Second)

--- a/internal/ai/cmdrunner.go
+++ b/internal/ai/cmdrunner.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"slices"
@@ -115,14 +116,24 @@ func (r *CommandRunner) runCommand(ctx context.Context, logger zerolog.Logger, r
 		return Response{}, fmt.Errorf("start %s: %w", r.backendName, err)
 	}
 
-	// Read stdout line by line. Each Scan blocks until a complete line arrives,
-	// so time.Now() reflects when that specific line was received from the
-	// subprocess — not when a larger pipe-read chunk happened to land.
+	// Read stdout line by line using ReadBytes so there is no per-line size cap
+	// (unlike bufio.Scanner which silently truncates at its buffer limit).
+	// ReadBytes blocks until a complete newline-delimited line arrives from the
+	// pipe, so time.Now() inside addLine reflects when that specific line was
+	// received — not when a larger pipe-read chunk happened to land.
 	var stdoutCap lineCapture
-	scanner := bufio.NewScanner(stdoutPipe)
-	scanner.Buffer(make([]byte, 1<<20), 1<<20) // 1 MB per line
-	for scanner.Scan() {
-		stdoutCap.addLine(scanner.Bytes())
+	reader := bufio.NewReader(stdoutPipe)
+	for {
+		line, err := reader.ReadBytes('\n')
+		if len(line) > 0 {
+			stdoutCap.addLine(bytes.TrimRight(line, "\n"))
+		}
+		if err != nil {
+			if err != io.EOF {
+				logger.Warn().Err(err).Msgf("read %s stdout", r.backendName)
+			}
+			break
+		}
 	}
 
 	cmdErr := cmd.Wait()

--- a/internal/ai/cmdrunner.go
+++ b/internal/ai/cmdrunner.go
@@ -102,28 +102,28 @@ func (r *CommandRunner) runCommand(ctx context.Context, logger zerolog.Logger, r
 	cmd := exec.CommandContext(cmdCtx, r.command, args...)
 	cmd.Env = buildCommandEnv(req, r.env)
 
-	var stdout bytes.Buffer
+	var stdoutCap lineCapture
 	var stderr bytes.Buffer
-	cmd.Stdout = &stdout
+	cmd.Stdout = &stdoutCap
 	cmd.Stderr = &stderr
 	cmd.Stdin = bytes.NewBufferString(stdin)
 
 	cmdErr := cmd.Run()
 
-	rawOut := stdout.String()
+	rawOut := stdoutCap.all.String()
 	logger.Debug().Str("raw_stdout", truncateString(rawOut, 4000)).Msgf("%s raw output", r.backendName)
 
 	// If the command exited non-zero but produced no stdout, treat it as a
 	// hard failure. If stdout has data we still attempt JSON parsing because
 	// some AI CLIs emit non-zero exit codes even on a successful run (e.g.
 	// after posting a GitHub comment via MCP tools).
-	if cmdErr != nil && stdout.Len() == 0 {
+	if cmdErr != nil && stdoutCap.all.Len() == 0 {
 		logger.Error().Err(cmdErr).Str("stderr", truncateString(stderr.String(), 2000)).Msgf("%s command failed", r.backendName)
 		return Response{}, fmt.Errorf("%s command failed: %w", r.backendName, cmdErr)
 	}
 
 	var response Response
-	if stdout.Len() == 0 {
+	if stdoutCap.all.Len() == 0 {
 		logger.Error().Msgf("%s command returned no output", r.backendName)
 		return Response{}, fmt.Errorf("parse %s response: empty response (no output)", r.backendName)
 	}
@@ -133,7 +133,7 @@ func (r *CommandRunner) runCommand(ctx context.Context, logger zerolog.Logger, r
 	// the schema-constrained response. Try parsing the full stdout as a single
 	// JSON envelope first (handles --output-format json and any backend that
 	// emits a single result object).
-	if parsed, ok := extractStructuredOutput(stdout.Bytes()); ok {
+	if parsed, ok := extractStructuredOutput(stdoutCap.all.Bytes()); ok {
 		if err := json.Unmarshal(parsed, &response); err != nil {
 			logger.Error().Err(err).Str("raw_stdout", truncateString(rawOut, 4000)).Msgf("invalid %s structured_output", r.backendName)
 			return Response{}, fmt.Errorf("parse %s response: %w", r.backendName, err)
@@ -143,7 +143,7 @@ func (r *CommandRunner) runCommand(ctx context.Context, logger zerolog.Logger, r
 		// --output-format stream-json this is the result event, which also
 		// has a structured_output wrapper. For legacy CLIs it may be a bare
 		// response object.
-		jsonBytes, err := extractJSON(stdout.Bytes())
+		jsonBytes, err := extractJSON(stdoutCap.all.Bytes())
 		if err != nil {
 			logger.Error().Err(err).Str("raw_stdout", truncateString(rawOut, 4000)).Msgf("invalid %s response", r.backendName)
 			return Response{}, fmt.Errorf("parse %s response: %w", r.backendName, err)
@@ -166,7 +166,7 @@ func (r *CommandRunner) runCommand(ctx context.Context, logger zerolog.Logger, r
 	// Extract the tool-loop transcript from stream-json output (claude backends).
 	// This is a best-effort parse — errors are logged but do not fail the run.
 	if strings.HasPrefix(r.backendName, "claude") {
-		response.Steps = parseClaudeSteps(stdout.Bytes())
+		response.Steps = parseClaudeSteps(stdoutCap.lines)
 	}
 	if response.Summary == "" && len(response.Artifacts) == 0 && len(response.Dispatch) == 0 {
 		logger.Error().Str("raw_stdout", truncateString(rawOut, 4000)).Msgf("%s response is empty (no summary, artifacts, or dispatch)", r.backendName)
@@ -392,14 +392,51 @@ func extractJSON(data []byte) ([]byte, error) {
 	return last, nil
 }
 
+// timedLine pairs a JSONL line with the wall-clock time it arrived from the
+// subprocess. Used by parseClaudeSteps to compute per-tool DurationMs.
+type timedLine struct {
+	data []byte
+	at   time.Time
+}
+
+// lineCapture is an io.Writer that records each complete line together with
+// its arrival timestamp. Partial lines (no trailing newline) are buffered and
+// flushed on the next Write that completes them.
+type lineCapture struct {
+	lines []timedLine
+	buf   []byte
+	all   bytes.Buffer // full unmodified bytes for the rest of the pipeline
+}
+
+func (c *lineCapture) Write(p []byte) (int, error) {
+	now := time.Now()
+	c.all.Write(p)
+	c.buf = append(c.buf, p...)
+	for {
+		idx := bytes.IndexByte(c.buf, '\n')
+		if idx < 0 {
+			break
+		}
+		line := make([]byte, idx+1)
+		copy(line, c.buf[:idx+1])
+		c.lines = append(c.lines, timedLine{data: line, at: now})
+		c.buf = c.buf[idx+1:]
+	}
+	return len(p), nil
+}
+
 // parseClaudeSteps scans --output-format stream-json stdout and reconstructs
 // the tool-loop transcript as a slice of TraceStep values. Each step pairs one
 // tool_use block (from an assistant event) with its corresponding tool_result
 // block (from the following user event), matched by tool_use_id.
 //
+// DurationMs is computed as the wall-clock interval between the line that
+// carried the tool_use block and the line that carried the matching
+// tool_result block, giving a coarse-grained measure of how long the tool ran.
+//
 // Steps are capped at 100 and input/output are truncated to 200 runes.
 // Any event that cannot be parsed is silently skipped — this is best-effort.
-func parseClaudeSteps(data []byte) []TraceStep {
+func parseClaudeSteps(lines []timedLine) []TraceStep {
 	// streamEvent is the minimal shape of a single JSONL line.
 	type contentBlock struct {
 		Type      string          `json:"type"`
@@ -417,16 +454,17 @@ func parseClaudeSteps(data []byte) []TraceStep {
 	}
 
 	type pending struct {
-		name  string
-		input string
-		order int
+		name   string
+		input  string
+		order  int
+		seenAt time.Time
 	}
 	pendingTools := make(map[string]pending) // tool_use_id → pending
 	var steps []TraceStep
 	order := 0
 
-	for _, line := range bytes.Split(data, []byte("\n")) {
-		line = bytes.TrimSpace(line)
+	for _, tl := range lines {
+		line := bytes.TrimSpace(tl.data)
 		if len(line) == 0 || line[0] != '{' {
 			continue
 		}
@@ -442,9 +480,10 @@ func parseClaudeSteps(data []byte) []TraceStep {
 					continue
 				}
 				pendingTools[b.ID] = pending{
-					name:  b.Name,
-					input: truncateString(string(b.Input), 200),
-					order: order,
+					name:   b.Name,
+					input:  truncateString(string(b.Input), 200),
+					order:  order,
+					seenAt: tl.at,
 				}
 				order++
 			}
@@ -463,6 +502,7 @@ func parseClaudeSteps(data []byte) []TraceStep {
 					ToolName:      p.name,
 					InputSummary:  p.input,
 					OutputSummary: truncateString(output, 200),
+					DurationMs:    tl.at.Sub(p.seenAt).Milliseconds(),
 				})
 				if len(steps) >= 100 {
 					return steps

--- a/internal/ai/cmdrunner.go
+++ b/internal/ai/cmdrunner.go
@@ -128,26 +128,45 @@ func (r *CommandRunner) runCommand(ctx context.Context, logger zerolog.Logger, r
 		return Response{}, fmt.Errorf("parse %s response: empty response (no output)", r.backendName)
 	}
 
-	// When the CLI uses --output-format json, stdout is a single JSON
-	// envelope with a structured_output field containing the schema-
-	// constrained response. Try that path first.
+	// When the CLI uses --output-format json (single-object envelope) or
+	// --output-format stream-json (JSONL), the structured_output field holds
+	// the schema-constrained response. Try parsing the full stdout as a single
+	// JSON envelope first (handles --output-format json and any backend that
+	// emits a single result object).
 	if parsed, ok := extractStructuredOutput(stdout.Bytes()); ok {
 		if err := json.Unmarshal(parsed, &response); err != nil {
 			logger.Error().Err(err).Str("raw_stdout", truncateString(rawOut, 4000)).Msgf("invalid %s structured_output", r.backendName)
 			return Response{}, fmt.Errorf("parse %s response: %w", r.backendName, err)
 		}
 	} else {
-		// Fallback: find the last top-level JSON object in raw stdout
-		// (legacy path for CLIs without structured output).
+		// Fallback: find the last top-level JSON object in raw stdout. For
+		// --output-format stream-json this is the result event, which also
+		// has a structured_output wrapper. For legacy CLIs it may be a bare
+		// response object.
 		jsonBytes, err := extractJSON(stdout.Bytes())
 		if err != nil {
 			logger.Error().Err(err).Str("raw_stdout", truncateString(rawOut, 4000)).Msgf("invalid %s response", r.backendName)
 			return Response{}, fmt.Errorf("parse %s response: %w", r.backendName, err)
 		}
-		if err := json.Unmarshal(jsonBytes, &response); err != nil {
-			logger.Error().Err(err).Str("raw_stdout", truncateString(rawOut, 4000)).Msgf("invalid %s response", r.backendName)
-			return Response{}, fmt.Errorf("parse %s response: %w", r.backendName, err)
+		// Try structured_output on the last JSON (handles stream-json result event).
+		if parsed2, ok2 := extractStructuredOutput(jsonBytes); ok2 {
+			if err := json.Unmarshal(parsed2, &response); err != nil {
+				logger.Error().Err(err).Str("raw_stdout", truncateString(rawOut, 4000)).Msgf("invalid %s structured_output", r.backendName)
+				return Response{}, fmt.Errorf("parse %s response: %w", r.backendName, err)
+			}
+		} else {
+			// Legacy path: bare JSON response object with no envelope.
+			if err := json.Unmarshal(jsonBytes, &response); err != nil {
+				logger.Error().Err(err).Str("raw_stdout", truncateString(rawOut, 4000)).Msgf("invalid %s response", r.backendName)
+				return Response{}, fmt.Errorf("parse %s response: %w", r.backendName, err)
+			}
 		}
+	}
+
+	// Extract the tool-loop transcript from stream-json output (claude backends).
+	// This is a best-effort parse — errors are logged but do not fail the run.
+	if strings.HasPrefix(r.backendName, "claude") {
+		response.Steps = parseClaudeSteps(stdout.Bytes())
 	}
 	if response.Summary == "" && len(response.Artifacts) == 0 && len(response.Dispatch) == 0 {
 		logger.Error().Str("raw_stdout", truncateString(rawOut, 4000)).Msgf("%s response is empty (no summary, artifacts, or dispatch)", r.backendName)
@@ -192,13 +211,15 @@ func (r *CommandRunner) buildDelivery(req Request) (args []string, stdin string)
 }
 
 // buildClaudeDelivery delivers system content via --append-system-prompt and
-// user content via stdin. It also appends --output-format json --json-schema
-// using the embedded response schema so config files don't carry inline JSON.
+// user content via stdin. It also appends --output-format stream-json
+// --json-schema using the embedded response schema so config files don't carry
+// inline JSON. stream-json emits one JSON event per line, letting the runner
+// capture the tool-loop transcript before the final result event.
 func (r *CommandRunner) buildClaudeDelivery(req Request) (args []string, stdin string) {
 	args = make([]string, 0, len(r.args)+6)
 	args = append(args, r.args...)
 	if !slices.Contains(args, "--json-schema") {
-		args = append(args, "--output-format", "json", "--json-schema", ResponseSchemaString())
+		args = append(args, "--output-format", "stream-json", "--json-schema", ResponseSchemaString())
 	}
 
 	if req.System == "" {
@@ -369,6 +390,115 @@ func extractJSON(data []byte) ([]byte, error) {
 		return nil, fmt.Errorf("no JSON object found in output")
 	}
 	return last, nil
+}
+
+// parseClaudeSteps scans --output-format stream-json stdout and reconstructs
+// the tool-loop transcript as a slice of TraceStep values. Each step pairs one
+// tool_use block (from an assistant event) with its corresponding tool_result
+// block (from the following user event), matched by tool_use_id.
+//
+// Steps are capped at 100 and input/output are truncated to 200 runes.
+// Any event that cannot be parsed is silently skipped — this is best-effort.
+func parseClaudeSteps(data []byte) []TraceStep {
+	// streamEvent is the minimal shape of a single JSONL line.
+	type contentBlock struct {
+		Type      string          `json:"type"`
+		ID        string          `json:"id"`
+		Name      string          `json:"name"`
+		Input     json.RawMessage `json:"input"`
+		ToolUseID string          `json:"tool_use_id"`
+		Content   json.RawMessage `json:"content"` // string or array
+	}
+	type streamEvent struct {
+		Type    string `json:"type"`
+		Message struct {
+			Content []contentBlock `json:"content"`
+		} `json:"message"`
+	}
+
+	type pending struct {
+		name  string
+		input string
+		order int
+	}
+	pendingTools := make(map[string]pending) // tool_use_id → pending
+	var steps []TraceStep
+	order := 0
+
+	for _, line := range bytes.Split(data, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 || line[0] != '{' {
+			continue
+		}
+		var ev streamEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			continue
+		}
+
+		switch ev.Type {
+		case "assistant":
+			for _, b := range ev.Message.Content {
+				if b.Type != "tool_use" || b.ID == "" {
+					continue
+				}
+				pendingTools[b.ID] = pending{
+					name:  b.Name,
+					input: truncateString(string(b.Input), 200),
+					order: order,
+				}
+				order++
+			}
+		case "user":
+			for _, b := range ev.Message.Content {
+				if b.Type != "tool_result" || b.ToolUseID == "" {
+					continue
+				}
+				p, ok := pendingTools[b.ToolUseID]
+				if !ok {
+					continue
+				}
+				delete(pendingTools, b.ToolUseID)
+				output := extractToolResultText(b.Content)
+				steps = append(steps, TraceStep{
+					ToolName:      p.name,
+					InputSummary:  p.input,
+					OutputSummary: truncateString(output, 200),
+				})
+				if len(steps) >= 100 {
+					return steps
+				}
+			}
+		}
+	}
+	return steps
+}
+
+// extractToolResultText returns a plain-text summary from a tool_result
+// content field, which may be a JSON string or an array of content blocks.
+func extractToolResultText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	// Try string first.
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	// Try array of content blocks — concatenate all text blocks.
+	var blocks []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(raw, &blocks); err == nil {
+		var parts []string
+		for _, b := range blocks {
+			if b.Type == "text" && b.Text != "" {
+				parts = append(parts, b.Text)
+			}
+		}
+		return strings.Join(parts, "\n")
+	}
+	return ""
 }
 
 // allowCommandEnvKey reports whether key is safe to forward to the AI backend

--- a/internal/ai/cmdrunner.go
+++ b/internal/ai/cmdrunner.go
@@ -1,6 +1,7 @@
 package ai
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"crypto/sha256"
@@ -102,13 +103,29 @@ func (r *CommandRunner) runCommand(ctx context.Context, logger zerolog.Logger, r
 	cmd := exec.CommandContext(cmdCtx, r.command, args...)
 	cmd.Env = buildCommandEnv(req, r.env)
 
-	var stdoutCap lineCapture
 	var stderr bytes.Buffer
-	cmd.Stdout = &stdoutCap
 	cmd.Stderr = &stderr
 	cmd.Stdin = bytes.NewBufferString(stdin)
 
-	cmdErr := cmd.Run()
+	stdoutPipe, pipeErr := cmd.StdoutPipe()
+	if pipeErr != nil {
+		return Response{}, fmt.Errorf("stdout pipe: %w", pipeErr)
+	}
+	if err := cmd.Start(); err != nil {
+		return Response{}, fmt.Errorf("start %s: %w", r.backendName, err)
+	}
+
+	// Read stdout line by line. Each Scan blocks until a complete line arrives,
+	// so time.Now() reflects when that specific line was received from the
+	// subprocess — not when a larger pipe-read chunk happened to land.
+	var stdoutCap lineCapture
+	scanner := bufio.NewScanner(stdoutPipe)
+	scanner.Buffer(make([]byte, 1<<20), 1<<20) // 1 MB per line
+	for scanner.Scan() {
+		stdoutCap.addLine(scanner.Bytes())
+	}
+
+	cmdErr := cmd.Wait()
 
 	rawOut := stdoutCap.all.String()
 	logger.Debug().Str("raw_stdout", truncateString(rawOut, 4000)).Msgf("%s raw output", r.backendName)
@@ -399,30 +416,22 @@ type timedLine struct {
 	at   time.Time
 }
 
-// lineCapture is an io.Writer that records each complete line together with
-// its arrival timestamp. Partial lines (no trailing newline) are buffered and
-// flushed on the next Write that completes them.
+// lineCapture records each stdout line together with the wall-clock time it
+// was read from the subprocess pipe. addLine is called once per Scanner.Scan
+// iteration, so each line gets its own time.Now() — lines that arrive in
+// different pipe reads will have meaningfully different timestamps.
 type lineCapture struct {
 	lines []timedLine
-	buf   []byte
-	all   bytes.Buffer // full unmodified bytes for the rest of the pipeline
+	all   bytes.Buffer
 }
 
-func (c *lineCapture) Write(p []byte) (int, error) {
-	now := time.Now()
-	c.all.Write(p)
-	c.buf = append(c.buf, p...)
-	for {
-		idx := bytes.IndexByte(c.buf, '\n')
-		if idx < 0 {
-			break
-		}
-		line := make([]byte, idx+1)
-		copy(line, c.buf[:idx+1])
-		c.lines = append(c.lines, timedLine{data: line, at: now})
-		c.buf = c.buf[idx+1:]
-	}
-	return len(p), nil
+// addLine records a single line (without trailing newline) and its arrival time.
+func (c *lineCapture) addLine(data []byte) {
+	line := make([]byte, len(data)+1)
+	copy(line, data)
+	line[len(data)] = '\n'
+	c.lines = append(c.lines, timedLine{data: line, at: time.Now()})
+	c.all.Write(line)
 }
 
 // parseClaudeSteps scans --output-format stream-json stdout and reconstructs

--- a/internal/ai/cmdrunner_test.go
+++ b/internal/ai/cmdrunner_test.go
@@ -1,11 +1,13 @@
 package ai
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"slices"
 	"strings"
 	"testing"
+	"time"
 	"unicode/utf8"
 
 	"github.com/rs/zerolog"
@@ -706,13 +708,21 @@ func TestPromptMetaReflectsDeliveredPrompt(t *testing.T) {
 func TestParseClaudeSteps(t *testing.T) {
 	t.Parallel()
 
-	// toTimedLines converts raw JSONL bytes to []timedLine, simulating the
-	// lineCapture writer that assigns arrival times during real execution.
-	// In tests all lines share the same base time; DurationMs will be 0.
-	toTimedLines := func(data []byte) []timedLine {
-		var cap lineCapture
-		cap.Write(data)
-		return cap.lines
+	// toTimedLines converts raw JSONL bytes to []timedLine with a fixed base
+	// time, simulating lineCapture.addLine but with a controllable clock.
+	toTimedLines := func(data []byte, base time.Time, step time.Duration) []timedLine {
+		var tls []timedLine
+		for _, raw := range bytes.Split(bytes.TrimRight(data, "\n"), []byte("\n")) {
+			if len(raw) == 0 {
+				continue
+			}
+			line := make([]byte, len(raw)+1)
+			copy(line, raw)
+			line[len(raw)] = '\n'
+			tls = append(tls, timedLine{data: line, at: base})
+			base = base.Add(step)
+		}
+		return tls
 	}
 
 	// streamJSON builds a minimal stream-json JSONL output with the given
@@ -735,10 +745,14 @@ func TestParseClaudeSteps(t *testing.T) {
 		return []byte(out)
 	}
 
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
 	tests := []struct {
-		name      string
-		input     []byte
-		wantNames []string
+		name        string
+		input       []byte
+		lineStep    time.Duration
+		wantNames   []string
+		wantMinDurMs int64 // minimum DurationMs for the first step (0 = don't check)
 	}{
 		{
 			name:      "empty input returns nil",
@@ -764,12 +778,26 @@ func TestParseClaudeSteps(t *testing.T) {
 			input:     []byte(`{"type":"result","subtype":"success","structured_output":{"summary":"ok","artifacts":[]}}` + "\n"),
 			wantNames: nil,
 		},
+		{
+			// Each line arrives 500 ms apart. tool_use is line 0, tool_result is
+			// line 1 → DurationMs must be ≥ 500.
+			name:         "duration reflects per-line timestamps",
+			input:        streamJSON([][2]string{{"Bash", "toolu_01"}}, `{"summary":"ok","artifacts":[]}`),
+			lineStep:     500 * time.Millisecond,
+			wantNames:    []string{"Bash"},
+			wantMinDurMs: 500,
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			steps := parseClaudeSteps(toTimedLines(tc.input))
+			step := tc.lineStep
+			if step == 0 {
+				step = 0 // zero means all lines share the same timestamp
+			}
+			lines := toTimedLines(tc.input, base, step)
+			steps := parseClaudeSteps(lines)
 			if len(steps) != len(tc.wantNames) {
 				t.Fatalf("got %d steps, want %d: %+v", len(steps), len(tc.wantNames), steps)
 			}
@@ -782,6 +810,11 @@ func TestParseClaudeSteps(t *testing.T) {
 				}
 				if s.OutputSummary == "" {
 					t.Errorf("step %d: output_summary should not be empty", i)
+				}
+			}
+			if tc.wantMinDurMs > 0 && len(steps) > 0 {
+				if steps[0].DurationMs < tc.wantMinDurMs {
+					t.Errorf("step 0: DurationMs = %d, want >= %d", steps[0].DurationMs, tc.wantMinDurMs)
 				}
 			}
 		})

--- a/internal/ai/cmdrunner_test.go
+++ b/internal/ai/cmdrunner_test.go
@@ -258,6 +258,49 @@ func TestCommandRunnerEmptyStdoutIsError(t *testing.T) {
 	}
 }
 
+// TestExtractStructuredOutputFallbackHandlesStreamJSON verifies that when the
+// full stdout cannot be parsed as a single JSON envelope (as happens with
+// --output-format stream-json output), the fallback path locates the final
+// result event line and correctly extracts the structured_output from it.
+func TestExtractStructuredOutputFallbackHandlesStreamJSON(t *testing.T) {
+	t.Parallel()
+
+	structuredPayload := `{"summary":"all done","artifacts":[],"memory":"","dispatch":[]}`
+	streamOut := `{"type":"system","subtype":"init"}` + "\n" +
+		`{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_01","name":"Bash","input":{"command":"ls"}}]}}` + "\n" +
+		`{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_01","content":"file.txt"}]}}` + "\n" +
+		`{"type":"result","subtype":"success","structured_output":` + structuredPayload + `}` + "\n"
+
+	// Full stdout is JSONL — extractStructuredOutput on the whole thing fails,
+	// falls through to extractJSON → last object → extractStructuredOutput succeeds.
+	full := []byte(streamOut)
+
+	// Step 1: full stdout is NOT a single-JSON envelope.
+	if _, ok := extractStructuredOutput(full); ok {
+		t.Fatal("expected extractStructuredOutput to fail on JSONL stdout, but it succeeded")
+	}
+
+	// Step 2: extractJSON returns the last JSON object (result event).
+	lastJSON, err := extractJSON(full)
+	if err != nil {
+		t.Fatalf("extractJSON failed: %v", err)
+	}
+
+	// Step 3: extractStructuredOutput on the result event succeeds.
+	parsed, ok := extractStructuredOutput(lastJSON)
+	if !ok {
+		t.Fatalf("extractStructuredOutput failed on result event: %s", string(lastJSON))
+	}
+
+	var resp Response
+	if err := json.Unmarshal(parsed, &resp); err != nil {
+		t.Fatalf("unmarshal structured_output: %v", err)
+	}
+	if resp.Summary != "all done" {
+		t.Errorf("summary = %q, want %q", resp.Summary, "all done")
+	}
+}
+
 // TestBuildDeliveryClaudeUsesAppendSystemPrompt verifies that the claude
 // backend routes system content through --append-system-prompt and leaves user
 // content for stdin, preserving Claude Code's default tool stack.
@@ -655,6 +698,109 @@ func TestPromptMetaReflectsDeliveredPrompt(t *testing.T) {
 			// Verify Length matches actual rune count of the delivered prompt.
 			if meta.Length != utf8.RuneCountInString(combined) {
 				t.Errorf("Length %d != utf8.RuneCountInString(%q)=%d", meta.Length, combined, utf8.RuneCountInString(combined))
+			}
+		})
+	}
+}
+
+func TestParseClaudeSteps(t *testing.T) {
+	t.Parallel()
+
+	// streamJSON builds a minimal stream-json JSONL output with the given
+	// assistant→user event pairs. The final line is a result event.
+	streamJSON := func(pairs [][2]string, finalOutput string) []byte {
+		// pairs[i][0] = tool_name, pairs[i][1] = tool_use_id
+		var lines []string
+		for i, p := range pairs {
+			name, id := p[0], p[1]
+			lines = append(lines,
+				`{"type":"assistant","message":{"content":[{"type":"tool_use","id":"`+id+`","name":"`+name+`","input":{"arg":"val`+string(rune('0'+i))+`"}}]}}`,
+				`{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"`+id+`","content":"result`+string(rune('0'+i))+`"}]}}`,
+			)
+		}
+		lines = append(lines, `{"type":"result","subtype":"success","structured_output":`+finalOutput+`}`)
+		out := ""
+		for _, l := range lines {
+			out += l + "\n"
+		}
+		return []byte(out)
+	}
+
+	tests := []struct {
+		name      string
+		input     []byte
+		wantNames []string
+	}{
+		{
+			name:      "empty input returns nil",
+			input:     []byte(""),
+			wantNames: nil,
+		},
+		{
+			name:      "single tool call",
+			input:     streamJSON([][2]string{{"Bash", "toolu_01"}}, `{"summary":"ok","artifacts":[]}`),
+			wantNames: []string{"Bash"},
+		},
+		{
+			name: "multiple tool calls",
+			input: streamJSON([][2]string{
+				{"Bash", "toolu_01"},
+				{"Read", "toolu_02"},
+				{"Write", "toolu_03"},
+			}, `{"summary":"done","artifacts":[]}`),
+			wantNames: []string{"Bash", "Read", "Write"},
+		},
+		{
+			name:      "result-only output — no tool events",
+			input:     []byte(`{"type":"result","subtype":"success","structured_output":{"summary":"ok","artifacts":[]}}` + "\n"),
+			wantNames: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			steps := parseClaudeSteps(tc.input)
+			if len(steps) != len(tc.wantNames) {
+				t.Fatalf("got %d steps, want %d: %+v", len(steps), len(tc.wantNames), steps)
+			}
+			for i, s := range steps {
+				if s.ToolName != tc.wantNames[i] {
+					t.Errorf("step %d: tool_name = %q, want %q", i, s.ToolName, tc.wantNames[i])
+				}
+				if s.InputSummary == "" {
+					t.Errorf("step %d: input_summary should not be empty", i)
+				}
+				if s.OutputSummary == "" {
+					t.Errorf("step %d: output_summary should not be empty", i)
+				}
+			}
+		})
+	}
+}
+
+func TestExtractToolResultText(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "plain string", input: `"hello world"`, want: "hello world"},
+		{name: "empty string", input: `""`, want: ""},
+		{name: "text block array", input: `[{"type":"text","text":"foo"},{"type":"text","text":"bar"}]`, want: "foo\nbar"},
+		{name: "mixed block array", input: `[{"type":"image"},{"type":"text","text":"only this"}]`, want: "only this"},
+		{name: "empty raw", input: ``, want: ""},
+		{name: "null", input: `null`, want: ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := extractToolResultText(json.RawMessage(tc.input))
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
 			}
 		})
 	}

--- a/internal/ai/cmdrunner_test.go
+++ b/internal/ai/cmdrunner_test.go
@@ -706,6 +706,15 @@ func TestPromptMetaReflectsDeliveredPrompt(t *testing.T) {
 func TestParseClaudeSteps(t *testing.T) {
 	t.Parallel()
 
+	// toTimedLines converts raw JSONL bytes to []timedLine, simulating the
+	// lineCapture writer that assigns arrival times during real execution.
+	// In tests all lines share the same base time; DurationMs will be 0.
+	toTimedLines := func(data []byte) []timedLine {
+		var cap lineCapture
+		cap.Write(data)
+		return cap.lines
+	}
+
 	// streamJSON builds a minimal stream-json JSONL output with the given
 	// assistant→user event pairs. The final line is a result event.
 	streamJSON := func(pairs [][2]string, finalOutput string) []byte {
@@ -760,7 +769,7 @@ func TestParseClaudeSteps(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			steps := parseClaudeSteps(tc.input)
+			steps := parseClaudeSteps(toTimedLines(tc.input))
 			if len(steps) != len(tc.wantNames) {
 				t.Fatalf("got %d steps, want %d: %+v", len(steps), len(tc.wantNames), steps)
 			}

--- a/internal/ai/schema.go
+++ b/internal/ai/schema.go
@@ -11,7 +11,7 @@ import (
 // It is embedded in the binary so the daemon is fully self-contained — no
 // external file mounts or inline JSON in config needed.
 //
-// - Claude backends receive it via --output-format json --json-schema <string>
+// - Claude backends receive it via --output-format stream-json --json-schema <string>
 // - Codex backends receive it via --output-schema <temp-file-path>
 //
 // Both are injected automatically by buildDelivery in cmdrunner.go.

--- a/internal/ai/types.go
+++ b/internal/ai/types.go
@@ -40,6 +40,16 @@ type DispatchRequest struct {
 	Reason string `json:"reason"`
 }
 
+// TraceStep records one tool call in the agent's tool loop.
+// It is populated by the runner from stream-json output and is never part of
+// the agent's JSON schema — agents do not return steps themselves.
+type TraceStep struct {
+	ToolName      string `json:"tool_name"`
+	InputSummary  string `json:"input_summary"`
+	OutputSummary string `json:"output_summary"`
+	DurationMs    int64  `json:"duration_ms"`
+}
+
 type Response struct {
 	Artifacts []Artifact        `json:"artifacts"`
 	Summary   string            `json:"summary"`
@@ -48,4 +58,7 @@ type Response struct {
 	// each run. The daemon writes this value back to the memory store (SQLite or
 	// filesystem) after the run completes. An empty string clears the memory.
 	Memory string `json:"memory"`
+	// Steps holds the tool-loop transcript extracted from stream-json CLI
+	// output. It is populated by the runner and not part of the agent schema.
+	Steps []TraceStep `json:"-"`
 }

--- a/internal/observe/observe.go
+++ b/internal/observe/observe.go
@@ -13,7 +13,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/eloylp/agents/internal/ai"
 	"github.com/eloylp/agents/internal/workflow"
 )
 
@@ -444,38 +443,38 @@ func (s *Store) RecordDispatch(from, to, repo string, number int, reason string)
 // RecordSteps implements workflow.StepRecorder. It persists the tool-loop
 // transcript steps for a completed span to SQLite. Steps are stored
 // sequentially (step_index 0, 1, …) and capped at 100 per span.
-func (s *Store) RecordSteps(spanID string, steps []ai.TraceStep) {
+// The write is synchronous so that a subsequent ListSteps call (e.g. from the
+// UI on first accordion open) always observes the committed rows.
+func (s *Store) RecordSteps(spanID string, steps []workflow.TraceStep) {
 	if s.db == nil || len(steps) == 0 {
 		return
 	}
-	go func() {
-		tx, err := s.db.Begin()
-		if err != nil {
-			log.Printf("observe: begin trace steps tx for %s: %v", spanID, err)
-			return
+	tx, err := s.db.Begin()
+	if err != nil {
+		log.Printf("observe: begin trace steps tx for %s: %v", spanID, err)
+		return
+	}
+	for i, step := range steps {
+		if i >= 100 {
+			break
 		}
-		for i, step := range steps {
-			if i >= 100 {
-				break
-			}
-			if _, err := tx.Exec(
-				`INSERT INTO trace_steps (span_id, step_index, tool_name, input_summary, output_summary, duration_ms) VALUES (?,?,?,?,?,?)`,
-				spanID, i, step.ToolName, step.InputSummary, step.OutputSummary, step.DurationMs,
-			); err != nil {
-				log.Printf("observe: insert trace step %d for %s: %v", i, spanID, err)
-			}
+		if _, err := tx.Exec(
+			`INSERT INTO trace_steps (span_id, step_index, tool_name, input_summary, output_summary, duration_ms) VALUES (?,?,?,?,?,?)`,
+			spanID, i, step.ToolName, step.InputSummary, step.OutputSummary, step.DurationMs,
+		); err != nil {
+			log.Printf("observe: insert trace step %d for %s: %v", i, spanID, err)
 		}
-		if err := tx.Commit(); err != nil {
-			log.Printf("observe: commit trace steps for %s: %v", spanID, err)
-			tx.Rollback()
-		}
-	}()
+	}
+	if err := tx.Commit(); err != nil {
+		log.Printf("observe: commit trace steps for %s: %v", spanID, err)
+		_ = tx.Rollback()
+	}
 }
 
 // ListSteps returns the tool-loop transcript steps for a span, ordered by
 // step_index ascending. Returns nil when no steps exist or the database is
 // not configured.
-func (s *Store) ListSteps(spanID string) []ai.TraceStep {
+func (s *Store) ListSteps(spanID string) []workflow.TraceStep {
 	if s.db == nil {
 		return nil
 	}
@@ -488,9 +487,9 @@ func (s *Store) ListSteps(spanID string) []ai.TraceStep {
 		return nil
 	}
 	defer rows.Close()
-	var out []ai.TraceStep
+	var out []workflow.TraceStep
 	for rows.Next() {
-		var step ai.TraceStep
+		var step workflow.TraceStep
 		if err := rows.Scan(&step.ToolName, &step.InputSummary, &step.OutputSummary, &step.DurationMs); err != nil {
 			log.Printf("observe: scan step for %s: %v", spanID, err)
 			continue

--- a/internal/observe/observe.go
+++ b/internal/observe/observe.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/eloylp/agents/internal/ai"
 	"github.com/eloylp/agents/internal/workflow"
 )
 
@@ -438,6 +439,65 @@ func (s *Store) RecordDispatch(from, to, repo string, number int, reason string)
 			}
 		}()
 	}
+}
+
+// RecordSteps implements workflow.StepRecorder. It persists the tool-loop
+// transcript steps for a completed span to SQLite. Steps are stored
+// sequentially (step_index 0, 1, …) and capped at 100 per span.
+func (s *Store) RecordSteps(spanID string, steps []ai.TraceStep) {
+	if s.db == nil || len(steps) == 0 {
+		return
+	}
+	go func() {
+		tx, err := s.db.Begin()
+		if err != nil {
+			log.Printf("observe: begin trace steps tx for %s: %v", spanID, err)
+			return
+		}
+		for i, step := range steps {
+			if i >= 100 {
+				break
+			}
+			if _, err := tx.Exec(
+				`INSERT INTO trace_steps (span_id, step_index, tool_name, input_summary, output_summary, duration_ms) VALUES (?,?,?,?,?,?)`,
+				spanID, i, step.ToolName, step.InputSummary, step.OutputSummary, step.DurationMs,
+			); err != nil {
+				log.Printf("observe: insert trace step %d for %s: %v", i, spanID, err)
+			}
+		}
+		if err := tx.Commit(); err != nil {
+			log.Printf("observe: commit trace steps for %s: %v", spanID, err)
+			tx.Rollback()
+		}
+	}()
+}
+
+// ListSteps returns the tool-loop transcript steps for a span, ordered by
+// step_index ascending. Returns nil when no steps exist or the database is
+// not configured.
+func (s *Store) ListSteps(spanID string) []ai.TraceStep {
+	if s.db == nil {
+		return nil
+	}
+	rows, err := s.db.Query(
+		`SELECT tool_name, input_summary, output_summary, duration_ms FROM trace_steps WHERE span_id=? ORDER BY step_index ASC`,
+		spanID,
+	)
+	if err != nil {
+		log.Printf("observe: list steps for %s: %v", spanID, err)
+		return nil
+	}
+	defer rows.Close()
+	var out []ai.TraceStep
+	for rows.Next() {
+		var step ai.TraceStep
+		if err := rows.Scan(&step.ToolName, &step.InputSummary, &step.OutputSummary, &step.DurationMs); err != nil {
+			log.Printf("observe: scan step for %s: %v", spanID, err)
+			continue
+		}
+		out = append(out, step)
+	}
+	return out
 }
 
 // PublishMemoryChange emits a MemoryChangeEvent to the MemorySSE hub for the

--- a/internal/observe/observe_test.go
+++ b/internal/observe/observe_test.go
@@ -570,10 +570,16 @@ func TestStoreTracesByRootEventID(t *testing.T) {
 	s.RecordSpan("s2", "root-B", "", "reviewer", "claude", "r", "push", "", 0, 0, 0, 0, "", now, now.Add(time.Second), "success", "")
 	s.RecordSpan("s3", "root-A", "", "coder", "claude", "r", "agent.dispatch", "", 1, 1, 0, 0, "", now.Add(time.Second), now.Add(2*time.Second), "success", "")
 
-	// Wait for async persistence.
-	time.Sleep(50 * time.Millisecond)
-
-	rootA := s.TracesByRootEventID("root-A")
+	// Poll until both spans for root-A are persisted (RecordSpan is async).
+	deadline := time.Now().Add(500 * time.Millisecond)
+	var rootA []observe.Span
+	for time.Now().Before(deadline) {
+		rootA = s.TracesByRootEventID("root-A")
+		if len(rootA) == 2 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
 	if len(rootA) != 2 {
 		t.Fatalf("want 2 spans for root-A, got %d", len(rootA))
 	}

--- a/internal/observe/observe_test.go
+++ b/internal/observe/observe_test.go
@@ -589,6 +589,53 @@ func TestStoreTracesByRootEventID(t *testing.T) {
 	}
 }
 
+// ─── Store.RecordSteps / ListSteps ───────────────────────────────────────────
+
+func TestStoreRecordAndListSteps(t *testing.T) {
+	t.Parallel()
+	s := testDB(t)
+
+	steps := []workflow.TraceStep{
+		{ToolName: "Bash", InputSummary: "go test ./...", OutputSummary: "ok", DurationMs: 200},
+		{ToolName: "Read", InputSummary: "/foo.go", OutputSummary: "package foo", DurationMs: 50},
+	}
+	s.RecordSteps("span-1", steps)
+
+	got := s.ListSteps("span-1")
+	if len(got) != 2 {
+		t.Fatalf("want 2 steps, got %d", len(got))
+	}
+	if got[0].ToolName != "Bash" || got[1].ToolName != "Read" {
+		t.Fatalf("unexpected order: %v %v", got[0].ToolName, got[1].ToolName)
+	}
+	if got[0].DurationMs != 200 || got[1].DurationMs != 50 {
+		t.Fatalf("unexpected DurationMs: %d %d", got[0].DurationMs, got[1].DurationMs)
+	}
+}
+
+func TestStoreListStepsEmptyWhenNoneRecorded(t *testing.T) {
+	t.Parallel()
+	s := testDB(t)
+
+	got := s.ListSteps("no-such-span")
+	if got != nil {
+		t.Fatalf("want nil for unknown span, got %v", got)
+	}
+}
+
+func TestStoreRecordStepsNoOpOnEmpty(t *testing.T) {
+	t.Parallel()
+	s := testDB(t)
+
+	s.RecordSteps("span-x", nil)
+	s.RecordSteps("span-x", []workflow.TraceStep{})
+
+	got := s.ListSteps("span-x")
+	if got != nil {
+		t.Fatalf("want nil after no-op records, got %v", got)
+	}
+}
+
 // mapKeys returns the sorted keys of a map for use in error messages.
 func mapKeys(m map[string]any) []string {
 	keys := make([]string, 0, len(m))

--- a/internal/store/crud_test.go
+++ b/internal/store/crud_test.go
@@ -34,8 +34,7 @@ func seedSkill(t *testing.T, db *sql.DB, name string) {
 
 func TestUpsertAndReadAgents(t *testing.T) {
 	t.Parallel()
-	db, cleanup := openTestDB(t)
-	defer cleanup()
+	db := openTestDB(t)
 
 	seedBackend(t, db, "claude")
 	seedSkill(t, db, "architect")
@@ -92,8 +91,7 @@ func TestUpsertAndReadAgents(t *testing.T) {
 
 func TestUpsertAgentIsIdempotent(t *testing.T) {
 	t.Parallel()
-	db, cleanup := openTestDB(t)
-	defer cleanup()
+	db := openTestDB(t)
 
 	seedBackend(t, db, "claude")
 
@@ -120,8 +118,7 @@ func TestUpsertAgentIsIdempotent(t *testing.T) {
 
 func TestDeleteAgent(t *testing.T) {
 	t.Parallel()
-	db, cleanup := openTestDB(t)
-	defer cleanup()
+	db := openTestDB(t)
 
 	seedBackend(t, db, "claude")
 
@@ -150,8 +147,7 @@ func TestDeleteAgent(t *testing.T) {
 
 func TestDeleteAgentNonExistentIsNoError(t *testing.T) {
 	t.Parallel()
-	db, cleanup := openTestDB(t)
-	defer cleanup()
+	db := openTestDB(t)
 
 	if err := store.DeleteAgent(db, "ghost"); err != nil {
 		t.Errorf("DeleteAgent non-existent: %v", err)
@@ -162,8 +158,7 @@ func TestDeleteAgentNonExistentIsNoError(t *testing.T) {
 
 func TestUpsertAndReadSkills(t *testing.T) {
 	t.Parallel()
-	db, cleanup := openTestDB(t)
-	defer cleanup()
+	db := openTestDB(t)
 
 	s := config.SkillDef{Prompt: "Focus on architecture."}
 	if err := store.UpsertSkill(db, "architect", s); err != nil {
@@ -183,8 +178,7 @@ func TestUpsertAndReadSkills(t *testing.T) {
 
 func TestDeleteSkill(t *testing.T) {
 	t.Parallel()
-	db, cleanup := openTestDB(t)
-	defer cleanup()
+	db := openTestDB(t)
 
 	if err := store.UpsertSkill(db, "architect", config.SkillDef{Prompt: "p"}); err != nil {
 		t.Fatalf("UpsertSkill: %v", err)
@@ -205,8 +199,7 @@ func TestDeleteSkill(t *testing.T) {
 
 func TestUpsertAndReadBackends(t *testing.T) {
 	t.Parallel()
-	db, cleanup := openTestDB(t)
-	defer cleanup()
+	db := openTestDB(t)
 
 	b := config.AIBackendConfig{
 		Command:        "claude",
@@ -239,8 +232,7 @@ func TestUpsertAndReadBackends(t *testing.T) {
 
 func TestUpsertBackendAppliesDefaults(t *testing.T) {
 	t.Parallel()
-	db, cleanup := openTestDB(t)
-	defer cleanup()
+	db := openTestDB(t)
 
 	// Persist a backend with zero numeric fields — the same payload that
 	// POST /api/store/backends would send when omitting timeout_seconds and
@@ -265,8 +257,7 @@ func TestUpsertBackendAppliesDefaults(t *testing.T) {
 
 func TestDeleteBackend(t *testing.T) {
 	t.Parallel()
-	db, cleanup := openTestDB(t)
-	defer cleanup()
+	db := openTestDB(t)
 
 	// Seed two backends so that deleting one still leaves the system valid.
 	for _, name := range []string{"claude", "codex"} {
@@ -295,8 +286,7 @@ func TestDeleteBackend(t *testing.T) {
 
 func TestUpsertAndReadRepos(t *testing.T) {
 	t.Parallel()
-	db, cleanup := openTestDB(t)
-	defer cleanup()
+	db := openTestDB(t)
 
 	seedBackend(t, db, "claude")
 
@@ -346,8 +336,7 @@ func TestUpsertAndReadRepos(t *testing.T) {
 
 func TestUpsertRepoReplacesBindings(t *testing.T) {
 	t.Parallel()
-	db, cleanup := openTestDB(t)
-	defer cleanup()
+	db := openTestDB(t)
 
 	seedBackend(t, db, "claude")
 
@@ -386,8 +375,7 @@ func TestUpsertRepoReplacesBindings(t *testing.T) {
 
 func TestDeleteRepo(t *testing.T) {
 	t.Parallel()
-	db, cleanup := openTestDB(t)
-	defer cleanup()
+	db := openTestDB(t)
 
 	seedBackend(t, db, "claude")
 
@@ -436,8 +424,7 @@ func TestDeleteRepo(t *testing.T) {
 // as a consistent point-in-time view.
 func TestReadSnapshot(t *testing.T) {
 	t.Parallel()
-	db, cleanup := openTestDB(t)
-	defer cleanup()
+	db := openTestDB(t)
 
 	seedBackend(t, db, "claude")
 
@@ -508,8 +495,7 @@ func TestUpsertAgentCrossRefErrors(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			db, cleanup := openTestDB(t)
-			defer cleanup()
+	db := openTestDB(t)
 			tc.setup(t, db)
 			err := store.UpsertAgent(db, tc.agent)
 			if err == nil {
@@ -524,8 +510,7 @@ func TestUpsertAgentCrossRefErrors(t *testing.T) {
 
 func TestUpsertRepoRejectedWithUnknownAgent(t *testing.T) {
 	t.Parallel()
-	db, cleanup := openTestDB(t)
-	defer cleanup()
+	db := openTestDB(t)
 
 	// No agent seeded — binding references "ghost". The FK constraint on
 	// bindings.agent may fire first, or validateCrossRefs catches it; either
@@ -551,8 +536,7 @@ func TestUpsertRepoRejectedWithUnknownAgent(t *testing.T) {
 
 func TestDeleteBackendRejectedWhenAgentReferences(t *testing.T) {
 	t.Parallel()
-	db, cleanup := openTestDB(t)
-	defer cleanup()
+	db := openTestDB(t)
 
 	// Seed two backends so that the "at least one backend" constraint is not the
 	// reason the delete fails — only the agent reference should block it.
@@ -588,8 +572,7 @@ func TestDeleteBackendRejectedWhenAgentReferences(t *testing.T) {
 
 func TestDeleteSkillRejectedWhenAgentReferences(t *testing.T) {
 	t.Parallel()
-	db, cleanup := openTestDB(t)
-	defer cleanup()
+	db := openTestDB(t)
 
 	seedBackend(t, db, "claude")
 	seedSkill(t, db, "architect")
@@ -623,8 +606,7 @@ func TestDeleteSkillRejectedWhenAgentReferences(t *testing.T) {
 
 func TestDeleteAgentRejectedWhenDispatchListReferences(t *testing.T) {
 	t.Parallel()
-	db, cleanup := openTestDB(t)
-	defer cleanup()
+	db := openTestDB(t)
 
 	seedBackend(t, db, "claude")
 
@@ -685,8 +667,7 @@ func TestUpsertBackendValidationErrors(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			db, cleanup := openTestDB(t)
-			defer cleanup()
+	db := openTestDB(t)
 			err := store.UpsertBackend(db, tc.bName, tc.cfg)
 			if err == nil {
 				t.Fatalf("UpsertBackend with %s: want error, got nil", tc.name)
@@ -700,8 +681,7 @@ func TestUpsertBackendValidationErrors(t *testing.T) {
 
 func TestUpsertSkillRejectedWithEmptyPrompt(t *testing.T) {
 	t.Parallel()
-	db, cleanup := openTestDB(t)
-	defer cleanup()
+	db := openTestDB(t)
 
 	err := store.UpsertSkill(db, "testing", config.SkillDef{Prompt: ""})
 	if err == nil {
@@ -714,8 +694,7 @@ func TestUpsertSkillRejectedWithEmptyPrompt(t *testing.T) {
 
 func TestUpsertAgentRejectedWithEmptyPrompt(t *testing.T) {
 	t.Parallel()
-	db, cleanup := openTestDB(t)
-	defer cleanup()
+	db := openTestDB(t)
 
 	seedBackend(t, db, "claude")
 	err := store.UpsertAgent(db, config.AgentDef{
@@ -734,8 +713,7 @@ func TestUpsertAgentRejectedWithEmptyPrompt(t *testing.T) {
 
 func TestUpsertRepoRejectedWithNoTrigger(t *testing.T) {
 	t.Parallel()
-	db, cleanup := openTestDB(t)
-	defer cleanup()
+	db := openTestDB(t)
 
 	seedBackend(t, db, "claude")
 	if err := store.UpsertAgent(db, config.AgentDef{
@@ -759,8 +737,7 @@ func TestUpsertRepoRejectedWithNoTrigger(t *testing.T) {
 
 func TestUpsertRepoRejectedWithMixedTriggers(t *testing.T) {
 	t.Parallel()
-	db, cleanup := openTestDB(t)
-	defer cleanup()
+	db := openTestDB(t)
 
 	seedBackend(t, db, "claude")
 	if err := store.UpsertAgent(db, config.AgentDef{
@@ -788,8 +765,7 @@ func TestUpsertRepoRejectedWithMixedTriggers(t *testing.T) {
 
 func TestDeleteAgentRejectedAsLast(t *testing.T) {
 	t.Parallel()
-	db, cleanup := openTestDB(t)
-	defer cleanup()
+	db := openTestDB(t)
 
 	seedBackend(t, db, "claude")
 	if err := store.UpsertAgent(db, config.AgentDef{
@@ -818,8 +794,7 @@ func TestDeleteAgentRejectedAsLast(t *testing.T) {
 
 func TestDeleteBackendRejectedAsLast(t *testing.T) {
 	t.Parallel()
-	db, cleanup := openTestDB(t)
-	defer cleanup()
+	db := openTestDB(t)
 
 	if err := store.UpsertBackend(db, "claude", config.AIBackendConfig{
 		Command: "claude", Args: []string{}, Env: map[string]string{},
@@ -847,8 +822,7 @@ func TestDeleteBackendRejectedAsLast(t *testing.T) {
 
 func TestUpsertRepoRejectedWhenDisablingLastEnabled(t *testing.T) {
 	t.Parallel()
-	db, cleanup := openTestDB(t)
-	defer cleanup()
+	db := openTestDB(t)
 
 	seedBackend(t, db, "claude")
 	if err := store.UpsertAgent(db, config.AgentDef{
@@ -893,8 +867,7 @@ func TestUpsertRepoRejectedWhenDisablingLastEnabled(t *testing.T) {
 
 func TestDeleteRepoRejectedAsLastEnabled(t *testing.T) {
 	t.Parallel()
-	db, cleanup := openTestDB(t)
-	defer cleanup()
+	db := openTestDB(t)
 
 	seedBackend(t, db, "claude")
 	if err := store.UpsertAgent(db, config.AgentDef{
@@ -937,8 +910,7 @@ func TestDeleteRepoRejectedAsLastEnabled(t *testing.T) {
 // never silently diverge from the persisted rows after a live CRUD write.
 func TestUpsertNormalizesNames(t *testing.T) {
 	t.Parallel()
-	db, cleanup := openTestDB(t)
-	defer cleanup()
+	db := openTestDB(t)
 
 	// Backend — mixed-case name should be stored lowercase.
 	if err := store.UpsertBackend(db, "Claude", config.AIBackendConfig{
@@ -1024,8 +996,7 @@ func TestUpsertNormalizesNames(t *testing.T) {
 // refuses to load on restart.
 func TestUpsertSkillNormalizesPrompt(t *testing.T) {
 	t.Parallel()
-	db, cleanup := openTestDB(t)
-	defer cleanup()
+	db := openTestDB(t)
 
 	// Whitespace-only prompt should be trimmed to "" and rejected.
 	err := store.UpsertSkill(db, "testing", config.SkillDef{Prompt: "   "})
@@ -1056,8 +1027,7 @@ func TestUpsertSkillNormalizesPrompt(t *testing.T) {
 // on restart after startup normalization changes its shape.
 func TestUpsertBackendNormalizesCommandAndEnv(t *testing.T) {
 	t.Parallel()
-	db, cleanup := openTestDB(t)
-	defer cleanup()
+	db := openTestDB(t)
 
 	// Whitespace-only command must be trimmed to "" and rejected.
 	err := store.UpsertBackend(db, "claude", config.AIBackendConfig{

--- a/internal/store/migrations/005_trace_steps.sql
+++ b/internal/store/migrations/005_trace_steps.sql
@@ -1,0 +1,20 @@
+-- Phase 5: Per-span tool-loop transcript (Level 2 observability).
+-- Stores the structured sequence of tool calls executed during an agent run.
+-- Bounded to 100 steps per span; input/output truncated to 200 chars each.
+--
+-- No foreign key to traces(span_id) is declared here: both RecordSpan and
+-- RecordSteps run as concurrent goroutines after a run completes, and a
+-- REFERENCES constraint would cause an integrity error if steps are written
+-- before the parent span row is committed. span_id is indexed for fast lookup.
+CREATE TABLE IF NOT EXISTS trace_steps (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    span_id        TEXT    NOT NULL,
+    step_index     INTEGER NOT NULL,
+    tool_name      TEXT    NOT NULL,
+    input_summary  TEXT    NOT NULL DEFAULT '',
+    output_summary TEXT    NOT NULL DEFAULT '',
+    duration_ms    INTEGER NOT NULL DEFAULT 0,
+    created_at     TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_trace_steps_span ON trace_steps(span_id, step_index);

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -67,6 +67,11 @@ func Open(path string) (*sql.DB, error) {
 		db.Close()
 		return nil, fmt.Errorf("store: set busy timeout: %w", err)
 	}
+	// Pin to a single connection so PRAGMAs set above (busy_timeout, WAL mode,
+	// foreign_keys) apply to every subsequent operation. Without this,
+	// database/sql may open additional connections that bypass those settings,
+	// causing spurious SQLITE_BUSY under concurrent goroutine writes.
+	db.SetMaxOpenConns(1)
 	if err := migrate(db); err != nil {
 		db.Close()
 		return nil, err

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -349,8 +349,7 @@ func seedAgent(t *testing.T, db *sql.DB, name string) {
 // entry returns ("", false, time.Time{}, nil).
 func TestReadWriteMemory(t *testing.T) {
 	t.Parallel()
-	db, cleanup := openTestDB(t)
-	defer cleanup()
+	db := openTestDB(t)
 	seedAgent(t, db, "coder")
 
 	// Non-existent agent/repo returns not-found (found=false).
@@ -413,8 +412,7 @@ func TestReadWriteMemory(t *testing.T) {
 // are stored independently.
 func TestReadWriteMemoryIsolation(t *testing.T) {
 	t.Parallel()
-	db, cleanup := openTestDB(t)
-	defer cleanup()
+	db := openTestDB(t)
 	seedAgent(t, db, "agent-a")
 	seedAgent(t, db, "agent-b")
 

--- a/internal/ui/src/app/traces/page.tsx
+++ b/internal/ui/src/app/traces/page.tsx
@@ -5,6 +5,13 @@ import Card from '@/components/Card'
 import StatusBadge from '@/components/StatusBadge'
 import Link from 'next/link'
 
+interface TraceStep {
+  tool_name: string
+  input_summary: string
+  output_summary: string
+  duration_ms: number
+}
+
 interface Span {
   span_id: string
   root_event_id: string
@@ -51,6 +58,65 @@ function GanttRow({ span, minMs, totalMs }: { span: Span; minMs: number; totalMs
       </div>
       <div style={{ width: '70px', flexShrink: 0, textAlign: 'right', color: 'var(--text-muted)' }}>{span.duration_ms}ms</div>
       <div style={{ width: '70px', flexShrink: 0 }}><StatusBadge status={span.status} /></div>
+    </div>
+  )
+}
+
+// SpanTranscript renders the expandable tool-loop transcript for a single span.
+// Steps are loaded lazily when the accordion is first opened.
+function SpanTranscript({ spanId, stepCount }: { spanId: string; stepCount?: number }) {
+  const [open, setOpen] = useState(false)
+  const [steps, setSteps] = useState<TraceStep[] | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const toggle = () => {
+    if (!open && steps === null) {
+      setLoading(true)
+      fetch(`/traces/${encodeURIComponent(spanId)}/steps`)
+        .then(r => r.json())
+        .then((data: TraceStep[]) => { setSteps(data ?? []); setLoading(false) })
+        .catch(() => { setSteps([]); setLoading(false) })
+    }
+    setOpen(o => !o)
+  }
+
+  const label = stepCount != null && stepCount > 0
+    ? `${stepCount} steps`
+    : 'transcript'
+
+  return (
+    <div style={{ marginTop: '4px' }}>
+      <button
+        onClick={toggle}
+        style={{ background: 'none', border: 'none', color: 'var(--text-muted)', cursor: 'pointer', fontSize: '0.75rem', padding: 0, display: 'flex', alignItems: 'center', gap: '4px' }}
+      >
+        <span style={{ fontFamily: 'monospace' }}>{open ? '▼' : '▶'}</span>
+        <span>{label}</span>
+      </button>
+      {open && (
+        <div style={{ marginTop: '6px', paddingLeft: '12px', borderLeft: '2px solid var(--border-subtle)' }}>
+          {loading && <p style={{ color: 'var(--text-muted)', fontSize: '0.75rem' }}>Loading…</p>}
+          {!loading && steps !== null && steps.length === 0 && (
+            <p style={{ color: 'var(--text-faint)', fontSize: '0.75rem', fontStyle: 'italic' }}>No transcript recorded for this span.</p>
+          )}
+          {!loading && steps !== null && steps.map((step, i) => (
+            <div key={i} style={{ display: 'flex', gap: '0.5rem', padding: '3px 0', fontSize: '0.73rem', borderTop: i > 0 ? '1px solid var(--border-subtle)' : undefined, alignItems: 'flex-start' }}>
+              <span style={{ color: 'var(--text-faint)', flexShrink: 0, width: '28px', textAlign: 'right' }}>{i + 1}.</span>
+              <span style={{ color: 'var(--accent)', flexShrink: 0, fontFamily: 'monospace', fontWeight: 600 }}>{step.tool_name}</span>
+              <span style={{ color: 'var(--text-muted)', fontFamily: 'monospace', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }} title={step.input_summary}>
+                ({step.input_summary})
+              </span>
+              <span style={{ color: 'var(--text-faint)', margin: '0 4px' }}>→</span>
+              <span style={{ color: 'var(--text)', fontFamily: 'monospace', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 2 }} title={step.output_summary}>
+                {step.output_summary || '—'}
+              </span>
+              {step.duration_ms > 0 && (
+                <span style={{ color: 'var(--text-faint)', flexShrink: 0, marginLeft: '4px' }}>({step.duration_ms}ms)</span>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   )
 }
@@ -109,14 +175,13 @@ function TraceDetail({ rootId, allSpans, onBack }: { rootId: string; allSpans: S
                     <td style={{ padding: '6px 0', color: 'var(--text-muted)' }}>{s.duration_ms}ms</td>
                     <td style={{ padding: '6px 0' }}><StatusBadge status={s.status} /></td>
                   </tr>
-                  {detail && (
-                    <tr>
-                      <td colSpan={7} style={{ padding: '4px 0 8px', paddingLeft: `${s.dispatch_depth * 12 + 12}px` }}>
-                        {s.summary && <div style={{ fontSize: '0.78rem', color: 'var(--text-faint)', fontStyle: 'italic' }}>{s.summary}</div>}
-                        {s.error && <div style={{ fontSize: '0.78rem', color: 'var(--text-danger)', marginTop: '2px' }}>{s.error}</div>}
-                      </td>
-                    </tr>
-                  )}
+                  <tr>
+                    <td colSpan={7} style={{ padding: '2px 0 8px', paddingLeft: `${s.dispatch_depth * 12 + 12}px` }}>
+                      {s.summary && <div style={{ fontSize: '0.78rem', color: 'var(--text-faint)', fontStyle: 'italic' }}>{s.summary}</div>}
+                      {s.error && <div style={{ fontSize: '0.78rem', color: 'var(--text-danger)', marginTop: '2px' }}>{s.error}</div>}
+                      <SpanTranscript spanId={s.span_id} />
+                    </td>
+                  </tr>
                 </React.Fragment>
               )
             })}

--- a/internal/webhook/api.go
+++ b/internal/webhook/api.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/eloylp/agents/internal/ai"
 	"github.com/eloylp/agents/internal/workflow"
 )
 
@@ -447,7 +446,7 @@ func (s *Server) handleAPITraceSteps(w http.ResponseWriter, r *http.Request) {
 	spanID := mux.Vars(r)["span_id"]
 	steps := s.observeStore.ListSteps(spanID)
 	if steps == nil {
-		steps = []ai.TraceStep{} // always return a JSON array, never null
+		steps = []workflow.TraceStep{} // always return a JSON array, never null
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(steps)

--- a/internal/webhook/api.go
+++ b/internal/webhook/api.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/eloylp/agents/internal/ai"
 	"github.com/eloylp/agents/internal/workflow"
 )
 
@@ -437,6 +438,19 @@ func (s *Server) handleAPITrace(w http.ResponseWriter, r *http.Request) {
 // stream. Each completed span is pushed as a "data: <json>\n\n" message.
 func (s *Server) handleAPITracesStream(w http.ResponseWriter, r *http.Request) {
 	serveSSE(w, r, s.observeStore.TracesSSE)
+}
+
+// handleAPITraceSteps serves GET /api/traces/{span_id}/steps — the tool-loop
+// transcript for a single span. Returns an empty JSON array when no steps have
+// been recorded (e.g. the span used a non-claude backend).
+func (s *Server) handleAPITraceSteps(w http.ResponseWriter, r *http.Request) {
+	spanID := mux.Vars(r)["span_id"]
+	steps := s.observeStore.ListSteps(spanID)
+	if steps == nil {
+		steps = []ai.TraceStep{} // always return a JSON array, never null
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(steps)
 }
 
 // ── /api/graph ─────────────────────────────────────────────────────────────

--- a/internal/webhook/api_test.go
+++ b/internal/webhook/api_test.go
@@ -1401,6 +1401,72 @@ func TestHandleAPIMemorySQLiteMode(t *testing.T) {
 	}
 }
 
+// ── /api/traces/{span_id}/steps ───────────────────────────────────────────
+
+func TestHandleAPITraceStepsReturnsOrderedSteps(t *testing.T) {
+	t.Parallel()
+	cfg := testCfg(nil)
+	srv, _ := newTestServer(cfg)
+	obs := newTestObserve(t)
+	srv.WithObserve(obs)
+
+	steps := []workflow.TraceStep{
+		{ToolName: "Bash", InputSummary: "go test", OutputSummary: "ok", DurationMs: 300},
+		{ToolName: "Read", InputSummary: "/main.go", OutputSummary: "package main", DurationMs: 10},
+	}
+	obs.RecordSteps("span-abc", steps)
+
+	router := srv.buildHandler()
+	req := httptest.NewRequest(http.MethodGet, "/traces/span-abc/steps", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rec.Code)
+	}
+	var got []workflow.TraceStep
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 steps, got %d", len(got))
+	}
+	if got[0].ToolName != "Bash" || got[1].ToolName != "Read" {
+		t.Fatalf("unexpected order: %v %v", got[0].ToolName, got[1].ToolName)
+	}
+	if got[0].DurationMs != 300 {
+		t.Fatalf("want DurationMs=300 for first step, got %d", got[0].DurationMs)
+	}
+}
+
+func TestHandleAPITraceStepsEmptyArray(t *testing.T) {
+	t.Parallel()
+	cfg := testCfg(nil)
+	srv, _ := newTestServer(cfg)
+	obs := newTestObserve(t)
+	srv.WithObserve(obs)
+
+	router := srv.buildHandler()
+	req := httptest.NewRequest(http.MethodGet, "/traces/no-such-span/steps", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rec.Code)
+	}
+	// Must decode as a JSON array (never null) even when no steps exist.
+	var got []workflow.TraceStep
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got == nil {
+		t.Fatal("want empty JSON array, got null")
+	}
+	if len(got) != 0 {
+		t.Fatalf("want 0 steps, got %d", len(got))
+	}
+}
+
 // mustReadSSEMsg drains one message from ch within timeout or fails the test.
 func mustReadSSEMsg(t *testing.T, ch <-chan []byte, timeout time.Duration) string {
 	t.Helper()

--- a/internal/webhook/server.go
+++ b/internal/webhook/server.go
@@ -224,8 +224,9 @@ func (s *Server) buildHandler() http.Handler {
 	router.Handle("/events", withTimeout(http.HandlerFunc(s.handleAPIEvents))).Methods(http.MethodGet)
 	router.HandleFunc("/events/stream", s.handleAPIEventsStream)           // SSE — no timeout
 	router.Handle("/traces", withTimeout(http.HandlerFunc(s.handleAPITraces))).Methods(http.MethodGet)
-	router.HandleFunc("/traces/stream", s.handleAPITracesStream)           // SSE — no timeout
+	router.HandleFunc("/traces/stream", s.handleAPITracesStream)                                                        // SSE — no timeout
 	router.Handle("/traces/{root_event_id}", withTimeout(http.HandlerFunc(s.handleAPITrace))).Methods(http.MethodGet)
+	router.Handle("/traces/{span_id}/steps", withTimeout(http.HandlerFunc(s.handleAPITraceSteps))).Methods(http.MethodGet)
 	router.Handle("/graph", withTimeout(http.HandlerFunc(s.handleAPIGraph))).Methods(http.MethodGet)
 	router.Handle("/dispatches", withTimeout(http.HandlerFunc(s.handleAPIDispatches))).Methods(http.MethodGet)
 	router.Handle("/memory/{agent}/{repo}", withTimeout(http.HandlerFunc(s.handleAPIMemory))).Methods(http.MethodGet)

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -44,7 +44,7 @@ type GraphRecorder interface {
 // produces a tool-loop transcript. Implementations must be safe for concurrent
 // use.
 type StepRecorder interface {
-	RecordSteps(spanID string, steps []ai.TraceStep)
+	RecordSteps(spanID string, steps []TraceStep)
 }
 
 // Engine dispatches workflow events to the agents bound to the target repo.
@@ -593,9 +593,19 @@ func (e *Engine) runAgent(ctx context.Context, ev Event, agent config.AgentDef, 
 		)
 	}
 
-	// Record transcript steps when available.
+	// Record transcript steps when available. Translate from the runner-internal
+	// ai.TraceStep to the domain-level workflow.TraceStep at this boundary.
 	if e.stepRec != nil && len(resp.Steps) > 0 {
-		e.stepRec.RecordSteps(spanID, resp.Steps)
+		wsteps := make([]TraceStep, len(resp.Steps))
+		for i, s := range resp.Steps {
+			wsteps[i] = TraceStep{
+				ToolName:      s.ToolName,
+				InputSummary:  s.InputSummary,
+				OutputSummary: s.OutputSummary,
+				DurationMs:    s.DurationMs,
+			}
+		}
+		e.stepRec.RecordSteps(spanID, wsteps)
 	}
 
 	if runErr != nil {

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -40,6 +40,13 @@ type GraphRecorder interface {
 	RecordDispatch(from, to, repo string, number int, reason string)
 }
 
+// StepRecorder is an optional observer that the Engine calls when an agent run
+// produces a tool-loop transcript. Implementations must be safe for concurrent
+// use.
+type StepRecorder interface {
+	RecordSteps(spanID string, steps []ai.TraceStep)
+}
+
 // Engine dispatches workflow events to the agents bound to the target repo.
 // It routes each event by matching against label bindings (labels:) for labeled
 // events and against event bindings (events:) for all event kinds.
@@ -58,6 +65,7 @@ type Engine struct {
 	traceRec      TraceRecorder
 	graphRec      GraphRecorder
 	runTracker    RunTracker
+	stepRec       StepRecorder
 	runsDeduped   atomic.Int64
 }
 
@@ -95,6 +103,13 @@ func (e *Engine) WithTraceRecorder(r TraceRecorder) {
 // starts and finishes. It is safe to call after NewEngine and before Run.
 func (e *Engine) WithRunTracker(rt RunTracker) {
 	e.runTracker = rt
+}
+
+// WithStepRecorder attaches an optional recorder that is called when an agent
+// run produces a tool-loop transcript. It is safe to call after NewEngine and
+// before Run.
+func (e *Engine) WithStepRecorder(r StepRecorder) {
+	e.stepRec = r
 }
 
 // WithGraphRecorder attaches an optional recorder that is called on each
@@ -576,6 +591,11 @@ func (e *Engine) runAgent(ctx context.Context, ev Event, agent config.AgentDef, 
 			spanStart, spanEnd,
 			status, errMsg,
 		)
+	}
+
+	// Record transcript steps when available.
+	if e.stepRec != nil && len(resp.Steps) > 0 {
+		e.stepRec.RecordSteps(spanID, resp.Steps)
 	}
 
 	if runErr != nil {

--- a/internal/workflow/steps.go
+++ b/internal/workflow/steps.go
@@ -1,0 +1,11 @@
+package workflow
+
+// TraceStep records one tool call in an agent's tool loop.
+// It is used by StepRecorder implementations to persist and serve the
+// per-span tool-loop transcript.
+type TraceStep struct {
+	ToolName      string `json:"tool_name"`
+	InputSummary  string `json:"input_summary"`
+	OutputSummary string `json:"output_summary"`
+	DurationMs    int64  `json:"duration_ms"`
+}


### PR DESCRIPTION
## Summary

- Switches claude backends from `--output-format json` to `--output-format stream-json` so per-turn tool calls and results are available in stdout
- Parses `tool_use`/`tool_result` JSONL events into `ai.TraceStep` values (up to 100 per run, summaries truncated to 200 chars)
- Adds `trace_steps` SQLite table (migration 005) for persistent storage
- Exposes `GET /api/traces/{span_id}/steps` endpoint returning the transcript as a JSON array
- Adds expandable ▶ transcript accordion in the traces UI under each span row; steps loaded lazily on first open

## Architecture decisions

- **No FK constraint** on `trace_steps.span_id`: both `RecordSpan` and `RecordSteps` launch goroutines after a run — a FK would cause integrity errors if steps are written before the span row is committed
- **Response parsing fallback updated**: for `stream-json` output the final JSON object is the result event (not the response directly); the fallback now tries `extractStructuredOutput` on the last JSON before falling back to bare unmarshal
- **`TraceStep.Steps` tagged `json:"-"`**: steps are populated by the runner, not returned by agents — they're never part of the structured output schema

## Test plan

- [ ] `TestParseClaudeSteps` — verifies JSONL parsing for 0, 1, and N tool calls
- [ ] `TestExtractToolResultText` — string, array, empty, null content forms
- [ ] `TestExtractStructuredOutputFallbackHandlesStreamJSON` — end-to-end fallback path with JSONL stdout
- [ ] `GET /api/traces/{span_id}/steps` — existing API test suite (server_test.go) unchanged; new route does not conflict
- [ ] CI (`go test ./... -race`) — all existing tests must still pass

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)