### PR TITLE
docs: sync HTTP endpoint paths, volume mounts, add trace-steps endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ internal/
   autonomous/                   # cron scheduler + agent memory (filesystem or SQLite)
   store/                        # SQLite-backed config store (--db mode): Open, Import, Load, CRUD
   workflow/                     # event routing engine (single event queue), processor, dispatcher
-  webhook/                      # HTTP server, HMAC signature verification, delivery dedupe, /api/store/* CRUD
+  webhook/                      # HTTP server, HMAC signature verification, delivery dedupe, CRUD API handlers
   ui/                           # embedded Next.js web dashboard (static assets served at /ui/)
   setup/                        # interactive first-time setup command
   logging/                      # zerolog configuration

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Repo-specific guidance for any coding agent (Claude Code, Codex, Cursor, Aider, 
 Agents can also invoke each other at runtime via the **reactive inter-agent dispatcher**: an agent returns `dispatch: [{agent, number, reason}]` in its response JSON, the daemon validates against per-agent whitelists and safety limits, then enqueues a synthetic `agent.dispatch` event that runs the target agent.
 
 Key numbers:
-- Language: **Go 1.24** (check `go.mod`).
+- Language: **Go 1.25** (check `go.mod`).
 - Binary entrypoint: `cmd/agents/main.go`.
 - Single-binary deployment; no required runtime dependencies beyond the AI CLI and `gh`.
 
@@ -33,7 +33,7 @@ internal/
   ai/                           # prompt composition + CLI runner (supports per-backend env overrides)
   anthropic_proxy/              # built-in Anthropic Messages ↔ OpenAI Chat Completions translation
   observe/                      # observability store: events, traces, dispatch graph, SSE hubs
-  autonomous/                   # cron scheduler + agent memory (filesystem or SQLite)
+  autonomous/                   # cron scheduler + agent memory (SQLite-backed)
   store/                        # SQLite-backed config store (--db mode): Open, Import, Load, CRUD
   workflow/                     # event routing engine (single event queue), processor, dispatcher
   webhook/                      # HTTP server, HMAC signature verification, delivery dedupe, CRUD API handlers
@@ -76,7 +76,7 @@ These constraints are load-bearing. Read them before changing the listed areas.
 - **The runner contract is stdin-in, single-JSON-object-out.**
   - `internal/ai/cmdrunner.go` sends the composed prompt on stdin and parses the last top-level JSON object from stdout.
   - Agents emit `{"summary": "...", "artifacts": [...], "dispatch": [...], "memory": "..."}`. `dispatch` and `memory` are optional fields but all four keys are present in the schema. A missing JSON object, an empty response, or a response where `summary`, `artifacts`, and `dispatch` are all empty fails the run with a clear error.
-  - `memory` is the agent's full updated memory state. The daemon writes it back to the store (filesystem or SQLite) after each autonomous run. An empty string clears the memory. Event-driven runs do not receive or persist memory.
+  - `memory` is the agent's full updated memory state. The daemon writes it back to the SQLite store after each autonomous run. An empty string clears the memory. Event-driven runs do not receive or persist memory.
   - Small prose outputs with no JSON are an agent-prompt issue, not a runner bug — don't relax the parser to cover them; fix the prompt.
 - **Subprocess env is filtered.** `internal/ai/cmdrunner.go::allowCommandEnvKey` is an explicit allowlist. When adding a new env-var-driven integration, add the variable to the allowlist **and** document why (see `ANTHROPIC_BASE_URL` / `OPENAI_*` for precedent).
 - **Backend config supports per-backend `env` overrides.** When introducing a feature that requires environment variables for a specific backend, use the `AIBackendConfig.Env` map instead of the global container env — it keeps the container config clean and lets users define multiple backends pointing at different endpoints with the same CLI.
@@ -113,11 +113,11 @@ When making common classes of changes, update all of these at once:
 
 - **`.env` is auto-loaded on startup** (`godotenv.Load()`). Required runtime secret: `GITHUB_WEBHOOK_SECRET`. Optional: `LOG_SALT`.
 - **Config is read once at daemon startup.** Changing `config.yaml` or any `prompt_file` / skill file requires a daemon restart. If you're testing prompt changes interactively, expect to `docker compose restart agents`.
-- **Autonomous agent memory** lives under `daemon.memory_dir` (default `/var/lib/agents/memory`), as one markdown file per `(agent, repo)` pair. It's the agent's job to update it in its response; the daemon just reads/writes the file unchanged.
+- **Autonomous agent memory** is stored in SQLite when `--db` is set (in the `memory` table), keyed by `(agent, repo)`. It's the agent's job to return updated memory in its response; the daemon writes it back to the store unchanged.
 - **Dispatch dedup is process-local and in-memory.** It's shared across cron-fired runs, event-fired runs, and `--run-agent` invocations within one process. Restarting the daemon clears the dedup state.
 - **`--run-agent` drains dispatch chains synchronously.** When invoking an agent on demand via the CLI flag, the process waits for the originating agent and all dispatched children to finish before exiting. The in-memory event queue is sized to hold `MaxFanout^MaxDepth` events so deep chains don't silently drop.
 - **Avoid `--no-verify` on commits.** Pre-commit hooks exist for a reason. If a hook fails, fix the underlying issue.
-- **The `expose: 8080` in `docker-compose.yml` is deliberate** — the daemon port is only reachable inside the docker network (via `traefik` at the labelled host). Don't publish it publicly by default.
+- **The `ports: "8080:8080"` in `docker-compose.yaml`** publishes the daemon port on the host. In production, consider restricting access via a reverse proxy (e.g. Traefik with basic auth) or binding to `127.0.0.1:8080:8080`.
 
 ## Common anti-patterns to avoid
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ internal/
   anthropic_proxy/              # built-in Anthropic Messages ↔ OpenAI Chat Completions translation
   observe/                      # observability store: events, traces, dispatch graph, SSE hubs
   autonomous/                   # cron scheduler + agent memory (SQLite-backed)
-  store/                        # SQLite-backed config store (--db mode): Open, Import, Load, CRUD
+  store/                        # SQLite-backed config store: Open, Import, Load, CRUD
   workflow/                     # event routing engine (single event queue), processor, dispatcher
   webhook/                      # HTTP server, HMAC signature verification, delivery dedupe, CRUD API handlers
   ui/                           # embedded Next.js web dashboard (static assets served at /ui/)
@@ -114,7 +114,7 @@ When making common classes of changes, update all of these at once:
 
 - **`.env` is auto-loaded on startup** (`godotenv.Load()`). Required runtime secret: `GITHUB_WEBHOOK_SECRET`. Optional: `LOG_SALT`.
 - **Config is loaded from SQLite at startup.** Use `--import config.yaml` to seed the database, then manage changes via the CRUD API. Prompt and skill file changes require re-import or an API update followed by a daemon restart.
-- **Autonomous agent memory** is stored in SQLite when `--db` is set (in the `memory` table), keyed by `(agent, repo)`. It's the agent's job to return updated memory in its response; the daemon writes it back to the store unchanged.
+- **Autonomous agent memory** is stored in SQLite (in the `memory` table), keyed by `(agent, repo)`. It's the agent's job to return updated memory in its response; the daemon writes it back to the store unchanged.
 - **Dispatch dedup is process-local and in-memory.** It's shared across cron-fired runs, event-fired runs, and `--run-agent` invocations within one process. Restarting the daemon clears the dedup state.
 - **`--run-agent` drains dispatch chains synchronously.** When invoking an agent on demand via the CLI flag, the process waits for the originating agent and all dispatched children to finish before exiting. The in-memory event queue is sized to hold `MaxFanout^MaxDepth` events so deep chains don't silently drop.
 - **Avoid `--no-verify` on commits.** Pre-commit hooks exist for a reason. If a hook fails, fix the underlying issue.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,8 +18,9 @@ Key numbers:
 ```bash
 go test ./... -race                             # run all tests
 go build -o agents ./cmd/agents                 # build the daemon
-go run ./cmd/agents -config config.yaml         # start the daemon
-./agents -config config.yaml \                  # one-shot synchronous pass
+./agents --db agents.db --import config.yaml    # import config + start
+./agents --db agents.db                         # start (after import)
+./agents --db agents.db \                       # one-shot synchronous pass
   --run-agent <agent-name> --repo owner/repo   # (drains any dispatch chain)
 docker compose up -d                            # containerised run
 ```
@@ -112,7 +113,7 @@ When making common classes of changes, update all of these at once:
 ## Operational notes
 
 - **`.env` is auto-loaded on startup** (`godotenv.Load()`). Required runtime secret: `GITHUB_WEBHOOK_SECRET`. Optional: `LOG_SALT`.
-- **Config is read once at daemon startup.** Changing `config.yaml` or any `prompt_file` / skill file requires a daemon restart. If you're testing prompt changes interactively, expect to `docker compose restart agents`.
+- **Config is loaded from SQLite at startup.** Use `--import config.yaml` to seed the database, then manage changes via the CRUD API. Prompt and skill file changes require re-import or an API update followed by a daemon restart.
 - **Autonomous agent memory** is stored in SQLite when `--db` is set (in the `memory` table), keyed by `(agent, repo)`. It's the agent's job to return updated memory in its response; the daemon writes it back to the store unchanged.
 - **Dispatch dedup is process-local and in-memory.** It's shared across cron-fired runs, event-fired runs, and `--run-agent` invocations within one process. Restarting the daemon clears the dedup state.
 - **`--run-agent` drains dispatch chains synchronously.** When invoking an agent on demand via the CLI flag, the process waits for the originating agent and all dispatched children to finish before exiting. The in-memory event queue is sized to hold `MaxFanout^MaxDepth` events so deep chains don't silently drop.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,14 +43,13 @@ No framework prompt templates. Each agent owns its full prompt; skill guidance i
 ```bash
 go test ./... -race
 go build -o agents ./cmd/agents
-go run ./cmd/agents -config config.yaml
 
-# On-demand single agent pass (synchronous, drains any dispatch chain, exits)
-./agents -config config.yaml --run-agent <agent-name> --repo owner/repo
-
-# SQLite mode: import from YAML once, then run without --config
+# Import config into SQLite and start
 ./agents --db agents.db --import config.yaml   # one-time import
 ./agents --db agents.db                         # subsequent starts
+
+# On-demand single agent pass (synchronous, drains any dispatch chain, exits)
+./agents --db agents.db --run-agent <agent-name> --repo owner/repo
 ```
 
 ## Docker
@@ -60,7 +59,7 @@ docker compose build
 docker compose up -d
 ```
 
-Multi-stage build on `node:22-alpine` so the image includes Claude Code, Codex, and `gh` CLIs alongside the daemon. Runs as non-root `agents` user. Default CMD is `--db /var/lib/agents/agents.db` (SQLite mode; no `--config` flag needed after the initial `--import`). Compose mounts:
+Multi-stage build on `node:22-alpine` so the image includes Claude Code, Codex, and `gh` CLIs alongside the daemon. Runs as non-root `agents` user. Default CMD is `--db /var/lib/agents/agents.db`. Compose mounts:
 - `./config.yaml` → `/etc/agents/config.yaml` (read-only; used for `--import` seeding)
 - `./agents` → `/etc/agents/agents` (optional; prompt/skill files when `prompt_file:` paths point here)
 - Claude/Codex/gh config dirs from host

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ Multi-stage build on `node:22-alpine` so the image includes Claude Code, Codex, 
   - `GET /memory/stream` — memory file change notifications (SSE).
   - `GET /config` — effective parsed config (secrets redacted).
   - `GET /ui/` — embedded web dashboard (Next.js static assets).
-  - `GET|POST /{resource}` and `GET|DELETE /{resource}/{name}` — SQLite CRUD endpoints (only registered when `--db` is set). Resources: `agents`, `skills`, `backends`, `repos` (repos use two-segment path: `repos/{owner}/{repo}`).
+  - `GET|POST /{resource}` and `GET|DELETE /{resource}/{name}` — SQLite CRUD endpoints (only registered when `--db` is set). Resources for `GET` list: `skills`, `backends`, `repos` (repos use two-segment path: `repos/{owner}/{repo}`). Note: `GET /agents` always returns the live fleet snapshot — not the CRUD list. `POST /agents` and `GET|DELETE /agents/{name}` are CRUD endpoints for agents.
   - `GET /export`, `POST /import` — export/import fleet config as YAML (only with `--db`).
 - Supported webhook events: `issues.*` (labeled, opened, edited, reopened, closed), `pull_request.*` (labeled, opened, synchronize, ready_for_review, closed), `issue_comment.created`, `pull_request_review.submitted`, `pull_request_review_comment.created`, `push` (branches only). Label-triggered routing uses `payload.label.name`. Non-label `events:` subscriptions match the event kind exactly. Draft PRs skip `pull_request.labeled`.
 - Internal event kinds (not from webhooks): `agents.run` (on-demand trigger from `POST /run` or `--run-agent`), `agent.dispatch` (inter-agent dispatch), `autonomous` (cron scheduler).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ internal/
   ai/                       # Prompt composition + command-based CLI runner (per-backend env)
   anthropic_proxy/          # Built-in Anthropic↔OpenAI Chat Completions translation proxy
   observe/                  # Observability store: events, traces, dispatch graph, SSE hubs
-  autonomous/               # Cron scheduler + agent memory (filesystem or SQLite)
+  autonomous/               # Cron scheduler + agent memory (SQLite-backed)
   store/                    # SQLite-backed config store (--db mode): Open, Import, Load, CRUD
   workflow/                 # Event routing engine, single event queue, processor, dispatcher
   webhook/                  # HTTP server, HMAC verification, delivery dedupe, CRUD API handlers
@@ -29,7 +29,7 @@ docs/                       # Long-form docs: configuration, events, dispatch, A
 
 The config file has four top-level domains:
 
-- `daemon` — log, http, processor (incl. `dispatch` safety limits), memory_dir, ai_backends, optional `proxy` block
+- `daemon` — log, http, processor (incl. `dispatch` safety limits), ai_backends, optional `proxy` block
 - `skills` — map of reusable guidance blocks, keyed by name (inline or `prompt_file:`)
 - `agents` — list of named capabilities (backend + skills + prompt, optional `allow_prs` / `allow_dispatch` / `can_dispatch` / `description`)
 - `repos` — list of repos and their `use[]` bindings (which agents run, and with what triggers)
@@ -98,7 +98,7 @@ Multi-stage build on `node:22-alpine` so the image includes Claude Code, Codex, 
 - Duplicate webhook suppression via `X-GitHub-Delivery` TTL cache.
 - Workflow execution is stateless in-process. Only autonomous agents persist memory (per-agent, per-repo).
 - Memory is delivered to the agent as part of its prompt context, and the agent returns its full updated memory in the `memory` field of the JSON response. The daemon writes the value back to the store after the run. An empty string clears the memory. Event-driven runs (webhook events, label triggers) do not receive or persist memory.
-- Memory backend: filesystem by default (one Markdown file per `(agent, repo)` pair under `daemon.memory_dir`), or SQLite when `--db` is set (stored in the `memory` table of the SQLite database).
+- Memory backend: SQLite (stored in the `memory` table alongside config data).
 - Backend resolution: agents declare `backend: claude | codex | auto`. `auto` picks the first configured backend in preference order (claude > codex).
 - Per-backend env overrides (`daemon.ai_backends.<name>.env`) let two backends run the same CLI with different endpoints — e.g. a default `claude` backend on hosted Anthropic plus a `claude_local` backend that routes the CLI via `ANTHROPIC_BASE_URL` through the built-in proxy to a local model. See [`docs/local-models.md`](docs/local-models.md).
 - **Reactive inter-agent dispatch**: agents can return a `dispatch: [{agent, number, reason}]` array in their JSON response to invoke other agents. Enqueued as synthetic `agent.dispatch` events. Target must opt in via `allow_dispatch: true`; originator must whitelist targets in `can_dispatch: [...]`. Safety limits (`daemon.processor.dispatch.{max_depth, max_fanout, dedup_window_seconds}`) prevent cascade storms and duplicate invocations. The originating agent's prompt receives an `## Available experts` roster listing dispatchable targets.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ internal/
   anthropic_proxy/          # Built-in Anthropic↔OpenAI Chat Completions translation proxy
   observe/                  # Observability store: events, traces, dispatch graph, SSE hubs
   autonomous/               # Cron scheduler + agent memory (SQLite-backed)
-  store/                    # SQLite-backed config store (--db mode): Open, Import, Load, CRUD
+  store/                    # SQLite-backed config store: Open, Import, Load, CRUD
   workflow/                 # Event routing engine, single event queue, processor, dispatcher
   webhook/                  # HTTP server, HMAC verification, delivery dedupe, CRUD API handlers
   ui/                       # Embedded Next.js web dashboard (served at /ui/)
@@ -63,7 +63,7 @@ Multi-stage build on `node:22-alpine` so the image includes Claude Code, Codex, 
 - `./config.yaml` → `/etc/agents/config.yaml` (read-only; used for `--import` seeding)
 - `./agents` → `/etc/agents/agents` (optional; prompt/skill files when `prompt_file:` paths point here)
 - Claude/Codex/gh config dirs from host
-- `agents-memory` named volume → `/var/lib/agents/memory`
+- `agents-data` named volume → `/var/lib/agents` (SQLite database persistence)
 
 ## Environment Variables
 
@@ -90,8 +90,8 @@ Multi-stage build on `node:22-alpine` so the image includes Claude Code, Codex, 
   - `GET /memory/stream` — memory file change notifications (SSE).
   - `GET /config` — effective parsed config (secrets redacted).
   - `GET /ui/` — embedded web dashboard (Next.js static assets).
-  - `GET|POST /{resource}` and `GET|DELETE /{resource}/{name}` — SQLite CRUD endpoints (always mounted; require `--db` to function — return errors without it). Resources for `GET` list: `skills`, `backends`, `repos` (repos use two-segment path: `repos/{owner}/{repo}`). Note: `GET /agents` always returns the live fleet snapshot — not the CRUD list. `POST /agents` and `GET|DELETE /agents/{name}` are CRUD endpoints for agents.
-  - `GET /export`, `POST /import` — export/import fleet config as YAML (require `--db` to function).
+  - `GET|POST /{resource}` and `GET|DELETE /{resource}/{name}` — SQLite CRUD endpoints (always mounted). Resources for `GET` list: `skills`, `backends`, `repos` (repos use two-segment path: `repos/{owner}/{repo}`). Note: `GET /agents` always returns the live fleet snapshot — not the CRUD list. `POST /agents` and `GET|DELETE /agents/{name}` are CRUD endpoints for agents.
+  - `GET /export`, `POST /import` — export/import fleet config as YAML.
 - Supported webhook events: `issues.*` (labeled, opened, edited, reopened, closed), `pull_request.*` (labeled, opened, synchronize, ready_for_review, closed), `issue_comment.created`, `pull_request_review.submitted`, `pull_request_review_comment.created`, `push` (branches only). Label-triggered routing uses `payload.label.name`. Non-label `events:` subscriptions match the event kind exactly. Draft PRs skip `pull_request.labeled`.
 - Internal event kinds (not from webhooks): `agents.run` (on-demand trigger from `POST /run` or `--run-agent`), `agent.dispatch` (inter-agent dispatch), `autonomous` (cron scheduler).
 - Duplicate webhook suppression via `X-GitHub-Delivery` TTL cache.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ internal/
   logging/                  # zerolog setup
 prompts/                    # Optional prompt files referenced by agent prompt_file:
 skills/                     # Optional skill files referenced by skill prompt_file:
-docs/                       # Long-form docs (docs/local-models.md, etc.)
+docs/                       # Long-form docs: configuration, events, dispatch, API, docker, local-models, security
 ```
 
 ## Config Model

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,8 +91,8 @@ Multi-stage build on `node:22-alpine` so the image includes Claude Code, Codex, 
   - `GET /memory/stream` — memory file change notifications (SSE).
   - `GET /config` — effective parsed config (secrets redacted).
   - `GET /ui/` — embedded web dashboard (Next.js static assets).
-  - `GET|POST /{resource}` and `GET|DELETE /{resource}/{name}` — SQLite CRUD endpoints (only registered when `--db` is set). Resources for `GET` list: `skills`, `backends`, `repos` (repos use two-segment path: `repos/{owner}/{repo}`). Note: `GET /agents` always returns the live fleet snapshot — not the CRUD list. `POST /agents` and `GET|DELETE /agents/{name}` are CRUD endpoints for agents.
-  - `GET /export`, `POST /import` — export/import fleet config as YAML (only with `--db`).
+  - `GET|POST /{resource}` and `GET|DELETE /{resource}/{name}` — SQLite CRUD endpoints (always mounted; require `--db` to function — return errors without it). Resources for `GET` list: `skills`, `backends`, `repos` (repos use two-segment path: `repos/{owner}/{repo}`). Note: `GET /agents` always returns the live fleet snapshot — not the CRUD list. `POST /agents` and `GET|DELETE /agents/{name}` are CRUD endpoints for agents.
+  - `GET /export`, `POST /import` — export/import fleet config as YAML (require `--db` to function).
 - Supported webhook events: `issues.*` (labeled, opened, edited, reopened, closed), `pull_request.*` (labeled, opened, synchronize, ready_for_review, closed), `issue_comment.created`, `pull_request_review.submitted`, `pull_request_review_comment.created`, `push` (branches only). Label-triggered routing uses `payload.label.name`. Non-label `events:` subscriptions match the event kind exactly. Draft PRs skip `pull_request.labeled`.
 - Internal event kinds (not from webhooks): `agents.run` (on-demand trigger from `POST /run` or `--run-agent`), `agent.dispatch` (inter-agent dispatch), `autonomous` (cron scheduler).
 - Duplicate webhook suppression via `X-GitHub-Delivery` TTL cache.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ internal/
   autonomous/               # Cron scheduler + agent memory (filesystem or SQLite)
   store/                    # SQLite-backed config store (--db mode): Open, Import, Load, CRUD
   workflow/                 # Event routing engine, single event queue, processor, dispatcher
-  webhook/                  # HTTP server, HMAC verification, delivery dedupe, /api/store/* CRUD
+  webhook/                  # HTTP server, HMAC verification, delivery dedupe, CRUD API handlers
   ui/                       # Embedded Next.js web dashboard (served at /ui/)
   setup/                    # Interactive first-time setup command
   logging/                  # zerolog setup
@@ -60,10 +60,9 @@ docker compose build
 docker compose up -d
 ```
 
-Multi-stage build on `node:22-alpine` so the image includes Claude Code, Codex, and `gh` CLIs alongside the daemon. Runs as non-root `agents` user. Compose mounts:
-- `./config.yaml` → `/etc/agents/config.yaml` (read-only)
-- `./prompts` → `/etc/agents/prompts` (read-only)
-- `./skills` → `/etc/agents/skills` (read-only; referenced by `skills.<name>.prompt_file`)
+Multi-stage build on `node:22-alpine` so the image includes Claude Code, Codex, and `gh` CLIs alongside the daemon. Runs as non-root `agents` user. Default CMD is `--db /var/lib/agents/agents.db` (SQLite mode; no `--config` flag needed after the initial `--import`). Compose mounts:
+- `./config.yaml` → `/etc/agents/config.yaml` (read-only; used for `--import` seeding)
+- `./agents` → `/etc/agents/agents` (optional; prompt/skill files when `prompt_file:` paths point here)
 - Claude/Codex/gh config dirs from host
 - `agents-memory` named volume → `/var/lib/agents/memory`
 
@@ -78,22 +77,24 @@ Multi-stage build on `node:22-alpine` so the image includes Claude Code, Codex, 
 - HTTP endpoints:
   - `GET /status` — JSON with uptime, event queue depth, agent schedules, dispatch counters.
   - `POST /webhooks/github` — HMAC-verified webhook receiver.
-  - `POST /agents/run` — on-demand agent trigger.
+  - `POST /run` — on-demand agent trigger (body: `{"agent":"<name>","repo":"owner/repo"}`).
   - `POST /v1/messages` — Anthropic↔OpenAI translation proxy (disabled by default; enabled via `daemon.proxy.enabled: true`).
   - `GET /v1/models` — companion stub for `/v1/messages`; returns the configured upstream model. Only mounted when the proxy is enabled.
-  - `POST /api/run` — unauthenticated on-demand trigger (same handler as `/agents/run`; relies on Traefik basic auth for the `/api/*` prefix). Enqueues a synthetic `agents.run` event.
-  - `GET /api/agents` — fleet snapshot with per-agent status, skills, dispatch wiring, bindings.
-  - `GET /api/events[/stream]` — recent events + SSE firehose.
-  - `GET /api/traces[/stream]` — recent agent run traces with timing, summary, status + SSE.
-  - `GET /api/graph` — agent interaction graph (dispatch edges + counts).
-  - `GET /api/dispatches` — dispatch dedup store snapshot + counters.
-  - `GET /api/memory/{agent}/{repo}` — raw agent memory markdown.
-  - `GET /api/memory/stream` — memory file change notifications (SSE).
-  - `GET /api/config` — effective parsed config (secrets redacted).
+  - `GET /agents` — fleet snapshot with per-agent status, skills, dispatch wiring, bindings.
+  - `GET /events[/stream]` — recent events + SSE firehose.
+  - `GET /traces[/stream]` — recent agent run traces with timing, summary, status + SSE.
+  - `GET /traces/{root_event_id}` — all spans for a single root event.
+  - `GET /traces/{span_id}/steps` — tool-loop transcript (ordered tool calls + durations) for a completed agent span.
+  - `GET /graph` — agent interaction graph (dispatch edges + counts).
+  - `GET /dispatches` — dispatch dedup store snapshot + counters.
+  - `GET /memory/{agent}/{repo}` — raw agent memory markdown.
+  - `GET /memory/stream` — memory file change notifications (SSE).
+  - `GET /config` — effective parsed config (secrets redacted).
   - `GET /ui/` — embedded web dashboard (Next.js static assets).
-  - `/api/store/{resource}[/{name}]` — SQLite CRUD endpoints (only registered when `--db` is set). Resources: `agents`, `skills`, `backends`, `repos` (repos use two-segment path: `{owner}/{repo}`).
+  - `GET|POST /{resource}` and `GET|DELETE /{resource}/{name}` — SQLite CRUD endpoints (only registered when `--db` is set). Resources: `agents`, `skills`, `backends`, `repos` (repos use two-segment path: `repos/{owner}/{repo}`).
+  - `GET /export`, `POST /import` — export/import fleet config as YAML (only with `--db`).
 - Supported webhook events: `issues.*` (labeled, opened, edited, reopened, closed), `pull_request.*` (labeled, opened, synchronize, ready_for_review, closed), `issue_comment.created`, `pull_request_review.submitted`, `pull_request_review_comment.created`, `push` (branches only). Label-triggered routing uses `payload.label.name`. Non-label `events:` subscriptions match the event kind exactly. Draft PRs skip `pull_request.labeled`.
-- Internal event kinds (not from webhooks): `agents.run` (on-demand trigger from `/api/run` or `--run-agent`), `agent.dispatch` (inter-agent dispatch), `autonomous` (cron scheduler).
+- Internal event kinds (not from webhooks): `agents.run` (on-demand trigger from `POST /run` or `--run-agent`), `agent.dispatch` (inter-agent dispatch), `autonomous` (cron scheduler).
 - Duplicate webhook suppression via `X-GitHub-Delivery` TTL cache.
 - Workflow execution is stateless in-process. Only autonomous agents persist memory (per-agent, per-repo).
 - Memory is delivered to the agent as part of its prompt context, and the agent returns its full updated memory in the `memory` field of the JSON response. The daemon writes the value back to the store after the run. An empty string clears the memory. Event-driven runs (webhook events, label triggers) do not receive or persist memory.
@@ -109,6 +110,6 @@ This project is built by its own agent fleet. External contributions come as iss
 ## Security Notes
 
 - Webhook authenticity is enforced with HMAC SHA-256 signature verification.
-- `/agents/run` and all other endpoints are unauthenticated at the daemon level; access control is the reverse proxy's responsibility.
+- All endpoints are unauthenticated at the daemon level; access control is the reverse proxy's responsibility.
 - Prompts are never logged in plaintext; only the hash and length are recorded.
 - The daemon delegates all GitHub writes to the configured AI backend via MCP tools.

--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ GitHub sends a ping immediately; the daemon will log the delivery.
 | `POST` | `/webhooks/github` | GitHub webhook receiver (`X-Hub-Signature-256` HMAC verified) |
 | `POST` | `/run` | On-demand agent trigger |
 | `POST` | `/v1/messages` | Anthropic↔OpenAI translation proxy (opt-in via `proxy.enabled`) |
-| `GET` | `/v1/models` | Companion stub for `/v1/messages`; lists the configured upstream model |
+| `GET` | `/v1/models` | Companion stub for `/v1/messages`; lists the configured upstream model (opt-in via `proxy.enabled`) |
 | `GET` | `/agents` | Fleet snapshot: per-agent status, bindings, dispatch wiring |
 | `GET` | `/events` | Recent webhook events (time-windowed) |
 | `GET` | `/events/stream` | Live event firehose (SSE) |

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ internal/
   anthropic_proxy/          # Built-in Anthropic-to-OpenAI translation proxy (opt-in)
   observe/                  # Observability store (events, traces, dispatch graph, SSE hubs)
   autonomous/               # Cron scheduler + agent memory (SQLite-backed)
-  store/                    # SQLite-backed config store (--db mode): schema migrations, CRUD helpers
+  store/                    # SQLite-backed config store: schema migrations, CRUD helpers
   workflow/                 # Event routing engine, single event queue, processor, inter-agent dispatcher
   webhook/                  # HTTP server, signature verification, delivery dedupe, CRUD API handlers
   ui/                       # Embedded Next.js web dashboard (served at /ui/)

--- a/README.md
+++ b/README.md
@@ -19,13 +19,12 @@ Define your agents once. Wire them to repos with labels, cron schedules, or even
 - **SQLite config store** -- manage the fleet over a CRUD API instead of editing YAML. Import/export between the two.
 - **Built-in web dashboard** -- live event firehose, agent traces with tool-loop transcripts, dispatch graph, memory viewer.
 - **Transparent** -- every agent action is a GitHub comment, issue, or PR. Reviewable. Revertable.
-- **Secure by default** -- HMAC-verified webhooks, hashed prompt logs, read-only daemon (all GitHub writes go through the AI backend's MCP tools).
 
 ---
 
 ## Web dashboard
 
-The daemon ships an embedded web dashboard at `/ui/` with real-time views of your fleet:
+The daemon ships an embedded web dashboard at `/ui/` with real-time views of your fleet. The dashboard is the primary interface for managing agents -- all fleet operations (create, edit, delete agents, skills, backends, repos) are available through the CRUD editors, alongside live monitoring and observability.
 
 <!-- TODO: add screenshots of the dashboard pages (events, traces, graph, agents, memory) -->
 
@@ -34,37 +33,57 @@ The daemon ships an embedded web dashboard at `/ui/` with real-time views of you
 | **Events** | Live webhook event firehose with SSE streaming |
 | **Traces** | Agent run traces with timing, status, and drill-down to tool-loop transcripts |
 | **Graph** | Visual dispatch graph -- which agents invoke which, with edge counts |
-| **Agents** | Fleet snapshot -- per-agent status, skills, bindings, dispatch wiring |
+| **Agents** | Fleet snapshot -- per-agent status, skills, bindings, dispatch wiring. Create, edit, and delete agents |
+| **Skills** | Manage reusable guidance blocks -- create, edit, delete |
+| **Backends** | AI backend configuration -- add, edit, remove backends with model discovery |
+| **Repos** | Repository bindings -- wire agents to repos with labels, events, or cron triggers |
 | **Memory** | Raw agent memory markdown per (agent, repo) pair |
-| **Config** | Effective parsed config (secrets redacted) |
+| **Config** | Effective parsed config (secrets redacted). YAML import/export |
 
 ---
 
 ## How it works
 
-```mermaid
-sequenceDiagram
-    actor Dev as Developer
-    participant GH as GitHub
-    participant D as agents
-    participant AI as AI Backend<br/>(Claude / Codex)
+Agents are triggered in three ways. Every path ends with the same execution model: the daemon composes a prompt (skills + agent prompt + context), hands it to the AI CLI, and the CLI reads/writes GitHub through its MCP tools.
 
-    Note over D: Two trigger kinds
-    Dev->>GH: Add label  ai:review:arch-reviewer
-    GH->>D: Webhook (pull_request:labeled)
-    Note over D: Verify signature,<br/>deduplicate delivery,<br/>match repo binding,<br/>queue event
+### Label-triggered (event-driven)
 
-    Note over D: ... or scheduled ...
-    D-->>D: Cron fires (e.g. hourly)
-
-    D->>AI: Compose prompt = skills + agent prompt + context
-    AI->>GH: Read context via MCP tools
-    AI->>GH: Post comment / review / open PR via MCP tools
-    AI-->>D: Return artifacts JSON
-    Note over D: Persist agent memory<br/>for next scheduled run
+```
+Developer adds label "ai:review:arch-reviewer" to a PR
+  → GitHub sends a webhook to the daemon
+  → Daemon verifies, deduplicates, matches the repo binding
+  → Dispatches the bound agent via the AI CLI
+  → AI reads the PR, posts a review comment
 ```
 
-The daemon is event-driven for label-based workflows and runs a cron scheduler for autonomous agents. Both paths resolve to the same agent definitions -- only the trigger differs.
+### Cron-scheduled (autonomous)
+
+```
+Cron fires (e.g. every 30 minutes)
+  → Daemon injects the agent's persisted memory into the prompt
+  → AI CLI picks up where it left off — checks open issues, continues work
+  → Returns updated memory + artifacts for the next cycle
+```
+
+### Event-subscribed
+
+```
+Developer opens an issue / pushes to a branch / submits a review
+  → GitHub sends the matching webhook event
+  → Daemon routes it to every agent subscribed to that event kind
+  → Each agent runs independently with the event payload as context
+```
+
+### Reactive dispatch (agent-to-agent)
+
+Any agent can invoke another at runtime by returning a `dispatch` array. The daemon enqueues the target agent as a new event with depth, fanout, and dedup safety limits.
+
+```
+Agent A finishes a code fix, returns dispatch: [{agent: "pr-reviewer", ...}]
+  → Daemon validates wiring (allow_dispatch + can_dispatch)
+  → Enqueues a synthetic event for Agent B
+  → Agent B reviews the PR opened by Agent A
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ An optional SQLite-backed config store lets you manage the fleet over the API in
 ./agents --db agents.db
 ```
 
-When started with `--db`, the daemon registers CRUD endpoints for each resource type (`/agents`, `/skills`, `/backends`, `/repos`) and auto-reloads cron schedules after any repo or agent write. Agent memory is also stored in SQLite instead of the filesystem. The YAML path remains fully supported — both modes are first-class.
+When started with `--db`, the daemon registers CRUD endpoints for `/skills`, `/backends`, and `/repos`. For `/agents`, `POST /agents` and `GET|DELETE /agents/{name}` are CRUD write endpoints, but `GET /agents` always returns the live fleet snapshot (not the stored agent list). The daemon auto-reloads cron schedules after any repo or agent write. Agent memory is also stored in SQLite instead of the filesystem. The YAML path remains fully supported — both modes are first-class.
 
 ### On-demand agent pass
 
@@ -500,9 +500,9 @@ GitHub sends a ping immediately; the daemon will log the delivery.
 | `GET` | `/memory/stream` | Memory file change notifications (SSE) |
 | `GET` | `/config` | Effective parsed config (secrets redacted) |
 | `GET` | `/ui/` | Built-in web dashboard (static assets; embedded in binary) |
-| `GET` | `/{resource}` | List all entries for a resource type (`agents`, `skills`, `backends`, `repos`). Only registered when `--db` is set. |
+| `GET` | `/{resource}` | List all entries for a resource type (`skills`, `backends`, `repos`). Only registered when `--db` is set. (`GET /agents` is the fleet snapshot above, not the CRUD list.) |
 | `GET` | `/{resource}/{name}` | Fetch one entry. Repos use two path segments: `/repos/{owner}/{repo}`. Only with `--db`. |
-| `POST` | `/{resource}` | Create or replace an entry (write API; requires `--db`). |
+| `POST` | `/{resource}` | Create or replace an entry (write API; requires `--db`). Resources: `agents`, `skills`, `backends`, `repos`. |
 | `DELETE` | `/{resource}/{name}` | Remove an entry (requires `--db`). |
 | `GET` | `/export` | Export full fleet config as YAML (requires `--db`). |
 | `POST` | `/import` | Import a YAML config into the SQLite store (requires `--db`). |

--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ daemon:
     listen_addr: ":8080"
     status_path: /status
     webhook_path: /webhooks/github
-    agents_run_path: /agents/run            # POST for on-demand triggers
     webhook_secret_env: GITHUB_WEBHOOK_SECRET
     shutdown_timeout_seconds: 15
 
@@ -301,7 +300,7 @@ The `events:` field accepts any of the following GitHub event kinds. Each event 
 | `pull_request_review.submitted` | Formal GitHub review submitted | `state`, `body` |
 | `pull_request_review_comment.created` | Inline review comment posted on a PR diff | `body` |
 | `push` | Commit pushed to a branch | `ref` (e.g. `refs/heads/main`), `head_sha` |
-| `agents.run` | On-demand trigger via `/agents/run`, `/api/run`, or `--run-agent` CLI | `target_agent` |
+| `agents.run` | On-demand trigger via `POST /run` or `--run-agent` CLI | `target_agent` |
 | `agent.dispatch` | Another agent dispatched this agent | `target_agent`, `reason`, `root_event_id`, `dispatch_depth`, `invoked_by` |
 
 > **`push` scope:** only branch pushes fire the event. Tag pushes, branch deletions, and pushes to non-`refs/heads/` refs are silently dropped. The agent receives the branch ref and the resulting head SHA — there is no PR number in the context.
@@ -411,7 +410,7 @@ An optional SQLite-backed config store lets you manage the fleet over the API in
 ./agents --db agents.db
 ```
 
-When started with `--db`, the daemon registers `/api/store/*` CRUD endpoints and auto-reloads cron schedules after any repo or agent write. Agent memory is also stored in SQLite instead of the filesystem. The YAML path remains fully supported — both modes are first-class.
+When started with `--db`, the daemon registers CRUD endpoints for each resource type (`/agents`, `/skills`, `/backends`, `/repos`) and auto-reloads cron schedules after any repo or agent write. Agent memory is also stored in SQLite instead of the filesystem. The YAML path remains fully supported — both modes are first-class.
 
 ### On-demand agent pass
 
@@ -424,7 +423,7 @@ Run one autonomous agent synchronously and exit (useful for testing):
 Or via HTTP on the running daemon:
 
 ```bash
-curl -X POST https://<your-host>/agents/run \
+curl -X POST https://<your-host>/run \
   -H "Content-Type: application/json" \
   -d '{"agent":"coder","repo":"owner/repo"}'
 ```
@@ -442,17 +441,14 @@ docker compose down
 
 The compose file expects:
 - `config.yaml` in the project root (mounted read-only at `/etc/agents/config.yaml`)
-- `prompts/` directory with any agent `prompt_file` targets (mounted read-only at `/etc/agents/prompts`)
-- `skills/` directory with any skill `prompt_file` targets (mounted read-only at `/etc/agents/skills`)
-- `.env` in the project root with `GITHUB_WEBHOOK_SECRET` (and optionally `LOG_SALT`)
+- `.env` in the project root with `GITHUB_WEBHOOK_SECRET` (and optionally `LOG_SALT` and `GITHUB_PAT_TOKEN`)
 
 #### Volume mounts
 
 | Host path | Container path | Purpose |
 |---|---|---|
-| `config.yaml` | `/etc/agents/config.yaml` (read-only) | Main daemon config |
-| `prompts/` | `/etc/agents/prompts` (read-only) | Prompt files referenced by agent `prompt_file:` |
-| `skills/` | `/etc/agents/skills` (read-only) | Skill files referenced by skill `prompt_file:` |
+| `config.yaml` | `/etc/agents/config.yaml` (read-only) | Main daemon config (used for `--import`; optional once DB is seeded) |
+| `./agents` | `/etc/agents/agents` (read-only) | Optional: prompt/skill files when agent `prompt_file:` paths point here |
 | `~/.claude` | `/home/agents/.claude` | Claude Code session data |
 | `~/.claude.json` | `/home/agents/.claude.json` | Claude Code main config |
 | `~/.codex` | `/home/agents/.codex` | Codex configuration |
@@ -484,31 +480,34 @@ GitHub sends a ping immediately; the daemon will log the delivery.
 
 ## HTTP endpoints
 
-| Method | Path | Auth | Description |
-|---|---|---|---|
-| `GET` | `/status` | none | Health check: JSON with uptime, event queue depth, agent schedules, dispatch counters |
-| `POST` | `/webhooks/github` | `X-Hub-Signature-256` HMAC | GitHub webhook receiver |
-| `POST` | `/agents/run` | none | On-demand agent trigger |
-| `POST` | `/v1/messages` | none | Anthropic↔OpenAI translation proxy (opt-in via `proxy.enabled`) |
-| `GET` | `/v1/models` | none | Companion stub for `/v1/messages`; lists the configured upstream model |
-| `POST` | `/api/run` | none | On-demand agent trigger (async, same as `/agents/run`) |
-| `GET` | `/api/agents` | Traefik basic auth | Fleet snapshot: per-agent status, bindings, dispatch wiring |
-| `GET` | `/api/events` | Traefik basic auth | Recent webhook events (time-windowed) |
-| `GET` | `/api/events/stream` | Traefik basic auth | Live event firehose (SSE) |
-| `GET` | `/api/traces` | Traefik basic auth | Recent agent run traces with timing |
-| `GET` | `/api/traces/stream` | Traefik basic auth | Live trace updates (SSE) |
-| `GET` | `/api/graph` | Traefik basic auth | Agent interaction graph (dispatch edges) |
-| `GET` | `/api/dispatches` | Traefik basic auth | Dispatch dedup store contents + counters |
-| `GET` | `/api/memory/{agent}/{repo}` | Traefik basic auth | Raw agent memory markdown |
-| `GET` | `/api/memory/stream` | Traefik basic auth | Memory file change notifications (SSE) |
-| `GET` | `/api/config` | Traefik basic auth | Effective parsed config (secrets redacted) |
-| `GET` | `/ui/` | none | Built-in web dashboard (static assets; embedded in binary) |
-| `GET` | `/api/store/{resource}` | Traefik basic auth | List all entries for a resource type (`agents`, `skills`, `backends`, `repos`). Only registered when `--db` is set. |
-| `GET` | `/api/store/{resource}/{name}` | Traefik basic auth | Fetch one entry. Repos use two path segments: `/api/store/repos/{owner}/{repo}`. |
-| `POST` | `/api/store/{resource}` | none | Create or replace an entry (write API; requires `--db`). |
-| `DELETE` | `/api/store/{resource}/{name}` | none | Remove an entry (requires `--db`). |
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/status` | Health check: JSON with uptime, event queue depth, agent schedules, dispatch counters |
+| `POST` | `/webhooks/github` | GitHub webhook receiver (`X-Hub-Signature-256` HMAC verified) |
+| `POST` | `/run` | On-demand agent trigger |
+| `POST` | `/v1/messages` | Anthropic↔OpenAI translation proxy (opt-in via `proxy.enabled`) |
+| `GET` | `/v1/models` | Companion stub for `/v1/messages`; lists the configured upstream model |
+| `GET` | `/agents` | Fleet snapshot: per-agent status, bindings, dispatch wiring |
+| `GET` | `/events` | Recent webhook events (time-windowed) |
+| `GET` | `/events/stream` | Live event firehose (SSE) |
+| `GET` | `/traces` | Recent agent run traces with timing |
+| `GET` | `/traces/stream` | Live trace updates (SSE) |
+| `GET` | `/traces/{root_event_id}` | All spans for a single root event |
+| `GET` | `/traces/{span_id}/steps` | Tool-loop transcript for a completed agent span |
+| `GET` | `/graph` | Agent interaction graph (dispatch edges) |
+| `GET` | `/dispatches` | Dispatch dedup store contents + counters |
+| `GET` | `/memory/{agent}/{repo}` | Raw agent memory markdown |
+| `GET` | `/memory/stream` | Memory file change notifications (SSE) |
+| `GET` | `/config` | Effective parsed config (secrets redacted) |
+| `GET` | `/ui/` | Built-in web dashboard (static assets; embedded in binary) |
+| `GET` | `/{resource}` | List all entries for a resource type (`agents`, `skills`, `backends`, `repos`). Only registered when `--db` is set. |
+| `GET` | `/{resource}/{name}` | Fetch one entry. Repos use two path segments: `/repos/{owner}/{repo}`. Only with `--db`. |
+| `POST` | `/{resource}` | Create or replace an entry (write API; requires `--db`). |
+| `DELETE` | `/{resource}/{name}` | Remove an entry (requires `--db`). |
+| `GET` | `/export` | Export full fleet config as YAML (requires `--db`). |
+| `POST` | `/import` | Import a YAML config into the SQLite store (requires `--db`). |
 
-The `/agents/run` and `/api/run` body is `{"agent": "<name>", "repo": "owner/repo"}`. Both return `202 Accepted` immediately with an `event_id`; the agent runs asynchronously. All endpoints are unauthenticated at the daemon level; access control is the reverse proxy's responsibility.
+The `/run` body is `{"agent": "<name>", "repo": "owner/repo"}`. It returns `202 Accepted` immediately with an `event_id`; the agent runs asynchronously. All endpoints are unauthenticated at the daemon level — access control is the reverse proxy's responsibility.
 
 Duplicate webhook deliveries are suppressed via `X-GitHub-Delivery` with a TTL cache.
 
@@ -640,7 +639,7 @@ internal/
   autonomous/               # Cron scheduler + agent memory (filesystem or SQLite)
   store/                    # SQLite-backed config store (--db mode): schema migrations, CRUD helpers
   workflow/                 # Event routing engine, single event queue, processor, inter-agent dispatcher
-  webhook/                  # HTTP server, signature verification, delivery dedupe, /api/store/* CRUD
+  webhook/                  # HTTP server, signature verification, delivery dedupe, CRUD API handlers
   ui/                       # Embedded Next.js web dashboard (served at /ui/)
   setup/                    # Interactive first-time setup command
   logging/                  # zerolog setup

--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ An optional SQLite-backed config store lets you manage the fleet over the API in
 ./agents --db agents.db
 ```
 
-When started with `--db`, the daemon registers CRUD endpoints for `/skills`, `/backends`, and `/repos`. For `/agents`, `POST /agents` and `GET|DELETE /agents/{name}` are CRUD write endpoints, but `GET /agents` always returns the live fleet snapshot (not the stored agent list). The daemon auto-reloads cron schedules after any repo or agent write. Agent memory is also stored in SQLite instead of the filesystem. The YAML path remains fully supported — both modes are first-class.
+The CRUD endpoints for `/skills`, `/backends`, and `/repos` are always mounted but require `--db` to function — without it they return errors. For `/agents`, `POST /agents` and `GET|DELETE /agents/{name}` are CRUD write endpoints, but `GET /agents` always returns the live fleet snapshot (not the stored agent list). The daemon auto-reloads cron schedules after any repo or agent write. Agent memory is also stored in SQLite instead of the filesystem. The YAML path remains fully supported — both modes are first-class.
 
 ### On-demand agent pass
 
@@ -500,8 +500,8 @@ GitHub sends a ping immediately; the daemon will log the delivery.
 | `GET` | `/memory/stream` | Memory file change notifications (SSE) |
 | `GET` | `/config` | Effective parsed config (secrets redacted) |
 | `GET` | `/ui/` | Built-in web dashboard (static assets; embedded in binary) |
-| `GET` | `/{resource}` | List all entries for a resource type (`skills`, `backends`, `repos`). Only registered when `--db` is set. (`GET /agents` is the fleet snapshot above, not the CRUD list.) |
-| `GET` | `/{resource}/{name}` | Fetch one entry. Repos use two path segments: `/repos/{owner}/{repo}`. Only with `--db`. |
+| `GET` | `/{resource}` | List all entries for a resource type (`skills`, `backends`, `repos`). Route is always mounted; requires `--db` to function. (`GET /agents` is the fleet snapshot above, not the CRUD list.) |
+| `GET` | `/{resource}/{name}` | Fetch one entry. Repos use two path segments: `/repos/{owner}/{repo}`. Requires `--db`. |
 | `POST` | `/{resource}` | Create or replace an entry (write API; requires `--db`). Resources: `agents`, `skills`, `backends`, `repos`. |
 | `DELETE` | `/{resource}/{name}` | Remove an entry (requires `--db`). |
 | `GET` | `/export` | Export full fleet config as YAML (requires `--db`). |

--- a/README.md
+++ b/README.md
@@ -2,20 +2,41 @@
 
 ![agents](docs/agents.jpg)
 
-**A self-hosted Go daemon that turns GitHub into an AI-driven development pipeline.**
+**Your personal, provider-agnostic tool for building reusable, event-driven agentic workflows.**
 
-Define your agents once. Wire them to repos with labels, cron schedules, or both. The daemon dispatches them via AI CLIs ([Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex](https://github.com/openai/codex)) and lets them work through native GitHub primitives — issues, PRs, reviews, comments.
+Define your agents once. Wire them to repos with labels, cron schedules, or event subscriptions. The daemon dispatches them via AI CLIs ([Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex](https://github.com/openai/codex)) and lets them work through native GitHub primitives -- issues, PRs, reviews, comments.
 
 ---
 
-## Why?
+## Features
 
-- **Self-hosted, no SaaS** — your code and prompts stay on your infrastructure.
-- **Multi-backend** — Claude, Codex, or any CLI that speaks MCP. Pick different backends for different agents.
-- **One agent model, many triggers** — label events, cron schedules, on-demand API calls. Same agent, wired however you want.
-- **Composable skills** — reusable guidance blocks (architecture, security, testing, DX, …) merged into any agent.
-- **Transparent** — every agent action is a GitHub comment, issue, or PR. Reviewable. Revertable.
-- **Secure by default** — HMAC-verified webhooks, API-key-gated trigger endpoint, hashed prompt logs, no direct GitHub writes from the daemon.
+- **Self-hosted, no SaaS** -- your code and prompts stay on your infrastructure.
+- **Multi-backend** -- Claude, Codex, or any CLI that speaks MCP. Mix backends per agent.
+- **Local model support** -- built-in Anthropic-to-OpenAI translation proxy routes the fleet through `llama.cpp`, Ollama, vLLM, or any OpenAI-compatible endpoint. Zero vendor lock-in.
+- **One agent model, many triggers** -- label events, cron schedules, GitHub event subscriptions, on-demand API calls. Same agent, wired however you want.
+- **Composable skills** -- reusable guidance blocks (architecture, security, testing, DX, ...) merged into any agent.
+- **Reactive inter-agent dispatch** -- agents invoke each other at runtime with depth, fanout, and dedup safety limits.
+- **SQLite config store** -- manage the fleet over a CRUD API instead of editing YAML. Import/export between the two.
+- **Built-in web dashboard** -- live event firehose, agent traces with tool-loop transcripts, dispatch graph, memory viewer.
+- **Transparent** -- every agent action is a GitHub comment, issue, or PR. Reviewable. Revertable.
+- **Secure by default** -- HMAC-verified webhooks, hashed prompt logs, read-only daemon (all GitHub writes go through the AI backend's MCP tools).
+
+---
+
+## Web dashboard
+
+The daemon ships an embedded web dashboard at `/ui/` with real-time views of your fleet:
+
+<!-- TODO: add screenshots of the dashboard pages (events, traces, graph, agents, memory) -->
+
+| Page | What it shows |
+|------|---------------|
+| **Events** | Live webhook event firehose with SSE streaming |
+| **Traces** | Agent run traces with timing, status, and drill-down to tool-loop transcripts |
+| **Graph** | Visual dispatch graph -- which agents invoke which, with edge counts |
+| **Agents** | Fleet snapshot -- per-agent status, skills, bindings, dispatch wiring |
+| **Memory** | Raw agent memory markdown per (agent, repo) pair |
+| **Config** | Effective parsed config (secrets redacted) |
 
 ---
 
@@ -43,72 +64,19 @@ sequenceDiagram
     Note over D: Persist agent memory<br/>for next scheduled run
 ```
 
-The daemon is event-driven for label-based workflows and runs a cron scheduler for autonomous agents. Both paths resolve to the same agent definitions — only the trigger differs.
+The daemon is event-driven for label-based workflows and runs a cron scheduler for autonomous agents. Both paths resolve to the same agent definitions -- only the trigger differs.
 
 ---
 
-## Configuration at a glance
+## Quick start
 
-The config file is split into four conceptual domains:
-
-```yaml
-daemon:    # how the service runs: log, http, processor, backends, optional proxy
-skills:    # reusable guidance blocks, keyed by name
-agents:    # named capabilities: backend + skills + prompt + dispatch wiring
-repos:     # wiring: which agents run on which repo, and when
-```
-
-Full walkthrough below. The shortest useful config is ~30 lines.
-
----
-
-## Label architecture
-
-Labels are plain strings matched against each binding's `labels` list. There is **no magic format** — you choose the labels. Convention across the example config is `ai:review:<agent-name>`, but any string works.
-
-```yaml
-repos:
-  - name: "eloylp/myrepo"
-    enabled: true
-    use:
-      # Label-triggered reviewer
-      - agent: arch-reviewer
-        labels: ["ai:review:arch-reviewer"]
-
-      # Multiple agents firing on the same label (fan-out)
-      - agent: arch-reviewer
-        labels: ["ai:review:all"]
-      - agent: sec-reviewer
-        labels: ["ai:review:all"]
-
-      # Cron-scheduled agent on the same repo
-      - agent: coder
-        cron: "0,30 8-18 * * *"
-
-      # Event-triggered agent (react to any new comment)
-      - agent: coder
-        events: ["issue_comment.created"]
-```
-
-Rules:
-
-- Labels are case-insensitive and trimmed. Only `labeled` actions fire (not `unlabeled`).
-- The trigger label comes from the webhook event payload, not the issue/PR's current label set.
-- Draft PRs skip `pull_request.labeled` for both `labels:` and `events:` bindings; they may still receive other event kinds such as `pull_request.opened` and `pull_request.synchronize`.
-- `events:` bindings fire on the exact event kinds listed, with no additional filtering.
-- Multiple bindings matching the same event fan out in parallel (capped by `daemon.processor.max_concurrent_agents`).
-
----
-
-## Requirements
+### Requirements
 
 | Dependency | Purpose |
 |---|---|
 | **Go 1.22+** | Build the daemon |
 | **GitHub CLI** (`gh`) | Authenticated access used by the AI CLIs' GitHub MCP tools |
 | **AI CLI** (Claude Code and/or Codex) | The actual AI backend, with GitHub MCP server configured |
-
-> **Why `gh` when the daemon never calls it?** The daemon only spawns the AI CLI and passes a prompt. The CLI uses GitHub MCP tools to read and write; those tools rely on `gh` authentication under the hood.
 
 ### Setup
 
@@ -122,295 +90,19 @@ Then follow the official setup guides:
 - [Claude Code](https://code.claude.com/docs/en/setup) + [GitHub MCP](https://github.com/github/github-mcp-server/blob/main/docs/installation-guides/install-claude.md)
 - [Codex](https://github.com/openai/codex) + [GitHub MCP](https://github.com/github/github-mcp-server/blob/main/docs/installation-guides/install-codex.md)
 
----
-
-## Configuration
-
-Copy `config.example.yaml` to `config.yaml` and adapt it.
-
-### `daemon` — how the service runs
-
-```yaml
-daemon:
-  log:
-    level: info            # trace, debug, info, warn, error, fatal
-    format: text           # text (human) or json (structured)
-
-  http:
-    listen_addr: ":8080"
-    status_path: /status
-    webhook_path: /webhooks/github
-    webhook_secret_env: GITHUB_WEBHOOK_SECRET
-    shutdown_timeout_seconds: 15
-
-  processor:
-    event_queue_buffer: 256
-    max_concurrent_agents: 4                # cap on per-event fan-out
-
-  dispatch:
-    max_depth: 3                            # max chain length before drop + WARN
-    max_fanout: 4                           # max dispatches per single agent run
-    dedup_window_seconds: 300               # suppress duplicate (target, repo, number) within window
-
-  memory_dir: /var/lib/agents/memory        # persistent autonomous agent memory
-
-  ai_backends:
-    claude:
-      command: claude
-      args: ["-p", "--dangerously-skip-permissions"]
-      timeout_seconds: 1500
-      max_prompt_chars: 12000
-      redaction_salt_env: LOG_SALT
-
-    codex:
-      command: codex
-      args: ["exec", "--skip-git-repo-check", "--dangerously-bypass-approvals-and-sandbox"]
-      timeout_seconds: 600
-      max_prompt_chars: 12000
-      redaction_salt_env: LOG_SALT
-```
-
-### `skills` — reusable guidance blocks
-
-```yaml
-skills:
-  architect:
-    prompt: |
-      Focus on architecture boundaries, coupling, extensibility, and maintainability risks.
-
-  security:
-    prompt: |
-      Focus on authn/authz, secrets exposure, injection vectors, and unsafe defaults.
-```
-
-Skills are referenced by name from agents. You can also use `prompt_file: path/to/file.md` instead of inline `prompt`.
-
-### `agents` — named capabilities
-
-```yaml
-agents:
-  # Short inline prompt — reviewer that never opens PRs (default)
-  - name: arch-reviewer
-    backend: auto              # auto | claude | codex
-    skills: [architect]
-    prompt: |
-      You are an architecture-focused PR reviewer. Post one high-signal review comment.
-
-  # Prompt loaded from a file (recommended for longer prompts)
-  # allow_prs: true lets this agent open pull requests
-  - name: coder
-    backend: claude
-    skills: [architect, testing]
-    prompt_file: prompts/coder.md
-    allow_prs: true            # required for agents that open PRs
-
-  # Dispatch target — can be invoked by pr-reviewer
-  - name: sec-reviewer
-    description: "Deep-dive security reviewer for risky changes"
-    backend: claude
-    allow_dispatch: true       # opt-in to being dispatched
-    prompt_file: prompts/sec-reviewer.md
-
-  # Agent that may dispatch to sec-reviewer
-  - name: pr-reviewer
-    backend: claude
-    can_dispatch: [sec-reviewer]   # whitelist of agents this agent may dispatch
-    prompt_file: prompts/pr-reviewer.md
-```
-
-Each agent is a pure capability definition: backend + skills + prompt. Agents don't run until a repo binds them to a trigger.
-
-- `backend: auto` picks the first configured backend in `daemon.ai_backends` (claude before codex).
-- `prompt_file` paths are resolved relative to the config file's directory.
-- Agent names must be unique.
-- `allow_prs` (default `false`) — when `false`, the scheduler prepends a hard instruction
-  forbidding the agent from opening pull requests, regardless of what the prompt says. Set
-  `allow_prs: true` only on agents that are explicitly meant to author PRs (e.g. coders,
-  refactorers). Reviewer-only agents should leave this unset.
-- `allow_dispatch` (default `false`) — opt-in gate. An agent must have `allow_dispatch: true`
-  for any other agent to dispatch it. Agents without this flag silently drop any incoming
-  dispatch requests.
-- `can_dispatch` — whitelist of agent names this agent is allowed to dispatch. A dispatch
-  to an agent not on this list is silently dropped. Entries must reference real agents in
-  the same config and must not include the agent itself.
-- `description` — required when an agent appears in any `can_dispatch` list. Used by the
-  dispatcher to include context about the target in the originating agent's prompt roster.
-
-### `repos` — wiring
-
-```yaml
-repos:
-  - name: "owner/repo"
-    enabled: true
-    use:
-      - agent: arch-reviewer
-        labels: ["ai:review:arch-reviewer"]
-
-      - agent: coder
-        cron: "0,30 8-18 * * *"             # standard 5-field cron
-
-      - agent: nightly-scout
-        cron: "0 7 * * *"
-        enabled: false                       # temporarily off without deletion
-```
-
-Each `use` entry binds one agent to one trigger. An agent can appear multiple times with different triggers. A binding must have at least one of `labels:`, `events:`, or `cron:`.
-
-```yaml
-repos:
-  - name: "owner/repo"
-    enabled: true
-    use:
-      # Label-triggered reviewer
-      - agent: arch-reviewer
-        labels: ["ai:review:arch-reviewer"]
-
-      # React to every new issue comment (issues and PRs alike)
-      - agent: coder
-        events: ["issue_comment.created"]
-
-      # React to new commits pushed to any branch
-      - agent: sec-reviewer
-        events: ["push"]
-
-      # Multiple event kinds in one binding (fan-out fires the agent once per match)
-      - agent: pr-reviewer
-        events: ["pull_request.opened", "pull_request.synchronize"]
-```
-
-A binding must set exactly one of `labels:`, `events:`, or `cron:` — mixing trigger types in a single binding is rejected at startup.
-
-#### Supported event kinds
-
-The `events:` field accepts any of the following GitHub event kinds. Each event delivers a `## Runtime context` block into the agent's prompt with `Event`, `Actor` (the GitHub login that triggered it), an issue/PR number where applicable, and the payload fields listed below.
-
-| Kind | When | Payload fields |
-|------|------|----------------|
-| `issues.labeled` | Issue receives any label | `label` |
-| `issues.opened` | Issue opened | `title`, `body` |
-| `issues.edited` | Issue body or title edited | `title`, `body` |
-| `issues.reopened` | Issue reopened | `title`, `body` |
-| `issues.closed` | Issue closed | `title`, `body` |
-| `pull_request.labeled` | PR receives any label (draft PRs are skipped) | `label` |
-| `pull_request.opened` | PR opened | `title`, `draft` |
-| `pull_request.synchronize` | New commit pushed to PR branch | `title`, `draft` |
-| `pull_request.ready_for_review` | Draft PR marked ready | `title`, `draft` |
-| `pull_request.closed` | PR closed or merged | `title`, `draft`, `merged` (`true` when PR was merged, `false` when closed without merge) |
-| `issue_comment.created` | Comment posted on an issue or PR | `body` |
-| `pull_request_review.submitted` | Formal GitHub review submitted | `state`, `body` |
-| `pull_request_review_comment.created` | Inline review comment posted on a PR diff | `body` |
-| `push` | Commit pushed to a branch | `ref` (e.g. `refs/heads/main`), `head_sha` |
-| `agents.run` | On-demand trigger via `POST /run` or `--run-agent` CLI | `target_agent` |
-| `agent.dispatch` | Another agent dispatched this agent | `target_agent`, `reason`, `root_event_id`, `dispatch_depth`, `invoked_by` |
-
-> **`push` scope:** only branch pushes fire the event. Tag pushes, branch deletions, and pushes to non-`refs/heads/` refs are silently dropped. The agent receives the branch ref and the resulting head SHA — there is no PR number in the context.
-
-Additional rules:
-
-- `issues.*` events that originate from a PR-backed GitHub issue are dropped; the corresponding `pull_request.*` event covers them instead.
-- `pull_request.labeled` events on draft PRs are dropped at the webhook boundary. Use `events: ["pull_request.ready_for_review"]` to act when a draft is marked ready.
-- Unknown event kinds are rejected at config load time with a clear error listing the supported set.
-
-### Reactive inter-agent dispatch
-
-Agents can invoke each other at runtime. When an agent's AI run returns a `dispatch[]` field in its JSON response, the daemon validates and enqueues a synthetic `agent.dispatch` event for each entry. The target agent then runs with the full event payload as its runtime context.
-
-#### Agent response contract (extended)
-
-```json
-{
-  "summary": "Reviewed PR — escalating to sec-reviewer for crypto usage",
-  "artifacts": [],
-  "dispatch": [
-    {
-      "agent": "sec-reviewer",
-      "number": 42,
-      "reason": "PR introduces custom crypto primitives — needs security review"
-    }
-  ]
-}
-```
-
-- `agent` — name of the target agent (must be in the originator's `can_dispatch` list and have `allow_dispatch: true`).
-- `number` — issue/PR number to associate with the dispatched run. If omitted, the originating event's number is used.
-- `reason` — human-readable rationale, included in the target agent's prompt context.
-
-#### Runtime context for dispatched agents
-
-The dispatched agent receives an `agent.dispatch` event with these payload fields:
-
-| Field | Value |
-|-------|-------|
-| `target_agent` | Name of the agent being invoked (this agent) |
-| `reason` | Reason string supplied by the originator |
-| `root_event_id` | ID of the original triggering event (stable across the full chain) |
-| `dispatch_depth` | How many hops deep in the chain this invocation is |
-| `invoked_by` | Name of the agent that dispatched this run |
-
-#### Safety limits (`daemon.dispatch`)
-
-| Field | Default | Meaning |
-|-------|---------|---------|
-| `max_depth` | 3 | Maximum dispatch chain length. Requests that would exceed this are dropped with a warning. |
-| `max_fanout` | 4 | Maximum number of dispatches a single agent run may enqueue. Additional requests are dropped. |
-| `dedup_window_seconds` | 300 | Suppress duplicate `(target, repo, number)` dispatch requests within this window (seconds). |
-
-All three fields must be positive integers; the daemon rejects non-positive values at startup.
-
-#### Dispatch flow
-
-```
-Agent A runs → returns dispatch[{agent:"B", number:42, reason:"..."}]
-    │
-    ▼
-Dispatcher checks:
-  1. B is in A's can_dispatch list
-  2. B has allow_dispatch: true
-  3. depth ≤ max_depth, fanout ≤ max_fanout
-  4. (B, repo, 42) not seen within dedup_window_seconds
-    │
-    ▼
-agent.dispatch event enqueued → Agent B runs with full payload
-```
-
-Dispatch chains work across both event-driven and cron/`--run-agent` paths, and the shared dedup store prevents a cron-triggered run and a near-simultaneous dispatch from running the same target twice within the window.
-
-### Environment variables
-
-Create a `.env` file in the project root (loaded automatically):
+### Build and run
 
 ```bash
-GITHUB_WEBHOOK_SECRET=your-webhook-secret
-LOG_SALT=optional-prompt-hash-salt
-```
+# Copy and edit the example config
+cp config.example.yaml config.yaml
 
----
-
-## Running
-
-```bash
-# Directly
+# Run directly
 go run ./cmd/agents -config config.yaml
 
 # Or build first
 go build -o agents ./cmd/agents
 ./agents -config config.yaml
 ```
-
-### SQLite mode (`--db`)
-
-An optional SQLite-backed config store lets you manage the fleet over the API instead of editing YAML files. Import once, then drop the `--config` flag entirely:
-
-```bash
-# Import from existing YAML (one-time)
-./agents --db agents.db --import config.yaml
-# → "import: imported 2 backends, 6 skills, 11 agents, 1 repos, 14 bindings"
-
-# All subsequent starts — no config.yaml needed
-./agents --db agents.db
-```
-
-The CRUD endpoints for `/skills`, `/backends`, and `/repos` are always mounted but require `--db` to function — without it they return errors. For `/agents`, `POST /agents` and `GET|DELETE /agents/{name}` are CRUD write endpoints, but `GET /agents` always returns the live fleet snapshot (not the stored agent list). The daemon auto-reloads cron schedules after any repo or agent write. Agent memory is also stored in SQLite instead of the filesystem. The YAML path remains fully supported — both modes are first-class.
 
 ### On-demand agent pass
 
@@ -428,193 +120,51 @@ curl -X POST https://<your-host>/run \
   -d '{"agent":"coder","repo":"owner/repo"}'
 ```
 
-The agent must be bound to the target repo (any trigger kind works).
+### GitHub webhook setup
 
-### Docker
-
-```bash
-docker compose up -d
-docker compose up -d --build   # rebuild after code changes
-docker compose logs -f agents
-docker compose down
-```
-
-The compose file expects:
-- `config.yaml` in the project root (mounted read-only at `/etc/agents/config.yaml`)
-- `.env` in the project root with `GITHUB_WEBHOOK_SECRET` (and optionally `LOG_SALT` and `GITHUB_PAT_TOKEN`)
-
-#### Volume mounts
-
-| Host path | Container path | Purpose |
-|---|---|---|
-| `config.yaml` | `/etc/agents/config.yaml` (read-only) | Main daemon config (used for `--import`; optional once DB is seeded) |
-| `./agents` | `/etc/agents/agents` (read-only) | Optional: source tree for agent and skill `prompt_file:` paths that reference this directory |
-| `~/.claude` | `/home/agents/.claude` | Claude Code session data |
-| `~/.claude.json` | `/home/agents/.claude.json` | Claude Code main config |
-| `~/.codex` | `/home/agents/.codex` | Codex configuration |
-| `~/.config/gh` | `/home/agents/.config/gh` (read-only) | GitHub CLI auth tokens |
-| `agents-memory` (volume) | `/var/lib/agents/memory` | Autonomous agent memory across restarts |
-
-#### MCP server configuration
-
-Claude Code stores MCP config per-project, keyed by working directory in `~/.claude.json`. Since the container's working directory is `/`, ensure `~/.claude.json` has a project entry for `/` with the GitHub MCP server configured. Verify with:
-
-```bash
-docker exec agents claude mcp list
-```
-
----
-
-## GitHub webhook setup
-
-1. Go to **Settings → Webhooks → Add webhook** in your repository.
+1. Go to **Settings -> Webhooks -> Add webhook** in your repository.
 2. **Payload URL**: `https://<your-host>/webhooks/github`
 3. **Content type**: `application/json`
 4. **Secret**: same value as `GITHUB_WEBHOOK_SECRET`.
-5. **Events**: the daemon accepts **Issues**, **Pull requests**, **Issue comments**, **Pull request reviews**, **Pull request review comments**, and **Pushes**. Enable whichever ones you want to trigger agents on. Unused events are silently dropped.
+5. **Events**: enable **Issues**, **Pull requests**, **Issue comments**, **Pull request reviews**, **Pull request review comments**, and/or **Pushes** -- whichever ones you want to trigger agents on. Unused events are silently dropped.
 6. **Active**: checked.
 
-GitHub sends a ping immediately; the daemon will log the delivery.
+---
+
+## Documentation
+
+| Document | What it covers |
+|----------|----------------|
+| [Configuration](docs/configuration.md) | Full config walkthrough: daemon, skills, agents, repos, labels, environment variables, SQLite mode |
+| [Supported events](docs/events.md) | All GitHub event kinds, payload fields, and filtering rules |
+| [Inter-agent dispatch](docs/dispatch.md) | Reactive dispatch: response contract, safety limits, config wiring |
+| [HTTP API](docs/api.md) | All endpoints: core, observability, proxy, CRUD, and the AI runner contract |
+| [Docker deployment](docs/docker.md) | Docker Compose setup, volume mounts, MCP configuration |
+| [Local models](docs/local-models.md) | Run the fleet on your own LLM: proxy setup, model picks, tuning, cost math |
+| [Security](docs/security.md) | Webhook verification, prompt redaction, access control model |
+| [Contributing](CONTRIBUTING.md) | How to contribute: issues-first model, what makes a great issue |
 
 ---
 
-## HTTP endpoints
+## Project structure
 
-| Method | Path | Description |
-|---|---|---|
-| `GET` | `/status` | Health check: JSON with uptime, event queue depth, agent schedules, dispatch counters |
-| `POST` | `/webhooks/github` | GitHub webhook receiver (`X-Hub-Signature-256` HMAC verified) |
-| `POST` | `/run` | On-demand agent trigger |
-| `POST` | `/v1/messages` | Anthropic↔OpenAI translation proxy (opt-in via `proxy.enabled`) |
-| `GET` | `/v1/models` | Companion stub for `/v1/messages`; lists the configured upstream model (opt-in via `proxy.enabled`) |
-| `GET` | `/agents` | Fleet snapshot: per-agent status, bindings, dispatch wiring |
-| `GET` | `/events` | Recent webhook events (time-windowed) |
-| `GET` | `/events/stream` | Live event firehose (SSE) |
-| `GET` | `/traces` | Recent agent run traces with timing |
-| `GET` | `/traces/stream` | Live trace updates (SSE) |
-| `GET` | `/traces/{root_event_id}` | All spans for a single root event |
-| `GET` | `/traces/{span_id}/steps` | Tool-loop transcript for a completed agent span |
-| `GET` | `/graph` | Agent interaction graph (dispatch edges) |
-| `GET` | `/dispatches` | Dispatch dedup store contents + counters |
-| `GET` | `/memory/{agent}/{repo}` | Raw agent memory markdown |
-| `GET` | `/memory/stream` | Memory file change notifications (SSE) |
-| `GET` | `/config` | Effective parsed config (secrets redacted) |
-| `GET` | `/ui/` | Built-in web dashboard (static assets; embedded in binary) |
-| `GET` | `/{resource}` | List all entries for a resource type (`skills`, `backends`, `repos`). Route is always mounted; requires `--db` to function. (`GET /agents` is the fleet snapshot above, not the CRUD list.) |
-| `GET` | `/{resource}/{name}` | Fetch one entry. Repos use two path segments: `/repos/{owner}/{repo}`. Requires `--db`. |
-| `POST` | `/{resource}` | Create or replace an entry (write API; requires `--db`). Resources: `agents`, `skills`, `backends`, `repos`. |
-| `DELETE` | `/{resource}/{name}` | Remove an entry (requires `--db`). |
-| `GET` | `/export` | Export full fleet config as YAML (requires `--db`). |
-| `POST` | `/import` | Import a YAML config into the SQLite store (requires `--db`). |
-
-The `/run` body is `{"agent": "<name>", "repo": "owner/repo"}`. It returns `202 Accepted` immediately with an `event_id`; the agent runs asynchronously. All endpoints are unauthenticated at the daemon level — access control is the reverse proxy's responsibility.
-
-Duplicate webhook deliveries are suppressed via `X-GitHub-Delivery` with a TTL cache.
-
----
-
-## Local models — run your fleet on your own LLM
-
-Point the agents daemon at any OpenAI-compatible endpoint (`llama.cpp`, Ollama, vLLM, hosted Qwen on Together/Alibaba, anything else) and run the entire fleet without paying per token or sending code to a vendor. No sidecar processes, no Python dependencies — a built-in Go proxy inside the daemon translates Anthropic Messages format to OpenAI Chat Completions and keeps Claude Code's full tool stack working on top of whatever model you pick.
-
-Quick wire-up in `config.yaml`:
-
-```yaml
-daemon:
-  proxy:
-    enabled: true
-    upstream:
-      url: http://localhost:18000/v1   # your llama.cpp / Ollama / vLLM / hosted endpoint
-      model: qwen                      # anything; most servers ignore this
-      timeout_seconds: 3600
-      extra_body:                      # merged into every upstream request
-        chat_template_kwargs:
-          enable_thinking: false       # Qwen 3.5: skip reasoning-token waste
-
-  ai_backends:
-    claude:                            # default: hosted Anthropic
-      command: claude
-      args: [-p, --dangerously-skip-permissions]
-    claude_local:                      # same binary, different env → proxy
-      command: claude
-      args: [-p, --dangerously-skip-permissions]
-      env:
-        ANTHROPIC_BASE_URL: http://localhost:8080
-        ANTHROPIC_API_KEY: sk-not-needed
-        ANTHROPIC_MODEL: qwen
-
-agents:
-  - { name: pr-reviewer, backend: claude_local }    # Qwen-backed
-  - { name: coder,        backend: claude }         # hosted Claude
 ```
-
-**Measured on our own infra** — Qwen3.5-35B-A3B at Q5 on a rented RTX 5090: **~75 tok/s decode, 5000+ tok/s prefill, 90+ tool-loop round-trips per run without a single translation error**. Same ballpark as hosted Claude Sonnet on a GPU that rents for `$0.60/hr`.
-
-See **[docs/local-models.md](docs/local-models.md)** for the full setup recipe, model picks by VRAM tier, recommended `llama.cpp` tuning flags (prefix caching, KV quantization, batch sizing), cost math, and honest caveats about capability gaps on action-taking agents.
-
----
-
-## AI runner contract
-
-The daemon spawns the configured CLI, sends the composed prompt on **stdin**, and expects a **single JSON object on stdout**:
-
-```json
-{
-  "summary": "Reviewed PR for security vulnerabilities",
-  "artifacts": [
-    {
-      "type": "pr_review",
-      "part_key": "review/claude/security",
-      "github_id": "123456",
-      "url": "https://github.com/owner/repo/pull/1#pullrequestreview-123456"
-    }
-  ],
-  "dispatch": [
-    {
-      "agent": "sec-reviewer",
-      "number": 42,
-      "reason": "Custom crypto primitives found — needs deeper security review"
-    }
-  ],
-  "memory": "## 2026-04-21\n- Reviewed PR #42 — escalated crypto concerns to sec-reviewer."
-}
-```
-
-The metadata is used for observability, logging, and run summaries. Agents that don't post anything still return an empty `artifacts: []`. The `dispatch` field is optional — omit it or leave it empty when the agent does not need to invoke another agent. See [Reactive inter-agent dispatch](#reactive-inter-agent-dispatch) for the full contract.
-
-The `memory` field is how autonomous agents persist state across scheduled runs. The daemon reads the stored memory before each autonomous run and writes the `memory` value from the response back to the store (filesystem or SQLite depending on how the daemon was started). An empty string clears the memory. Event-driven runs (webhooks, label triggers) do not receive or persist memory.
-
----
-
-## Contributing
-
-This project is built by its own agent fleet. **You bring the ideas, the agents bring the implementation.** Open an issue with the `discussing` label, a maintainer triages it, and the autonomous coder agent implements accepted issues — reviewed by the pr-reviewer agent before merge.
-
-See **[CONTRIBUTING.md](CONTRIBUTING.md)** for the full process, what makes a great issue, and the exceptions (doc typo PRs and security patches are accepted directly).
-
----
-
-## Security
-
-- **Webhook verification** — HMAC SHA-256 on every payload (`X-Hub-Signature-256`).
-- **Reverse-proxy auth** — the daemon delegates access control to the reverse proxy (e.g. Traefik basic auth).
-- **Read-only daemon** — all GitHub writes go through the AI backend's MCP tools.
-- **Prompt redaction** — prompts are never logged in plaintext; only their hash and length.
-- **`--dangerously-skip-permissions`** — required for headless Claude operation. Ensure the host is trusted.
-
----
-
-## Logging
-
-Two formats via `daemon.log.format`:
-
-- **`text`** (default) — coloured, human-readable.
-- **`json`** — structured for log aggregation (Loki, Datadog, etc).
-
-Every entry includes `repo`, `issue_number` or `pr_number`, and `component` for filtering.
-
-```json
-{"level":"info","component":"workflow_engine","repo":"owner/repo","pr_number":42,"backend":"claude","message":"invoking ai agent"}
+cmd/agents/main.go          # Daemon entry point + --run-agent / --db / --import modes
+internal/
+  config/                   # YAML parsing, prompt/skill file resolution, validation
+  ai/                       # Prompt composition + command-based CLI runner (per-backend env)
+  anthropic_proxy/          # Built-in Anthropic-to-OpenAI translation proxy (opt-in)
+  observe/                  # Observability store (events, traces, dispatch graph, SSE hubs)
+  autonomous/               # Cron scheduler + agent memory (filesystem or SQLite)
+  store/                    # SQLite-backed config store (--db mode): schema migrations, CRUD helpers
+  workflow/                 # Event routing engine, single event queue, processor, inter-agent dispatcher
+  webhook/                  # HTTP server, signature verification, delivery dedupe, CRUD API handlers
+  ui/                       # Embedded Next.js web dashboard (served at /ui/)
+  setup/                    # Interactive first-time setup command
+  logging/                  # zerolog setup
+prompts/                    # Optional: prompt files referenced by agent prompt_file
+skills/                     # Optional: skill files referenced by skill prompt_file
+docs/                       # Long-form docs (configuration, events, dispatch, API, docker, etc.)
 ```
 
 ---
@@ -627,23 +177,23 @@ go test ./... -race
 
 ---
 
-## Project structure
+## Logging
 
+Two formats via `daemon.log.format`:
+
+- **`text`** (default) -- coloured, human-readable.
+- **`json`** -- structured for log aggregation (Loki, Datadog, etc).
+
+Every entry includes `repo`, `issue_number` or `pr_number`, and `component` for filtering.
+
+```json
+{"level":"info","component":"workflow_engine","repo":"owner/repo","pr_number":42,"backend":"claude","message":"invoking ai agent"}
 ```
-cmd/agents/main.go          # Daemon entry point + --run-agent / --db / --import modes
-internal/
-  config/                   # YAML parsing, prompt/skill file resolution, validation
-  ai/                       # Prompt composition + command-based CLI runner (per-backend env)
-  anthropic_proxy/          # Built-in Anthropic↔OpenAI translation proxy (opt-in)
-  observe/                  # Observability store (events, traces, dispatch graph, SSE hubs)
-  autonomous/               # Cron scheduler + agent memory (filesystem or SQLite)
-  store/                    # SQLite-backed config store (--db mode): schema migrations, CRUD helpers
-  workflow/                 # Event routing engine, single event queue, processor, inter-agent dispatcher
-  webhook/                  # HTTP server, signature verification, delivery dedupe, CRUD API handlers
-  ui/                       # Embedded Next.js web dashboard (served at /ui/)
-  setup/                    # Interactive first-time setup command
-  logging/                  # zerolog setup
-prompts/                    # Optional: prompt files referenced by agent prompt_file
-skills/                     # Optional: skill files referenced by skill prompt_file
-docs/                       # Long-form docs (docs/local-models.md, etc.)
-```
+
+---
+
+## Contributing
+
+This project is built by its own agent fleet. **You bring the ideas, the agents bring the implementation.** Open an issue with the `discussing` label, a maintainer triages it, and the autonomous coder agent implements accepted issues -- reviewed by the pr-reviewer agent before merge.
+
+See **[CONTRIBUTING.md](CONTRIBUTING.md)** for the full process, what makes a great issue, and the exceptions (doc typo PRs and security patches are accepted directly).

--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ The compose file expects:
 | Host path | Container path | Purpose |
 |---|---|---|
 | `config.yaml` | `/etc/agents/config.yaml` (read-only) | Main daemon config (used for `--import`; optional once DB is seeded) |
-| `./agents` | `/etc/agents/agents` (read-only) | Optional: prompt/skill files when agent `prompt_file:` paths point here |
+| `./agents` | `/etc/agents/agents` (read-only) | Optional: source tree for agent and skill `prompt_file:` paths that reference this directory |
 | `~/.claude` | `/home/agents/.claude` | Claude Code session data |
 | `~/.claude.json` | `/home/agents/.claude.json` | Claude Code main config |
 | `~/.codex` | `/home/agents/.codex` | Codex configuration |

--- a/README.md
+++ b/README.md
@@ -96,12 +96,14 @@ Then follow the official setup guides:
 # Copy and edit the example config
 cp config.example.yaml config.yaml
 
-# Run directly
-go run ./cmd/agents -config config.yaml
-
-# Or build first
+# Build
 go build -o agents ./cmd/agents
-./agents -config config.yaml
+
+# Import config into SQLite and start
+./agents --db agents.db --import config.yaml
+
+# Subsequent starts (no --import needed)
+./agents --db agents.db
 ```
 
 ### On-demand agent pass
@@ -109,7 +111,7 @@ go build -o agents ./cmd/agents
 Run one autonomous agent synchronously and exit (useful for testing):
 
 ```bash
-./agents -config config.yaml --run-agent coder --repo owner/repo
+./agents --db agents.db --run-agent coder --repo owner/repo
 ```
 
 Or via HTTP on the running daemon:

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The daemon is event-driven for label-based workflows and runs a cron scheduler f
 
 | Dependency | Purpose |
 |---|---|
-| **Go 1.22+** | Build the daemon |
+| **Go 1.25+** | Build the daemon |
 | **GitHub CLI** (`gh`) | Authenticated access used by the AI CLIs' GitHub MCP tools |
 | **AI CLI** (Claude Code and/or Codex) | The actual AI backend, with GitHub MCP server configured |
 
@@ -155,7 +155,7 @@ internal/
   ai/                       # Prompt composition + command-based CLI runner (per-backend env)
   anthropic_proxy/          # Built-in Anthropic-to-OpenAI translation proxy (opt-in)
   observe/                  # Observability store (events, traces, dispatch graph, SSE hubs)
-  autonomous/               # Cron scheduler + agent memory (filesystem or SQLite)
+  autonomous/               # Cron scheduler + agent memory (SQLite-backed)
   store/                    # SQLite-backed config store (--db mode): schema migrations, CRUD helpers
   workflow/                 # Event routing engine, single event queue, processor, inter-agent dispatcher
   webhook/                  # HTTP server, signature verification, delivery dedupe, CRUD API handlers

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,8 +10,8 @@ services:
       - ./config.yaml:/etc/agents/config.yaml:ro
       # Optional: required only when config uses prompt_file paths under agents_dir.
       - ./agents:/etc/agents/agents:ro
-      # Recommended: persists autonomous MEMORY.md files across restarts.
-      - agents-memory:/var/lib/agents/memory
+      # Persists the SQLite database (config + agent memory) across restarts.
+      - agents-data:/var/lib/agents
       - ~/.claude:/home/agents/.claude
       - ~/.claude.json:/home/agents/.claude.json
       - ~/.codex:/home/agents/.codex
@@ -21,4 +21,4 @@ services:
     restart: unless-stopped
 
 volumes:
-  agents-memory:
+  agents-data:

--- a/docs/api.md
+++ b/docs/api.md
@@ -25,7 +25,7 @@ The `/run` body is `{"agent": "<name>", "repo": "owner/repo"}`. It returns `202 
 | `GET` | `/traces/{span_id}/steps` | Tool-loop transcript for a completed agent span |
 | `GET` | `/graph` | Agent interaction graph (dispatch edges) |
 | `GET` | `/dispatches` | Dispatch dedup store contents + counters |
-| `GET` | `/memory/{agent}/{repo}` | Raw agent memory markdown |
+| `GET` | `/memory/{agent}/{repo}` | Raw agent memory markdown. `{repo}` uses `owner_repo` format (underscore-separated) |
 | `GET` | `/memory/stream` | Memory file change notifications (SSE) |
 | `GET` | `/config` | Effective parsed config (secrets redacted) |
 
@@ -44,9 +44,9 @@ These are only mounted when `daemon.proxy.enabled: true` is set in the config.
 | `POST` | `/v1/messages` | Anthropic-to-OpenAI translation proxy |
 | `GET` | `/v1/models` | Companion stub; lists the configured upstream model |
 
-## CRUD endpoints (SQLite mode)
+## CRUD endpoints
 
-These routes are always mounted but require `--db` to function -- without it they return errors.
+These routes are always mounted and backed by the SQLite database.
 
 | Method | Path | Description |
 |---|---|---|

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,90 @@
+# HTTP API reference
+
+All endpoints are unauthenticated at the daemon level -- access control is the reverse proxy's responsibility.
+
+## Core endpoints
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/status` | Health check: JSON with uptime, event queue depth, agent schedules, dispatch counters |
+| `POST` | `/webhooks/github` | GitHub webhook receiver (`X-Hub-Signature-256` HMAC verified) |
+| `POST` | `/run` | On-demand agent trigger |
+
+The `/run` body is `{"agent": "<name>", "repo": "owner/repo"}`. It returns `202 Accepted` immediately with an `event_id`; the agent runs asynchronously.
+
+## Observability endpoints
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/agents` | Fleet snapshot: per-agent status, bindings, dispatch wiring |
+| `GET` | `/events` | Recent webhook events (time-windowed) |
+| `GET` | `/events/stream` | Live event firehose (SSE) |
+| `GET` | `/traces` | Recent agent run traces with timing |
+| `GET` | `/traces/stream` | Live trace updates (SSE) |
+| `GET` | `/traces/{root_event_id}` | All spans for a single root event |
+| `GET` | `/traces/{span_id}/steps` | Tool-loop transcript for a completed agent span |
+| `GET` | `/graph` | Agent interaction graph (dispatch edges) |
+| `GET` | `/dispatches` | Dispatch dedup store contents + counters |
+| `GET` | `/memory/{agent}/{repo}` | Raw agent memory markdown |
+| `GET` | `/memory/stream` | Memory file change notifications (SSE) |
+| `GET` | `/config` | Effective parsed config (secrets redacted) |
+
+## Web dashboard
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/ui/` | Built-in web dashboard (static assets; embedded in binary) |
+
+## Proxy endpoints (opt-in)
+
+These are only mounted when `daemon.proxy.enabled: true` is set in the config.
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/v1/messages` | Anthropic-to-OpenAI translation proxy |
+| `GET` | `/v1/models` | Companion stub; lists the configured upstream model |
+
+## CRUD endpoints (SQLite mode)
+
+These routes are always mounted but require `--db` to function -- without it they return errors.
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/{resource}` | List all entries for a resource type (`skills`, `backends`, `repos`). Note: `GET /agents` is the fleet snapshot above, not the CRUD list. |
+| `GET` | `/{resource}/{name}` | Fetch one entry. Repos use two path segments: `/repos/{owner}/{repo}`. |
+| `POST` | `/{resource}` | Create or replace an entry. Resources: `agents`, `skills`, `backends`, `repos`. |
+| `DELETE` | `/{resource}/{name}` | Remove an entry. |
+| `GET` | `/export` | Export full fleet config as YAML. |
+| `POST` | `/import` | Import a YAML config into the SQLite store. |
+
+Duplicate webhook deliveries are suppressed via `X-GitHub-Delivery` with a TTL cache.
+
+## AI runner contract
+
+The daemon spawns the configured CLI, sends the composed prompt on **stdin**, and expects a **single JSON object on stdout**:
+
+```json
+{
+  "summary": "Reviewed PR for security vulnerabilities",
+  "artifacts": [
+    {
+      "type": "pr_review",
+      "part_key": "review/claude/security",
+      "github_id": "123456",
+      "url": "https://github.com/owner/repo/pull/1#pullrequestreview-123456"
+    }
+  ],
+  "dispatch": [
+    {
+      "agent": "sec-reviewer",
+      "number": 42,
+      "reason": "Custom crypto primitives found -- needs deeper security review"
+    }
+  ],
+  "memory": "## 2026-04-21\n- Reviewed PR #42 -- escalated crypto concerns to sec-reviewer."
+}
+```
+
+The metadata is used for observability, logging, and run summaries. Agents that don't post anything still return an empty `artifacts: []`. The `dispatch` field is optional -- omit it or leave it empty when the agent does not need to invoke another agent. See [dispatch.md](dispatch.md) for the full contract.
+
+The `memory` field is how autonomous agents persist state across scheduled runs. The daemon reads the stored memory before each autonomous run and writes the `memory` value from the response back to the store (filesystem or SQLite depending on how the daemon was started). An empty string clears the memory. Event-driven runs (webhooks, label triggers) do not receive or persist memory.

--- a/docs/api.md
+++ b/docs/api.md
@@ -87,4 +87,4 @@ The daemon spawns the configured CLI, sends the composed prompt on **stdin**, an
 
 The metadata is used for observability, logging, and run summaries. Agents that don't post anything still return an empty `artifacts: []`. The `dispatch` field is optional -- omit it or leave it empty when the agent does not need to invoke another agent. See [dispatch.md](dispatch.md) for the full contract.
 
-The `memory` field is how autonomous agents persist state across scheduled runs. The daemon reads the stored memory before each autonomous run and writes the `memory` value from the response back to the store (filesystem or SQLite depending on how the daemon was started). An empty string clears the memory. Event-driven runs (webhooks, label triggers) do not receive or persist memory.
+The `memory` field is how autonomous agents persist state across scheduled runs. The daemon reads the stored memory before each autonomous run and writes the `memory` value from the response back to the SQLite store. An empty string clears the memory. Event-driven runs (webhooks, label triggers) do not receive or persist memory.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,193 @@
+# Configuration
+
+Copy `config.example.yaml` to `config.yaml` and adapt it. The config file is split into four conceptual domains:
+
+```yaml
+daemon:    # how the service runs: log, http, processor, backends, optional proxy
+skills:    # reusable guidance blocks, keyed by name
+agents:    # named capabilities: backend + skills + prompt + dispatch wiring
+repos:     # wiring: which agents run on which repo, and when
+```
+
+The shortest useful config is ~30 lines.
+
+---
+
+## `daemon` -- how the service runs
+
+```yaml
+daemon:
+  log:
+    level: info            # trace, debug, info, warn, error, fatal
+    format: text           # text (human) or json (structured)
+
+  http:
+    listen_addr: ":8080"
+    status_path: /status
+    webhook_path: /webhooks/github
+    webhook_secret_env: GITHUB_WEBHOOK_SECRET
+    shutdown_timeout_seconds: 15
+
+  processor:
+    event_queue_buffer: 256
+    max_concurrent_agents: 4                # cap on per-event fan-out
+
+  dispatch:
+    max_depth: 3                            # max chain length before drop + WARN
+    max_fanout: 4                           # max dispatches per single agent run
+    dedup_window_seconds: 300               # suppress duplicate (target, repo, number) within window
+
+  memory_dir: /var/lib/agents/memory        # persistent autonomous agent memory
+
+  ai_backends:
+    claude:
+      command: claude
+      args: ["-p", "--dangerously-skip-permissions"]
+      timeout_seconds: 1500
+      max_prompt_chars: 12000
+      redaction_salt_env: LOG_SALT
+
+    codex:
+      command: codex
+      args: ["exec", "--skip-git-repo-check", "--dangerously-bypass-approvals-and-sandbox"]
+      timeout_seconds: 600
+      max_prompt_chars: 12000
+      redaction_salt_env: LOG_SALT
+```
+
+## `skills` -- reusable guidance blocks
+
+```yaml
+skills:
+  architect:
+    prompt: |
+      Focus on architecture boundaries, coupling, extensibility, and maintainability risks.
+
+  security:
+    prompt: |
+      Focus on authn/authz, secrets exposure, injection vectors, and unsafe defaults.
+```
+
+Skills are referenced by name from agents. You can also use `prompt_file: path/to/file.md` instead of inline `prompt`.
+
+## `agents` -- named capabilities
+
+```yaml
+agents:
+  # Short inline prompt -- reviewer that never opens PRs (default)
+  - name: arch-reviewer
+    backend: auto              # auto | claude | codex
+    skills: [architect]
+    prompt: |
+      You are an architecture-focused PR reviewer. Post one high-signal review comment.
+
+  # Prompt loaded from a file (recommended for longer prompts)
+  # allow_prs: true lets this agent open pull requests
+  - name: coder
+    backend: claude
+    skills: [architect, testing]
+    prompt_file: prompts/coder.md
+    allow_prs: true            # required for agents that open PRs
+
+  # Dispatch target -- can be invoked by pr-reviewer
+  - name: sec-reviewer
+    description: "Deep-dive security reviewer for risky changes"
+    backend: claude
+    allow_dispatch: true       # opt-in to being dispatched
+    prompt_file: prompts/sec-reviewer.md
+
+  # Agent that may dispatch to sec-reviewer
+  - name: pr-reviewer
+    backend: claude
+    can_dispatch: [sec-reviewer]   # whitelist of agents this agent may dispatch
+    prompt_file: prompts/pr-reviewer.md
+```
+
+Each agent is a pure capability definition: backend + skills + prompt. Agents don't run until a repo binds them to a trigger.
+
+- `backend: auto` picks the first configured backend in `daemon.ai_backends` (claude before codex).
+- `prompt_file` paths are resolved relative to the config file's directory.
+- Agent names must be unique.
+- `allow_prs` (default `false`) -- when `false`, the scheduler prepends a hard instruction forbidding the agent from opening pull requests, regardless of what the prompt says. Set `allow_prs: true` only on agents that are explicitly meant to author PRs (e.g. coders, refactorers). Reviewer-only agents should leave this unset.
+- `allow_dispatch` (default `false`) -- opt-in gate. An agent must have `allow_dispatch: true` for any other agent to dispatch it. Agents without this flag silently drop any incoming dispatch requests.
+- `can_dispatch` -- whitelist of agent names this agent is allowed to dispatch. A dispatch to an agent not on this list is silently dropped. Entries must reference real agents in the same config and must not include the agent itself.
+- `description` -- required when an agent appears in any `can_dispatch` list. Used by the dispatcher to include context about the target in the originating agent's prompt roster.
+
+## `repos` -- wiring
+
+```yaml
+repos:
+  - name: "owner/repo"
+    enabled: true
+    use:
+      - agent: arch-reviewer
+        labels: ["ai:review:arch-reviewer"]
+
+      - agent: coder
+        cron: "0,30 8-18 * * *"             # standard 5-field cron
+
+      - agent: nightly-scout
+        cron: "0 7 * * *"
+        enabled: false                       # temporarily off without deletion
+```
+
+Each `use` entry binds one agent to one trigger. An agent can appear multiple times with different triggers. A binding must set exactly one of `labels:`, `events:`, or `cron:` -- mixing trigger types in a single binding is rejected at startup.
+
+### Label architecture
+
+Labels are plain strings matched against each binding's `labels` list. There is **no magic format** -- you choose the labels. Convention across the example config is `ai:review:<agent-name>`, but any string works.
+
+```yaml
+repos:
+  - name: "eloylp/myrepo"
+    enabled: true
+    use:
+      # Label-triggered reviewer
+      - agent: arch-reviewer
+        labels: ["ai:review:arch-reviewer"]
+
+      # Multiple agents firing on the same label (fan-out)
+      - agent: arch-reviewer
+        labels: ["ai:review:all"]
+      - agent: sec-reviewer
+        labels: ["ai:review:all"]
+
+      # Cron-scheduled agent on the same repo
+      - agent: coder
+        cron: "0,30 8-18 * * *"
+
+      # Event-triggered agent (react to any new comment)
+      - agent: coder
+        events: ["issue_comment.created"]
+```
+
+Rules:
+
+- Labels are case-insensitive and trimmed. Only `labeled` actions fire (not `unlabeled`).
+- The trigger label comes from the webhook event payload, not the issue/PR's current label set.
+- Draft PRs skip `pull_request.labeled` for both `labels:` and `events:` bindings; they may still receive other event kinds such as `pull_request.opened` and `pull_request.synchronize`.
+- `events:` bindings fire on the exact event kinds listed, with no additional filtering.
+- Multiple bindings matching the same event fan out in parallel (capped by `daemon.processor.max_concurrent_agents`).
+
+## Environment variables
+
+Create a `.env` file in the project root (loaded automatically):
+
+```bash
+GITHUB_WEBHOOK_SECRET=your-webhook-secret
+LOG_SALT=optional-prompt-hash-salt
+```
+
+## SQLite mode (`--db`)
+
+An optional SQLite-backed config store lets you manage the fleet over the API instead of editing YAML files. Import once, then drop the `--config` flag entirely:
+
+```bash
+# Import from existing YAML (one-time)
+./agents --db agents.db --import config.yaml
+
+# All subsequent starts -- no config.yaml needed
+./agents --db agents.db
+```
+
+The CRUD endpoints for `/skills`, `/backends`, and `/repos` are always mounted but require `--db` to function -- without it they return errors. For `/agents`, `POST /agents` and `GET|DELETE /agents/{name}` are CRUD write endpoints, but `GET /agents` always returns the live fleet snapshot (not the stored agent list). The daemon auto-reloads cron schedules after any repo or agent write. Agent memory is also stored in SQLite instead of the filesystem. The YAML path remains fully supported -- both modes are first-class.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,13 +31,10 @@ daemon:
   processor:
     event_queue_buffer: 256
     max_concurrent_agents: 4                # cap on per-event fan-out
-
-  dispatch:
-    max_depth: 3                            # max chain length before drop + WARN
-    max_fanout: 4                           # max dispatches per single agent run
-    dedup_window_seconds: 300               # suppress duplicate (target, repo, number) within window
-
-  memory_dir: /var/lib/agents/memory        # persistent autonomous agent memory
+    dispatch:
+      max_depth: 3                          # max chain length before drop + WARN
+      max_fanout: 4                         # max dispatches per single agent run
+      dedup_window_seconds: 300             # suppress duplicate (target, repo, number) within window
 
   ai_backends:
     claude:
@@ -190,4 +187,4 @@ An optional SQLite-backed config store lets you manage the fleet over the API in
 ./agents --db agents.db
 ```
 
-The CRUD endpoints for `/skills`, `/backends`, and `/repos` are always mounted but require `--db` to function -- without it they return errors. For `/agents`, `POST /agents` and `GET|DELETE /agents/{name}` are CRUD write endpoints, but `GET /agents` always returns the live fleet snapshot (not the stored agent list). The daemon auto-reloads cron schedules after any repo or agent write. Agent memory is also stored in SQLite instead of the filesystem. The YAML path remains fully supported -- both modes are first-class.
+The CRUD endpoints for `/skills`, `/backends`, and `/repos` are always mounted but require `--db` to function -- without it they return errors. For `/agents`, `POST /agents` and `GET|DELETE /agents/{name}` are CRUD write endpoints, but `GET /agents` always returns the live fleet snapshot (not the stored agent list). The daemon auto-reloads cron schedules after any repo or agent write. Agent memory is stored in the same SQLite database. The YAML path remains fully supported -- both modes are first-class.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -177,7 +177,7 @@ LOG_SALT=optional-prompt-hash-salt
 
 ## SQLite mode (`--db`)
 
-An optional SQLite-backed config store lets you manage the fleet over the API instead of editing YAML files. Import once, then drop the `--config` flag entirely:
+SQLite is the config store. Import your YAML once, then manage the fleet over the CRUD API:
 
 ```bash
 # Import from existing YAML (one-time)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -187,4 +187,4 @@ SQLite is the config store. Import your YAML once, then manage the fleet over th
 ./agents --db agents.db
 ```
 
-The CRUD endpoints for `/skills`, `/backends`, and `/repos` are always mounted but require `--db` to function -- without it they return errors. For `/agents`, `POST /agents` and `GET|DELETE /agents/{name}` are CRUD write endpoints, but `GET /agents` always returns the live fleet snapshot (not the stored agent list). The daemon auto-reloads cron schedules after any repo or agent write. Agent memory is stored in the same SQLite database. The YAML path remains fully supported -- both modes are first-class.
+The CRUD endpoints for `/skills`, `/backends`, and `/repos` are always mounted and backed by the SQLite database. For `/agents`, `POST /agents` and `GET|DELETE /agents/{name}` are CRUD write endpoints, but `GET /agents` always returns the live fleet snapshot (not the stored agent list). The daemon auto-reloads cron schedules after any repo or agent write. Agent memory is stored in the same SQLite database. YAML is an import source (`--import`), not a second runtime mode -- the daemon always boots from SQLite.

--- a/docs/dispatch.md
+++ b/docs/dispatch.md
@@ -1,0 +1,79 @@
+# Reactive inter-agent dispatch
+
+Agents can invoke each other at runtime. When an agent's AI run returns a `dispatch[]` field in its JSON response, the daemon validates and enqueues a synthetic `agent.dispatch` event for each entry. The target agent then runs with the full event payload as its runtime context.
+
+## Agent response contract
+
+```json
+{
+  "summary": "Reviewed PR -- escalating to sec-reviewer for crypto usage",
+  "artifacts": [],
+  "dispatch": [
+    {
+      "agent": "sec-reviewer",
+      "number": 42,
+      "reason": "PR introduces custom crypto primitives -- needs security review"
+    }
+  ]
+}
+```
+
+- `agent` -- name of the target agent (must be in the originator's `can_dispatch` list and have `allow_dispatch: true`).
+- `number` -- issue/PR number to associate with the dispatched run. If omitted, the originating event's number is used.
+- `reason` -- human-readable rationale, included in the target agent's prompt context.
+
+## Runtime context for dispatched agents
+
+The dispatched agent receives an `agent.dispatch` event with these payload fields:
+
+| Field | Value |
+|-------|-------|
+| `target_agent` | Name of the agent being invoked (this agent) |
+| `reason` | Reason string supplied by the originator |
+| `root_event_id` | ID of the original triggering event (stable across the full chain) |
+| `dispatch_depth` | How many hops deep in the chain this invocation is |
+| `invoked_by` | Name of the agent that dispatched this run |
+
+## Safety limits (`daemon.dispatch`)
+
+| Field | Default | Meaning |
+|-------|---------|---------|
+| `max_depth` | 3 | Maximum dispatch chain length. Requests that would exceed this are dropped with a warning. |
+| `max_fanout` | 4 | Maximum number of dispatches a single agent run may enqueue. Additional requests are dropped. |
+| `dedup_window_seconds` | 300 | Suppress duplicate `(target, repo, number)` dispatch requests within this window (seconds). |
+
+All three fields must be positive integers; the daemon rejects non-positive values at startup.
+
+## Dispatch flow
+
+```
+Agent A runs -> returns dispatch[{agent:"B", number:42, reason:"..."}]
+    |
+    v
+Dispatcher checks:
+  1. B is in A's can_dispatch list
+  2. B has allow_dispatch: true
+  3. depth <= max_depth, fanout <= max_fanout
+  4. (B, repo, 42) not seen within dedup_window_seconds
+    |
+    v
+agent.dispatch event enqueued -> Agent B runs with full payload
+```
+
+Dispatch chains work across both event-driven and cron/`--run-agent` paths, and the shared dedup store prevents a cron-triggered run and a near-simultaneous dispatch from running the same target twice within the window.
+
+## Config wiring
+
+```yaml
+agents:
+  - name: pr-reviewer
+    backend: claude
+    can_dispatch: [sec-reviewer]       # whitelist of targets
+    prompt_file: prompts/pr-reviewer.md
+
+  - name: sec-reviewer
+    description: "Deep-dive security reviewer"
+    backend: claude
+    allow_dispatch: true               # opt-in to being dispatched
+    prompt_file: prompts/sec-reviewer.md
+```

--- a/docs/dispatch.md
+++ b/docs/dispatch.md
@@ -34,7 +34,7 @@ The dispatched agent receives an `agent.dispatch` event with these payload field
 | `dispatch_depth` | How many hops deep in the chain this invocation is |
 | `invoked_by` | Name of the agent that dispatched this run |
 
-## Safety limits (`daemon.dispatch`)
+## Safety limits (`daemon.processor.dispatch`)
 
 | Field | Default | Meaning |
 |-------|---------|---------|

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -35,4 +35,4 @@ docker exec agents claude mcp list
 
 ## Image details
 
-Multi-stage build on `node:22-alpine`. The image includes Claude Code, Codex, and `gh` CLIs alongside the daemon. Runs as non-root `agents` user. Default CMD is `--db /var/lib/agents/agents.db` (SQLite mode; no `--config` flag needed after the initial `--import`).
+Multi-stage build on `node:22-alpine`. The image includes Claude Code, Codex, and `gh` CLIs alongside the daemon. Runs as non-root `agents` user. Default CMD is `--db /var/lib/agents/agents.db`.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -3,8 +3,11 @@
 ## Quick start
 
 ```bash
+# First run: import config into the SQLite database
+docker compose run --rm agents --db /var/lib/agents/agents.db --import /etc/agents/config.yaml
+
+# Start the daemon (subsequent runs boot from the persisted DB)
 docker compose up -d
-docker compose up -d --build   # rebuild after code changes
 docker compose logs -f agents
 docker compose down
 ```
@@ -17,20 +20,20 @@ The compose file expects:
 
 | Host path | Container path | Purpose |
 |---|---|---|
-| `config.yaml` | `/etc/agents/config.yaml` (read-only) | Main daemon config (used for `--import`; optional once DB is seeded) |
+| `config.yaml` | `/etc/agents/config.yaml` (read-only) | Daemon config (used for `--import` seeding; optional once DB is seeded) |
 | `./agents` | `/etc/agents/agents` (read-only) | Optional: source tree for agent and skill `prompt_file:` paths that reference this directory |
 | `~/.claude` | `/home/agents/.claude` | Claude Code session data |
 | `~/.claude.json` | `/home/agents/.claude.json` | Claude Code main config |
 | `~/.codex` | `/home/agents/.codex` | Codex configuration |
 | `~/.config/gh` | `/home/agents/.config/gh` (read-only) | GitHub CLI auth tokens |
-| `agents-memory` (volume) | `/var/lib/agents/memory` | Autonomous agent memory across restarts |
+| `agents-data` (volume) | `/var/lib/agents` | SQLite database (config + agent memory) across restarts |
 
 ## MCP server configuration
 
 Claude Code stores MCP config per-project, keyed by working directory in `~/.claude.json`. Since the container's working directory is `/`, ensure `~/.claude.json` has a project entry for `/` with the GitHub MCP server configured. Verify with:
 
 ```bash
-docker exec agents claude mcp list
+docker compose exec agents claude mcp list
 ```
 
 ## Image details

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,38 @@
+# Docker deployment
+
+## Quick start
+
+```bash
+docker compose up -d
+docker compose up -d --build   # rebuild after code changes
+docker compose logs -f agents
+docker compose down
+```
+
+The compose file expects:
+- `config.yaml` in the project root (mounted read-only at `/etc/agents/config.yaml`)
+- `.env` in the project root with `GITHUB_WEBHOOK_SECRET` (and optionally `LOG_SALT` and `GITHUB_PAT_TOKEN`)
+
+## Volume mounts
+
+| Host path | Container path | Purpose |
+|---|---|---|
+| `config.yaml` | `/etc/agents/config.yaml` (read-only) | Main daemon config (used for `--import`; optional once DB is seeded) |
+| `./agents` | `/etc/agents/agents` (read-only) | Optional: source tree for agent and skill `prompt_file:` paths that reference this directory |
+| `~/.claude` | `/home/agents/.claude` | Claude Code session data |
+| `~/.claude.json` | `/home/agents/.claude.json` | Claude Code main config |
+| `~/.codex` | `/home/agents/.codex` | Codex configuration |
+| `~/.config/gh` | `/home/agents/.config/gh` (read-only) | GitHub CLI auth tokens |
+| `agents-memory` (volume) | `/var/lib/agents/memory` | Autonomous agent memory across restarts |
+
+## MCP server configuration
+
+Claude Code stores MCP config per-project, keyed by working directory in `~/.claude.json`. Since the container's working directory is `/`, ensure `~/.claude.json` has a project entry for `/` with the GitHub MCP server configured. Verify with:
+
+```bash
+docker exec agents claude mcp list
+```
+
+## Image details
+
+Multi-stage build on `node:22-alpine`. The image includes Claude Code, Codex, and `gh` CLIs alongside the daemon. Runs as non-root `agents` user. Default CMD is `--db /var/lib/agents/agents.db` (SQLite mode; no `--config` flag needed after the initial `--import`).

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,51 @@
+# Supported events
+
+The `events:` field in repo bindings accepts any of the following GitHub event kinds. Each event delivers a `## Runtime context` block into the agent's prompt with `Event`, `Actor` (the GitHub login that triggered it), an issue/PR number where applicable, and the payload fields listed below.
+
+## Event reference
+
+| Kind | When | Payload fields |
+|------|------|----------------|
+| `issues.labeled` | Issue receives any label | `label` |
+| `issues.opened` | Issue opened | `title`, `body` |
+| `issues.edited` | Issue body or title edited | `title`, `body` |
+| `issues.reopened` | Issue reopened | `title`, `body` |
+| `issues.closed` | Issue closed | `title`, `body` |
+| `pull_request.labeled` | PR receives any label (draft PRs are skipped) | `label` |
+| `pull_request.opened` | PR opened | `title`, `draft` |
+| `pull_request.synchronize` | New commit pushed to PR branch | `title`, `draft` |
+| `pull_request.ready_for_review` | Draft PR marked ready | `title`, `draft` |
+| `pull_request.closed` | PR closed or merged | `title`, `draft`, `merged` (`true` when PR was merged, `false` when closed without merge) |
+| `issue_comment.created` | Comment posted on an issue or PR | `body` |
+| `pull_request_review.submitted` | Formal GitHub review submitted | `state`, `body` |
+| `pull_request_review_comment.created` | Inline review comment posted on a PR diff | `body` |
+| `push` | Commit pushed to a branch | `ref` (e.g. `refs/heads/main`), `head_sha` |
+| `agents.run` | On-demand trigger via `POST /run` or `--run-agent` CLI | `target_agent` |
+| `agent.dispatch` | Another agent dispatched this agent | `target_agent`, `reason`, `root_event_id`, `dispatch_depth`, `invoked_by` |
+
+## Event rules
+
+- **`push` scope:** only branch pushes fire the event. Tag pushes, branch deletions, and pushes to non-`refs/heads/` refs are silently dropped. The agent receives the branch ref and the resulting head SHA -- there is no PR number in the context.
+- `issues.*` events that originate from a PR-backed GitHub issue are dropped; the corresponding `pull_request.*` event covers them instead.
+- `pull_request.labeled` events on draft PRs are dropped at the webhook boundary. Use `events: ["pull_request.ready_for_review"]` to act when a draft is marked ready.
+- Unknown event kinds are rejected at config load time with a clear error listing the supported set.
+
+## Example binding
+
+```yaml
+repos:
+  - name: "owner/repo"
+    enabled: true
+    use:
+      # React to every new issue comment (issues and PRs alike)
+      - agent: coder
+        events: ["issue_comment.created"]
+
+      # React to new commits pushed to any branch
+      - agent: sec-reviewer
+        events: ["push"]
+
+      # Multiple event kinds in one binding
+      - agent: pr-reviewer
+        events: ["pull_request.opened", "pull_request.synchronize"]
+```

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,7 @@
+# Security
+
+- **Webhook verification** -- HMAC SHA-256 on every payload (`X-Hub-Signature-256`).
+- **Reverse-proxy auth** -- the daemon delegates access control to the reverse proxy (e.g. Traefik basic auth).
+- **Read-only daemon** -- all GitHub writes go through the AI backend's MCP tools.
+- **Prompt redaction** -- prompts are never logged in plaintext; only their hash and length.
+- **`--dangerously-skip-permissions`** -- required for headless Claude operation. Ensure the host is trusted.

--- a/internal/setup/prompt.md
+++ b/internal/setup/prompt.md
@@ -225,7 +225,7 @@ Skip if the label already exists (exit code 1 with "already exists" message is f
 
 Start the daemon in the background for a quick health check:
 ```
-go build -o ./agents-bin ./cmd/agents && ./agents-bin --config config.yaml &
+go build -o ./agents-bin ./cmd/agents && ./agents-bin --db agents.db --import config.yaml &
 sleep 2
 curl -s http://localhost:8080/status
 ```
@@ -243,6 +243,6 @@ Once all phases succeed, print a summary:
 - Which agents were created and what labels trigger them
 - Any scheduled autonomous agents and their cron schedules
 - The public webhook URL
-- How to start the daemon: `agents --config config.yaml` or via Docker
+- How to start the daemon: `agents --db agents.db` or via Docker
 
 Congratulate the user and let them know they can trigger agents by applying labels to issues and PRs.

--- a/internal/setup/prompt.md
+++ b/internal/setup/prompt.md
@@ -136,7 +136,6 @@ processor:
   event_queue_buffer: 256
 
 agents_dir: "./agents"
-memory_dir: "/var/lib/agents/memory"
 
 prompts:
   issue_refinement:


### PR DESCRIPTION
## Summary

Documentation drift fixed across README, CLAUDE.md, AGENTS.md, and docs/*.md — all verified against `server.go`, `config.go`, `docker-compose.yaml`, and `go.mod` on `main`:

- **HTTP endpoint paths**: Routes are registered without an `/api/` prefix (confirmed in `webhook/server.go` `buildHandler`). Remove the `/api/` prefix from README, CLAUDE.md, and AGENTS.md. The on-demand trigger endpoint is `POST /run` (not `/agents/run` or `/api/run`). Remove the non-existent `agents_run_path` config field from the `daemon.http` snippet — `HTTPConfig` has no such field.

- **New endpoints missing from docs**: Add `GET /traces/{root_event_id}` and `GET /traces/{span_id}/steps` (introduced in PR #237) to the README endpoint table and CLAUDE.md Architecture Notes. Also add `GET /export` and `POST /import` (SQLite YAML export/import, also missing).

- **Docker Compose volume mounts**: README described `prompts/` and `skills/` host mounts that don't exist in `docker-compose.yaml`. The actual compose mounts `./agents → /etc/agents/agents` (optional). Update the volume table and preceding prose to match. Note the `GITHUB_PAT_TOKEN` env var (present in compose, undocumented). Note the Dockerfile default CMD uses `--db` mode.

- **Go version**: README said "Go 1.22+", AGENTS.md said "Go 1.24". Actual `go.mod` declares `go 1.25.0`. Updated to "Go 1.25+" / "Go 1.25" respectively.

- **Stale `memory_dir` references**: `DaemonConfig` has no `MemoryDir` field — the filesystem memory backend was removed when memory moved to SQLite-only. Removed `memory_dir` from `docs/configuration.md` daemon snippet, CLAUDE.md config model, and AGENTS.md operational notes. Updated "filesystem or SQLite" → "SQLite-backed" across all directory tree descriptions.

- **Dispatch config nesting**: `docs/configuration.md` showed `dispatch:` as a sibling of `processor:` under `daemon:`. The actual path is `daemon.processor.dispatch` (confirmed in `config.go` `ProcessorConfig.Dispatch` and `config.example.yaml`). Also fixed `docs/dispatch.md` heading.

- **Docker operational note**: AGENTS.md referenced `expose: 8080` (Traefik-only networking). Actual `docker-compose.yaml` uses `ports: "8080:8080"`. Updated to describe the actual behavior and recommend production access control.

## Test plan

- [x] Read README HTTP endpoints table and verify each path exists in `internal/webhook/server.go` `buildHandler`
- [x] Read `daemon.http` config snippet and verify every field exists in `internal/config/config.go` `HTTPConfig`
- [x] Verify `dispatch` nesting matches `ProcessorConfig.Dispatch` in config.go
- [x] Grep for `memory_dir` in *.md — only `internal/setup/prompt.md` remains (code, not docs)
- [x] Verify Go version matches `go.mod`
- [ ] Run `docker compose up -d` and confirm the volume mounts match what's documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)