### PR TITLE
feat: runtime backend discovery and per-agent model selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
 .env
 config.yaml
 main
+agents
+*.db
+*.db-shm
+*.db-wal
+*.db-journal
+*.test.yaml
 agents/**/MEMORY.md
 internal/ui/node_modules/
 internal/ui/.next/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ docker compose up -d                            # containerised run
 cmd/agents/main.go              # wires config, logger, runners, scheduler, webhook server, proxy
 internal/
   config/                       # YAML parsing, defaults, validation, prompt/skill file resolution
-  ai/                           # prompt composition + CLI runner (supports per-backend env overrides)
+  ai/                           # prompt composition + CLI runner (hardcoded backend args + schema enforcement)
   anthropic_proxy/              # built-in Anthropic Messages ↔ OpenAI Chat Completions translation
   observe/                      # observability store: events, traces, dispatch graph, SSE hubs
   autonomous/                   # cron scheduler + agent memory (SQLite-backed)
@@ -51,7 +51,7 @@ internal/ai/response-schema.json # embedded JSON schema for structured output (c
 - **Agent** — a named capability: `backend` + `skills: []` + `prompt`. An agent is a pure definition. It does not run by itself. Prompts are stored in SQLite (seeded via `--import` from YAML, or created directly in the UI).
 - **Skill** — a reusable chunk of guidance referenced by name in multiple agents. Skill text is concatenated before the agent's own prompt at render time.
 - **Binding** — `repos[*].use[*]`: pairs one agent with exactly one trigger (`labels:`, `events:`, or `cron:`). The same agent can have multiple bindings on the same repo with different triggers.
-- **Backend** — one of `claude`, `codex`, or `auto` (picks the first configured in preference order). Two separate backend entries can point at the **same CLI binary** with different `env:` — this is the mechanism for routing the `claude` CLI through the built-in proxy to a local LLM.
+- **Backend** — explicit backend selection per agent (no `auto`). Built-ins are `claude` and `codex`; additional named local backends are supported via `local_model_url`.
 - **Proxy** — optional in-daemon Anthropic↔OpenAI translator mounted at `/v1/messages` and `/v1/models`. Disabled by default. When enabled, the `claude` CLI can be pointed at it via `ANTHROPIC_BASE_URL` in the backend's `env:` map.
 - **Dispatcher** — the runtime mechanism by which agents invoke each other. See "Reactive dispatch" below.
 
@@ -71,14 +71,15 @@ These constraints are load-bearing. Read them before changing the listed areas.
 - **The daemon never writes to GitHub directly.** All writes go through the AI backend's MCP tools. If you introduce a new feature that seems to need a direct GitHub API call, raise it in an issue first — there's almost always a way to keep the daemon read-only.
 - **Agents must not mention external GitHub users.** Do NOT request reviews from, assign to, or @mention any GitHub user in PRs, comments, or issue descriptions. All review routing is handled by the daemon's dispatch system. Unsolicited pings to external contributors from an automated agent are a trust and reputation risk — the GitHub account could be flagged. This rule applies to every agent prompt.
 - **Prompts are never logged in plaintext.** Only their salted hash and length are recorded. If you add new log lines near prompt handling, preserve this property.
-- **Structured output is enforced at the CLI level.** Claude uses `--output-format json --json-schema <schema>` which wraps stdout in a CLI envelope; `extractStructuredOutput` in cmdrunner.go unwraps the `structured_output` field. Codex uses `--output-schema <file>` — the daemon embeds `internal/ai/response-schema.json` in the binary and appends the flag automatically when the command is `codex`. Both paths feed the same `Response` struct. When changing the response contract, update `internal/ai/response-schema.json` alongside `internal/ai/types.go`.
+- **Structured output is enforced at the CLI level.** Claude uses hardcoded `--output-format stream-json --json-schema <embedded-schema>` args; codex uses hardcoded `--output-schema <temp-file>`. The daemon embeds `internal/ai/response-schema.json` and appends the correct flags automatically. When changing the response contract, update `internal/ai/response-schema.json` alongside `internal/ai/types.go`.
 - **The runner contract is stdin-in, single-JSON-object-out.**
   - `internal/ai/cmdrunner.go` sends the composed prompt on stdin and parses the last top-level JSON object from stdout.
   - Agents emit `{"summary": "...", "artifacts": [...], "dispatch": [...], "memory": "..."}`. `dispatch` and `memory` are optional fields but all four keys are present in the schema. A missing JSON object, an empty response, or a response where `summary`, `artifacts`, and `dispatch` are all empty fails the run with a clear error.
   - `memory` is the agent's full updated memory state. The daemon writes it back to the SQLite store after each autonomous run. An empty string clears the memory. Event-driven runs do not receive or persist memory.
   - Small prose outputs with no JSON are an agent-prompt issue, not a runner bug — don't relax the parser to cover them; fix the prompt.
 - **Subprocess env is filtered.** `internal/ai/cmdrunner.go::allowCommandEnvKey` is an explicit allowlist. When adding a new env-var-driven integration, add the variable to the allowlist **and** document why (see `ANTHROPIC_BASE_URL` / `OPENAI_*` for precedent).
-- **Backend config supports per-backend `env` overrides.** When introducing a feature that requires environment variables for a specific backend, use the `AIBackendConfig.Env` map instead of the global container env — it keeps the container config clean and lets users define multiple backends pointing at different endpoints with the same CLI.
+- **Backend args are daemon-managed.** User/runtime edits are limited to `timeout_seconds`, `max_prompt_chars`, and (for local backends) `local_model_url`. Do not reintroduce user-configurable runner args.
+- **Model pinning safety.** Config may contain pinned models that become unavailable after discovery. These agents are treated as orphaned in diagnostics/UI and fail fast at runtime until remapped or cleared.
 - **Dispatch validation is belt-and-braces.** `can_dispatch` is validated at config load time (targets must exist, no self-reference, targets require `description`). Runtime validation in `internal/workflow/dispatch.go` enforces the same invariants again so config-only checks can't be bypassed by agent-generated dispatch requests.
 - **Webhook HMAC verification runs before any parsing.** Don't read the body before verifying the signature.
 
@@ -112,6 +113,8 @@ When making common classes of changes, update all of these at once:
 
 - **`.env` is auto-loaded on startup** (`godotenv.Load()`). Required runtime secret: `GITHUB_WEBHOOK_SECRET`. Optional: `LOG_SALT`.
 - **Config is loaded from SQLite at startup.** Use `--import config.yaml` to seed the database, then manage changes via the CRUD API or the web dashboard. Prompt and skill content is stored in the database; changes via the API or UI take effect on the next agent run without a restart.
+- **Backend discovery lifecycle.** Startup auto-discovery runs only when the backends table is empty. Manual refresh is explicit via `POST /backends/discover`; `GET /backends/status` is diagnostics-only.
+- **Orphan visibility.** `GET /agents/orphans/status` and `/status` (`orphaned_agents.count`) expose model/backend drift requiring user remediation.
 - **Autonomous agent memory** is stored in SQLite (in the `memory` table), keyed by `(agent, repo)`. It's the agent's job to return updated memory in its response; the daemon writes it back to the store unchanged.
 - **Dispatch dedup is process-local and in-memory.** It's shared across cron-fired runs, event-fired runs, and `--run-agent` invocations within one process. Restarting the daemon clears the dedup state.
 - **`--run-agent` drains dispatch chains synchronously.** When invoking an agent on demand via the CLI flag, the process waits for the originating agent and all dispatched children to finish before exiting. The in-memory event queue is sized to hold `MaxFanout^MaxDepth` events so deep chains don't silently drop.
@@ -138,7 +141,7 @@ Pattern: two backend entries using the same `claude` binary, different `env:` ma
 
 When contributing in this area:
 - Proxy changes live in `internal/anthropic_proxy/`. Keep translation rules pure (no I/O in the `translate*` functions) and test them directly.
-- Per-backend env overrides live on `AIBackendConfig.Env` and are merged after the host-env allowlist in `buildCommandEnv`.
+- Local-model routing uses `local_model_url` and is translated into `ANTHROPIC_BASE_URL` at runner construction time (`cmd/agents/main.go::backendEnvOverrides`).
 - Don't assume local models behave like Claude. They are more cautious with write tools and more prone to hallucinating facts inside templated outputs. Design agent prompts and guardrails for the least capable backend you want to support.
 
 ## Contribution model

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,12 +71,13 @@ Multi-stage build on `node:22-alpine` so the image includes Claude Code, Codex, 
 
 - Event-driven for label-based workflows; cron scheduler for autonomous agents. Both paths resolve to the same agent definitions.
 - HTTP endpoints:
-  - `GET /status` — JSON with uptime, event queue depth, agent schedules, dispatch counters.
+  - `GET /status` — JSON with uptime, event queue depth, agent schedules, dispatch counters, and orphaned-agent summary.
   - `POST /webhooks/github` — HMAC-verified webhook receiver.
   - `POST /run` — on-demand agent trigger (body: `{"agent":"<name>","repo":"owner/repo"}`).
   - `POST /v1/messages` — Anthropic↔OpenAI translation proxy (disabled by default; enabled via `daemon.proxy.enabled: true`).
   - `GET /v1/models` — companion stub for `/v1/messages`; returns the configured upstream model. Only mounted when the proxy is enabled.
   - `GET /agents` — fleet snapshot with per-agent status, skills, dispatch wiring, bindings.
+  - `GET /agents/orphans/status` — DB-only orphan report (agents pinning models unavailable in backend model catalogs).
   - `GET /events[/stream]` — recent events + SSE firehose.
   - `GET /traces[/stream]` — recent agent run traces with timing, summary, status + SSE.
   - `GET /traces/{root_event_id}` — all spans for a single root event.
@@ -87,7 +88,8 @@ Multi-stage build on `node:22-alpine` so the image includes Claude Code, Codex, 
   - `GET /memory/stream` — memory file change notifications (SSE).
   - `GET /config` — effective parsed config (secrets redacted).
   - `GET /ui/` — embedded web dashboard (Next.js static assets).
-  - `GET|POST /{resource}` and `GET|DELETE /{resource}/{name}` — SQLite CRUD endpoints (always mounted). Resources for `GET` list: `skills`, `backends`, `repos` (repos use two-segment path: `repos/{owner}/{repo}`). Note: `GET /agents` always returns the live fleet snapshot — not the CRUD list. `POST /agents` and `GET|DELETE /agents/{name}` are CRUD endpoints for agents.
+  - CRUD endpoints (always mounted): `GET|POST /skills`, `GET|POST /backends`, `GET|POST /repos`, `POST /agents`, plus item routes (`GET|DELETE /agents/{name}`, `GET|DELETE /skills/{name}`, `GET|PATCH|DELETE /backends/{name}`, `GET|DELETE /repos/{owner}/{repo}`).
+  - Backend diagnostics endpoints: `GET /backends/status`, `POST /backends/discover`, `POST /backends/local`.
   - `GET /export`, `POST /import` — export/import fleet config as YAML.
 - Supported webhook events: `issues.*` (labeled, opened, edited, reopened, closed), `pull_request.*` (labeled, opened, synchronize, ready_for_review, closed), `issue_comment.created`, `pull_request_review.submitted`, `pull_request_review_comment.created`, `push` (branches only). Label-triggered routing uses `payload.label.name`. Non-label `events:` subscriptions match the event kind exactly. Draft PRs skip `pull_request.labeled`.
 - Internal event kinds (not from webhooks): `agents.run` (on-demand trigger from `POST /run` or `--run-agent`), `agent.dispatch` (inter-agent dispatch), `autonomous` (cron scheduler).
@@ -95,8 +97,10 @@ Multi-stage build on `node:22-alpine` so the image includes Claude Code, Codex, 
 - Workflow execution is stateless in-process. Only autonomous agents persist memory (per-agent, per-repo).
 - Memory is delivered to the agent as part of its prompt context, and the agent returns its full updated memory in the `memory` field of the JSON response. The daemon writes the value back to the store after the run. An empty string clears the memory. Event-driven runs (webhook events, label triggers) do not receive or persist memory.
 - Memory backend: SQLite (stored in the `memory` table alongside config data).
-- Backend resolution: agents declare `backend: claude | codex | auto`. `auto` picks the first configured backend in preference order (claude > codex).
-- Per-backend env overrides (`daemon.ai_backends.<name>.env`) let two backends run the same CLI with different endpoints — e.g. a default `claude` backend on hosted Anthropic plus a `claude_local` backend that routes the CLI via `ANTHROPIC_BASE_URL` through the built-in proxy to a local model. See [`docs/local-models.md`](docs/local-models.md).
+- Backend resolution: agents must explicitly name a backend (no `auto` behavior). Built-ins are `claude` and `codex`; additional local backends are named entries with `local_model_url`.
+- Startup auto-discovery runs only when the backends table is empty. Manual refresh is explicit via `POST /backends/discover`.
+- Runtime guardrail: if an agent pins a model not present in its backend's DB model catalog, the run fails fast with an actionable error (and the agent appears in orphan reports).
+- Local-model routing is configured via `local_model_url`; the daemon injects `ANTHROPIC_BASE_URL` for that backend at runtime. See [`docs/local-models.md`](docs/local-models.md).
 - **Reactive inter-agent dispatch**: agents can return a `dispatch: [{agent, number, reason}]` array in their JSON response to invoke other agents. Enqueued as synthetic `agent.dispatch` events. Target must opt in via `allow_dispatch: true`; originator must whitelist targets in `can_dispatch: [...]`. Safety limits (`daemon.processor.dispatch.{max_depth, max_fanout, dedup_window_seconds}`) prevent cascade storms and duplicate invocations. The originating agent's prompt receives an `## Available experts` roster listing dispatchable targets.
 
 ## Contribution Model

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Define your agents once. Wire them to repos with labels, cron schedules, or even
 ## Features
 
 - **Self-hosted, no SaaS** -- your code and prompts stay on your infrastructure.
-- **Multi-backend** -- Claude, Codex, or any CLI that speaks MCP. Mix backends per agent.
+- **Multi-backend** -- Claude, Codex, and named local backends. Mix backends per agent.
+- **Discovery + diagnostics** -- daemon detects backend/tools, validates CLI health (`gh`, MCP connectivity, models), and persists discovery snapshots.
 - **Local model support** -- built-in Anthropic-to-OpenAI translation proxy routes the fleet through `llama.cpp`, Ollama, vLLM, or any OpenAI-compatible endpoint. Zero vendor lock-in.
 - **One agent model, many triggers** -- label events, cron schedules, GitHub event subscriptions, on-demand API calls. Same agent, wired however you want.
 - **Composable skills** -- reusable guidance blocks (architecture, security, testing, DX, ...) merged into any agent.
@@ -35,7 +36,7 @@ The daemon ships an embedded web dashboard at `/ui/` with real-time views of you
 | **Graph** | Visual dispatch graph -- which agents invoke which, with edge counts |
 | **Agents** | Fleet snapshot -- per-agent status, skills, bindings, dispatch wiring. Create, edit, and delete agents |
 | **Skills** | Manage reusable guidance blocks -- create, edit, delete |
-| **Backends** | AI backend configuration -- add, edit, remove backends with model discovery |
+| **Backends and tools** | Backend discovery status, GitHub CLI diagnostics, runtime limits, local backend URL management, and orphaned-model remediation |
 | **Repos** | Repository bindings -- wire agents to repos with labels, events, or cron triggers |
 | **Memory** | Raw agent memory markdown per (agent, repo) pair |
 | **Config** | Effective parsed config (secrets redacted). YAML import/export |
@@ -125,6 +126,14 @@ go build -o agents ./cmd/agents
 ./agents --db agents.db
 ```
 
+Or run the interactive assistant:
+
+```bash
+./agents setup
+```
+
+The setup assistant now validates daemon APIs during setup (`/status`, `/backends/status`, `/backends/discover`, `/agents/orphans/status`) so backend/tool readiness is verified before completion.
+
 ### On-demand agent pass
 
 Run one autonomous agent synchronously and exit (useful for testing):
@@ -140,6 +149,14 @@ curl -X POST https://<your-host>/run \
   -H "Content-Type: application/json" \
   -d '{"agent":"coder","repo":"owner/repo"}'
 ```
+
+### Backend discovery and diagnostics
+
+- On startup, backend auto-discovery runs only when the backends table is empty.
+- `POST /backends/discover` reruns discovery and persists results to DB.
+- `GET /backends/status` runs live diagnostics without mutating DB.
+- `GET /agents/orphans/status` reports agents that pin unavailable models.
+- `GET /status` includes `orphaned_agents.count` for global warning/banner UX.
 
 ### GitHub webhook setup
 

--- a/cmd/agents/main.go
+++ b/cmd/agents/main.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/eloylp/agents/internal/ai"
 	"github.com/eloylp/agents/internal/autonomous"
+	"github.com/eloylp/agents/internal/backends"
 	"github.com/eloylp/agents/internal/config"
 	"github.com/eloylp/agents/internal/logging"
 	"github.com/eloylp/agents/internal/observe"
@@ -71,7 +72,7 @@ func run() error {
 	// setup, so the two paths stay in sync automatically.
 	scheduler.WithRunnerBuilder(func(name string, b config.AIBackendConfig) ai.Runner {
 		return ai.NewCommandRunner(
-			name, "command", b.Command, b.Args, b.Env,
+			name, "command", b.Command, backendEnvOverrides(b),
 			b.TimeoutSeconds, b.MaxPromptChars, b.RedactionSaltEnv,
 			logger,
 		)
@@ -189,8 +190,7 @@ func setupRunners(cfg *config.Config, logger zerolog.Logger) map[string]ai.Runne
 			name,
 			"command",
 			backend.Command,
-			backend.Args,
-			backend.Env,
+			backendEnvOverrides(backend),
 			backend.TimeoutSeconds,
 			backend.MaxPromptChars,
 			backend.RedactionSaltEnv,
@@ -198,6 +198,15 @@ func setupRunners(cfg *config.Config, logger zerolog.Logger) map[string]ai.Runne
 		)
 	}
 	return runners
+}
+
+func backendEnvOverrides(b config.AIBackendConfig) map[string]string {
+	if b.LocalModelURL == "" {
+		return nil
+	}
+	return map[string]string{
+		"ANTHROPIC_BASE_URL": b.LocalModelURL,
+	}
 }
 
 func setupScheduler(cfg *config.Config, runners map[string]ai.Runner, db *sql.DB, logger zerolog.Logger) (*autonomous.Scheduler, autonomous.MemoryBackend, error) {
@@ -282,6 +291,15 @@ func loadConfig(dbPath, importPath string) (*config.Config, *sql.DB, error) {
 		fmt.Fprintf(os.Stderr, "import: imported %d backends, %d skills, %d agents, %d repos, %d bindings\n",
 			len(yamlCfg.Daemon.AIBackends), len(yamlCfg.Skills),
 			len(yamlCfg.Agents), len(yamlCfg.Repos), nBindings)
+	}
+
+	autoDiscovered, _, err := backends.AutoDiscoverIfBackendsMissing(context.Background(), db)
+	if err != nil {
+		db.Close()
+		return nil, nil, fmt.Errorf("auto-discover backends: %w", err)
+	}
+	if autoDiscovered {
+		fmt.Fprintln(os.Stderr, "startup: discovered AI backends from local CLI tools")
 	}
 
 	cfg, err := store.LoadAndValidate(db)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -135,7 +135,7 @@ skills:
 # it uses, and a prompt file. Agents don't run on their own — repos
 # below decide when and where they run.
 #
-# backend: auto | claude | codex   ("auto" picks the default)
+# backend: claude | codex | claude_local
 # allow_prs: false (default) | true
 #   When false the scheduler prepends a hard "do not open PRs" instruction
 #   before the agent's prompt. Set to true only for agents explicitly
@@ -178,14 +178,14 @@ skills:
 agents:
   # Autonomous scouts — survey the codebase and open issues for follow-up.
   - name: scout-issues
-    backend: auto
+    backend: claude
     description: "Surveys the codebase for issues worth tracking in the issue tracker"
     skills: &scout-skills [architect, dx]
     prompt_file: prompts/codebase-scout-issues.md
     can_dispatch: [product-strategist]
 
   - name: scout-code
-    backend: auto
+    backend: claude
     description: "Surveys the codebase for code-quality and architectural concerns"
     skills: *scout-skills
     prompt_file: prompts/codebase-scout-code.md
@@ -234,32 +234,32 @@ agents:
 
   # Single-axis review agents, one per skill.
   - name: arch-reviewer
-    backend: auto
+    backend: claude
     description: "Reviews architecture and design decisions"
     skills: [architect]
     prompt_file: prompts/arch-reviewer.md
 
   - name: sec-reviewer
-    backend: auto
+    backend: claude
     description: "Reviews security concerns and potential vulnerabilities"
     skills: [security]
     prompt_file: prompts/sec-reviewer.md
     allow_dispatch: true    # pr-reviewer escalates security smells here
 
   - name: test-reviewer
-    backend: auto
+    backend: claude
     description: "Reviews test coverage and testing strategy"
     skills: [testing]
     prompt_file: prompts/test-reviewer.md
 
   - name: ops-reviewer
-    backend: auto
+    backend: claude
     description: "Reviews operational concerns: CI, deployment, observability"
     skills: [devops]
     prompt_file: prompts/ops-reviewer.md
 
   - name: dx-reviewer
-    backend: auto
+    backend: claude
     description: "Reviews developer experience: docs, tooling, onboarding"
     skills: [dx]
     prompt_file: prompts/dx-reviewer.md

--- a/internal/ai/cmdrunner.go
+++ b/internal/ai/cmdrunner.go
@@ -11,7 +11,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"slices"
+	"path/filepath"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -23,7 +23,6 @@ type CommandRunner struct {
 	backendName    string
 	mode           string
 	command        string
-	args           []string
 	env            map[string]string
 	timeout        time.Duration
 	maxPromptChars int
@@ -31,7 +30,7 @@ type CommandRunner struct {
 	logger         zerolog.Logger
 }
 
-func NewCommandRunner(backendName string, mode string, command string, args []string, env map[string]string, timeoutSeconds int, maxPromptChars int, redactionSaltEnv string, logger zerolog.Logger) *CommandRunner {
+func NewCommandRunner(backendName string, mode string, command string, env map[string]string, timeoutSeconds int, maxPromptChars int, redactionSaltEnv string, logger zerolog.Logger) *CommandRunner {
 	salt := []byte{}
 	if redactionSaltEnv != "" {
 		value := os.Getenv(redactionSaltEnv)
@@ -43,7 +42,6 @@ func NewCommandRunner(backendName string, mode string, command string, args []st
 		backendName:    backendName,
 		mode:           mode,
 		command:        command,
-		args:           args,
 		env:            env,
 		timeout:        time.Duration(timeoutSeconds) * time.Second,
 		maxPromptChars: maxPromptChars,
@@ -229,25 +227,39 @@ const separatorRunes = 2
 //     This matches the previous single-prompt behaviour and documents the
 //     limitation that codex has no native system channel.
 func (r *CommandRunner) buildDelivery(req Request) (args []string, stdin string) {
-	if strings.HasPrefix(r.backendName, "claude") {
+	if r.isClaudeBackend() {
 		return r.buildClaudeDelivery(req)
 	}
-	if r.command == "codex" {
+	if r.isCodexBackend() {
 		return r.buildCodexDelivery(req)
 	}
-	return r.args, truncateString(combineSystemUser(req.System, req.User), r.maxPromptChars)
+	return nil, truncateString(combineSystemUser(req.System, req.User), r.maxPromptChars)
 }
 
-// buildClaudeDelivery delivers system content via --append-system-prompt and
-// user content via stdin. It also appends --output-format stream-json
-// --json-schema using the embedded response schema so config files don't carry
-// inline JSON. stream-json emits one JSON event per line, letting the runner
-// capture the tool-loop transcript before the final result event.
+func (r *CommandRunner) isClaudeBackend() bool {
+	name := strings.ToLower(strings.TrimSpace(r.backendName))
+	cmd := strings.ToLower(filepath.Base(strings.TrimSpace(r.command)))
+	return strings.HasPrefix(name, "claude") || strings.HasPrefix(cmd, "claude")
+}
+
+func (r *CommandRunner) isCodexBackend() bool {
+	name := strings.ToLower(strings.TrimSpace(r.backendName))
+	cmd := strings.ToLower(filepath.Base(strings.TrimSpace(r.command)))
+	return strings.HasPrefix(name, "codex") || strings.HasPrefix(cmd, "codex")
+}
+
+// buildClaudeDelivery builds hardcoded Claude CLI args and delivers system
+// content via --append-system-prompt and user content via stdin.
 func (r *CommandRunner) buildClaudeDelivery(req Request) (args []string, stdin string) {
-	args = make([]string, 0, len(r.args)+6)
-	args = append(args, r.args...)
-	if !slices.Contains(args, "--json-schema") {
-		args = append(args, "--verbose", "--output-format", "stream-json", "--json-schema", ResponseSchemaString())
+	args = []string{
+		"-p",
+		"--dangerously-skip-permissions",
+		"--verbose",
+		"--output-format", "stream-json",
+		"--json-schema", ResponseSchemaString(),
+	}
+	if req.Model != "" {
+		args = append(args, "--model", req.Model)
 	}
 
 	if req.System == "" {
@@ -282,16 +294,19 @@ func (r *CommandRunner) buildClaudeDelivery(req Request) (args []string, stdin s
 // --output-schema pointing to the embedded response schema temp file.
 func (r *CommandRunner) buildCodexDelivery(req Request) (args []string, stdin string) {
 	combinedStdin := truncateString(combineSystemUser(req.System, req.User), r.maxPromptChars)
-	if slices.Contains(r.args, "--output-schema") {
-		return r.args, combinedStdin
+	args = []string{
+		"exec",
+		"--skip-git-repo-check",
+		"--dangerously-bypass-approvals-and-sandbox",
+	}
+	if req.Model != "" {
+		args = append(args, "--model", req.Model)
 	}
 	schemaPath, err := ResponseSchemaPath()
 	if err != nil {
 		r.logger.Error().Err(err).Msg("failed to materialize embedded response schema")
-		return r.args, combinedStdin
+		return args, combinedStdin
 	}
-	args = make([]string, 0, len(r.args)+2)
-	args = append(args, r.args...)
 	args = append(args, "--output-schema", schemaPath)
 	return args, combinedStdin
 }

--- a/internal/ai/cmdrunner_test.go
+++ b/internal/ai/cmdrunner_test.go
@@ -250,7 +250,7 @@ func TestResponseDispatchOmittedWhenEmpty(t *testing.T) {
 func TestCommandRunnerEmptyStdoutIsError(t *testing.T) {
 	t.Parallel()
 	// "true" exits 0 with no stdout — the canonical empty-output case.
-	r := NewCommandRunner("test", "command", "true", nil, nil, 10, 4000, "", zerolog.Nop())
+	r := NewCommandRunner("test", "command", "true", nil, 10, 4000, "", zerolog.Nop())
 	_, err := r.Run(context.Background(), Request{Workflow: "wf", Repo: "owner/repo"})
 	if err == nil {
 		t.Fatal("expected error for empty stdout, got nil")
@@ -311,7 +311,6 @@ func TestBuildDeliveryClaudeUsesAppendSystemPrompt(t *testing.T) {
 	tests := []struct {
 		name        string
 		backendName string
-		staticArgs  []string
 		system      string
 		user        string
 		wantFlag    bool // whether --append-system-prompt flag is expected
@@ -319,7 +318,6 @@ func TestBuildDeliveryClaudeUsesAppendSystemPrompt(t *testing.T) {
 		{
 			name:        "claude-routes-system-via-flag",
 			backendName: "claude",
-			staticArgs:  []string{"--dangerously-skip-permissions"},
 			system:      "You are a reviewer.",
 			user:        "Review PR #5.",
 			wantFlag:    true,
@@ -327,7 +325,6 @@ func TestBuildDeliveryClaudeUsesAppendSystemPrompt(t *testing.T) {
 		{
 			name:        "claude-local-also-uses-flag",
 			backendName: "claude_local",
-			staticArgs:  nil,
 			system:      "System guidance.",
 			user:        "Runtime context.",
 			wantFlag:    true,
@@ -335,7 +332,6 @@ func TestBuildDeliveryClaudeUsesAppendSystemPrompt(t *testing.T) {
 		{
 			name:        "codex-concatenates-on-stdin",
 			backendName: "codex",
-			staticArgs:  []string{"exec"},
 			system:      "System guidance.",
 			user:        "Runtime context.",
 			wantFlag:    false,
@@ -343,7 +339,6 @@ func TestBuildDeliveryClaudeUsesAppendSystemPrompt(t *testing.T) {
 		{
 			name:        "unknown-backend-concatenates",
 			backendName: "openai_compatible",
-			staticArgs:  nil,
 			system:      "System guidance.",
 			user:        "Runtime context.",
 			wantFlag:    false,
@@ -351,7 +346,6 @@ func TestBuildDeliveryClaudeUsesAppendSystemPrompt(t *testing.T) {
 		{
 			name:        "claude-empty-system-no-flag",
 			backendName: "claude",
-			staticArgs:  nil,
 			system:      "",
 			user:        "Only user content.",
 			wantFlag:    false, // no flag when system is empty
@@ -361,7 +355,7 @@ func TestBuildDeliveryClaudeUsesAppendSystemPrompt(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			r := NewCommandRunner(tc.backendName, "command", "true", tc.staticArgs, nil, 10, 0, "", zerolog.Nop())
+			r := NewCommandRunner(tc.backendName, "command", "true", nil, 10, 0, "", zerolog.Nop())
 			args, stdin := r.buildDelivery(Request{System: tc.system, User: tc.user})
 
 			hasFlag := slices.Contains(args, "--append-system-prompt")
@@ -385,12 +379,6 @@ func TestBuildDeliveryClaudeUsesAppendSystemPrompt(t *testing.T) {
 				// User content goes on stdin (maxPromptChars=0 means no truncation).
 				if stdin != tc.user {
 					t.Errorf("stdin = %q, want user content %q", stdin, tc.user)
-				}
-				// Static args must still be present.
-				for _, sa := range tc.staticArgs {
-					if !slices.Contains(args, sa) {
-						t.Errorf("static arg %q missing from args=%v", sa, args)
-					}
 				}
 			} else {
 				// Non-claude (or empty system): combined content on stdin.
@@ -485,10 +473,10 @@ func TestBuildDeliveryRespectsTotalBudget(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			r := NewCommandRunner(tc.backendName, "command", "true", nil, nil, 10, tc.maxChars, "", zerolog.Nop())
-			args, stdin := r.buildDelivery(Request{System: tc.system, User: tc.user})
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				r := NewCommandRunner(tc.backendName, "command", "true", nil, 10, tc.maxChars, "", zerolog.Nop())
+				args, stdin := r.buildDelivery(Request{System: tc.system, User: tc.user})
 			if stdin != tc.wantStdin {
 				t.Errorf("stdin = %q, want %q", stdin, tc.wantStdin)
 			}
@@ -555,10 +543,10 @@ func TestBuildDeliveryClaudeAndCodexSameTruncationBoundary(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			claude := NewCommandRunner("claude", "command", "true", nil, nil, 10, tc.maxChars, "", zerolog.Nop())
-			codex := NewCommandRunner("codex", "command", "true", nil, nil, 10, tc.maxChars, "", zerolog.Nop())
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				claude := NewCommandRunner("claude", "command", "true", nil, 10, tc.maxChars, "", zerolog.Nop())
+				codex := NewCommandRunner("codex", "command", "true", nil, 10, tc.maxChars, "", zerolog.Nop())
 
 			claudeArgs, claudeStdin := claude.buildDelivery(Request{System: tc.system, User: tc.user})
 			_, codexStdin := codex.buildDelivery(Request{System: tc.system, User: tc.user})
@@ -685,9 +673,9 @@ func TestPromptMetaReflectsDeliveredPrompt(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			r := NewCommandRunner("codex", "noop", "", nil, nil, 10, tc.maxChars, "", zerolog.Nop())
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				r := NewCommandRunner("codex", "noop", "", nil, 10, tc.maxChars, "", zerolog.Nop())
 			combined := truncateString(combineSystemUser(tc.system, tc.user), tc.maxChars)
 			meta := r.promptMeta(combined)
 

--- a/internal/ai/types.go
+++ b/internal/ai/types.go
@@ -20,6 +20,7 @@ type Request struct {
 	Workflow string
 	Repo     string
 	Number   int
+	Model    string // optional per-agent model override
 	System   string // stable system-level content (from RenderedPrompt.System)
 	User     string // per-run user content (from RenderedPrompt.User)
 }

--- a/internal/autonomous/scheduler.go
+++ b/internal/autonomous/scheduler.go
@@ -119,8 +119,8 @@ func (r *runLocks) release(key string) {
 type Scheduler struct {
 	cfg           *config.Config
 	runners       map[string]ai.Runner
-	runnerBuilder RunnerBuilder  // optional; nil means Reload does not update runners
-	hotReloadSink HotReloadSink  // optional; nil means no external component to notify
+	runnerBuilder RunnerBuilder // optional; nil means Reload does not update runners
+	hotReloadSink HotReloadSink // optional; nil means no external component to notify
 	memory        MemoryBackend
 	cron          *cron.Cron
 	logger        zerolog.Logger
@@ -130,9 +130,9 @@ type Scheduler struct {
 	agentEntries  []agentEntry
 	lastRunsMu    sync.RWMutex
 	lastRuns      map[string]lastRunRecord // key: "name\x00repo"
-	dispatcher    *workflow.Dispatcher    // nil when dispatch is not configured
-	traceRec      workflow.TraceRecorder  // nil when tracing is not configured
-	runLock        runLocks               // per-(agent,repo) mutex serializing the read/run/write sequence
+	dispatcher    *workflow.Dispatcher     // nil when dispatch is not configured
+	traceRec      workflow.TraceRecorder   // nil when tracing is not configured
+	runLock       runLocks                 // per-(agent,repo) mutex serializing the read/run/write sequence
 }
 
 // WithDispatcher attaches a Dispatcher to the Scheduler so that dispatch
@@ -448,6 +448,7 @@ func (s *Scheduler) executeAgentRun(ctx context.Context, repo string, agent conf
 	resp, runErr := runner.Run(ctx, ai.Request{
 		Workflow: fmt.Sprintf("autonomous:%s:%s", backend, agent.Name),
 		Repo:     repo,
+		Model:    agent.Model,
 		System:   rendered.System,
 		User:     rendered.User,
 	})

--- a/internal/autonomous/scheduler.go
+++ b/internal/autonomous/scheduler.go
@@ -396,6 +396,17 @@ func (s *Scheduler) executeAgentRun(ctx context.Context, repo string, agent conf
 		}
 		return fmt.Errorf("no configured backend for agent %q (configured: %q)", agent.Name, agent.Backend)
 	}
+	if backendCfg, ok := cfg.Daemon.AIBackends[backend]; ok && config.IsPinnedModelUnavailable(agent.Model, backendCfg) {
+		if s.dispatcher != nil {
+			s.dispatcher.RollbackAutonomousRun(agent.Name, repo)
+		}
+		return fmt.Errorf(
+			"agent %q: configured model %q is not available for backend %q; run backend discovery and update the agent model",
+			agent.Name,
+			agent.Model,
+			backend,
+		)
+	}
 	runner, ok := runners[backend]
 	if !ok {
 		if s.dispatcher != nil {

--- a/internal/autonomous/scheduler_test.go
+++ b/internal/autonomous/scheduler_test.go
@@ -223,21 +223,22 @@ func TestTriggerAgentRejections(t *testing.T) {
 	}
 }
 
-func TestResolveBackendAutoFallsBackToDefault(t *testing.T) {
+func TestResolveBackendRequiresExplicitBackend(t *testing.T) {
 	t.Parallel()
-	cfg := baseCfg(func(c *config.Config) { c.Agents[0].Backend = "auto" })
+	cfg := baseCfg(func(c *config.Config) { c.Agents[0].Backend = "" })
 	runner := &stubRunner{}
 	s, err := NewScheduler(cfg, map[string]ai.Runner{"claude": runner}, newMapMemory(), zerolog.Nop())
 	if err != nil {
 		t.Fatalf("NewScheduler: %v", err)
 	}
-	if err := s.TriggerAgent(context.Background(), "reviewer", "owner/repo"); err != nil {
-		t.Fatalf("TriggerAgent: %v", err)
+	err = s.TriggerAgent(context.Background(), "reviewer", "owner/repo")
+	if err == nil || !strings.Contains(err.Error(), "no configured backend") {
+		t.Fatalf("TriggerAgent: got %v, want explicit backend error", err)
 	}
 	runner.mu.Lock()
 	defer runner.mu.Unlock()
-	if runner.calls != 1 {
-		t.Errorf("expected auto to resolve to claude and run once, got %d calls", runner.calls)
+	if runner.calls != 0 {
+		t.Errorf("expected no runner invocation when backend is missing, got %d calls", runner.calls)
 	}
 }
 
@@ -517,8 +518,8 @@ type blockingQueue struct {
 }
 
 func (q *blockingQueue) PushEvent(_ context.Context, _ workflow.Event) error {
-	close(q.readyCh)   // signal that TryClaim has run and we're now blocking
-	<-q.releaseCh      // wait for the test to release us
+	close(q.readyCh) // signal that TryClaim has run and we're now blocking
+	<-q.releaseCh    // wait for the test to release us
 	return nil
 }
 
@@ -1654,8 +1655,8 @@ func TestSchedulerCronJobUsesPostReloadAgentDef(t *testing.T) {
 
 // stubTraceRecorder records calls to RecordSpan for assertion in tests.
 type stubTraceRecorder struct {
-	mu      sync.Mutex
-	spans   []stubSpan
+	mu    sync.Mutex
+	spans []stubSpan
 }
 
 type stubSpan struct {
@@ -1892,7 +1893,7 @@ func TestSchedulerMemoryRunsSerializedPerAgentRepo(t *testing.T) {
 	mem := &readTrackingMemory{inner: newMapMemory()}
 
 	ready := make(chan struct{}, 1) // first run signals when inside runner.Run
-	block := make(chan struct{})     // closed to unblock first run
+	block := make(chan struct{})    // closed to unblock first run
 	runner := &firstCallBlockingRunner{
 		ready: ready,
 		block: block,

--- a/internal/backends/discovery.go
+++ b/internal/backends/discovery.go
@@ -1,0 +1,400 @@
+package backends
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/store"
+)
+
+const (
+	ClaudeName      = "claude"
+	CodexName       = "codex"
+	ClaudeLocalName = "claude_local"
+)
+
+var builtinBackendNames = []string{ClaudeName, CodexName}
+
+// GitHubStatus captures diagnostics for the GitHub CLI dependency.
+type GitHubStatus struct {
+	Detected      bool   `json:"detected"`
+	Command       string `json:"command,omitempty"`
+	Authenticated bool   `json:"authenticated"`
+	Healthy       bool   `json:"healthy"`
+	Detail        string `json:"detail,omitempty"`
+}
+
+// BackendStatus captures diagnostics for one backend.
+type BackendStatus struct {
+	Name          string   `json:"name"`
+	Detected      bool     `json:"detected"`
+	Command       string   `json:"command,omitempty"`
+	Version       string   `json:"version,omitempty"`
+	Models        []string `json:"models,omitempty"`
+	Healthy       bool     `json:"healthy"`
+	HealthDetail  string   `json:"health_detail,omitempty"`
+	LocalModelURL string   `json:"local_model_url,omitempty"`
+}
+
+// Diagnostics is the full tool-discovery and health snapshot.
+type Diagnostics struct {
+	GeneratedAt time.Time       `json:"generated_at"`
+	GitHub      GitHubStatus    `json:"github_cli"`
+	Backends    []BackendStatus `json:"backends"`
+}
+
+// AutoDiscoverIfBackendsMissing runs discovery and persists results only when
+// the backends table is currently empty.
+func AutoDiscoverIfBackendsMissing(ctx context.Context, db *sql.DB) (bool, Diagnostics, error) {
+	existing, err := store.ReadBackends(db)
+	if err != nil {
+		return false, Diagnostics{}, err
+	}
+	if len(existing) > 0 {
+		return false, RunDiagnostics(ctx, existing), nil
+	}
+	diag, err := DiscoverAndPersist(ctx, db)
+	if err != nil {
+		return false, Diagnostics{}, err
+	}
+	return true, diag, nil
+}
+
+// DiscoverAndPersist runs diagnostics and writes discovered backend metadata to
+// the store (upsert semantics).
+func DiscoverAndPersist(ctx context.Context, db *sql.DB) (Diagnostics, error) {
+	existing, err := store.ReadBackends(db)
+	if err != nil {
+		return Diagnostics{}, err
+	}
+	diag := RunDiagnostics(ctx, existing)
+	if err := persistDiagnostics(db, existing, diag); err != nil {
+		return Diagnostics{}, err
+	}
+	return diag, nil
+}
+
+// RunDiagnostics executes live discovery checks without mutating the store.
+func RunDiagnostics(ctx context.Context, existing map[string]config.AIBackendConfig) Diagnostics {
+	diag := Diagnostics{
+		GeneratedAt: time.Now().UTC(),
+		GitHub:      diagnoseGitHubCLI(ctx),
+	}
+	for _, name := range builtinBackendNames {
+		cfg := existing[name]
+		diag.Backends = append(diag.Backends, diagnoseBackend(ctx, name, name, cfg.Command, ""))
+	}
+	if local, ok := existing[ClaudeLocalName]; ok && strings.TrimSpace(local.LocalModelURL) != "" {
+		diag.Backends = append(diag.Backends, diagnoseBackend(ctx, ClaudeLocalName, ClaudeName, local.Command, local.LocalModelURL))
+	}
+	sort.Slice(diag.Backends, func(i, j int) bool {
+		return diag.Backends[i].Name < diag.Backends[j].Name
+	})
+	return diag
+}
+
+func persistDiagnostics(db *sql.DB, existing map[string]config.AIBackendConfig, diag Diagnostics) error {
+	for _, b := range diag.Backends {
+		prev, hadPrev := existing[b.Name]
+		if !b.Detected && !hadPrev {
+			// No newly detected command and no prior record to update.
+			continue
+		}
+
+		next := prev
+		if b.Command != "" {
+			next.Command = b.Command
+		}
+		next.Version = b.Version
+		next.Models = b.Models
+		next.Healthy = b.Healthy
+		next.HealthDetail = b.HealthDetail
+		next.LocalModelURL = b.LocalModelURL
+		config.ApplyBackendDefaults(&next)
+		config.NormalizeBackendConfig(&next)
+
+		if err := store.UpsertBackend(db, b.Name, next); err != nil {
+			return fmt.Errorf("persist backend %s: %w", b.Name, err)
+		}
+	}
+	return nil
+}
+
+func diagnoseGitHubCLI(ctx context.Context) GitHubStatus {
+	path, err := exec.LookPath("gh")
+	if err != nil {
+		return GitHubStatus{
+			Detected: false,
+			Healthy:  false,
+			Detail:   "gh binary not found on PATH",
+		}
+	}
+	stdout, stderr, runErr := runToolCommand(ctx, path, []string{"auth", "status"}, nil)
+	detail := firstNonEmptyLine(stdout, stderr)
+	if detail == "" {
+		detail = "authentication check completed"
+	}
+	return GitHubStatus{
+		Detected:      true,
+		Command:       path,
+		Authenticated: runErr == nil,
+		Healthy:       runErr == nil,
+		Detail:        detail,
+	}
+}
+
+func diagnoseBackend(ctx context.Context, backendName, commandName, preferredCommand, localURL string) BackendStatus {
+	path, detected := resolveCommand(commandName, preferredCommand)
+	status := BackendStatus{
+		Name:          backendName,
+		Detected:      detected,
+		Command:       path,
+		LocalModelURL: localURL,
+	}
+	if !detected {
+		status.Healthy = false
+		status.HealthDetail = fmt.Sprintf("%s binary not found on PATH", commandName)
+		return status
+	}
+
+	env := map[string]string{}
+	if localURL != "" {
+		env["ANTHROPIC_BASE_URL"] = localURL
+	}
+
+	versionOut, versionErr, versionRunErr := runToolCommand(ctx, path, []string{"--version"}, env)
+	versionOK := versionRunErr == nil
+	status.Version = firstNonEmptyLine(versionOut, versionErr)
+
+	models, modelsDetail := discoverModels(ctx, backendName, path, env)
+	status.Models = models
+
+	mcpOK, mcpDetail := checkGitHubMCP(ctx, path, env)
+	status.Healthy = versionOK && mcpOK
+
+	details := make([]string, 0, 3)
+	if versionOK {
+		if status.Version != "" {
+			details = append(details, "version: "+status.Version)
+		} else {
+			details = append(details, "version: ok")
+		}
+	} else {
+		details = append(details, "version check failed: "+firstNonEmptyLine(versionErr, versionOut))
+	}
+	if mcpDetail != "" {
+		details = append(details, mcpDetail)
+	}
+	if modelsDetail != "" {
+		details = append(details, modelsDetail)
+	}
+	status.HealthDetail = strings.Join(details, " | ")
+	return status
+}
+
+func discoverModels(ctx context.Context, backendName, command string, env map[string]string) ([]string, string) {
+	commands := modelCommands(backendName)
+	for _, args := range commands {
+		stdout, _, err := runToolCommand(ctx, command, args, env)
+		if err != nil {
+			continue
+		}
+		models := parseModels(stdout)
+		if len(models) == 0 {
+			return nil, "models: none reported"
+		}
+		return models, fmt.Sprintf("models: %d discovered", len(models))
+	}
+	return nil, "models discovery failed"
+}
+
+func modelCommands(name string) [][]string {
+	switch {
+	case strings.HasPrefix(name, "claude"):
+		return [][]string{
+			{"models", "list", "--output", "json"},
+			{"models", "list"},
+		}
+	case strings.HasPrefix(name, "codex"):
+		return [][]string{
+			{"models", "list", "--json"},
+			{"models", "list"},
+			{"models"},
+		}
+	default:
+		return [][]string{
+			{"models", "list"},
+		}
+	}
+}
+
+func checkGitHubMCP(ctx context.Context, command string, env map[string]string) (bool, string) {
+	stdout, stderr, err := runToolCommand(ctx, command, []string{"mcp", "list"}, env)
+	if err != nil {
+		detail := firstNonEmptyLine(stderr, stdout)
+		if detail == "" {
+			detail = err.Error()
+		}
+		return false, "mcp check failed: " + detail
+	}
+	out := strings.ToLower(stdout + "\n" + stderr)
+	hasGitHub := strings.Contains(out, "github")
+	disconnected := strings.Contains(out, "disconnected") || strings.Contains(out, "not connected")
+	if hasGitHub && !disconnected {
+		return true, "github MCP: connected"
+	}
+	if hasGitHub {
+		return false, "github MCP: found but disconnected"
+	}
+	return false, "github MCP: not configured"
+}
+
+func parseModels(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+
+	var list []string
+	if err := json.Unmarshal([]byte(raw), &list); err == nil {
+		return dedupeSorted(list)
+	}
+
+	var objects []map[string]any
+	if err := json.Unmarshal([]byte(raw), &objects); err == nil {
+		names := make([]string, 0, len(objects))
+		for _, obj := range objects {
+			for _, k := range []string{"id", "name", "model"} {
+				if v, ok := obj[k].(string); ok && strings.TrimSpace(v) != "" {
+					names = append(names, strings.TrimSpace(v))
+					break
+				}
+			}
+		}
+		return dedupeSorted(names)
+	}
+
+	var wrapped struct {
+		Data []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(raw), &wrapped); err == nil && len(wrapped.Data) > 0 {
+		names := make([]string, 0, len(wrapped.Data))
+		for _, it := range wrapped.Data {
+			if strings.TrimSpace(it.ID) != "" {
+				names = append(names, strings.TrimSpace(it.ID))
+				continue
+			}
+			if strings.TrimSpace(it.Name) != "" {
+				names = append(names, strings.TrimSpace(it.Name))
+			}
+		}
+		return dedupeSorted(names)
+	}
+
+	lines := strings.Split(raw, "\n")
+	names := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		lower := strings.ToLower(line)
+		if strings.HasPrefix(lower, "model") || strings.HasPrefix(lower, "available models") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		names = append(names, fields[0])
+	}
+	return dedupeSorted(names)
+}
+
+func dedupeSorted(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func resolveCommand(defaultName, preferred string) (string, bool) {
+	preferred = strings.TrimSpace(preferred)
+	if preferred != "" {
+		if p, err := exec.LookPath(preferred); err == nil {
+			return p, true
+		}
+	}
+	p, err := exec.LookPath(defaultName)
+	if err != nil {
+		return "", false
+	}
+	return p, true
+}
+
+func firstNonEmptyLine(values ...string) string {
+	for _, v := range values {
+		for _, line := range strings.Split(strings.TrimSpace(v), "\n") {
+			line = strings.TrimSpace(line)
+			if line != "" {
+				return line
+			}
+		}
+	}
+	return ""
+}
+
+func runToolCommand(ctx context.Context, command string, args []string, env map[string]string) (string, string, error) {
+	runCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(runCtx, command, args...)
+	cmd.Env = mergeEnv(os.Environ(), env)
+	out, err := cmd.Output()
+	if err == nil {
+		return strings.TrimSpace(string(out)), "", nil
+	}
+
+	var stderr string
+	if ee, ok := err.(*exec.ExitError); ok {
+		stderr = strings.TrimSpace(string(ee.Stderr))
+	}
+	return strings.TrimSpace(string(out)), stderr, err
+}
+
+func mergeEnv(base []string, override map[string]string) []string {
+	if len(override) == 0 {
+		return base
+	}
+	out := make([]string, 0, len(base)+len(override))
+	out = append(out, base...)
+	for k, v := range override {
+		out = append(out, k+"="+v)
+	}
+	return out
+}

--- a/internal/backends/discovery.go
+++ b/internal/backends/discovery.go
@@ -1,6 +1,7 @@
 package backends
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -9,6 +10,7 @@ import (
 	"os/exec"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/eloylp/agents/internal/config"
@@ -59,7 +61,7 @@ func AutoDiscoverIfBackendsMissing(ctx context.Context, db *sql.DB) (bool, Diagn
 		return false, Diagnostics{}, err
 	}
 	if len(existing) > 0 {
-		return false, RunDiagnostics(ctx, existing), nil
+		return false, Diagnostics{}, nil
 	}
 	diag, err := DiscoverAndPersist(ctx, db)
 	if err != nil {
@@ -84,20 +86,62 @@ func DiscoverAndPersist(ctx context.Context, db *sql.DB) (Diagnostics, error) {
 
 // RunDiagnostics executes live discovery checks without mutating the store.
 func RunDiagnostics(ctx context.Context, existing map[string]config.AIBackendConfig) Diagnostics {
-	diag := Diagnostics{
-		GeneratedAt: time.Now().UTC(),
-		GitHub:      diagnoseGitHubCLI(ctx),
+	diag := Diagnostics{GeneratedAt: time.Now().UTC()}
+	type backendTarget struct {
+		name             string
+		commandName      string
+		preferredCommand string
+		localURL         string
 	}
+	targets := make([]backendTarget, 0, len(existing)+len(builtinBackendNames))
 	for _, name := range builtinBackendNames {
 		cfg := existing[name]
-		diag.Backends = append(diag.Backends, diagnoseBackend(ctx, name, name, cfg.Command, ""))
+		targets = append(targets, backendTarget{
+			name:             name,
+			commandName:      name,
+			preferredCommand: cfg.Command,
+			localURL:         "",
+		})
 	}
-	if local, ok := existing[ClaudeLocalName]; ok && strings.TrimSpace(local.LocalModelURL) != "" {
-		diag.Backends = append(diag.Backends, diagnoseBackend(ctx, ClaudeLocalName, ClaudeName, local.Command, local.LocalModelURL))
+	for name, cfg := range existing {
+		if isBuiltinBackendName(name) || strings.TrimSpace(cfg.LocalModelURL) == "" {
+			continue
+		}
+		targets = append(targets, backendTarget{
+			name:             name,
+			commandName:      ClaudeName,
+			preferredCommand: cfg.Command,
+			localURL:         cfg.LocalModelURL,
+		})
 	}
-	sort.Slice(diag.Backends, func(i, j int) bool {
-		return diag.Backends[i].Name < diag.Backends[j].Name
-	})
+
+	backendsOut := make([]BackendStatus, 0, len(targets))
+	var outMu sync.Mutex
+	var githubOut GitHubStatus
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		githubOut = diagnoseGitHubCLI(ctx)
+	}()
+
+	for _, target := range targets {
+		target := target
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			status := diagnoseBackend(ctx, target.name, target.commandName, target.preferredCommand, target.localURL)
+			outMu.Lock()
+			backendsOut = append(backendsOut, status)
+			outMu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	diag.GitHub = githubOut
+	diag.Backends = backendsOut
+	sort.Slice(diag.Backends, func(i, j int) bool { return diag.Backends[i].Name < diag.Backends[j].Name })
 	return diag
 }
 
@@ -174,7 +218,7 @@ func diagnoseBackend(ctx context.Context, backendName, commandName, preferredCom
 	versionOK := versionRunErr == nil
 	status.Version = firstNonEmptyLine(versionOut, versionErr)
 
-	models, modelsDetail := discoverModels(ctx, backendName, path, env)
+	models, modelsDetail := discoverModels(ctx, commandName, path, env)
 	status.Models = models
 
 	mcpOK, mcpDetail := checkGitHubMCP(ctx, path, env)
@@ -202,29 +246,42 @@ func diagnoseBackend(ctx context.Context, backendName, commandName, preferredCom
 
 func discoverModels(ctx context.Context, backendName, command string, env map[string]string) ([]string, string) {
 	commands := modelCommands(backendName)
+	if len(commands) == 0 {
+		return nil, "models discovery not supported"
+	}
+	failures := make([]string, 0, len(commands))
 	for _, args := range commands {
-		stdout, _, err := runToolCommand(ctx, command, args, env)
+		stdout, stderr, err := runToolCommand(ctx, command, args, env)
 		if err != nil {
+			detail := firstNonEmptyLine(stderr, stdout, err.Error())
+			if detail == "" {
+				detail = "command failed"
+			}
+			failures = append(failures, fmt.Sprintf("%s: %s", strings.Join(args, " "), detail))
 			continue
 		}
 		models := parseModels(stdout)
 		if len(models) == 0 {
-			return nil, "models: none reported"
+			failures = append(failures, fmt.Sprintf("%s: no models in output", strings.Join(args, " ")))
+			continue
 		}
 		return models, fmt.Sprintf("models: %d discovered", len(models))
 	}
-	return nil, "models discovery failed"
+	if len(failures) == 0 {
+		return nil, "models discovery failed"
+	}
+	return nil, "models discovery failed: " + failures[0]
 }
 
 func modelCommands(name string) [][]string {
 	switch {
 	case strings.HasPrefix(name, "claude"):
 		return [][]string{
-			{"models", "list", "--output", "json"},
 			{"models", "list"},
 		}
 	case strings.HasPrefix(name, "codex"):
 		return [][]string{
+			{"debug", "models"},
 			{"models", "list", "--json"},
 			{"models", "list"},
 			{"models"},
@@ -245,16 +302,40 @@ func checkGitHubMCP(ctx context.Context, command string, env map[string]string) 
 		}
 		return false, "mcp check failed: " + detail
 	}
-	out := strings.ToLower(stdout + "\n" + stderr)
-	hasGitHub := strings.Contains(out, "github")
-	disconnected := strings.Contains(out, "disconnected") || strings.Contains(out, "not connected")
-	if hasGitHub && !disconnected {
+	hasGitHub, connected := parseGitHubMCPStatus(stdout + "\n" + stderr)
+	if connected {
 		return true, "github MCP: connected"
 	}
 	if hasGitHub {
 		return false, "github MCP: found but disconnected"
 	}
 	return false, "github MCP: not configured"
+}
+
+func parseGitHubMCPStatus(output string) (hasGitHub bool, connected bool) {
+	for _, line := range strings.Split(strings.ToLower(output), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || !strings.Contains(line, "github") {
+			continue
+		}
+		hasGitHub = true
+
+		disconnected := strings.Contains(line, "not connected") ||
+			strings.Contains(line, "disconnected") ||
+			strings.Contains(line, "needs authentication")
+		if disconnected {
+			continue
+		}
+		if strings.Contains(line, "connected") {
+			return true, true
+		}
+		// codex mcp list (table output) marks healthy entries as:
+		// "... github ... status enabled ... auth bearer token"
+		if strings.Contains(line, "enabled") && strings.Contains(line, "bearer token") {
+			return true, true
+		}
+	}
+	return hasGitHub, false
 }
 
 func parseModels(raw string) []string {
@@ -297,6 +378,28 @@ func parseModels(raw string) []string {
 			}
 			if strings.TrimSpace(it.Name) != "" {
 				names = append(names, strings.TrimSpace(it.Name))
+			}
+		}
+		return dedupeSorted(names)
+	}
+
+	var codexCatalog struct {
+		Models []struct {
+			Slug  string `json:"slug"`
+			ID    string `json:"id"`
+			Name  string `json:"name"`
+			Model string `json:"model"`
+		} `json:"models"`
+	}
+	if err := json.Unmarshal([]byte(raw), &codexCatalog); err == nil && len(codexCatalog.Models) > 0 {
+		names := make([]string, 0, len(codexCatalog.Models))
+		for _, it := range codexCatalog.Models {
+			for _, v := range []string{it.Slug, it.ID, it.Name, it.Model} {
+				if strings.TrimSpace(v) == "" {
+					continue
+				}
+				names = append(names, strings.TrimSpace(v))
+				break
 			}
 		}
 		return dedupeSorted(names)
@@ -375,16 +478,15 @@ func runToolCommand(ctx context.Context, command string, args []string, env map[
 
 	cmd := exec.CommandContext(runCtx, command, args...)
 	cmd.Env = mergeEnv(os.Environ(), env)
-	out, err := cmd.Output()
-	if err == nil {
-		return strings.TrimSpace(string(out)), "", nil
+	if home, err := os.UserHomeDir(); err == nil {
+		cmd.Dir = home
 	}
-
-	var stderr string
-	if ee, ok := err.(*exec.ExitError); ok {
-		stderr = strings.TrimSpace(string(ee.Stderr))
-	}
-	return strings.TrimSpace(string(out)), stderr, err
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return strings.TrimSpace(stdout.String()), strings.TrimSpace(stderr.String()), err
 }
 
 func mergeEnv(base []string, override map[string]string) []string {
@@ -397,4 +499,13 @@ func mergeEnv(base []string, override map[string]string) []string {
 		out = append(out, k+"="+v)
 	}
 	return out
+}
+
+func isBuiltinBackendName(name string) bool {
+	for _, builtin := range builtinBackendNames {
+		if name == builtin {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/backends/discovery_test.go
+++ b/internal/backends/discovery_test.go
@@ -1,0 +1,78 @@
+package backends
+
+import "testing"
+
+func TestParseGitHubMCPStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		output     string
+		wantFound  bool
+		wantOnline bool
+	}{
+		{
+			name: "github connected with other unauthenticated servers",
+			output: `claude.ai Google Drive: https://drivemcp.googleapis.com/mcp/v1 - ! Needs authentication
+claude.ai Gmail: https://gmailmcp.googleapis.com/mcp/v1 - ! Needs authentication
+github: https://api.githubcopilot.com/mcp (HTTP) - ✓ Connected`,
+			wantFound:  true,
+			wantOnline: true,
+		},
+		{
+			name:       "github configured but needs auth",
+			output:     `github: https://api.githubcopilot.com/mcp (HTTP) - ! Needs authentication`,
+			wantFound:  true,
+			wantOnline: false,
+		},
+		{
+			name:       "github disconnected",
+			output:     `github: https://api.githubcopilot.com/mcp (HTTP) - not connected`,
+			wantFound:  true,
+			wantOnline: false,
+		},
+		{
+			name:       "github listed without status",
+			output:     `github: https://api.githubcopilot.com/mcp (HTTP)`,
+			wantFound:  true,
+			wantOnline: false,
+		},
+		{
+			name: "codex table output enabled bearer token",
+			output: `Name    Url                                 Bearer Token Env Var  Status   Auth
+github  https://api.githubcopilot.com/mcp/  GITHUB_PAT_TOKEN      enabled  Bearer token`,
+			wantFound:  true,
+			wantOnline: true,
+		},
+		{
+			name:       "github not configured",
+			output:     `youtrack: https://keldai.youtrack.cloud/mcp (HTTP) - ✓ Connected`,
+			wantFound:  false,
+			wantOnline: false,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			found, online := parseGitHubMCPStatus(tc.output)
+			if found != tc.wantFound || online != tc.wantOnline {
+				t.Fatalf("parseGitHubMCPStatus() = (%v, %v), want (%v, %v)", found, online, tc.wantFound, tc.wantOnline)
+			}
+		})
+	}
+}
+
+func TestParseModelsCodexDebugCatalog(t *testing.T) {
+	t.Parallel()
+
+	raw := `{"models":[{"slug":"gpt-5.4","display_name":"gpt-5.4"},{"slug":"gpt-5.3-codex","display_name":"gpt-5.3-codex"}]}`
+	got := parseModels(raw)
+	if len(got) != 2 {
+		t.Fatalf("parseModels() length = %d, want 2 (got=%v)", len(got), got)
+	}
+	if got[0] != "gpt-5.3-codex" || got[1] != "gpt-5.4" {
+		t.Fatalf("parseModels() = %v, want [gpt-5.3-codex gpt-5.4]", got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -172,11 +172,6 @@ type AIBackendConfig struct {
 	TimeoutSeconds   int      `yaml:"timeout_seconds"`
 	MaxPromptChars   int      `yaml:"max_prompt_chars"`
 	RedactionSaltEnv string   `yaml:"redaction_salt_env"`
-
-	// Args and Env are retained for backward-compatible YAML import only.
-	// They are ignored at runtime.
-	Args []string          `yaml:"args,omitempty"`
-	Env  map[string]string `yaml:"env,omitempty"`
 }
 
 // SkillDef is a reusable block of guidance that agents can compose.
@@ -568,17 +563,6 @@ func (c *Config) normalize() {
 			backend.Version = strings.TrimSpace(backend.Version)
 			backend.HealthDetail = strings.TrimSpace(backend.HealthDetail)
 			backend.LocalModelURL = strings.TrimSpace(backend.LocalModelURL)
-			if len(backend.Env) > 0 {
-				cleaned := make(map[string]string, len(backend.Env))
-				for k, v := range backend.Env {
-					k = strings.TrimSpace(k)
-					if k == "" {
-						continue
-					}
-					cleaned[k] = v
-				}
-				backend.Env = cleaned
-			}
 			for i := range backend.Models {
 				backend.Models[i] = strings.TrimSpace(backend.Models[i])
 			}
@@ -971,17 +955,6 @@ func NormalizeBackendConfig(b *AIBackendConfig) {
 	b.Version = strings.TrimSpace(b.Version)
 	b.HealthDetail = strings.TrimSpace(b.HealthDetail)
 	b.LocalModelURL = strings.TrimSpace(b.LocalModelURL)
-	if len(b.Env) > 0 {
-		cleaned := make(map[string]string, len(b.Env))
-		for k, v := range b.Env {
-			k = strings.TrimSpace(k)
-			if k == "" {
-				continue
-			}
-			cleaned[k] = v
-		}
-		b.Env = cleaned
-	}
 	for i := range b.Models {
 		b.Models[i] = strings.TrimSpace(b.Models[i])
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -331,8 +331,8 @@ func ValidateEntities(agents []AgentDef, repos []RepoDef, skills map[string]Skil
 
 	// Backend field checks (without "at least one" aggregate check).
 	for name, b := range backends {
-		if !isValidBackendName(name) {
-			return fmt.Errorf("config: unsupported ai backend %q (supported: %s)", name, strings.Join(validAIBackendNames, ", "))
+		if !isSupportedBackend(name, b) {
+			return fmt.Errorf("config: unsupported ai backend %q (supported: %s, or any custom name with local_model_url set)", name, strings.Join(validAIBackendNames, ", "))
 		}
 		if b.Command == "" {
 			return fmt.Errorf("config: ai backend %q: command is required", name)
@@ -770,8 +770,8 @@ func (c *Config) validateLogConfig() error {
 
 func (c *Config) validateBackends() error {
 	for name, backend := range c.Daemon.AIBackends {
-		if !isValidBackendName(name) {
-			return fmt.Errorf("config: unsupported ai backend %q (supported: %s)", name, strings.Join(validAIBackendNames, ", "))
+		if !isSupportedBackend(name, backend) {
+			return fmt.Errorf("config: unsupported ai backend %q (supported: %s, or any custom name with local_model_url set)", name, strings.Join(validAIBackendNames, ", "))
 		}
 		if backend.Command == "" {
 			return fmt.Errorf("config: ai backend %q: command is required", name)
@@ -918,18 +918,38 @@ func isValidBackendName(name string) bool {
 	return slices.Contains(validAIBackendNames, name)
 }
 
-func validateAgentModel(agentName, model string, backend AIBackendConfig) error {
+func isSupportedBackend(name string, backend AIBackendConfig) bool {
+	if isValidBackendName(name) {
+		return true
+	}
+	return strings.TrimSpace(backend.LocalModelURL) != ""
+}
+
+// IsPinnedModelUnavailable reports whether a non-empty model is explicitly
+// known to be unavailable for the given backend snapshot.
+//
+// If backend.Models is empty, availability is treated as unknown (returns
+// false) so callers can avoid blocking on missing catalog metadata.
+func IsPinnedModelUnavailable(model string, backend AIBackendConfig) bool {
 	model = strings.TrimSpace(model)
 	if model == "" {
-		return nil
+		return false
 	}
 	if len(backend.Models) == 0 {
+		return false
+	}
+	return !slices.Contains(backend.Models, model)
+}
+
+func validateAgentModel(_ string, model string, backend AIBackendConfig) error {
+	// Model/backend mismatches are intentionally allowed at config validation
+	// time so discovery can persist backend model changes even if agents become
+	// temporarily orphaned. Runtime paths enforce this strictly before invoking
+	// a backend, and UI surfaces orphan remediation flows.
+	if IsPinnedModelUnavailable(model, backend) {
 		return nil
 	}
-	if slices.Contains(backend.Models, model) {
-		return nil
-	}
-	return fmt.Errorf("config: agent %q: model %q is not available for backend (available: %s)", agentName, model, strings.Join(backend.Models, ", "))
+	return nil
 }
 
 // ApplyBackendDefaults fills in zero-value fields of b with the same defaults

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,10 +2,10 @@
 //
 // The config file is structured in three top-level sections:
 //
-//   daemon — how the service runs (logging, HTTP, queues, AI backends)
-//   skills — reusable guidance blocks referenced by agents
-//   agents — named capabilities (backend + skills + prompt)
-//   repos  — wiring: which agents run on which repo, and when
+//	daemon — how the service runs (logging, HTTP, queues, AI backends)
+//	skills — reusable guidance blocks referenced by agents
+//	agents — named capabilities (backend + skills + prompt)
+//	repos  — wiring: which agents run on which repo, and when
 //
 // See config.example.yaml for a complete annotated example.
 package config
@@ -22,29 +22,28 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// validAIBackendNames is the canonical ordered list of supported AI backend
-// names. Preference order for the "auto" backend resolution follows slice
-// order. Adding a new backend only requires updating this slice.
-var validAIBackendNames = []string{"claude", "codex"}
+// validAIBackendNames is the canonical list of supported AI backend names.
+// Adding a new backend only requires updating this slice.
+var validAIBackendNames = []string{"claude", "codex", "claude_local"}
 
 // validEventKinds is the set of event kind strings accepted in the events:
 // binding field. It must be kept in sync with the kinds emitted by the webhook
 // server handlers.
 var validEventKinds = map[string]struct{}{
-	"issues.labeled":              {},
-	"issues.opened":               {},
-	"issues.edited":               {},
-	"issues.reopened":             {},
-	"issues.closed":               {},
-	"pull_request.labeled":        {},
-	"pull_request.opened":         {},
-	"pull_request.synchronize":    {},
-	"pull_request.ready_for_review": {},
-	"pull_request.closed":         {},
-	"issue_comment.created":       {},
-	"pull_request_review.submitted":         {},
-	"pull_request_review_comment.created":   {},
-	"push":                                  {},
+	"issues.labeled":                      {},
+	"issues.opened":                       {},
+	"issues.edited":                       {},
+	"issues.reopened":                     {},
+	"issues.closed":                       {},
+	"pull_request.labeled":                {},
+	"pull_request.opened":                 {},
+	"pull_request.synchronize":            {},
+	"pull_request.ready_for_review":       {},
+	"pull_request.closed":                 {},
+	"issue_comment.created":               {},
+	"pull_request_review.submitted":       {},
+	"pull_request_review_comment.created": {},
+	"push":                                {},
 }
 
 // validEventKindsSorted is a precomputed, sorted list of validEventKinds keys
@@ -97,8 +96,8 @@ type DaemonConfig struct {
 // ProxyConfig controls the built-in Anthropic↔OpenAI translation proxy.
 // When Enabled is false (the default) no additional route is mounted.
 type ProxyConfig struct {
-	Enabled  bool              `yaml:"enabled"`
-	Path     string            `yaml:"path"`
+	Enabled  bool                `yaml:"enabled"`
+	Path     string              `yaml:"path"`
 	Upstream ProxyUpstreamConfig `yaml:"upstream"`
 }
 
@@ -161,18 +160,23 @@ type DispatchConfig struct {
 
 // AIBackendConfig describes how to invoke a CLI-based AI backend.
 //
-// Env is merged on top of the inherited subprocess environment (after the
-// daemon's allowlist is applied). Typical use: route the claude CLI through
-// a local OpenAI-compatible endpoint by setting
-// ANTHROPIC_BASE_URL / ANTHROPIC_API_KEY / ANTHROPIC_MODEL here, without
-// touching the global container env.
+// LocalModelURL, when set, routes the CLI through the built-in translation
+// proxy by injecting ANTHROPIC_BASE_URL into the subprocess environment.
 type AIBackendConfig struct {
-	Command          string            `yaml:"command"`
-	Args             []string          `yaml:"args"`
-	Env              map[string]string `yaml:"env"`
-	TimeoutSeconds   int               `yaml:"timeout_seconds"`
-	MaxPromptChars   int               `yaml:"max_prompt_chars"`
-	RedactionSaltEnv string            `yaml:"redaction_salt_env"`
+	Command          string   `yaml:"command"`
+	Version          string   `yaml:"version"`
+	Models           []string `yaml:"models"`
+	Healthy          bool     `yaml:"healthy"`
+	HealthDetail     string   `yaml:"health_detail"`
+	LocalModelURL    string   `yaml:"local_model_url"`
+	TimeoutSeconds   int      `yaml:"timeout_seconds"`
+	MaxPromptChars   int      `yaml:"max_prompt_chars"`
+	RedactionSaltEnv string   `yaml:"redaction_salt_env"`
+
+	// Args and Env are retained for backward-compatible YAML import only.
+	// They are ignored at runtime.
+	Args []string          `yaml:"args,omitempty"`
+	Env  map[string]string `yaml:"env,omitempty"`
 }
 
 // SkillDef is a reusable block of guidance that agents can compose.
@@ -189,6 +193,7 @@ type SkillDef struct {
 type AgentDef struct {
 	Name       string   `yaml:"name"`
 	Backend    string   `yaml:"backend"`
+	Model      string   `yaml:"model"`
 	Skills     []string `yaml:"skills"`
 	Prompt     string   `yaml:"prompt"`
 	PromptFile string   `yaml:"prompt_file"`
@@ -251,7 +256,7 @@ func (b Binding) IsEvent() bool { return len(b.Events) > 0 }
 // committed to the database.
 //
 // Specifically it verifies:
-//   - every agent references a known backend (unless "auto") and known skills
+//   - every agent references a known backend and known skills
 //   - dispatch wiring (can_dispatch) references existing agents with descriptions
 //   - every repo binding references a known agent
 func ValidateCrossRefs(agents []AgentDef, repos []RepoDef, skills map[string]SkillDef, backends map[string]AIBackendConfig) error {
@@ -262,10 +267,14 @@ func ValidateCrossRefs(agents []AgentDef, repos []RepoDef, skills map[string]Ski
 
 	// Validate agent → backend and skill references.
 	for _, a := range agents {
-		if a.Backend != "auto" {
-			if _, ok := backends[a.Backend]; !ok {
-				return fmt.Errorf("config: agent %q: unknown backend %q", a.Name, a.Backend)
-			}
+		if a.Backend == "" {
+			return fmt.Errorf("config: agent %q: backend is required", a.Name)
+		}
+		if _, ok := backends[a.Backend]; !ok {
+			return fmt.Errorf("config: agent %q: unknown backend %q", a.Name, a.Backend)
+		}
+		if err := validateAgentModel(a.Name, a.Model, backends[a.Backend]); err != nil {
+			return err
 		}
 		for _, s := range a.Skills {
 			if _, ok := skills[s]; !ok {
@@ -351,10 +360,14 @@ func ValidateEntities(agents []AgentDef, repos []RepoDef, skills map[string]Skil
 			return fmt.Errorf("config: duplicate agent name %q", a.Name)
 		}
 		seen[a.Name] = struct{}{}
-		if a.Backend != "auto" {
-			if _, ok := backends[a.Backend]; !ok {
-				return fmt.Errorf("config: agent %q: unknown backend %q", a.Name, a.Backend)
-			}
+		if a.Backend == "" {
+			return fmt.Errorf("config: agent %q: backend is required", a.Name)
+		}
+		if _, ok := backends[a.Backend]; !ok {
+			return fmt.Errorf("config: agent %q: unknown backend %q", a.Name, a.Backend)
+		}
+		if err := validateAgentModel(a.Name, a.Model, backends[a.Backend]); err != nil {
+			return err
 		}
 		for _, s := range a.Skills {
 			if _, ok := skills[s]; !ok {
@@ -490,25 +503,13 @@ func (c *Config) AgentByName(name string) (AgentDef, bool) {
 	return AgentDef{}, false
 }
 
-// DefaultBackend returns the first configured backend from validAIBackendNames.
-// Used when an agent specifies backend: "auto" or leaves it empty.
-func (c *Config) DefaultBackend() string {
-	for _, name := range validAIBackendNames {
-		if _, ok := c.Daemon.AIBackends[name]; ok {
-			return name
-		}
-	}
-	return ""
-}
-
 // ResolveBackend returns the concrete backend name for the given agent
-// configuration value. "auto" or empty resolves to the default configured
-// backend; an explicit name is returned as-is if it is present in
-// ai_backends. Returns "" if the name is explicit but not configured.
+// configuration value. The backend must be explicitly configured; empty
+// or unknown names return "".
 func (c *Config) ResolveBackend(configured string) string {
 	configured = strings.ToLower(strings.TrimSpace(configured))
-	if configured == "" || configured == "auto" {
-		return c.DefaultBackend()
+	if configured == "" {
+		return ""
 	}
 	if _, ok := c.Daemon.AIBackends[configured]; !ok {
 		return ""
@@ -552,13 +553,6 @@ func (c *Config) applyDefaults() {
 		c.Daemon.AIBackends[name] = backend
 	}
 
-	// agents: default backend to "auto" when empty
-	for i := range c.Agents {
-		if strings.TrimSpace(c.Agents[i].Backend) == "" {
-			c.Agents[i].Backend = "auto"
-		}
-	}
-
 	// repos: default enabled to true when field absent is ambiguous; YAML
 	// zero-value is false. We leave it as-is — absent means false here,
 	// because repos are an explicit allow-list.
@@ -571,6 +565,9 @@ func (c *Config) normalize() {
 		for name, backend := range c.Daemon.AIBackends {
 			key := strings.ToLower(strings.TrimSpace(name))
 			backend.Command = strings.TrimSpace(backend.Command)
+			backend.Version = strings.TrimSpace(backend.Version)
+			backend.HealthDetail = strings.TrimSpace(backend.HealthDetail)
+			backend.LocalModelURL = strings.TrimSpace(backend.LocalModelURL)
 			if len(backend.Env) > 0 {
 				cleaned := make(map[string]string, len(backend.Env))
 				for k, v := range backend.Env {
@@ -581,6 +578,9 @@ func (c *Config) normalize() {
 					cleaned[k] = v
 				}
 				backend.Env = cleaned
+			}
+			for i := range backend.Models {
+				backend.Models[i] = strings.TrimSpace(backend.Models[i])
 			}
 			lower[key] = backend
 		}
@@ -603,6 +603,7 @@ func (c *Config) normalize() {
 	for i := range c.Agents {
 		c.Agents[i].Name = strings.ToLower(strings.TrimSpace(c.Agents[i].Name))
 		c.Agents[i].Backend = strings.ToLower(strings.TrimSpace(c.Agents[i].Backend))
+		c.Agents[i].Model = strings.TrimSpace(c.Agents[i].Model)
 		c.Agents[i].Prompt = strings.TrimSpace(c.Agents[i].Prompt)
 		c.Agents[i].PromptFile = strings.TrimSpace(c.Agents[i].PromptFile)
 		c.Agents[i].Description = strings.TrimSpace(c.Agents[i].Description)
@@ -802,10 +803,14 @@ func (c *Config) validateAgents() error {
 		}
 		seen[a.Name] = struct{}{}
 
-		if a.Backend != "auto" {
-			if _, ok := c.Daemon.AIBackends[a.Backend]; !ok {
-				return fmt.Errorf("config: agent %q: unknown backend %q", a.Name, a.Backend)
-			}
+		if a.Backend == "" {
+			return fmt.Errorf("config: agent %q: backend is required", a.Name)
+		}
+		if _, ok := c.Daemon.AIBackends[a.Backend]; !ok {
+			return fmt.Errorf("config: agent %q: unknown backend %q", a.Name, a.Backend)
+		}
+		if err := validateAgentModel(a.Name, a.Model, c.Daemon.AIBackends[a.Backend]); err != nil {
+			return err
 		}
 		for _, s := range a.Skills {
 			if _, ok := c.Skills[s]; !ok {
@@ -821,9 +826,9 @@ func (c *Config) validateAgents() error {
 }
 
 // validateDispatchWiring checks cross-agent dispatch references:
-//  - can_dispatch entries must reference real agents in this config
-//  - can_dispatch must not include the agent itself
-//  - agents referenced in any can_dispatch list must have a description
+//   - can_dispatch entries must reference real agents in this config
+//   - can_dispatch must not include the agent itself
+//   - agents referenced in any can_dispatch list must have a description
 func (c *Config) validateDispatchWiring() error {
 	// Build set of all agent names for O(1) lookup.
 	agentNames := make(map[string]struct{}, len(c.Agents))
@@ -913,6 +918,20 @@ func isValidBackendName(name string) bool {
 	return slices.Contains(validAIBackendNames, name)
 }
 
+func validateAgentModel(agentName, model string, backend AIBackendConfig) error {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return nil
+	}
+	if len(backend.Models) == 0 {
+		return nil
+	}
+	if slices.Contains(backend.Models, model) {
+		return nil
+	}
+	return fmt.Errorf("config: agent %q: model %q is not available for backend (available: %s)", agentName, model, strings.Join(backend.Models, ", "))
+}
+
 // ApplyBackendDefaults fills in zero-value fields of b with the same defaults
 // that Load / FinishLoad apply at startup. Callers that persist a backend via
 // the CRUD API should call this before writing so that the stored values match
@@ -929,6 +948,9 @@ func ApplyBackendDefaults(b *AIBackendConfig) {
 // at boot, preventing live behavior from diverging until a restart.
 func NormalizeBackendConfig(b *AIBackendConfig) {
 	b.Command = strings.TrimSpace(b.Command)
+	b.Version = strings.TrimSpace(b.Version)
+	b.HealthDetail = strings.TrimSpace(b.HealthDetail)
+	b.LocalModelURL = strings.TrimSpace(b.LocalModelURL)
 	if len(b.Env) > 0 {
 		cleaned := make(map[string]string, len(b.Env))
 		for k, v := range b.Env {
@@ -939,6 +961,9 @@ func NormalizeBackendConfig(b *AIBackendConfig) {
 			cleaned[k] = v
 		}
 		b.Env = cleaned
+	}
+	for i := range b.Models {
+		b.Models[i] = strings.TrimSpace(b.Models[i])
 	}
 }
 
@@ -959,6 +984,7 @@ func NormalizeSkillDef(s *SkillDef) {
 func NormalizeAgentDef(a *AgentDef) {
 	a.Name = strings.ToLower(strings.TrimSpace(a.Name))
 	a.Backend = strings.ToLower(strings.TrimSpace(a.Backend))
+	a.Model = strings.TrimSpace(a.Model)
 	a.Prompt = strings.TrimSpace(a.Prompt)
 	a.PromptFile = strings.TrimSpace(a.PromptFile)
 	a.Description = strings.TrimSpace(a.Description)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -325,7 +325,6 @@ repos:
 	}
 }
 
-
 func TestBindingIsEnabledDefaultsTrue(t *testing.T) {
 	t.Parallel()
 	var b Binding
@@ -336,21 +335,6 @@ func TestBindingIsEnabledDefaultsTrue(t *testing.T) {
 	b.Enabled = &f
 	if b.IsEnabled() {
 		t.Errorf("expected disabled when Enabled=false")
-	}
-}
-
-func TestDefaultBackendPrefersFirstConfigured(t *testing.T) {
-	t.Parallel()
-	cfg := &Config{
-		Daemon: DaemonConfig{
-			AIBackends: map[string]AIBackendConfig{
-				"claude": {Command: "claude"},
-				"codex":  {Command: "codex"},
-			},
-		},
-	}
-	if got := cfg.DefaultBackend(); got != "claude" {
-		t.Errorf("DefaultBackend: got %q, want claude", got)
 	}
 }
 
@@ -367,10 +351,10 @@ func TestResolveBackend(t *testing.T) {
 		configured string
 		want       string
 	}{
-		{"", "claude"},
-		{"auto", "claude"},
+		{"", ""},
+		{"auto", ""},
 		{"claude", "claude"},
-		{"codex", ""},  // not in ai_backends
+		{"codex", ""},        // not in ai_backends
 		{"CLAUDE", "claude"}, // case-folded
 	}
 	for _, tc := range cases {

--- a/internal/setup/prompt.md
+++ b/internal/setup/prompt.md
@@ -1,247 +1,178 @@
-You are a setup assistant for the **agents** daemon — a GitHub webhook-driven AI review system. Your job is to guide the user through the full setup from scratch, step by step. Be conversational, validate each step before proceeding, and offer to roll back if anything fails.
+You are the interactive setup assistant for the **agents** daemon.
+
+Your job is to guide the user through a complete, working setup and validate it with the daemon's diagnostics APIs before finishing.
+
+Core rule: backend runner arguments are daemon-managed. Do **not** ask users to tune Claude/Codex CLI args. Only user-facing backend runtime fields should be timeouts, max prompt chars, and local backend URLs.
 
 ## Your tools
 
-You have full access to shell tools. Use them freely:
-- `gh` CLI for GitHub operations (auth, repos, webhooks, labels)
-- `which`, `brew`, `apt`, `curl` for checking and installing prerequisites
-- File writing tools for creating `.env` and `config.yaml`
+You can use shell tools directly:
+- `gh` for GitHub auth/repo/webhook/label operations
+- `which`, `<tool> --version`, `curl`, `jq`
+- file editing tools for `.env` and `config.yaml`
 
-## Setup flow
-
-Work through the following phases in order. After each phase succeeds, confirm with the user before moving on.
+Work phase by phase. Confirm each phase outcome before moving on.
 
 ---
 
-### Phase 1 — Prerequisites
+## Phase 1 — Verify prerequisites
 
-Check for required tools:
+Check these commands and report exact results:
+1. `gh --version` (required)
+2. `claude --version` (required)
+3. `codex --version` (optional but recommended)
+4. `go version` (required to run local build)
 
-1. `gh` CLI: run `gh --version`. If missing, install it (offer `brew install gh` on macOS, `apt install gh` on Debian/Ubuntu, or direct download link for Linux).
-2. `claude` CLI: run `claude --version`. If missing, tell the user to install it from https://claude.ai/download and re-run setup.
-3. Optional: `codex` CLI: run `codex --version`. Note if absent — codex backend won't be available.
-4. Optional: `docker` CLI: run `docker --version`. Note if absent.
-
----
-
-### Phase 2 — GitHub authentication
-
-Run `gh auth status`. If not logged in, run `gh auth login` interactively and wait for it to complete. Verify with `gh api user --jq .login` and greet the user by their GitHub username.
+If a required tool is missing, provide install steps for the current OS and pause until user confirms.
 
 ---
 
-### Phase 3 — Repo selection
+## Phase 2 — Verify auth + MCP readiness
 
-Ask the user which GitHub repositories they want the agents daemon to manage. For each repo:
-- Validate it exists and is accessible: `gh repo view <owner/repo>`
-- Confirm the user has admin access (needed for webhook creation): `gh api repos/<owner/repo> --jq .permissions.admin`
-- Collect the list as `owner/repo` pairs.
+1. GitHub auth:
+   - Run `gh auth status`.
+   - If not authenticated, run `gh auth login` and re-check.
+2. Claude MCP:
+   - If `claude` exists, run `claude mcp list`.
+   - Check whether GitHub MCP appears and whether it is connected.
+3. Codex MCP:
+   - If `codex` exists, run `codex mcp list`.
+   - Check whether GitHub MCP appears and whether it is connected.
 
----
-
-### Phase 4 — Network setup
-
-Ask the user for the **public URL** where the agents daemon will be reachable by GitHub (e.g. `https://agents.example.com`). This is the URL GitHub will POST webhooks to.
-
-If the user doesn't have a public URL yet, offer to set up a tunnel:
-- **Cloudflare Tunnel:** `brew install cloudflared` then `cloudflared tunnel --url http://localhost:8080`
-- **ngrok:** `brew install ngrok` then `ngrok http 8080`
-
-Run the chosen tunnel in the background and capture the assigned public URL.
+Important:
+- Missing/disconnected MCP should be reported clearly, but setup can continue (user may run non-GitHub workflows).
+- Summarize readiness as: `gh auth`, `claude mcp github`, `codex mcp github`.
 
 ---
 
-### Phase 5 — Secrets
+## Phase 3 — Gather setup inputs
 
-Generate a cryptographically strong webhook secret:
-```
-WEBHOOK_SECRET=$(openssl rand -hex 32)
-```
+Ask for:
+1. Repositories to manage (`owner/repo`, one or many)
+2. Public webhook base URL (e.g. `https://agents.example.com`)
+3. Whether to include codex-based agents now (yes/no)
 
-Ask if the user wants an API key for the on-demand trigger endpoint (`POST /agents/run`):
-```
-API_KEY=$(openssl rand -hex 32)
-```
-
-Write `.env` with:
-```
-GITHUB_WEBHOOK_SECRET=<generated secret>
-LOG_SALT=<openssl rand -hex 16>
-```
+Validate each repo with:
+- `gh repo view <owner/repo>`
+- `gh api repos/<owner/repo> --jq .permissions.admin` (must be `true` for webhook creation)
 
 ---
 
-### Phase 6 — Webhook creation
+## Phase 4 — Write secrets and baseline config
 
-For each selected repo, create a GitHub webhook:
-```
+Generate:
+- `GITHUB_WEBHOOK_SECRET` via `openssl rand -hex 32`
+- `LOG_SALT` via `openssl rand -hex 16`
+
+Write `.env` with those values.
+
+Generate a `config.yaml` compatible with this repo's current schema:
+- `daemon`, `skills`, `agents`, `repos`
+- include at least one enabled repo and at least one agent
+- include backend entries for the backends the user intends to use (`claude`, optional `codex`)
+
+Backend config guidance:
+- keep backend config minimal and stable
+- do not add custom runner args tuned by the user
+- do not use `backend: auto` in agents
+- model pinning in agents is optional; empty model means backend default
+
+Before writing, show the proposed `config.yaml` and ask for explicit confirmation.
+
+---
+
+## Phase 5 — Import and start daemon
+
+Run:
+1. `go build -o ./agents-bin ./cmd/agents`
+2. `./agents-bin --db agents.db --import config.yaml`
+
+If start fails, inspect and fix errors before proceeding.
+
+---
+
+## Phase 6 — Run diagnostics APIs (mandatory)
+
+Now validate using the daemon APIs:
+
+1. Health:
+   - `curl -s http://127.0.0.1:8080/status | jq`
+   - Must return `"status":"ok"`.
+
+2. Live backend/tool diagnostics:
+   - `curl -s http://127.0.0.1:8080/backends/status | jq`
+   - Review:
+     - detected backends
+     - backend health and model lists
+     - GitHub CLI status/auth
+     - MCP connectivity notes
+
+3. Persist fresh discovery snapshot:
+   - `curl -s -X POST http://127.0.0.1:8080/backends/discover | jq`
+   - Explain this writes discovery results into DB.
+
+4. Orphaned model check:
+   - `curl -s http://127.0.0.1:8080/agents/orphans/status | jq`
+   - If `count > 0`, explain that these agents pin unavailable models and should be remapped or cleared from the Backends UI.
+
+If diagnostics show issues, help the user fix them and re-run checks.
+
+---
+
+## Phase 7 — GitHub webhook setup
+
+For each selected repo, create webhook:
+
+```bash
 gh api repos/<owner/repo>/hooks \
   --method POST \
   --field name=web \
   --field active=true \
   --field "events[]=issues" \
   --field "events[]=pull_request" \
-  --field "config[url]=<public_url>/webhooks/github" \
+  --field "events[]=issue_comment" \
+  --field "events[]=pull_request_review" \
+  --field "events[]=pull_request_review_comment" \
+  --field "events[]=push" \
+  --field "config[url]=<public_base_url>/webhooks/github" \
   --field "config[content_type]=json" \
-  --field "config[secret]=<WEBHOOK_SECRET>"
+  --field "config[secret]=<GITHUB_WEBHOOK_SECRET>"
 ```
 
-Confirm each webhook was created (status 201). If creation fails, offer to retry or skip.
+If a webhook already exists, detect and avoid duplicates.
 
 ---
 
-### Phase 7 — Agent design (conversational)
+## Phase 8 — Optional local backend setup
 
-Now ask the user what automations they want. Be conversational. Examples of good questions:
+If user wants local OpenAI-compatible models:
+- Ensure `claude` backend is present.
+- Add a local backend through API:
 
-- "What kind of code reviews do you want? (architecture, security, testing, ops, UX?)"
-- "Do you want scheduled autonomous agents that sweep open issues or the codebase on a schedule?"
-- "Any specific prompt style you want (strict, concise, detailed)?"
+```bash
+curl -s -X POST http://127.0.0.1:8080/backends/local \
+  -H "Content-Type: application/json" \
+  -d '{"name":"qwen_local","url":"http://localhost:18000/v1/messages"}' | jq
+```
 
-Available built-in skills:
-- `architect` — architecture boundaries, coupling, extensibility
-- `security` — authn/authz, secrets, injection vectors
-- `testing` — missing tests, regression coverage, testability
-- `devops` — reliability, deployment safety, observability
-- `ux` — clarity, accessibility, copy quality
+Then re-run:
+- `GET /backends/status`
+- `POST /backends/discover`
 
-For each automation the user describes, map it to an agent config:
-- Label-triggered PR reviewer → entry under `agents:` with a label-based skill
-- Scheduled autonomous sweep → entry under `autonomous_agents:`
+Explain that local backend URL and runtime limits can be edited later from **Config → Backends and tools**.
 
 ---
 
-### Phase 8 — Config generation
+## Completion checklist
 
-Generate a `config.yaml` based on everything learned. Use this schema (keep the structure, fill in real values):
+Before finishing, verify and summarize:
+1. `gh` authenticated
+2. claude/codex availability
+3. daemon running and `/status` healthy
+4. discovery executed and persisted
+5. orphaned agent count
+6. webhooks created for each repo
+7. exact start command for the user:
+   - `./agents --db agents.db`
 
-```yaml
-log:
-  level: info
-  format: text
-
-http:
-  listen_addr: ":8080"
-  status_path: /status
-  webhook_path: /webhooks/github
-  read_timeout_seconds: 15
-  write_timeout_seconds: 15
-  idle_timeout_seconds: 60
-  max_body_bytes: 1048576
-  webhook_secret_env: GITHUB_WEBHOOK_SECRET
-  delivery_ttl_seconds: 3600
-  shutdown_timeout_seconds: 15
-
-processor:
-  event_queue_buffer: 256
-
-agents_dir: "./agents"
-
-prompts:
-  issue_refinement:
-    prompt: |
-      Refine issue #{{.Number}} in {{.Repo}}.
-      Post exactly one concise GitHub comment with: feasibility, approach, acceptance criteria, and open questions.
-      Return one JSON object on stdout.
-  pr_review:
-    prompt: |
-      {{.AgentHeading}}
-      Review PR #{{.Number}} in {{.Repo}} from the perspective of {{.Agent}}.
-      {{template "agent_guidance" .}}
-      Post one high-signal review comment and return one JSON object on stdout.
-  autonomous:
-    prompt: |
-      Autonomous run for {{.Repo}} as {{.AgentName}}.
-      Focus: {{.Description}}
-      Task: {{.Task}}
-      The daemon injects your existing memory in the ## Runtime context section below.
-      {{template "agent_guidance" .}}
-      Return one JSON object on stdout. Include a "memory" field with your full updated
-      memory state — the daemon persists this after each run. An empty string clears it.
-
-skills:
-  - name: architect
-    prompt: |
-      Focus on architecture boundaries, coupling, extensibility, and maintainability risks.
-  - name: security
-    prompt: |
-      Focus on authn/authz, secrets exposure, injection vectors, and unsafe defaults.
-  - name: testing
-    prompt: |
-      Focus on missing tests, brittle tests, regression coverage, and testability.
-  - name: devops
-    prompt: |
-      Focus on reliability, deployment safety, observability, and operational simplicity.
-  - name: ux
-    prompt: |
-      Focus on clarity, accessibility, copy quality, and user flow friction.
-
-agents:
-  # Fill in from agent design phase
-  # - name: arch-reviewer
-  #   skills: [architect]
-
-ai_backends:
-  claude:
-    mode: command
-    command: claude
-    args:
-      - "-p"
-      - "--dangerously-skip-permissions"
-    timeout_seconds: 600
-    max_prompt_chars: 12000
-    redaction_salt_env: LOG_SALT
-
-repos:
-  # Fill in from repo selection phase
-
-autonomous_agents:
-  # Fill in from agent design phase (if any scheduled agents were requested)
-```
-
-Write the completed `config.yaml` to the current directory. Show the final YAML to the user and ask for confirmation before writing.
-
----
-
-### Phase 9 — GitHub label creation
-
-For each repo and each label-triggered agent, create the required GitHub labels:
-
-```
-gh label create "ai:review:claude:<agent-name>" --repo <owner/repo> --color 0075ca --description "Trigger AI review by <agent-name>"
-```
-
-Also create:
-```
-gh label create "ai:refine" --repo <owner/repo> --color e4e669 --description "Trigger AI issue refinement"
-```
-
-Skip if the label already exists (exit code 1 with "already exists" message is fine).
-
----
-
-### Phase 10 — Verification
-
-Start the daemon in the background for a quick health check:
-```
-go build -o ./agents-bin ./cmd/agents && ./agents-bin --db agents.db --import config.yaml &
-sleep 2
-curl -s http://localhost:8080/status
-```
-
-If `/status` returns a JSON object with `"status":"ok"`, setup is complete. Kill the background process.
-
-If it fails, show the daemon logs and help the user diagnose the issue.
-
----
-
-## Completion
-
-Once all phases succeed, print a summary:
-- Which repos are configured
-- Which agents were created and what labels trigger them
-- Any scheduled autonomous agents and their cron schedules
-- The public webhook URL
-- How to start the daemon: `agents --db agents.db` or via Docker
-
-Congratulate the user and let them know they can trigger agents by applying labels to issues and PRs.
+Be explicit, concise, and only claim success for checks you actually ran.

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -74,6 +74,25 @@ func TestRunPassesPromptAsArg(t *testing.T) {
 	}
 }
 
+func TestRunPromptMentionsDiagnosticsEndpoints(t *testing.T) {
+	t.Parallel()
+	runner := &captureRunner{}
+
+	_ = setup.Run(runner, false, &bytes.Buffer{}, &bytes.Buffer{}, &bytes.Buffer{})
+
+	prompt := runner.args[len(runner.args)-1]
+	for _, want := range []string{
+		"/status",
+		"/backends/status",
+		"/backends/discover",
+		"/agents/orphans/status",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("embedded setup prompt missing %q", want)
+		}
+	}
+}
+
 func TestRunForwardsStdin(t *testing.T) {
 	t.Parallel()
 	var capturedStdin io.Reader

--- a/internal/store/crud_test.go
+++ b/internal/store/crud_test.go
@@ -15,7 +15,7 @@ import (
 // reference it pass cross-ref validation.
 func seedBackend(t *testing.T, db *sql.DB, name string) {
 	t.Helper()
-	b := config.AIBackendConfig{Command: name, Args: []string{}, Env: map[string]string{}}
+	b := config.AIBackendConfig{Command: name}
 	if err := store.UpsertBackend(db, name, b); err != nil {
 		t.Fatalf("seedBackend %s: %v", name, err)
 	}
@@ -203,8 +203,6 @@ func TestUpsertAndReadBackends(t *testing.T) {
 
 	b := config.AIBackendConfig{
 		Command:        "claude",
-		Args:           []string{"-p", "--output-format", "json"},
-		Env:            map[string]string{"K": "V"},
 		TimeoutSeconds: 300,
 		MaxPromptChars: 8000,
 	}
@@ -222,11 +220,8 @@ func TestUpsertAndReadBackends(t *testing.T) {
 	if got.Command != "claude" {
 		t.Errorf("Command: got %q, want %q", got.Command, "claude")
 	}
-	if len(got.Args) != 3 {
-		t.Errorf("Args: got %v", got.Args)
-	}
-	if got.Env["K"] != "V" {
-		t.Errorf("Env[K]: got %q, want %q", got.Env["K"], "V")
+	if got.TimeoutSeconds != 300 {
+		t.Errorf("TimeoutSeconds: got %d, want 300", got.TimeoutSeconds)
 	}
 }
 
@@ -237,7 +232,7 @@ func TestUpsertBackendAppliesDefaults(t *testing.T) {
 	// Persist a backend with zero numeric fields — the same payload that
 	// POST /api/store/backends would send when omitting timeout_seconds and
 	// max_prompt_chars from the request body.
-	b := config.AIBackendConfig{Command: "claude", Args: []string{}, Env: map[string]string{}}
+	b := config.AIBackendConfig{Command: "claude"}
 	if err := store.UpsertBackend(db, "claude", b); err != nil {
 		t.Fatalf("UpsertBackend: %v", err)
 	}
@@ -262,7 +257,7 @@ func TestDeleteBackend(t *testing.T) {
 	// Seed two backends so that deleting one still leaves the system valid.
 	for _, name := range []string{"claude", "codex"} {
 		if err := store.UpsertBackend(db, name, config.AIBackendConfig{
-			Command: name, Args: []string{}, Env: map[string]string{},
+			Command: name,
 		}); err != nil {
 			t.Fatalf("UpsertBackend %s: %v", name, err)
 		}
@@ -654,13 +649,13 @@ func TestUpsertBackendValidationErrors(t *testing.T) {
 		{
 			name:    "empty command",
 			bName:   "claude",
-			cfg:     config.AIBackendConfig{Command: "", Args: []string{}, Env: map[string]string{}},
+			cfg:     config.AIBackendConfig{Command: "", },
 			wantErr: "command is required",
 		},
 		{
 			name:    "invalid name",
 			bName:   "unknown-ai",
-			cfg:     config.AIBackendConfig{Command: "ai", Args: []string{}, Env: map[string]string{}},
+			cfg:     config.AIBackendConfig{Command: "ai", },
 			wantErr: "unsupported ai backend",
 		},
 	}
@@ -797,7 +792,7 @@ func TestDeleteBackendRejectedAsLast(t *testing.T) {
 	db := openTestDB(t)
 
 	if err := store.UpsertBackend(db, "claude", config.AIBackendConfig{
-		Command: "claude", Args: []string{}, Env: map[string]string{},
+		Command: "claude",
 	}); err != nil {
 		t.Fatalf("UpsertBackend: %v", err)
 	}
@@ -869,7 +864,7 @@ func TestUpsertNormalizesNames(t *testing.T) {
 
 	// Backend — mixed-case name should be stored lowercase.
 	if err := store.UpsertBackend(db, "Claude", config.AIBackendConfig{
-		Command: "claude", Args: []string{}, Env: map[string]string{},
+		Command: "claude",
 	}); err != nil {
 		t.Fatalf("UpsertBackend: %v", err)
 	}
@@ -980,14 +975,13 @@ func TestUpsertSkillNormalizesPrompt(t *testing.T) {
 // normalization startup applies in normalize(). This prevents a write that
 // passes validation from creating a backend that the daemon refuses to load
 // on restart after startup normalization changes its shape.
-func TestUpsertBackendNormalizesCommandAndEnv(t *testing.T) {
+func TestUpsertBackendNormalizesCommand(t *testing.T) {
 	t.Parallel()
 	db := openTestDB(t)
 
 	// Whitespace-only command must be trimmed to "" and rejected.
 	err := store.UpsertBackend(db, "claude", config.AIBackendConfig{
 		Command: "   ",
-		Env:     map[string]string{},
 	})
 	if err == nil {
 		t.Fatal("UpsertBackend with whitespace-only command: want error, got nil")
@@ -996,10 +990,9 @@ func TestUpsertBackendNormalizesCommandAndEnv(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	// Padded command should be stored trimmed; blank env key should be dropped.
+	// Padded command should be stored trimmed.
 	if err := store.UpsertBackend(db, "claude", config.AIBackendConfig{
 		Command: "  claude  ",
-		Env:     map[string]string{"VALID_KEY": "val", "  ": "blank-key"},
 	}); err != nil {
 		t.Fatalf("UpsertBackend with padded command: %v", err)
 	}
@@ -1010,14 +1003,5 @@ func TestUpsertBackendNormalizesCommandAndEnv(t *testing.T) {
 	got := backends["claude"]
 	if got.Command != "claude" {
 		t.Errorf("Command not trimmed: got %q, want %q", got.Command, "claude")
-	}
-	if _, ok := got.Env[""]; ok {
-		t.Error("blank env key should have been removed")
-	}
-	if _, ok := got.Env["  "]; ok {
-		t.Error("whitespace env key should have been removed")
-	}
-	if got.Env["VALID_KEY"] != "val" {
-		t.Errorf("valid env key lost: got %v", got.Env)
 	}
 }

--- a/internal/store/migrations/006_backend_metadata_and_agent_model.sql
+++ b/internal/store/migrations/006_backend_metadata_and_agent_model.sql
@@ -1,0 +1,9 @@
+-- Add backend discovery metadata and per-agent model selection support.
+
+ALTER TABLE backends ADD COLUMN version TEXT NOT NULL DEFAULT '';
+ALTER TABLE backends ADD COLUMN models TEXT NOT NULL DEFAULT '[]';
+ALTER TABLE backends ADD COLUMN healthy INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE backends ADD COLUMN health_detail TEXT NOT NULL DEFAULT '';
+ALTER TABLE backends ADD COLUMN local_model_url TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE agents ADD COLUMN model TEXT NOT NULL DEFAULT '';

--- a/internal/store/migrations/006_backend_metadata_and_agent_model.sql
+++ b/internal/store/migrations/006_backend_metadata_and_agent_model.sql
@@ -1,9 +1,23 @@
--- Add backend discovery metadata and per-agent model selection support.
+-- Add backend discovery metadata, per-agent model selection, and drop
+-- legacy args/env columns that are now hardcoded in the runner.
 
-ALTER TABLE backends ADD COLUMN version TEXT NOT NULL DEFAULT '';
-ALTER TABLE backends ADD COLUMN models TEXT NOT NULL DEFAULT '[]';
-ALTER TABLE backends ADD COLUMN healthy INTEGER NOT NULL DEFAULT 0;
-ALTER TABLE backends ADD COLUMN health_detail TEXT NOT NULL DEFAULT '';
-ALTER TABLE backends ADD COLUMN local_model_url TEXT NOT NULL DEFAULT '';
+CREATE TABLE backends_new (
+    name             TEXT PRIMARY KEY,
+    command          TEXT NOT NULL,
+    version          TEXT NOT NULL DEFAULT '',
+    models           TEXT NOT NULL DEFAULT '[]',
+    healthy          INTEGER NOT NULL DEFAULT 0,
+    health_detail    TEXT NOT NULL DEFAULT '',
+    local_model_url  TEXT NOT NULL DEFAULT '',
+    timeout_seconds  INTEGER NOT NULL DEFAULT 600,
+    max_prompt_chars INTEGER NOT NULL DEFAULT 12000,
+    redaction_salt_env TEXT NOT NULL DEFAULT ''
+);
+
+INSERT INTO backends_new (name, command, timeout_seconds, max_prompt_chars, redaction_salt_env)
+    SELECT name, command, timeout_seconds, max_prompt_chars, redaction_salt_env FROM backends;
+
+DROP TABLE backends;
+ALTER TABLE backends_new RENAME TO backends;
 
 ALTER TABLE agents ADD COLUMN model TEXT NOT NULL DEFAULT '';

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -252,14 +252,6 @@ func importDaemon(tx *sql.Tx, d config.DaemonConfig) error {
 
 func importBackends(tx *sql.Tx, backends map[string]config.AIBackendConfig) error {
 	for name, b := range backends {
-		args, err := json.Marshal(b.Args)
-		if err != nil {
-			return fmt.Errorf("store import: marshal backend %s args: %w", name, err)
-		}
-		env, err := json.Marshal(b.Env)
-		if err != nil {
-			return fmt.Errorf("store import: marshal backend %s env: %w", name, err)
-		}
 		models, err := json.Marshal(b.Models)
 		if err != nil {
 			return fmt.Errorf("store import: marshal backend %s models: %w", name, err)
@@ -267,9 +259,9 @@ func importBackends(tx *sql.Tx, backends map[string]config.AIBackendConfig) erro
 		healthy := boolToInt(b.Healthy)
 		if _, err := tx.Exec(`
 			INSERT OR REPLACE INTO backends
-			  (name,command,args,env,version,models,healthy,health_detail,local_model_url,timeout_seconds,max_prompt_chars,redaction_salt_env)
-			VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`,
-			name, b.Command, string(args), string(env),
+			  (name,command,version,models,healthy,health_detail,local_model_url,timeout_seconds,max_prompt_chars,redaction_salt_env)
+			VALUES (?,?,?,?,?,?,?,?,?,?)`,
+			name, b.Command,
 			b.Version, string(models), healthy, b.HealthDetail, b.LocalModelURL,
 			b.TimeoutSeconds, b.MaxPromptChars, b.RedactionSaltEnv,
 		); err != nil {
@@ -426,7 +418,7 @@ func loadDaemon(db *sql.DB, cfg *config.Config) error {
 }
 
 func loadBackends(db querier, cfg *config.Config) error {
-	rows, err := db.Query("SELECT name,command,args,env,version,models,healthy,health_detail,local_model_url,timeout_seconds,max_prompt_chars,redaction_salt_env FROM backends")
+	rows, err := db.Query("SELECT name,command,version,models,healthy,health_detail,local_model_url,timeout_seconds,max_prompt_chars,redaction_salt_env FROM backends")
 	if err != nil {
 		return fmt.Errorf("store load: query backends: %w", err)
 	}
@@ -434,18 +426,10 @@ func loadBackends(db querier, cfg *config.Config) error {
 
 	backends := make(map[string]config.AIBackendConfig)
 	for rows.Next() {
-		var name, command, argsJSON, envJSON, version, modelsJSON, healthDetail, localModelURL, saltEnv string
+		var name, command, version, modelsJSON, healthDetail, localModelURL, saltEnv string
 		var timeout, maxChars, healthy int
-		if err := rows.Scan(&name, &command, &argsJSON, &envJSON, &version, &modelsJSON, &healthy, &healthDetail, &localModelURL, &timeout, &maxChars, &saltEnv); err != nil {
+		if err := rows.Scan(&name, &command, &version, &modelsJSON, &healthy, &healthDetail, &localModelURL, &timeout, &maxChars, &saltEnv); err != nil {
 			return fmt.Errorf("store load: scan backend: %w", err)
-		}
-		var args []string
-		if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
-			return fmt.Errorf("store load: parse backend %s args: %w", name, err)
-		}
-		var env map[string]string
-		if err := json.Unmarshal([]byte(envJSON), &env); err != nil {
-			return fmt.Errorf("store load: parse backend %s env: %w", name, err)
 		}
 		var models []string
 		if err := json.Unmarshal([]byte(modelsJSON), &models); err != nil {
@@ -458,8 +442,6 @@ func loadBackends(db querier, cfg *config.Config) error {
 			Healthy:          intToBool(healthy),
 			HealthDetail:     healthDetail,
 			LocalModelURL:    localModelURL,
-			Args:             args,
-			Env:              env,
 			TimeoutSeconds:   timeout,
 			MaxPromptChars:   maxChars,
 			RedactionSaltEnv: saltEnv,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -18,8 +18,8 @@ package store
 
 import (
 	"database/sql"
-	"encoding/json"
 	"embed"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -196,8 +196,8 @@ type httpRecord struct {
 
 // proxyRecord mirrors ProxyConfig but omits the resolved APIKey.
 type proxyRecord struct {
-	Enabled  bool               `json:"enabled"`
-	Path     string             `json:"path"`
+	Enabled  bool                `json:"enabled"`
+	Path     string              `json:"path"`
 	Upstream proxyUpstreamRecord `json:"upstream"`
 }
 
@@ -213,10 +213,10 @@ func importDaemon(tx *sql.Tx, d config.DaemonConfig) error {
 	rec := daemonRecord{
 		Log: d.Log,
 		HTTP: httpRecord{
-			ListenAddr:             d.HTTP.ListenAddr,
-			StatusPath:             d.HTTP.StatusPath,
-			WebhookPath:            d.HTTP.WebhookPath,
-			WebhookSecretEnv:       d.HTTP.WebhookSecretEnv,
+			ListenAddr:       d.HTTP.ListenAddr,
+			StatusPath:       d.HTTP.StatusPath,
+			WebhookPath:      d.HTTP.WebhookPath,
+			WebhookSecretEnv: d.HTTP.WebhookSecretEnv,
 
 			ReadTimeoutSeconds:     d.HTTP.ReadTimeoutSeconds,
 			WriteTimeoutSeconds:    d.HTTP.WriteTimeoutSeconds,
@@ -260,11 +260,17 @@ func importBackends(tx *sql.Tx, backends map[string]config.AIBackendConfig) erro
 		if err != nil {
 			return fmt.Errorf("store import: marshal backend %s env: %w", name, err)
 		}
+		models, err := json.Marshal(b.Models)
+		if err != nil {
+			return fmt.Errorf("store import: marshal backend %s models: %w", name, err)
+		}
+		healthy := boolToInt(b.Healthy)
 		if _, err := tx.Exec(`
 			INSERT OR REPLACE INTO backends
-			  (name,command,args,env,timeout_seconds,max_prompt_chars,redaction_salt_env)
-			VALUES (?,?,?,?,?,?,?)`,
+			  (name,command,args,env,version,models,healthy,health_detail,local_model_url,timeout_seconds,max_prompt_chars,redaction_salt_env)
+			VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`,
 			name, b.Command, string(args), string(env),
+			b.Version, string(models), healthy, b.HealthDetail, b.LocalModelURL,
 			b.TimeoutSeconds, b.MaxPromptChars, b.RedactionSaltEnv,
 		); err != nil {
 			return fmt.Errorf("store import: upsert backend %s: %w", name, err)
@@ -299,9 +305,9 @@ func importAgents(tx *sql.Tx, agents []config.AgentDef) error {
 		allowDispatch := boolToInt(a.AllowDispatch)
 		if _, err := tx.Exec(`
 			INSERT OR REPLACE INTO agents
-			  (name,backend,skills,prompt,allow_prs,allow_dispatch,can_dispatch,description)
-			VALUES (?,?,?,?,?,?,?,?)`,
-			a.Name, a.Backend, string(skills), a.Prompt,
+			  (name,backend,model,skills,prompt,allow_prs,allow_dispatch,can_dispatch,description)
+			VALUES (?,?,?,?,?,?,?,?,?)`,
+			a.Name, a.Backend, a.Model, string(skills), a.Prompt,
 			allowPRs, allowDispatch, string(canDispatch), a.Description,
 		); err != nil {
 			return fmt.Errorf("store import: upsert agent %s: %w", a.Name, err)
@@ -392,10 +398,10 @@ func loadDaemon(db *sql.DB, cfg *config.Config) error {
 
 	cfg.Daemon.Log = rec.Log
 	cfg.Daemon.HTTP = config.HTTPConfig{
-		ListenAddr:             rec.HTTP.ListenAddr,
-		StatusPath:             rec.HTTP.StatusPath,
-		WebhookPath:            rec.HTTP.WebhookPath,
-		WebhookSecretEnv:       rec.HTTP.WebhookSecretEnv,
+		ListenAddr:       rec.HTTP.ListenAddr,
+		StatusPath:       rec.HTTP.StatusPath,
+		WebhookPath:      rec.HTTP.WebhookPath,
+		WebhookSecretEnv: rec.HTTP.WebhookSecretEnv,
 
 		ReadTimeoutSeconds:     rec.HTTP.ReadTimeoutSeconds,
 		WriteTimeoutSeconds:    rec.HTTP.WriteTimeoutSeconds,
@@ -420,7 +426,7 @@ func loadDaemon(db *sql.DB, cfg *config.Config) error {
 }
 
 func loadBackends(db querier, cfg *config.Config) error {
-	rows, err := db.Query("SELECT name,command,args,env,timeout_seconds,max_prompt_chars,redaction_salt_env FROM backends")
+	rows, err := db.Query("SELECT name,command,args,env,version,models,healthy,health_detail,local_model_url,timeout_seconds,max_prompt_chars,redaction_salt_env FROM backends")
 	if err != nil {
 		return fmt.Errorf("store load: query backends: %w", err)
 	}
@@ -428,9 +434,9 @@ func loadBackends(db querier, cfg *config.Config) error {
 
 	backends := make(map[string]config.AIBackendConfig)
 	for rows.Next() {
-		var name, command, argsJSON, envJSON, saltEnv string
-		var timeout, maxChars int
-		if err := rows.Scan(&name, &command, &argsJSON, &envJSON, &timeout, &maxChars, &saltEnv); err != nil {
+		var name, command, argsJSON, envJSON, version, modelsJSON, healthDetail, localModelURL, saltEnv string
+		var timeout, maxChars, healthy int
+		if err := rows.Scan(&name, &command, &argsJSON, &envJSON, &version, &modelsJSON, &healthy, &healthDetail, &localModelURL, &timeout, &maxChars, &saltEnv); err != nil {
 			return fmt.Errorf("store load: scan backend: %w", err)
 		}
 		var args []string
@@ -441,8 +447,17 @@ func loadBackends(db querier, cfg *config.Config) error {
 		if err := json.Unmarshal([]byte(envJSON), &env); err != nil {
 			return fmt.Errorf("store load: parse backend %s env: %w", name, err)
 		}
+		var models []string
+		if err := json.Unmarshal([]byte(modelsJSON), &models); err != nil {
+			return fmt.Errorf("store load: parse backend %s models: %w", name, err)
+		}
 		backends[name] = config.AIBackendConfig{
 			Command:          command,
+			Version:          version,
+			Models:           models,
+			Healthy:          intToBool(healthy),
+			HealthDetail:     healthDetail,
+			LocalModelURL:    localModelURL,
 			Args:             args,
 			Env:              env,
 			TimeoutSeconds:   timeout,
@@ -481,7 +496,7 @@ func loadSkills(db querier, cfg *config.Config) error {
 
 func loadAgents(db querier, cfg *config.Config) error {
 	rows, err := db.Query(`
-		SELECT name,backend,skills,prompt,allow_prs,allow_dispatch,can_dispatch,description
+		SELECT name,backend,model,skills,prompt,allow_prs,allow_dispatch,can_dispatch,description
 		FROM agents ORDER BY name`)
 	if err != nil {
 		return fmt.Errorf("store load: query agents: %w", err)
@@ -490,10 +505,10 @@ func loadAgents(db querier, cfg *config.Config) error {
 
 	var agents []config.AgentDef
 	for rows.Next() {
-		var name, backend, skillsJSON, prompt, canDispatchJSON, description string
+		var name, backend, model, skillsJSON, prompt, canDispatchJSON, description string
 		var allowPRs, allowDispatch int
 		if err := rows.Scan(
-			&name, &backend, &skillsJSON, &prompt,
+			&name, &backend, &model, &skillsJSON, &prompt,
 			&allowPRs, &allowDispatch, &canDispatchJSON, &description,
 		); err != nil {
 			return fmt.Errorf("store load: scan agent: %w", err)
@@ -509,6 +524,7 @@ func loadAgents(db querier, cfg *config.Config) error {
 		agents = append(agents, config.AgentDef{
 			Name:          name,
 			Backend:       backend,
+			Model:         model,
 			Skills:        skills,
 			Prompt:        prompt,
 			AllowPRs:      intToBool(allowPRs),
@@ -694,4 +710,3 @@ func LoadAndValidate(db *sql.DB) (*config.Config, error) {
 	}
 	return config.FinishLoad(cfg)
 }
-

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -45,8 +45,6 @@ func minimalCfg() *config.Config {
 			AIBackends: map[string]config.AIBackendConfig{
 				"claude": {
 					Command:          "claude",
-					Args:             []string{"-p", "--output-format", "json"},
-					Env:              map[string]string{"MY_VAR": "my_val"},
 					TimeoutSeconds:   600,
 					MaxPromptChars:   12000,
 					RedactionSaltEnv: "LOG_SALT",
@@ -176,13 +174,6 @@ func TestImportLoad(t *testing.T) {
 	if claude.Command != "claude" {
 		t.Errorf("backend command: got %q, want %q", claude.Command, "claude")
 	}
-	if len(claude.Args) != 3 {
-		t.Errorf("backend args: got %v, want 3 items", claude.Args)
-	}
-	if claude.Env["MY_VAR"] != "my_val" {
-		t.Errorf("backend env MY_VAR: got %q, want %q", claude.Env["MY_VAR"], "my_val")
-	}
-
 	// Skills.
 	if len(out.Skills) != 2 {
 		t.Fatalf("skills: got %d, want 2", len(out.Skills))
@@ -333,7 +324,7 @@ func TestLoadEmptyDatabase(t *testing.T) {
 func seedAgent(t *testing.T, db *sql.DB, name string) {
 	t.Helper()
 	if err := store.UpsertBackend(db, "claude", config.AIBackendConfig{
-		Command: "claude", Args: []string{}, Env: map[string]string{},
+		Command: "claude",
 	}); err != nil {
 		t.Fatalf("seedAgent backend: %v", err)
 	}

--- a/internal/ui/src/app/config/page.tsx
+++ b/internal/ui/src/app/config/page.tsx
@@ -8,6 +8,12 @@ type Config = Record<string, unknown>
 interface Backend {
   name: string
   command: string
+  version?: string
+  models?: string[]
+  healthy?: boolean
+  health_detail?: string
+  local_model_url?: string
+  detected?: boolean
   args: string[]
   env: Record<string, string>
   timeout_seconds: number
@@ -205,9 +211,9 @@ export default function ConfigPage() {
 
   const loadBackends = () => {
     setBackendsLoading(true)
-    fetch('/backends')
+    fetch('/backends/status')
       .then(r => r.json())
-      .then((data: Backend[]) => { setBackends(data); setBackendsLoading(false) })
+      .then((data: { backends?: Backend[] }) => { setBackends(data.backends ?? []); setBackendsLoading(false) })
       .catch(() => setBackendsLoading(false))
   }
 
@@ -247,6 +253,46 @@ export default function ConfigPage() {
         return
       }
       setModal(null)
+      loadBackends()
+    } catch (e) {
+      setSaveError(String(e))
+    }
+    setSaving(false)
+  }
+
+  const runDiscovery = async () => {
+    setSaving(true)
+    setSaveError('')
+    try {
+      const res = await fetch('/backends/discover', { method: 'POST' })
+      if (!res.ok) {
+        setSaveError((await res.text()) || 'Discovery failed')
+        setSaving(false)
+        return
+      }
+      loadBackends()
+    } catch (e) {
+      setSaveError(String(e))
+    }
+    setSaving(false)
+  }
+
+  const addLocalBackend = async () => {
+    const url = window.prompt('Local model URL (OpenAI-compatible endpoint):', 'http://localhost:8080/v1/messages')
+    if (!url) return
+    setSaving(true)
+    setSaveError('')
+    try {
+      const res = await fetch('/backends/local', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url }),
+      })
+      if (!res.ok) {
+        setSaveError((await res.text()) || 'Local backend save failed')
+        setSaving(false)
+        return
+      }
       loadBackends()
     } catch (e) {
       setSaveError(String(e))
@@ -343,10 +389,16 @@ export default function ConfigPage() {
             </span>
             <div style={{ display: 'flex', gap: '0.5rem' }}>
               <button
-                onClick={() => { setSaveError(''); setSelected({ ...emptyBackend }); setModal('create') }}
+                onClick={runDiscovery}
                 style={{ background: 'var(--btn-primary-bg)', border: '1px solid var(--btn-primary-border)', color: '#fff', padding: '5px 12px', borderRadius: '6px', cursor: 'pointer', fontSize: '0.8rem', fontWeight: 600 }}
               >
-                + Add backend
+                {saving ? 'Running…' : 'Run discovery'}
+              </button>
+              <button
+                onClick={addLocalBackend}
+                style={{ background: 'var(--bg-card)', border: '1px solid var(--border)', color: 'var(--text)', padding: '5px 10px', borderRadius: '6px', cursor: 'pointer', fontSize: '0.8rem' }}
+              >
+                + Local backend
               </button>
               <button onClick={loadBackends} style={{ background: 'var(--bg-card)', border: '1px solid var(--border)', color: 'var(--text-muted)', padding: '5px 10px', borderRadius: '6px', cursor: 'pointer', fontSize: '0.8rem' }}>
                 Refresh
@@ -364,28 +416,16 @@ export default function ConfigPage() {
                   <div>
                     <div style={{ fontWeight: 700, color: 'var(--text-heading)' }}>{b.name}</div>
                     <div style={{ fontSize: '0.78rem', color: 'var(--text-muted)', marginTop: '2px' }}>
-                      {b.command} {b.args.slice(0, 3).join(' ')}{b.args.length > 3 ? ' …' : ''} · {b.timeout_seconds}s · {b.max_prompt_chars} chars
+                      {b.command || 'not detected'}{b.version ? ` · ${b.version}` : ''}{b.local_model_url ? ' · local URL configured' : ''} · {b.healthy ? 'healthy' : 'unhealthy'}
                     </div>
-                    {Object.keys(b.env).length > 0 && (
-                      <div style={{ fontSize: '0.75rem', color: 'var(--text-faint)', marginTop: '2px' }}>
-                        env: {Object.keys(b.env).join(', ')}
-                      </div>
-                    )}
-                  </div>
-                  <div style={{ display: 'flex', gap: '0.5rem' }}>
-                    <button
-                      onClick={() => { setSaveError(''); setSelected(b); setModal('edit') }}
-                      style={{ padding: '3px 10px', borderRadius: '5px', border: '1px solid var(--border)', background: 'var(--bg-card)', cursor: 'pointer', fontSize: '0.75rem', color: 'var(--accent)' }}
-                    >Edit</button>
-                    <button
-                      onClick={() => { setDeleteTarget(b.name); setSaveError(''); setModal('delete') }}
-                      style={{ padding: '3px 10px', borderRadius: '5px', border: '1px solid var(--border-danger)', background: 'var(--bg-danger)', cursor: 'pointer', fontSize: '0.75rem', color: 'var(--text-danger)' }}
-                    >Delete</button>
+                    {!!(b.models && b.models.length > 0) && <div style={{ fontSize: '0.75rem', color: 'var(--text-faint)', marginTop: '2px' }}>models: {b.models.join(', ')}</div>}
+                    {b.health_detail && <div style={{ fontSize: '0.75rem', color: 'var(--text-faint)', marginTop: '2px' }}>{b.health_detail}</div>}
                   </div>
                 </div>
               </div>
             ))}
           </div>
+          {saveError && <p style={{ color: 'var(--text-danger)', fontSize: '0.85rem', marginTop: '0.75rem' }}>{saveError}</p>}
         </Card>
       )}
 

--- a/internal/ui/src/app/config/page.tsx
+++ b/internal/ui/src/app/config/page.tsx
@@ -14,22 +14,113 @@ interface Backend {
   health_detail?: string
   local_model_url?: string
   detected?: boolean
-  args: string[]
-  env: Record<string, string>
   timeout_seconds: number
   max_prompt_chars: number
-  redaction_salt_env: string
 }
 
-const emptyBackend: Backend = {
-  name: '', command: '', args: [], env: {}, timeout_seconds: 600, max_prompt_chars: 12000, redaction_salt_env: '',
+interface GitHubCLIStatus {
+  detected?: boolean
+  command?: string
+  authenticated?: boolean
+  healthy?: boolean
+  detail?: string
+}
+
+interface BackendsDiscoveryResponse {
+  backends?: Backend[]
+  github_cli?: GitHubCLIStatus
+}
+
+interface OrphanedAgent {
+  name: string
+  backend: string
+  model: string
+  repos?: string[]
+  available_models?: string[]
+}
+
+interface OrphanedAgentsResponse {
+  count?: number
+  agents?: OrphanedAgent[]
+}
+
+const orderedBackendNames = ['claude', 'codex']
+
+const normalizeModels = (models?: string[]) => (models ?? []).map(m => m.trim()).filter(Boolean).sort()
+
+const buildBackendDriftWarnings = (dbBackends: Backend[], diagnosticsBackends: Backend[]) => {
+  const warnings: string[] = []
+  const dbByName = new Map(dbBackends.map(b => [b.name, b]))
+  const diagByName = new Map(diagnosticsBackends.map(b => [b.name, b]))
+  const names = Array.from(new Set(Array.from(dbByName.keys()).concat(Array.from(diagByName.keys())))).sort()
+
+  for (const name of names) {
+    const db = dbByName.get(name)
+    const diag = diagByName.get(name)
+
+    if (!db && diag) {
+      warnings.push(`${name}: detected by diagnostics but missing in database.`)
+      continue
+    }
+    if (db && !diag) {
+      warnings.push(`${name}: present in database but missing in diagnostics.`)
+      continue
+    }
+    if (!db || !diag) continue
+
+    if ((db.command || '') !== (diag.command || '')) {
+      warnings.push(`${name}: command changed (db: ${db.command || 'empty'} → diagnostics: ${diag.command || 'empty'}).`)
+    }
+    if ((db.version || '') !== (diag.version || '')) {
+      warnings.push(`${name}: version changed (db: ${db.version || 'empty'} → diagnostics: ${diag.version || 'empty'}).`)
+    }
+    if (!!db.healthy !== !!diag.healthy) {
+      warnings.push(`${name}: health changed (db: ${db.healthy ? 'healthy' : 'failed'} → diagnostics: ${diag.healthy ? 'healthy' : 'failed'}).`)
+    }
+    if ((db.local_model_url || '') !== (diag.local_model_url || '')) {
+      warnings.push(`${name}: local URL changed (db: ${db.local_model_url || 'empty'} → diagnostics: ${diag.local_model_url || 'empty'}).`)
+    }
+    const dbModels = normalizeModels(db.models)
+    const diagModels = normalizeModels(diag.models)
+    if (dbModels.join(',') !== diagModels.join(',')) {
+      warnings.push(`${name}: models list changed (db: ${dbModels.length}, diagnostics: ${diagModels.length}).`)
+    }
+    if ((db.health_detail || '') !== (diag.health_detail || '')) {
+      warnings.push(`${name}: health detail changed.`)
+    }
+  }
+  return warnings
 }
 
 const inputStyle: React.CSSProperties = {
-  width: '100%', padding: '6px 8px', border: '1px solid var(--border)', borderRadius: '6px',
-  fontSize: '0.85rem', fontFamily: 'inherit', background: 'var(--bg-input)', color: 'var(--text)',
+  width: '100%',
+  padding: '6px 8px',
+  border: '1px solid var(--border)',
+  borderRadius: '6px',
+  fontSize: '0.85rem',
+  fontFamily: 'inherit',
+  background: 'var(--bg-input)',
+  color: 'var(--text)',
 }
-const labelStyle: React.CSSProperties = { fontSize: '0.8rem', color: 'var(--text-muted)', display: 'block', marginBottom: '3px' }
+
+const labelStyle: React.CSSProperties = {
+  fontSize: '0.8rem',
+  color: 'var(--text-muted)',
+  display: 'block',
+  marginBottom: '3px',
+}
+
+const healthBadgeStyle = (ok: boolean | undefined): React.CSSProperties => ({
+  display: 'inline-block',
+  fontSize: '0.68rem',
+  textTransform: 'uppercase',
+  letterSpacing: '0.02em',
+  padding: '1px 6px',
+  borderRadius: '999px',
+  border: `1px solid ${ok ? 'var(--success)' : 'var(--border-danger)'}`,
+  color: ok ? 'var(--success)' : 'var(--text-danger)',
+  background: ok ? 'rgba(16,185,129,0.1)' : 'var(--bg-danger)',
+})
 
 function JsonTree({ value, depth = 0 }: { value: unknown; depth?: number }) {
   if (value === null) return <span style={{ color: 'var(--text-muted)' }}>null</span>
@@ -76,112 +167,8 @@ function JsonTree({ value, depth = 0 }: { value: unknown; depth?: number }) {
   return <span style={{ color: 'var(--text-muted)' }}>{JSON.stringify(value)}</span>
 }
 
-function EnvEditor({ env, onChange }: { env: Record<string, string>; onChange: (e: Record<string, string>) => void }) {
-  const [pairs, setPairs] = useState<[string, string][]>(() => Object.entries(env))
-
-  const update = (newPairs: [string, string][]) => {
-    setPairs(newPairs)
-    onChange(Object.fromEntries(newPairs.filter(([k]) => k.trim())))
-  }
-
-  return (
-    <div>
-      {pairs.map(([k, v], i) => (
-        <div key={i} style={{ display: 'flex', gap: '0.4rem', marginBottom: '0.35rem' }}>
-          <input
-            style={{ ...inputStyle, flex: 1 }}
-            placeholder="KEY"
-            value={k}
-            onChange={e => { const p = [...pairs]; p[i] = [e.target.value, v]; update(p) }}
-          />
-          <input
-            style={{ ...inputStyle, flex: 2 }}
-            placeholder="value"
-            value={v}
-            onChange={e => { const p = [...pairs]; p[i] = [k, e.target.value]; update(p) }}
-          />
-          <button
-            onClick={() => update(pairs.filter((_, idx) => idx !== i))}
-            style={{ padding: '3px 8px', border: '1px solid var(--border-danger)', background: 'var(--bg-danger)', borderRadius: '5px', cursor: 'pointer', fontSize: '0.75rem', color: 'var(--text-danger)' }}
-          >✕</button>
-        </div>
-      ))}
-      <button
-        onClick={() => update([...pairs, ['', '']])}
-        style={{ fontSize: '0.75rem', color: 'var(--accent)', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
-      >
-        + Add env var
-      </button>
-    </div>
-  )
-}
-
-function BackendForm({ initial, isNew, onSave, onCancel, saving, error }: {
-  initial: Backend
-  isNew: boolean
-  onSave: (b: Backend) => void
-  onCancel: () => void
-  saving: boolean
-  error: string
-}) {
-  const [form, setForm] = useState<Backend>(initial)
-  const set = (k: keyof Backend, v: unknown) => setForm(f => ({ ...f, [k]: v }))
-
-  return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.85rem' }}>
-      <div>
-        <label style={labelStyle}>Name *</label>
-        <input style={inputStyle} value={form.name} onChange={e => set('name', e.target.value)} placeholder="claude" disabled={!isNew} />
-      </div>
-      <div>
-        <label style={labelStyle}>Command</label>
-        <input style={inputStyle} value={form.command} onChange={e => set('command', e.target.value)} placeholder="claude" />
-      </div>
-      <div>
-        <label style={labelStyle}>Args (comma-separated)</label>
-        <input
-          style={inputStyle}
-          value={form.args.join(', ')}
-          onChange={e => set('args', e.target.value.split(',').map(s => s.trim()).filter(Boolean))}
-          placeholder="-p, --dangerously-skip-permissions"
-        />
-      </div>
-      <div style={{ display: 'flex', gap: '1rem' }}>
-        <div style={{ flex: 1 }}>
-          <label style={labelStyle}>Timeout (seconds)</label>
-          <input style={inputStyle} type="number" value={form.timeout_seconds} onChange={e => set('timeout_seconds', Number(e.target.value))} />
-        </div>
-        <div style={{ flex: 1 }}>
-          <label style={labelStyle}>Max prompt chars</label>
-          <input style={inputStyle} type="number" value={form.max_prompt_chars} onChange={e => set('max_prompt_chars', Number(e.target.value))} />
-        </div>
-      </div>
-      <div>
-        <label style={labelStyle}>Redaction salt env var</label>
-        <input style={inputStyle} value={form.redaction_salt_env} onChange={e => set('redaction_salt_env', e.target.value)} placeholder="LOG_SALT" />
-      </div>
-      <div>
-        <label style={{ ...labelStyle, marginBottom: '0.4rem' }}>Environment variables</label>
-        <EnvEditor env={form.env} onChange={env => set('env', env)} />
-      </div>
-      {error && <p style={{ color: 'var(--text-danger)', fontSize: '0.8rem' }}>{error}</p>}
-      <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'flex-end' }}>
-        <button onClick={onCancel} style={{ padding: '6px 16px', borderRadius: '6px', border: '1px solid var(--border)', background: 'var(--bg-card)', cursor: 'pointer', fontSize: '0.875rem', color: 'var(--text-muted)' }}>
-          Cancel
-        </button>
-        <button
-          onClick={() => onSave(form)}
-          disabled={saving || !form.name.trim()}
-          style={{ padding: '6px 16px', borderRadius: '6px', border: '1px solid var(--btn-primary-border)', background: 'var(--btn-primary-bg)', color: '#fff', cursor: saving ? 'wait' : 'pointer', fontSize: '0.875rem', fontWeight: 600 }}
-        >
-          {saving ? 'Saving…' : 'Save'}
-        </button>
-      </div>
-    </div>
-  )
-}
-
 export default function ConfigPage() {
+  const [orphanFocus, setOrphanFocus] = useState(false)
   const [config, setConfig] = useState<Config | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
@@ -189,18 +176,40 @@ export default function ConfigPage() {
   const [tab, setTab] = useState<'inspector' | 'backends' | 'import-export'>('inspector')
 
   const [backends, setBackends] = useState<Backend[]>([])
+  const [githubCLI, setGitHubCLI] = useState<GitHubCLIStatus | null>(null)
   const [backendsLoading, setBackendsLoading] = useState(false)
+  const [backendDriftWarnings, setBackendDriftWarnings] = useState<string[]>([])
+  const [orphanedAgents, setOrphanedAgents] = useState<OrphanedAgent[]>([])
+  const [orphanModelSelection, setOrphanModelSelection] = useState<Record<string, string>>({})
 
-  const [modal, setModal] = useState<'create' | 'edit' | 'delete' | null>(null)
-  const [selected, setSelected] = useState<Backend>(emptyBackend)
-  const [deleteTarget, setDeleteTarget] = useState('')
   const [saving, setSaving] = useState(false)
   const [saveError, setSaveError] = useState('')
+  const [localBackendModalOpen, setLocalBackendModalOpen] = useState(false)
+  const [localBackendName, setLocalBackendName] = useState('claude_local')
+  const [localBackendURL, setLocalBackendURL] = useState('http://localhost:8080/v1/messages')
+  const [deleteTarget, setDeleteTarget] = useState<Backend | null>(null)
+  const [settingsTarget, setSettingsTarget] = useState<Backend | null>(null)
+  const [settingsTimeout, setSettingsTimeout] = useState('600')
+  const [settingsMaxPromptChars, setSettingsMaxPromptChars] = useState('12000')
+  const [settingsLocalModelURL, setSettingsLocalModelURL] = useState('')
 
   const [importStatus, setImportStatus] = useState('')
   const [importError, setImportError] = useState('')
   const [importMode, setImportMode] = useState<'merge' | 'replace'>('merge')
   const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const sortBackends = (list: Backend[]) => {
+    const rank = (name: string) => {
+      const idx = orderedBackendNames.indexOf(name)
+      if (idx >= 0) return idx
+      return 100
+    }
+    return [...list].sort((a, b) => {
+      const byRank = rank(a.name) - rank(b.name)
+      if (byRank !== 0) return byRank
+      return a.name.localeCompare(b.name)
+    })
+  }
 
   useEffect(() => {
     fetch('/config')
@@ -209,56 +218,57 @@ export default function ConfigPage() {
       .catch(e => { setError(String(e)); setLoading(false) })
   }, [])
 
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const requestedTab = params.get('tab')
+    if (requestedTab === 'inspector' || requestedTab === 'backends' || requestedTab === 'import-export') {
+      setTab(requestedTab)
+    }
+    setOrphanFocus(params.get('focus') === 'orphans')
+  }, [])
+
   const loadBackends = () => {
     setBackendsLoading(true)
-    fetch('/backends/status')
-      .then(r => r.json())
-      .then((data: { backends?: Backend[] }) => { setBackends(data.backends ?? []); setBackendsLoading(false) })
-      .catch(() => setBackendsLoading(false))
+    Promise.all([fetch('/backends'), fetch('/backends/status'), fetch('/agents/orphans/status')])
+      .then(async ([dbRes, diagRes, orphanRes]) => {
+        if (!dbRes.ok) throw new Error((await dbRes.text()) || 'Failed to load backends from database')
+        if (!diagRes.ok) throw new Error((await diagRes.text()) || 'Failed to load diagnostics')
+        if (!orphanRes.ok) throw new Error((await orphanRes.text()) || 'Failed to load orphaned agents')
+
+        const dbData = sortBackends(await dbRes.json() as Backend[])
+        const diagData = await diagRes.json() as BackendsDiscoveryResponse
+        const diagBackends = sortBackends(diagData.backends ?? [])
+        const orphanData = await orphanRes.json() as OrphanedAgentsResponse
+        const orphanAgents = orphanData.agents ?? []
+
+        setBackends(dbData)
+        setGitHubCLI(diagData.github_cli ?? null)
+        setBackendDriftWarnings(buildBackendDriftWarnings(dbData, diagBackends))
+        setOrphanedAgents(orphanAgents)
+        setOrphanModelSelection(prev => {
+          const next: Record<string, string> = {}
+          for (const orphan of orphanAgents) {
+            const suggested = orphan.available_models?.[0] ?? ''
+            next[orphan.name] = prev[orphan.name] ?? suggested
+          }
+          return next
+        })
+        setBackendsLoading(false)
+      })
+      .catch((e: unknown) => {
+        setSaveError(String(e))
+        setBackendDriftWarnings([])
+        setGitHubCLI(null)
+        setOrphanedAgents([])
+        setOrphanModelSelection({})
+        setBackends([])
+        setBackendsLoading(false)
+      })
   }
 
   useEffect(() => {
     if (tab === 'backends') loadBackends()
   }, [tab])
-
-  const saveBackend = async (form: Backend) => {
-    setSaving(true)
-    setSaveError('')
-    try {
-      const res = await fetch('/backends', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(form),
-      })
-      if (!res.ok) {
-        setSaveError((await res.text()) || 'Save failed')
-        setSaving(false)
-        return
-      }
-      setModal(null)
-      loadBackends()
-    } catch (e) {
-      setSaveError(String(e))
-    }
-    setSaving(false)
-  }
-
-  const deleteBackend = async () => {
-    setSaving(true)
-    try {
-      const res = await fetch(`/backends/${encodeURIComponent(deleteTarget)}`, { method: 'DELETE' })
-      if (!res.ok && res.status !== 204) {
-        setSaveError((await res.text()) || 'Delete failed')
-        setSaving(false)
-        return
-      }
-      setModal(null)
-      loadBackends()
-    } catch (e) {
-      setSaveError(String(e))
-    }
-    setSaving(false)
-  }
 
   const runDiscovery = async () => {
     setSaving(true)
@@ -270,6 +280,8 @@ export default function ConfigPage() {
         setSaving(false)
         return
       }
+      const data = await res.json() as BackendsDiscoveryResponse
+      setGitHubCLI(data.github_cli ?? null)
       loadBackends()
     } catch (e) {
       setSaveError(String(e))
@@ -278,20 +290,160 @@ export default function ConfigPage() {
   }
 
   const addLocalBackend = async () => {
-    const url = window.prompt('Local model URL (OpenAI-compatible endpoint):', 'http://localhost:8080/v1/messages')
-    if (!url) return
     setSaving(true)
     setSaveError('')
     try {
       const res = await fetch('/backends/local', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ url }),
+        body: JSON.stringify({ name: localBackendName, url: localBackendURL }),
       })
       if (!res.ok) {
         setSaveError((await res.text()) || 'Local backend save failed')
         setSaving(false)
         return
+      }
+      setLocalBackendModalOpen(false)
+      loadBackends()
+    } catch (e) {
+      setSaveError(String(e))
+    }
+    setSaving(false)
+  }
+
+  const removeBackend = async () => {
+    if (!deleteTarget) return
+    setSaving(true)
+    setSaveError('')
+    try {
+      const res = await fetch(`/backends/${encodeURIComponent(deleteTarget.name)}`, { method: 'DELETE' })
+      if (!res.ok && res.status !== 204) {
+        setSaveError((await res.text()) || 'Remove failed')
+        setSaving(false)
+        return
+      }
+      setDeleteTarget(null)
+      loadBackends()
+    } catch (e) {
+      setSaveError(String(e))
+    }
+    setSaving(false)
+  }
+
+  const saveBackendRuntimeSettings = async () => {
+    if (!settingsTarget) return
+    const timeout = Number(settingsTimeout)
+    const maxPromptChars = Number(settingsMaxPromptChars)
+    const isLocalBackend = !!settingsTarget.local_model_url
+    const localURL = settingsLocalModelURL.trim()
+    if (!Number.isFinite(timeout) || timeout <= 0) {
+      setSaveError('Timeout must be a positive number')
+      return
+    }
+    if (!Number.isFinite(maxPromptChars) || maxPromptChars <= 0) {
+      setSaveError('Max prompt chars must be a positive number')
+      return
+    }
+    if (isLocalBackend && !localURL) {
+      setSaveError('Local model URL is required')
+      return
+    }
+
+    setSaving(true)
+    setSaveError('')
+    try {
+      if (isLocalBackend) {
+        const localRes = await fetch('/backends/local', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            name: settingsTarget.name,
+            url: localURL,
+          }),
+        })
+        if (!localRes.ok) {
+          setSaveError((await localRes.text()) || 'Local backend URL update failed')
+          setSaving(false)
+          return
+        }
+      }
+      const res = await fetch(`/backends/${encodeURIComponent(settingsTarget.name)}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          timeout_seconds: timeout,
+          max_prompt_chars: maxPromptChars,
+        }),
+      })
+      if (!res.ok) {
+        setSaveError((await res.text()) || 'Runtime settings update failed')
+        setSaving(false)
+        return
+      }
+      setSettingsTarget(null)
+      loadBackends()
+    } catch (e) {
+      setSaveError(String(e))
+    }
+    setSaving(false)
+  }
+
+  const upsertAgentModel = async (agentName: string, model: string) => {
+    const readRes = await fetch(`/agents/${encodeURIComponent(agentName)}`)
+    if (!readRes.ok) {
+      throw new Error((await readRes.text()) || `Failed to load agent ${agentName}`)
+    }
+    const agent = await readRes.json() as Record<string, unknown>
+    agent.model = model
+
+    const writeRes = await fetch('/agents', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(agent),
+    })
+    if (!writeRes.ok) {
+      throw new Error((await writeRes.text()) || `Failed to update agent ${agentName}`)
+    }
+  }
+
+  const saveOrphanModel = async (agentName: string) => {
+    const model = (orphanModelSelection[agentName] ?? '').trim()
+    if (!model) {
+      setSaveError(`Select a model for ${agentName} first`)
+      return
+    }
+    setSaving(true)
+    setSaveError('')
+    try {
+      await upsertAgentModel(agentName, model)
+      loadBackends()
+    } catch (e) {
+      setSaveError(String(e))
+    }
+    setSaving(false)
+  }
+
+  const clearOrphanModel = async (agentName: string) => {
+    setSaving(true)
+    setSaveError('')
+    try {
+      await upsertAgentModel(agentName, '')
+      loadBackends()
+    } catch (e) {
+      setSaveError(String(e))
+    }
+    setSaving(false)
+  }
+
+  const clearAllOrphanModels = async () => {
+    if (orphanedAgents.length === 0) return
+    setSaving(true)
+    setSaveError('')
+    try {
+      const results = await Promise.allSettled(orphanedAgents.map(orphan => upsertAgentModel(orphan.name, '')))
+      const failed = results.filter(r => r.status === 'rejected')
+      if (failed.length > 0) {
+        setSaveError(`Cleared ${orphanedAgents.length - failed.length}/${orphanedAgents.length} orphaned agents. Some updates failed.`)
       }
       loadBackends()
     } catch (e) {
@@ -357,7 +509,7 @@ export default function ConfigPage() {
 
       <div style={{ display: 'flex', gap: '0', marginBottom: '0', borderBottom: '1px solid var(--border)' }}>
         <button style={tabStyle('inspector')} onClick={() => setTab('inspector')}>Inspector</button>
-        <button style={tabStyle('backends')} onClick={() => setTab('backends')}>Backends</button>
+        <button style={tabStyle('backends')} onClick={() => setTab('backends')}>Backends and tools</button>
         <button style={tabStyle('import-export')} onClick={() => setTab('import-export')}>Import / Export</button>
       </div>
 
@@ -385,7 +537,7 @@ export default function ConfigPage() {
         <Card style={{ borderTopLeftRadius: 0 }}>
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
             <span style={{ color: 'var(--text-muted)', fontSize: '0.875rem' }}>
-              {backends.length} backend{backends.length !== 1 ? 's' : ''} configured
+              {backendsLoading ? 'Loading backends…' : `${backends.length} backend${backends.length !== 1 ? 's' : ''} configured`}
             </span>
             <div style={{ display: 'flex', gap: '0.5rem' }}>
               <button
@@ -395,35 +547,205 @@ export default function ConfigPage() {
                 {saving ? 'Running…' : 'Run discovery'}
               </button>
               <button
-                onClick={addLocalBackend}
+                onClick={() => {
+                  setSaveError('')
+                  setLocalBackendName('claude_local')
+                  setLocalBackendURL('http://localhost:8080/v1/messages')
+                  setLocalBackendModalOpen(true)
+                }}
                 style={{ background: 'var(--bg-card)', border: '1px solid var(--border)', color: 'var(--text)', padding: '5px 10px', borderRadius: '6px', cursor: 'pointer', fontSize: '0.8rem' }}
               >
                 + Local backend
               </button>
-              <button onClick={loadBackends} style={{ background: 'var(--bg-card)', border: '1px solid var(--border)', color: 'var(--text-muted)', padding: '5px 10px', borderRadius: '6px', cursor: 'pointer', fontSize: '0.8rem' }}>
-                Refresh
-              </button>
             </div>
           </div>
-          {backendsLoading && <p style={{ color: 'var(--text-muted)', fontSize: '0.85rem' }}>Loading…</p>}
-          {!backendsLoading && backends.length === 0 && (
-            <p style={{ color: 'var(--text-faint)', fontSize: '0.85rem' }}>No backends configured.</p>
-          )}
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.6rem' }}>
-            {backends.map(b => (
-              <div key={b.name} style={{ border: '1px solid var(--border-subtle)', borderRadius: '6px', padding: '0.75rem', background: 'var(--bg)' }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
-                  <div>
-                    <div style={{ fontWeight: 700, color: 'var(--text-heading)' }}>{b.name}</div>
-                    <div style={{ fontSize: '0.78rem', color: 'var(--text-muted)', marginTop: '2px' }}>
-                      {b.command || 'not detected'}{b.version ? ` · ${b.version}` : ''}{b.local_model_url ? ' · local URL configured' : ''} · {b.healthy ? 'healthy' : 'unhealthy'}
+          <p style={{ color: 'var(--text-faint)', fontSize: '0.8rem', marginBottom: '0.75rem' }}>
+            Backend arguments are managed by the daemon and are not user-editable.
+          </p>
+          {!backendsLoading && orphanedAgents.length > 0 && (
+            <div style={{
+              border: `1px solid ${orphanFocus ? 'var(--text-danger)' : 'var(--border-danger)'}`,
+              borderRadius: '6px',
+              padding: '0.75rem',
+              background: 'var(--bg-danger)',
+              marginBottom: '0.75rem',
+            }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '0.75rem', marginBottom: '0.5rem' }}>
+                <div style={{ fontWeight: 700, color: 'var(--text-danger)' }}>
+                  Orphaned agents detected
+                </div>
+                <button
+                  onClick={clearAllOrphanModels}
+                  disabled={saving}
+                  style={{ padding: '5px 10px', borderRadius: '6px', border: '1px solid var(--border-danger)', background: 'var(--bg-card)', color: 'var(--text-danger)', cursor: saving ? 'wait' : 'pointer', fontSize: '0.76rem', fontWeight: 600 }}
+                >
+                  Clear all pinned models
+                </button>
+              </div>
+              <div style={{ color: 'var(--text)', fontSize: '0.8rem', marginBottom: '0.55rem' }}>
+                These agents pin models not present in current backend models. Remap or clear the pin so backend defaults are used.
+              </div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '0.45rem' }}>
+                {orphanedAgents.map(orphan => (
+                  <div key={orphan.name} style={{ border: '1px solid var(--border-danger)', borderRadius: '6px', padding: '0.55rem', background: 'var(--bg-card)' }}>
+                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '0.75rem' }}>
+                      <div style={{ minWidth: 0, flex: 1 }}>
+                        <div style={{ fontSize: '0.8rem', fontWeight: 700, color: 'var(--text-heading)' }}>
+                          {orphan.name}
+                        </div>
+                        <div style={{ fontSize: '0.76rem', color: 'var(--text-muted)', marginTop: '2px' }}>
+                          backend: {orphan.backend} · missing model: {orphan.model}
+                        </div>
+                        {!!(orphan.repos && orphan.repos.length > 0) && (
+                          <div style={{ fontSize: '0.74rem', color: 'var(--text-faint)', marginTop: '2px' }}>
+                            repos: {orphan.repos.join(', ')}
+                          </div>
+                        )}
+                      </div>
+                      <div style={{ display: 'flex', gap: '0.35rem', alignItems: 'center' }}>
+                        <select
+                          value={orphanModelSelection[orphan.name] ?? ''}
+                          onChange={e => setOrphanModelSelection(prev => ({ ...prev, [orphan.name]: e.target.value }))}
+                          style={{ ...inputStyle, width: '200px', fontSize: '0.76rem' }}
+                        >
+                          <option value="">Select replacement model</option>
+                          {(orphan.available_models ?? []).map(model => (
+                            <option key={model} value={model}>{model}</option>
+                          ))}
+                        </select>
+                        <button
+                          onClick={() => saveOrphanModel(orphan.name)}
+                          disabled={saving}
+                          style={{ padding: '5px 9px', borderRadius: '6px', border: '1px solid var(--btn-primary-border)', background: 'var(--btn-primary-bg)', color: '#fff', cursor: saving ? 'wait' : 'pointer', fontSize: '0.75rem', fontWeight: 600 }}
+                        >
+                          Remap
+                        </button>
+                        <button
+                          onClick={() => clearOrphanModel(orphan.name)}
+                          disabled={saving}
+                          style={{ padding: '5px 9px', borderRadius: '6px', border: '1px solid var(--border-danger)', background: 'var(--bg-card)', color: 'var(--text-danger)', cursor: saving ? 'wait' : 'pointer', fontSize: '0.75rem', fontWeight: 600 }}
+                        >
+                          Clear
+                        </button>
+                      </div>
                     </div>
-                    {!!(b.models && b.models.length > 0) && <div style={{ fontSize: '0.75rem', color: 'var(--text-faint)', marginTop: '2px' }}>models: {b.models.join(', ')}</div>}
-                    {b.health_detail && <div style={{ fontSize: '0.75rem', color: 'var(--text-faint)', marginTop: '2px' }}>{b.health_detail}</div>}
                   </div>
+                ))}
+              </div>
+            </div>
+          )}
+          {!backendsLoading && backendDriftWarnings.length > 0 && (
+            <div style={{ border: '1px solid var(--border-danger)', borderRadius: '6px', padding: '0.75rem', background: 'var(--bg-danger)', marginBottom: '0.75rem' }}>
+              <div style={{ fontWeight: 700, color: 'var(--text-danger)', marginBottom: '0.35rem' }}>
+                Diagnostics differ from stored backend configuration
+              </div>
+              <div style={{ color: 'var(--text)', fontSize: '0.8rem', marginBottom: '0.35rem' }}>
+                Run discovery to persist the latest runtime state.
+              </div>
+              <ul style={{ margin: 0, paddingLeft: '1rem', color: 'var(--text-danger)', fontSize: '0.78rem', lineHeight: 1.45 }}>
+                {backendDriftWarnings.map(w => <li key={w}>{w}</li>)}
+              </ul>
+            </div>
+          )}
+          <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap', alignItems: 'flex-start' }}>
+            <div style={{ flex: '2 1 540px', minWidth: 0 }}>
+              <div style={{ border: '1px solid var(--border-subtle)', borderRadius: '6px', padding: '0.75rem', background: 'var(--bg)' }}>
+                <div style={{ fontWeight: 700, color: 'var(--text-heading)', marginBottom: '0.4rem' }}>Backends</div>
+                {!backendsLoading && backends.length === 0 && (
+                  <p style={{ color: 'var(--text-faint)', fontSize: '0.85rem' }}>No backends configured.</p>
+                )}
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '0.6rem' }}>
+                  {backends.map(b => (
+                    <div key={b.name} style={{ border: `1px solid ${b.healthy ? 'var(--border-subtle)' : 'var(--border-danger)'}`, borderRadius: '6px', padding: '0.75rem', background: 'var(--bg)' }}>
+                      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '0.75rem' }}>
+                        <div style={{ minWidth: 0, flex: 1 }}>
+                          <div style={{ display: 'flex', alignItems: 'center', gap: '0.45rem' }}>
+                            <div style={{ fontWeight: 700, color: 'var(--text-heading)' }}>{b.name}</div>
+                            <span style={healthBadgeStyle(b.healthy)}>{b.healthy ? 'healthy' : 'failed'}</span>
+                          </div>
+                          <div style={{ fontSize: '0.78rem', color: 'var(--text-muted)', marginTop: '2px' }}>
+                            {b.command || 'not detected'}{b.version ? ` · ${b.version}` : ''}
+                          </div>
+                          {!!b.local_model_url && (
+                            <div style={{ fontSize: '0.75rem', color: 'var(--text-faint)', marginTop: '2px', overflowWrap: 'anywhere' }}>
+                              local URL: {b.local_model_url}
+                            </div>
+                          )}
+                          <div style={{ fontSize: '0.75rem', color: 'var(--text-faint)', marginTop: '2px' }}>
+                            timeout: {b.timeout_seconds}s · max prompt chars: {b.max_prompt_chars}
+                          </div>
+                          {b.health_detail && <div style={{ fontSize: '0.75rem', color: b.healthy ? 'var(--text-faint)' : 'var(--text-danger)', marginTop: '2px' }}>{b.health_detail}</div>}
+                          {!!(b.models && b.models.length > 0) && (
+                            <div style={{ marginTop: '0.5rem' }}>
+                              <div style={{ fontSize: '0.74rem', color: 'var(--text-faint)', marginBottom: '0.3rem' }}>Models</div>
+                              <ul style={{ margin: 0, padding: 0, listStyle: 'none', display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+                                {b.models.map(model => (
+                                  <li key={model} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '0.5rem', border: '1px solid var(--border-subtle)', borderRadius: '6px', padding: '0.2rem 0.4rem', background: 'var(--bg-card)' }}>
+                                    <span style={{ fontSize: '0.76rem', color: 'var(--text)' }}>{model}</span>
+                                    <span style={{ fontSize: '0.68rem', color: 'var(--text-faint)', border: '1px solid var(--border-subtle)', borderRadius: '999px', padding: '1px 6px', textTransform: 'uppercase', letterSpacing: '0.02em' }}>
+                                      Read only
+                                    </span>
+                                  </li>
+                                ))}
+                              </ul>
+                            </div>
+                          )}
+                        </div>
+                        <div style={{ display: 'flex', gap: '0.35rem', alignItems: 'center' }}>
+                          <button
+                            onClick={() => {
+                              setSaveError('')
+                              setSettingsTarget(b)
+                              setSettingsTimeout(String(b.timeout_seconds))
+                              setSettingsMaxPromptChars(String(b.max_prompt_chars))
+                              setSettingsLocalModelURL(b.local_model_url ?? '')
+                            }}
+                            style={{ padding: '5px 10px', borderRadius: '6px', border: '1px solid var(--border)', background: 'var(--bg-card)', color: 'var(--text)', cursor: 'pointer', fontSize: '0.78rem', fontWeight: 600 }}
+                          >
+                            Runtime
+                          </button>
+                          {!!b.local_model_url && (
+                            <button
+                              onClick={() => {
+                                setSaveError('')
+                                setDeleteTarget(b)
+                              }}
+                              style={{ padding: '5px 10px', borderRadius: '6px', border: '1px solid var(--border-danger)', background: 'var(--bg-danger)', color: 'var(--text-danger)', cursor: 'pointer', fontSize: '0.78rem', fontWeight: 600 }}
+                            >
+                              Remove
+                            </button>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  ))}
                 </div>
               </div>
-            ))}
+            </div>
+
+            <div style={{ flex: '1 1 300px', minWidth: '280px' }}>
+              <div style={{ border: '1px solid var(--border-subtle)', borderRadius: '6px', padding: '0.75rem', background: 'var(--bg)' }}>
+                <div style={{ fontWeight: 700, color: 'var(--text-heading)', marginBottom: '0.4rem' }}>Tools</div>
+                <div style={{ border: '1px solid var(--border-subtle)', borderRadius: '6px', padding: '0.65rem', background: 'var(--bg-card)' }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.45rem' }}>
+                    <div style={{ fontWeight: 700, color: 'var(--text-heading)' }}>GitHub CLI</div>
+                    {githubCLI && <span style={healthBadgeStyle(githubCLI.healthy)}>{githubCLI.healthy ? 'healthy' : 'failed'}</span>}
+                  </div>
+                  {githubCLI ? (
+                    <>
+                      <div style={{ fontSize: '0.78rem', color: 'var(--text-muted)', marginTop: '2px' }}>
+                        {githubCLI.command || 'not detected'} · auth {githubCLI.authenticated ? 'ok' : 'missing'}
+                      </div>
+                      {githubCLI.detail && <div style={{ fontSize: '0.75rem', color: githubCLI.healthy ? 'var(--text-faint)' : 'var(--text-danger)', marginTop: '2px' }}>{githubCLI.detail}</div>}
+                    </>
+                  ) : (
+                    <div style={{ color: 'var(--text-faint)', fontSize: '0.78rem', marginTop: '2px' }}>
+                      Run discovery to refresh tool diagnostics.
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
           </div>
           {saveError && <p style={{ color: 'var(--text-danger)', fontSize: '0.85rem', marginTop: '0.75rem' }}>{saveError}</p>}
         </Card>
@@ -484,35 +806,144 @@ export default function ConfigPage() {
         </Card>
       )}
 
-      {(modal === 'create' || modal === 'edit') && (
-        <Modal title={modal === 'create' ? 'Add backend' : `Edit — ${selected.name}`} onClose={() => setModal(null)}>
-          <BackendForm
-            initial={selected}
-            isNew={modal === 'create'}
-            onSave={saveBackend}
-            onCancel={() => setModal(null)}
-            saving={saving}
-            error={saveError}
-          />
-        </Modal>
-      )}
-
-      {modal === 'delete' && (
-        <Modal title="Delete backend" onClose={() => setModal(null)}>
-          <p style={{ color: 'var(--text)', fontSize: '0.9rem', marginBottom: '1.25rem' }}>
-            Delete backend <strong>{deleteTarget}</strong>? This cannot be undone.
-          </p>
-          {saveError && <p style={{ color: 'var(--text-danger)', fontSize: '0.8rem', marginBottom: '0.75rem' }}>{saveError}</p>}
-          <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'flex-end' }}>
-            <button onClick={() => setModal(null)} style={{ padding: '6px 16px', borderRadius: '6px', border: '1px solid var(--border)', background: 'var(--bg-card)', cursor: 'pointer', fontSize: '0.875rem', color: 'var(--text-muted)' }}>
-              Cancel
-            </button>
-            <button onClick={deleteBackend} disabled={saving} style={{ padding: '6px 16px', borderRadius: '6px', border: '1px solid var(--border-danger)', background: '#dc2626', color: '#fff', cursor: saving ? 'wait' : 'pointer', fontSize: '0.875rem', fontWeight: 600 }}>
-              {saving ? 'Deleting…' : 'Delete'}
-            </button>
+      {localBackendModalOpen && (
+        <Modal title="Add Local Backend" onClose={() => setLocalBackendModalOpen(false)}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.85rem' }}>
+            <div>
+              <label style={labelStyle}>Backend name</label>
+              <input
+                style={inputStyle}
+                value={localBackendName}
+                onChange={e => setLocalBackendName(e.target.value)}
+                placeholder="qwen_local"
+              />
+            </div>
+            <div>
+              <label style={labelStyle}>Local model URL</label>
+              <input
+                style={inputStyle}
+                value={localBackendURL}
+                onChange={e => setLocalBackendURL(e.target.value)}
+                placeholder="http://localhost:8080/v1/messages"
+              />
+            </div>
+            <div style={{ border: '1px solid var(--border-subtle)', borderRadius: '6px', background: 'var(--bg)', padding: '0.7rem' }}>
+              <div style={{ fontSize: '0.8rem', color: 'var(--text-heading)', fontWeight: 600, marginBottom: '0.4rem' }}>What to expect with local models</div>
+              <ul style={{ margin: 0, paddingLeft: '1rem', color: 'var(--text-faint)', fontSize: '0.78rem', lineHeight: 1.45 }}>
+                <li>Strong fit today: reviewer/scout specialists. Action-heavy coder flows can be more conservative with write tools.</li>
+                <li>Local models can hallucinate templated facts (for example SHAs/statuses). Prompt for live verification before posting results.</li>
+                <li>This backend reuses your discovered Claude CLI and routes it to your local OpenAI-compatible endpoint.</li>
+                <li>Structured JSON schema is still enforced by the daemon, but output quality still depends on model capability.</li>
+                <li>If runs are long, raise timeouts (proxy/backend) so tool loops do not fail mid-run.</li>
+              </ul>
+            </div>
+            {saveError && <p style={{ color: 'var(--text-danger)', fontSize: '0.8rem' }}>{saveError}</p>}
+            <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'flex-end' }}>
+              <button
+                onClick={() => setLocalBackendModalOpen(false)}
+                style={{ padding: '6px 16px', borderRadius: '6px', border: '1px solid var(--border)', background: 'var(--bg-card)', cursor: 'pointer', fontSize: '0.875rem', color: 'var(--text-muted)' }}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={addLocalBackend}
+                disabled={saving || !localBackendName.trim() || !localBackendURL.trim()}
+                style={{ padding: '6px 16px', borderRadius: '6px', border: '1px solid var(--btn-primary-border)', background: 'var(--btn-primary-bg)', color: '#fff', cursor: saving ? 'wait' : 'pointer', fontSize: '0.875rem', fontWeight: 600 }}
+              >
+                {saving ? 'Saving…' : 'Save local backend'}
+              </button>
+            </div>
           </div>
         </Modal>
       )}
+
+      {deleteTarget && (
+        <Modal title="Remove Local Backend" onClose={() => setDeleteTarget(null)}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.85rem' }}>
+            <p style={{ color: 'var(--text)', fontSize: '0.9rem', margin: 0 }}>
+              Remove backend <strong>{deleteTarget.name}</strong>?
+            </p>
+            <p style={{ color: 'var(--text-faint)', fontSize: '0.8rem', margin: 0 }}>
+              Any agents using this backend will fail until you reconfigure them.
+            </p>
+            {saveError && <p style={{ color: 'var(--text-danger)', fontSize: '0.8rem', margin: 0 }}>{saveError}</p>}
+            <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'flex-end' }}>
+              <button
+                onClick={() => setDeleteTarget(null)}
+                style={{ padding: '6px 16px', borderRadius: '6px', border: '1px solid var(--border)', background: 'var(--bg-card)', cursor: 'pointer', fontSize: '0.875rem', color: 'var(--text-muted)' }}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={removeBackend}
+                disabled={saving}
+                style={{ padding: '6px 16px', borderRadius: '6px', border: '1px solid var(--border-danger)', background: '#dc2626', color: '#fff', cursor: saving ? 'wait' : 'pointer', fontSize: '0.875rem', fontWeight: 600 }}
+              >
+                {saving ? 'Removing…' : 'Remove'}
+              </button>
+            </div>
+          </div>
+        </Modal>
+      )}
+
+      {settingsTarget && (
+        <Modal title={`Runtime settings — ${settingsTarget.name}`} onClose={() => setSettingsTarget(null)}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.85rem' }}>
+            <div>
+              <label style={labelStyle}>Timeout (seconds)</label>
+              <input
+                style={inputStyle}
+                type="number"
+                min={1}
+                value={settingsTimeout}
+                onChange={e => setSettingsTimeout(e.target.value)}
+              />
+            </div>
+            <div>
+              <label style={labelStyle}>Max prompt chars</label>
+              <input
+                style={inputStyle}
+                type="number"
+                min={1}
+                value={settingsMaxPromptChars}
+                onChange={e => setSettingsMaxPromptChars(e.target.value)}
+              />
+            </div>
+            {!!settingsTarget.local_model_url && (
+              <div>
+                <label style={labelStyle}>Local model URL</label>
+                <input
+                  style={inputStyle}
+                  type="url"
+                  value={settingsLocalModelURL}
+                  onChange={e => setSettingsLocalModelURL(e.target.value)}
+                  placeholder="http://localhost:8080/v1/messages"
+                />
+              </div>
+            )}
+            <p style={{ color: 'var(--text-faint)', fontSize: '0.78rem', margin: 0 }}>
+              Only runtime limits are editable here{settingsTarget.local_model_url ? ', plus local URL for local backends' : ''}. Backend command and runner flags remain managed by discovery/runtime.
+            </p>
+            {saveError && <p style={{ color: 'var(--text-danger)', fontSize: '0.8rem', margin: 0 }}>{saveError}</p>}
+            <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'flex-end' }}>
+              <button
+                onClick={() => setSettingsTarget(null)}
+                style={{ padding: '6px 16px', borderRadius: '6px', border: '1px solid var(--border)', background: 'var(--bg-card)', cursor: 'pointer', fontSize: '0.875rem', color: 'var(--text-muted)' }}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={saveBackendRuntimeSettings}
+                disabled={saving}
+                style={{ padding: '6px 16px', borderRadius: '6px', border: '1px solid var(--btn-primary-border)', background: 'var(--btn-primary-bg)', color: '#fff', cursor: saving ? 'wait' : 'pointer', fontSize: '0.875rem', fontWeight: 600 }}
+              >
+                {saving ? 'Saving…' : 'Save settings'}
+              </button>
+            </div>
+          </div>
+        </Modal>
+      )}
+
     </div>
   )
 }

--- a/internal/ui/src/app/page.tsx
+++ b/internal/ui/src/app/page.tsx
@@ -22,6 +22,7 @@ interface Binding {
 interface Agent {
   name: string
   backend: string
+  model?: string
   skills?: string[]
   description?: string
   allow_dispatch: boolean
@@ -34,6 +35,7 @@ interface Agent {
 interface StoreAgent {
   name: string
   backend: string
+  model: string
   skills: string[]
   prompt: string
   allow_prs: boolean
@@ -98,8 +100,14 @@ function RunButton({ agent, repo }: { agent: string; repo: string }) {
 }
 
 const emptyForm: StoreAgent = {
-  name: '', backend: 'auto', skills: [], prompt: '',
+  name: '', backend: '', model: '', skills: [], prompt: '',
   allow_prs: false, allow_dispatch: false, can_dispatch: [], description: '',
+}
+
+interface BackendOption {
+  name: string
+  models?: string[]
+  detected?: boolean
 }
 
 function AgentForm({
@@ -107,7 +115,7 @@ function AgentForm({
 }: {
   initial: StoreAgent
   isNew: boolean
-  backends: string[]
+  backends: BackendOption[]
   skillNames: string[]
   agentNames: string[]
   onSave: (a: StoreAgent) => void
@@ -125,8 +133,16 @@ function AgentForm({
     fontSize: '0.85rem', fontFamily: 'inherit', background: 'var(--bg-input)', color: 'var(--text)',
   }
 
-  // Derive options: always include "auto", then any store-configured backends.
-  const backendOptions = ['auto', ...backends.filter(b => b !== 'auto')]
+  const backendOptions = backends.filter(b => b.detected !== false)
+  const modelsForBackend = backendOptions.find(b => b.name === form.backend)?.models ?? []
+
+  useEffect(() => {
+    if (!form.model) return
+    if (modelsForBackend.length === 0) return
+    if (!modelsForBackend.includes(form.model)) {
+      set('model', '')
+    }
+  }, [form.backend, form.model, modelsForBackend.join('|')])
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '0.85rem' }}>
@@ -137,7 +153,15 @@ function AgentForm({
       <div>
         <label style={labelStyle}>Backend</label>
         <select style={inputStyle} value={form.backend} onChange={e => set('backend', e.target.value)}>
-          {backendOptions.map(b => <option key={b} value={b}>{b}</option>)}
+          <option value="">Select backend…</option>
+          {backendOptions.map(b => <option key={b.name} value={b.name}>{b.name}</option>)}
+        </select>
+      </div>
+      <div>
+        <label style={labelStyle}>Model</label>
+        <select style={inputStyle} value={form.model} onChange={e => set('model', e.target.value)} disabled={!form.backend || modelsForBackend.length === 0}>
+          <option value="">Default (backend decides)</option>
+          {modelsForBackend.map(m => <option key={m} value={m}>{m}</option>)}
         </select>
       </div>
       <div>
@@ -178,7 +202,7 @@ function AgentForm({
         </button>
         <button
           onClick={() => onSave(form)}
-          disabled={saving || !form.name.trim()}
+          disabled={saving || !form.name.trim() || !form.backend.trim()}
           style={{ padding: '6px 16px', borderRadius: '6px', border: '1px solid var(--btn-primary-border)', background: 'var(--btn-primary-bg)', color: '#fff', cursor: saving ? 'wait' : 'pointer', fontSize: '0.875rem', fontWeight: 600 }}
         >
           {saving ? 'Saving…' : 'Save'}
@@ -209,7 +233,7 @@ function AgentCard({ agent, onEdit, onDelete }: { agent: Agent; onEdit: () => vo
 
       <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
         <span style={{ background: 'var(--bg)', border: '1px solid var(--border)', borderRadius: '4px', padding: '2px 6px', fontSize: '0.75rem', color: 'var(--text-muted)' }}>
-          {agent.backend}
+          {agent.backend}{agent.model ? ` · ${agent.model}` : ''}
         </span>
         {agent.skills?.map(s => (
           <span key={s} style={{ background: 'var(--badge-skill-bg)', border: '1px solid var(--badge-skill-border)', borderRadius: '4px', padding: '2px 6px', fontSize: '0.75rem', color: 'var(--badge-skill-text)' }}>
@@ -263,7 +287,7 @@ export default function FleetPage() {
   const [agents, setAgents] = useState<Agent[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
-  const [backendNames, setBackendNames] = useState<string[]>([])
+  const [backendOptions, setBackendOptions] = useState<BackendOption[]>([])
   const [skillNames, setSkillNames] = useState<string[]>([])
   const [agentNames, setAgentNames] = useState<string[]>([])
 
@@ -285,9 +309,9 @@ export default function FleetPage() {
 
   useEffect(() => {
     load()
-    fetch('/backends')
-      .then(r => r.ok ? r.json() : [])
-      .then((data: { name: string }[]) => setBackendNames(data.map(b => b.name)))
+    fetch('/backends/status')
+      .then(r => r.ok ? r.json() : { backends: [] })
+      .then((data: { backends?: BackendOption[] }) => setBackendOptions((data.backends ?? []).filter(b => b.detected !== false)))
       .catch(() => {})
     fetch('/skills')
       .then(r => r.ok ? r.json() : [])
@@ -306,13 +330,22 @@ export default function FleetPage() {
     try {
       const res = await fetch(`/agents/${encodeURIComponent(agentName)}`)
       if (res.ok) {
-        const data = await res.json()
-        setSelected(data)
+        const data = await res.json() as Partial<StoreAgent>
+        setSelected({
+          ...emptyForm,
+          ...data,
+          name: data.name ?? agentName,
+          backend: data.backend ?? '',
+          model: data.model ?? '',
+          skills: data.skills ?? [],
+          can_dispatch: data.can_dispatch ?? [],
+        })
       } else {
         const a = agents.find(a => a.name === agentName)
         setSelected({
           name: agentName,
-          backend: a?.backend ?? 'claude',
+          backend: a?.backend ?? '',
+          model: a?.model ?? '',
           skills: a?.skills ?? [],
           prompt: '',
           allow_prs: a?.allow_prs ?? false,
@@ -427,7 +460,7 @@ export default function FleetPage() {
           <AgentForm
             initial={selected}
             isNew={modal === 'create'}
-            backends={backendNames}
+            backends={backendOptions}
             skillNames={skillNames}
             agentNames={agentNames}
             onSave={saveAgent}

--- a/internal/ui/src/app/page.tsx
+++ b/internal/ui/src/app/page.tsx
@@ -127,6 +127,10 @@ function AgentForm({
 
   const set = (k: keyof StoreAgent, v: unknown) => setForm(f => ({ ...f, [k]: v }))
 
+  useEffect(() => {
+    setForm(initial)
+  }, [initial])
+
   const labelStyle: React.CSSProperties = { fontSize: '0.8rem', color: 'var(--text-muted)', display: 'block', marginBottom: '3px' }
   const inputStyle: React.CSSProperties = {
     width: '100%', padding: '6px 8px', border: '1px solid var(--border)', borderRadius: '6px',
@@ -298,6 +302,21 @@ export default function FleetPage() {
   const [saveError, setSaveError] = useState('')
 
   const loadRef = useRef(false)
+  const loadLookups = () => {
+    fetch('/backends')
+      .then(r => r.ok ? r.json() : [])
+      .then((data: BackendOption[]) => setBackendOptions((data ?? []).filter(b => b.detected !== false)))
+      .catch(() => {})
+    fetch('/skills')
+      .then(r => r.ok ? r.json() : [])
+      .then((data: { name: string }[]) => setSkillNames(data.map(s => s.name)))
+      .catch(() => {})
+    fetch('/agents')
+      .then(r => r.ok ? r.json() : [])
+      .then((data: { name: string }[]) => setAgentNames(data.map(a => a.name)))
+      .catch(() => {})
+  }
+
   const load = () => {
     if (!loadRef.current) setLoading(true)
     loadRef.current = true
@@ -309,24 +328,26 @@ export default function FleetPage() {
 
   useEffect(() => {
     load()
-    fetch('/backends/status')
-      .then(r => r.ok ? r.json() : { backends: [] })
-      .then((data: { backends?: BackendOption[] }) => setBackendOptions((data.backends ?? []).filter(b => b.detected !== false)))
-      .catch(() => {})
-    fetch('/skills')
-      .then(r => r.ok ? r.json() : [])
-      .then((data: { name: string }[]) => setSkillNames(data.map(s => s.name)))
-      .catch(() => {})
-    fetch('/agents')
-      .then(r => r.ok ? r.json() : [])
-      .then((data: { name: string }[]) => setAgentNames(data.map(a => a.name)))
-      .catch(() => {})
+    loadLookups()
     const interval = setInterval(load, 5000)
     return () => clearInterval(interval)
   }, [])
 
   const openEdit = async (agentName: string) => {
     setSaveError('')
+    const a = agents.find(agent => agent.name === agentName)
+    setSelected({
+      name: agentName,
+      backend: a?.backend ?? '',
+      model: a?.model ?? '',
+      skills: a?.skills ?? [],
+      prompt: '',
+      allow_prs: a?.allow_prs ?? false,
+      allow_dispatch: a?.allow_dispatch ?? false,
+      can_dispatch: a?.can_dispatch ?? [],
+      description: a?.description ?? '',
+    })
+    setModal('edit')
     try {
       const res = await fetch(`/agents/${encodeURIComponent(agentName)}`)
       if (res.ok) {
@@ -340,24 +361,10 @@ export default function FleetPage() {
           skills: data.skills ?? [],
           can_dispatch: data.can_dispatch ?? [],
         })
-      } else {
-        const a = agents.find(a => a.name === agentName)
-        setSelected({
-          name: agentName,
-          backend: a?.backend ?? '',
-          model: a?.model ?? '',
-          skills: a?.skills ?? [],
-          prompt: '',
-          allow_prs: a?.allow_prs ?? false,
-          allow_dispatch: a?.allow_dispatch ?? false,
-          can_dispatch: a?.can_dispatch ?? [],
-          description: a?.description ?? '',
-        })
       }
     } catch {
-      setSelected(emptyForm)
+      // Keep optimistic modal data on fetch failures.
     }
-    setModal('edit')
   }
 
   const openCreate = () => {
@@ -383,6 +390,7 @@ export default function FleetPage() {
       }
       setModal(null)
       load()
+      loadLookups()
     } catch (e) {
       setSaveError(String(e))
     }
@@ -406,6 +414,7 @@ export default function FleetPage() {
       }
       setModal(null)
       load()
+      loadLookups()
     } catch (e) {
       setSaveError(String(e))
     }
@@ -458,6 +467,7 @@ export default function FleetPage() {
       {(modal === 'create' || modal === 'edit') && (
         <Modal title={modal === 'create' ? 'Create agent' : `Edit — ${selected.name}`} onClose={() => setModal(null)}>
           <AgentForm
+            key={`${modal}:${selected.name}`}
             initial={selected}
             isNew={modal === 'create'}
             backends={backendOptions}

--- a/internal/ui/src/components/NavBar.tsx
+++ b/internal/ui/src/components/NavBar.tsx
@@ -1,6 +1,7 @@
 'use client'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
+import { useEffect, useState } from 'react'
 import { useTheme } from '@/lib/theme'
 
 const links = [
@@ -17,55 +18,98 @@ const links = [
 export default function NavBar() {
   const pathname = usePathname()
   const { theme, toggle } = useTheme()
+  const [orphanCount, setOrphanCount] = useState(0)
+
+  useEffect(() => {
+    let cancelled = false
+    const load = async () => {
+      try {
+        const res = await fetch('/status', { cache: 'no-store' })
+        if (!res.ok) return
+        const data = await res.json() as { orphaned_agents?: { count?: number } }
+        if (cancelled) return
+        setOrphanCount(Number(data.orphaned_agents?.count ?? 0))
+      } catch {
+        // keep last known banner state on transient polling errors
+      }
+    }
+
+    load()
+    const id = window.setInterval(load, 30000)
+    return () => {
+      cancelled = true
+      window.clearInterval(id)
+    }
+  }, [])
+
   return (
-    <nav style={{
-      background: 'var(--bg-nav)',
-      borderBottom: '2px solid var(--border-nav)',
-      padding: '0 1.5rem',
-      display: 'flex',
-      alignItems: 'center',
-      gap: '0',
-      height: '48px',
-    }}>
-      <span style={{ fontWeight: 700, fontSize: '0.95rem', color: 'var(--accent)', marginRight: '2rem', letterSpacing: '0.05em' }}>
-        AGENTS
-      </span>
-      {links.map(({ href, label }) => {
-        const active = pathname === href || (href !== '/' && pathname.startsWith(href))
-        return (
-          <Link
-            key={href}
-            href={href}
-            style={{
-              padding: '0 1rem',
-              height: '48px',
-              display: 'flex',
-              alignItems: 'center',
-              fontSize: '0.875rem',
-              color: active ? 'var(--accent)' : 'var(--text-muted)',
-              borderBottom: active ? '2px solid var(--accent)' : '2px solid transparent',
-              fontWeight: active ? 600 : 400,
-            }}
-          >
-            {label}
-          </Link>
-        )
-      })}
-      <button
-        onClick={toggle}
-        style={{
-          marginLeft: 'auto',
-          background: 'none',
-          border: '1px solid var(--border)',
-          borderRadius: '6px',
-          padding: '4px 10px',
-          cursor: 'pointer',
-          fontSize: '0.78rem',
-          color: 'var(--text-muted)',
-        }}
-      >
-        {theme === 'light' ? 'Dark' : 'Light'}
-      </button>
-    </nav>
+    <>
+      <nav style={{
+        background: 'var(--bg-nav)',
+        borderBottom: '2px solid var(--border-nav)',
+        padding: '0 1.5rem',
+        display: 'flex',
+        alignItems: 'center',
+        gap: '0',
+        height: '48px',
+      }}>
+        <span style={{ fontWeight: 700, fontSize: '0.95rem', color: 'var(--accent)', marginRight: '2rem', letterSpacing: '0.05em' }}>
+          AGENTS
+        </span>
+        {links.map(({ href, label }) => {
+          const active = pathname === href || (href !== '/' && pathname.startsWith(href))
+          return (
+            <Link
+              key={href}
+              href={href}
+              style={{
+                padding: '0 1rem',
+                height: '48px',
+                display: 'flex',
+                alignItems: 'center',
+                fontSize: '0.875rem',
+                color: active ? 'var(--accent)' : 'var(--text-muted)',
+                borderBottom: active ? '2px solid var(--accent)' : '2px solid transparent',
+                fontWeight: active ? 600 : 400,
+              }}
+            >
+              {label}
+            </Link>
+          )
+        })}
+        <button
+          onClick={toggle}
+          style={{
+            marginLeft: 'auto',
+            background: 'none',
+            border: '1px solid var(--border)',
+            borderRadius: '6px',
+            padding: '4px 10px',
+            cursor: 'pointer',
+            fontSize: '0.78rem',
+            color: 'var(--text-muted)',
+          }}
+        >
+          {theme === 'light' ? 'Dark' : 'Light'}
+        </button>
+      </nav>
+      {orphanCount > 0 && (
+        <Link
+          href="/config/?tab=backends&focus=orphans"
+          style={{
+            display: 'block',
+            background: 'var(--bg-danger)',
+            borderBottom: '1px solid var(--border-danger)',
+            color: 'var(--text-danger)',
+            padding: '0.5rem 1.5rem',
+            fontSize: '0.82rem',
+            fontWeight: 600,
+            textDecoration: 'none',
+          }}
+        >
+          {orphanCount} orphaned agent{orphanCount === 1 ? '' : 's'} detected (pinned model unavailable). Click to review and fix in Backends and tools.
+        </Link>
+      )}
+    </>
   )
 }

--- a/internal/webhook/api.go
+++ b/internal/webhook/api.go
@@ -37,6 +37,7 @@ type agentBindingJSON struct {
 type apiAgentJSON struct {
 	Name          string             `json:"name"`
 	Backend       string             `json:"backend"`
+	Model         string             `json:"model,omitempty"`
 	Skills        []string           `json:"skills,omitempty"`
 	Description   string             `json:"description,omitempty"`
 	AllowDispatch bool               `json:"allow_dispatch"`
@@ -69,6 +70,7 @@ func (s *Server) handleAPIAgents(w http.ResponseWriter, _ *http.Request) {
 		entry := apiAgentJSON{
 			Name:          a.Name,
 			Backend:       a.Backend,
+			Model:         a.Model,
 			Skills:        a.Skills,
 			Description:   a.Description,
 			AllowDispatch: a.AllowDispatch,
@@ -126,18 +128,18 @@ func (s *Server) handleAPIAgents(w http.ResponseWriter, _ *http.Request) {
 // apiConfigJSON is the wire shape for /api/config with secrets redacted.
 // Secrets (resolved values of *_env fields) are replaced with "[redacted]".
 type apiConfigJSON struct {
-	Daemon   apiDaemonJSON              `json:"daemon"`
-	Skills   map[string]apiSkillJSON    `json:"skills,omitempty"`
-	Agents   []apiAgentConfigJSON       `json:"agents,omitempty"`
-	Repos    []apiRepoConfigJSON        `json:"repos,omitempty"`
+	Daemon apiDaemonJSON           `json:"daemon"`
+	Skills map[string]apiSkillJSON `json:"skills,omitempty"`
+	Agents []apiAgentConfigJSON    `json:"agents,omitempty"`
+	Repos  []apiRepoConfigJSON     `json:"repos,omitempty"`
 }
 
 type apiDaemonJSON struct {
-	Log        apiLogConfigJSON                   `json:"log"`
-	HTTP       apiHTTPConfigJSON                  `json:"http"`
-	Processor  apiProcessorConfigJSON             `json:"processor"`
-	AIBackends map[string]apiAIBackendConfigJSON  `json:"ai_backends,omitempty"`
-	Proxy      apiProxyConfigJSON                 `json:"proxy"`
+	Log        apiLogConfigJSON                  `json:"log"`
+	HTTP       apiHTTPConfigJSON                 `json:"http"`
+	Processor  apiProcessorConfigJSON            `json:"processor"`
+	AIBackends map[string]apiAIBackendConfigJSON `json:"ai_backends,omitempty"`
+	Proxy      apiProxyConfigJSON                `json:"proxy"`
 }
 
 type apiLogConfigJSON struct {
@@ -154,7 +156,7 @@ type apiDispatchConfigJSON struct {
 type apiProcessorConfigJSON struct {
 	EventQueueBuffer    int                   `json:"event_queue_buffer"`
 	MaxConcurrentAgents int                   `json:"max_concurrent_agents"`
-	Dispatch            apiDispatchConfigJSON  `json:"dispatch"`
+	Dispatch            apiDispatchConfigJSON `json:"dispatch"`
 }
 
 // apiBindingConfigJSON is the wire shape for a repo binding in /api/config.
@@ -191,6 +193,11 @@ type apiHTTPConfigJSON struct {
 
 type apiAIBackendConfigJSON struct {
 	Command          string            `json:"command"`
+	Version          string            `json:"version,omitempty"`
+	Models           []string          `json:"models,omitempty"`
+	Healthy          bool              `json:"healthy"`
+	HealthDetail     string            `json:"health_detail,omitempty"`
+	LocalModelURL    string            `json:"local_model_url,omitempty"`
 	Args             []string          `json:"args,omitempty"`
 	Env              map[string]string `json:"env,omitempty"` // values are "[redacted]"
 	TimeoutSeconds   int               `json:"timeout_seconds"`
@@ -199,9 +206,9 @@ type apiAIBackendConfigJSON struct {
 }
 
 type apiProxyConfigJSON struct {
-	Enabled  bool                   `json:"enabled"`
-	Path     string                 `json:"path,omitempty"`
-	Upstream apiProxyUpstreamJSON   `json:"upstream,omitempty"`
+	Enabled  bool                 `json:"enabled"`
+	Path     string               `json:"path,omitempty"`
+	Upstream apiProxyUpstreamJSON `json:"upstream,omitempty"`
 }
 
 type apiProxyUpstreamJSON struct {
@@ -223,6 +230,7 @@ type apiSkillJSON struct {
 type apiAgentConfigJSON struct {
 	Name          string   `json:"name"`
 	Backend       string   `json:"backend,omitempty"`
+	Model         string   `json:"model,omitempty"`
 	Skills        []string `json:"skills,omitempty"`
 	PromptFile    string   `json:"prompt_file,omitempty"`
 	Description   string   `json:"description,omitempty"`
@@ -262,6 +270,11 @@ func (s *Server) handleAPIConfig(w http.ResponseWriter, _ *http.Request) {
 		}
 		backends[name] = apiAIBackendConfigJSON{
 			Command:          b.Command,
+			Version:          b.Version,
+			Models:           b.Models,
+			Healthy:          b.Healthy,
+			HealthDetail:     b.HealthDetail,
+			LocalModelURL:    b.LocalModelURL,
 			Args:             b.Args,
 			Env:              redactedEnv,
 			TimeoutSeconds:   b.TimeoutSeconds,
@@ -295,6 +308,7 @@ func (s *Server) handleAPIConfig(w http.ResponseWriter, _ *http.Request) {
 		agents = append(agents, apiAgentConfigJSON{
 			Name:          a.Name,
 			Backend:       a.Backend,
+			Model:         a.Model,
 			Skills:        a.Skills,
 			PromptFile:    a.PromptFile,
 			Description:   a.Description,

--- a/internal/webhook/api.go
+++ b/internal/webhook/api.go
@@ -198,8 +198,6 @@ type apiAIBackendConfigJSON struct {
 	Healthy          bool              `json:"healthy"`
 	HealthDetail     string            `json:"health_detail,omitempty"`
 	LocalModelURL    string            `json:"local_model_url,omitempty"`
-	Args             []string          `json:"args,omitempty"`
-	Env              map[string]string `json:"env,omitempty"` // values are "[redacted]"
 	TimeoutSeconds   int               `json:"timeout_seconds"`
 	MaxPromptChars   int               `json:"max_prompt_chars"`
 	RedactionSaltEnv string            `json:"redaction_salt_env,omitempty"`
@@ -264,10 +262,6 @@ func (s *Server) handleAPIConfig(w http.ResponseWriter, _ *http.Request) {
 	}
 	backends := make(map[string]apiAIBackendConfigJSON, len(cfg.Daemon.AIBackends))
 	for name, b := range cfg.Daemon.AIBackends {
-		redactedEnv := make(map[string]string, len(b.Env))
-		for k := range b.Env {
-			redactedEnv[k] = redacted
-		}
 		backends[name] = apiAIBackendConfigJSON{
 			Command:          b.Command,
 			Version:          b.Version,
@@ -275,8 +269,6 @@ func (s *Server) handleAPIConfig(w http.ResponseWriter, _ *http.Request) {
 			Healthy:          b.Healthy,
 			HealthDetail:     b.HealthDetail,
 			LocalModelURL:    b.LocalModelURL,
-			Args:             b.Args,
-			Env:              redactedEnv,
 			TimeoutSeconds:   b.TimeoutSeconds,
 			MaxPromptChars:   b.MaxPromptChars,
 			RedactionSaltEnv: b.RedactionSaltEnv,

--- a/internal/webhook/api_test.go
+++ b/internal/webhook/api_test.go
@@ -356,7 +356,6 @@ func TestHandleAPIConfigRedactsSecrets(t *testing.T) {
 		c.Daemon.AIBackends = map[string]config.AIBackendConfig{
 			"claude": {
 				Command: "claude",
-				Env:     map[string]string{"ANTHROPIC_API_KEY": "sk-ant-secret"},
 			},
 		}
 	})
@@ -386,10 +385,6 @@ func TestHandleAPIConfigRedactsSecrets(t *testing.T) {
 	}
 	if !strings.Contains(body,"GITHUB_WEBHOOK_SECRET") {
 		t.Error("env var name GITHUB_WEBHOOK_SECRET must be preserved")
-	}
-	// Backend env key must appear, but value must be redacted.
-	if !strings.Contains(body,"ANTHROPIC_API_KEY") {
-		t.Error("backend env key ANTHROPIC_API_KEY must be preserved")
 	}
 }
 

--- a/internal/webhook/crud.go
+++ b/internal/webhook/crud.go
@@ -1,7 +1,6 @@
 package webhook
 
 import (
-	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -82,7 +81,13 @@ type storeBackendJSON struct {
 }
 
 type localBackendRequest struct {
-	URL string `json:"url"`
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
+type backendRuntimeSettingsJSON struct {
+	TimeoutSeconds *int `json:"timeout_seconds,omitempty"`
+	MaxPromptChars *int `json:"max_prompt_chars,omitempty"`
 }
 
 func backendToStoreJSON(name string, b config.AIBackendConfig) storeBackendJSON {
@@ -301,6 +306,7 @@ func (s *Server) reloadCron() error {
 	newCfg.Daemon.AIBackends = backends
 	s.cfg = &newCfg
 	s.cfgMu.Unlock()
+	s.refreshOrphanedAgents(&newCfg)
 
 	return nil
 }
@@ -552,12 +558,20 @@ func (s *Server) handleBackendsDiscover(w http.ResponseWriter, r *http.Request) 
 	writeJSON(w, http.StatusOK, diag)
 }
 
-// handleBackendsLocal serves POST /backends/local. It creates or updates the
-// special claude_local backend by wiring the discovered Claude CLI to a local
+// handleBackendsLocal serves POST /backends/local. It creates or updates a
+// named local backend by wiring the discovered Claude CLI to a local
 // OpenAI-compatible URL via ANTHROPIC_BASE_URL.
 func (s *Server) handleBackendsLocal(w http.ResponseWriter, r *http.Request) {
 	var req localBackendRequest
 	if !decodeBody(w, r, s.loadCfg().Daemon.HTTP.MaxBodyBytes, &req) {
+		return
+	}
+	name := config.NormalizeBackendName(req.Name)
+	if name == "" {
+		name = backends.ClaudeLocalName
+	}
+	if name == backends.ClaudeName || name == backends.CodexName {
+		http.Error(w, "name is reserved for built-in backends", http.StatusBadRequest)
 		return
 	}
 	req.URL = strings.TrimSpace(req.URL)
@@ -584,17 +598,23 @@ func (s *Server) handleBackendsLocal(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	local := existing[backends.ClaudeLocalName]
+	if current, ok := existing[name]; ok && strings.TrimSpace(current.LocalModelURL) == "" {
+		s.storeMu.Unlock()
+		http.Error(w, "name already exists and is not a local backend", http.StatusConflict)
+		return
+	}
+
+	local := existing[name]
 	local.Command = base.Command
 	local.LocalModelURL = req.URL
 
 	diagMap := map[string]config.AIBackendConfig{
-		backends.ClaudeName:      base,
-		backends.ClaudeLocalName: local,
+		backends.ClaudeName: base,
+		name:                local,
 	}
-	diag := backends.RunDiagnostics(context.Background(), diagMap)
+	diag := backends.RunDiagnostics(r.Context(), diagMap)
 	for _, b := range diag.Backends {
-		if b.Name != backends.ClaudeLocalName {
+		if b.Name != name {
 			continue
 		}
 		local.Version = b.Version
@@ -606,7 +626,7 @@ func (s *Server) handleBackendsLocal(w http.ResponseWriter, r *http.Request) {
 		break
 	}
 
-	err = store.UpsertBackend(s.db, backends.ClaudeLocalName, local)
+	err = store.UpsertBackend(s.db, name, local)
 	if err == nil {
 		err = s.reloadCron()
 	}
@@ -617,41 +637,102 @@ func (s *Server) handleBackendsLocal(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("local backend upsert or cron reload: %v", err), status)
 		return
 	}
-	writeJSON(w, http.StatusOK, backendToStoreJSON(backends.ClaudeLocalName, local))
+	writeJSON(w, http.StatusOK, backendToStoreJSON(name, local))
 }
 
-// handleStoreBackend serves GET and DELETE /api/store/backends/{name}.
-func (s *Server) handleStoreBackend(w http.ResponseWriter, r *http.Request) {
+func backendPathName(r *http.Request) string {
 	name := config.NormalizeBackendName(mux.Vars(r)["name"])
-	switch r.Method {
-	case http.MethodGet:
-		backends, err := store.ReadBackends(s.db)
-		if err != nil {
-			http.Error(w, fmt.Sprintf("read backends: %v", err), http.StatusInternalServerError)
-			return
-		}
-		b, ok := backends[name]
-		if !ok {
-			http.NotFound(w, r)
-			return
-		}
-		writeJSON(w, http.StatusOK, backendToStoreJSON(name, b))
+	return name
+}
 
-	case http.MethodDelete:
-		s.storeMu.Lock()
-		err := store.DeleteBackend(s.db, name)
-		if err == nil {
-			err = s.reloadCron()
-		}
-		s.storeMu.Unlock()
-		if err != nil {
-			status := storeErrStatus(err)
-			s.logger.Error().Err(err).Msg("store crud: backend delete or cron reload failed")
-			http.Error(w, fmt.Sprintf("backend delete or cron reload: %v", err), status)
-			return
-		}
-		w.WriteHeader(http.StatusNoContent)
+// handleStoreBackendGet serves GET /api/store/backends/{name}.
+func (s *Server) handleStoreBackendGet(w http.ResponseWriter, r *http.Request) {
+	name := backendPathName(r)
+	backends, err := store.ReadBackends(s.db)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("read backends: %v", err), http.StatusInternalServerError)
+		return
 	}
+	b, ok := backends[name]
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	writeJSON(w, http.StatusOK, backendToStoreJSON(name, b))
+}
+
+// handleStoreBackendPatch serves PATCH /api/store/backends/{name}.
+func (s *Server) handleStoreBackendPatch(w http.ResponseWriter, r *http.Request) {
+	name := backendPathName(r)
+
+	var req backendRuntimeSettingsJSON
+	if !decodeBody(w, r, s.loadCfg().Daemon.HTTP.MaxBodyBytes, &req) {
+		return
+	}
+	if req.TimeoutSeconds == nil && req.MaxPromptChars == nil {
+		http.Error(w, "at least one field is required", http.StatusBadRequest)
+		return
+	}
+	if req.TimeoutSeconds != nil && *req.TimeoutSeconds <= 0 {
+		http.Error(w, "timeout_seconds must be positive", http.StatusBadRequest)
+		return
+	}
+	if req.MaxPromptChars != nil && *req.MaxPromptChars <= 0 {
+		http.Error(w, "max_prompt_chars must be positive", http.StatusBadRequest)
+		return
+	}
+
+	s.storeMu.Lock()
+	backendsByName, err := store.ReadBackends(s.db)
+	if err != nil {
+		s.storeMu.Unlock()
+		http.Error(w, fmt.Sprintf("read backends: %v", err), http.StatusInternalServerError)
+		return
+	}
+	b, ok := backendsByName[name]
+	if !ok {
+		s.storeMu.Unlock()
+		http.NotFound(w, r)
+		return
+	}
+	if req.TimeoutSeconds != nil {
+		b.TimeoutSeconds = *req.TimeoutSeconds
+	}
+	if req.MaxPromptChars != nil {
+		b.MaxPromptChars = *req.MaxPromptChars
+	}
+
+	err = store.UpsertBackend(s.db, name, b)
+	if err == nil {
+		err = s.reloadCron()
+	}
+	s.storeMu.Unlock()
+	if err != nil {
+		status := storeErrStatus(err)
+		s.logger.Error().Err(err).Msg("store crud: backend runtime settings update or cron reload failed")
+		http.Error(w, fmt.Sprintf("backend runtime settings update or cron reload: %v", err), status)
+		return
+	}
+	writeJSON(w, http.StatusOK, backendToStoreJSON(name, b))
+}
+
+// handleStoreBackendDelete serves DELETE /api/store/backends/{name}.
+func (s *Server) handleStoreBackendDelete(w http.ResponseWriter, r *http.Request) {
+	name := backendPathName(r)
+
+	s.storeMu.Lock()
+	err := store.DeleteBackend(s.db, name)
+	if err == nil {
+		err = s.reloadCron()
+	}
+	s.storeMu.Unlock()
+	if err != nil {
+		status := storeErrStatus(err)
+		s.logger.Error().Err(err).Msg("store crud: backend delete or cron reload failed")
+		http.Error(w, fmt.Sprintf("backend delete or cron reload: %v", err), status)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // ── /api/store/repos ──────────────────────────────────────────────────────────

--- a/internal/webhook/crud.go
+++ b/internal/webhook/crud.go
@@ -1,16 +1,20 @@
 package webhook
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/gorilla/mux"
 	"gopkg.in/yaml.v3"
 
+	"github.com/eloylp/agents/internal/backends"
 	"github.com/eloylp/agents/internal/config"
 	"github.com/eloylp/agents/internal/store"
 )
@@ -20,6 +24,7 @@ import (
 type storeAgentJSON struct {
 	Name          string   `json:"name"`
 	Backend       string   `json:"backend"`
+	Model         string   `json:"model,omitempty"`
 	Skills        []string `json:"skills"`
 	Prompt        string   `json:"prompt"`
 	AllowPRs      bool     `json:"allow_prs"`
@@ -32,6 +37,7 @@ func agentToStoreJSON(a config.AgentDef) storeAgentJSON {
 	return storeAgentJSON{
 		Name:          a.Name,
 		Backend:       a.Backend,
+		Model:         a.Model,
 		Skills:        nilSafeStrings(a.Skills),
 		Prompt:        a.Prompt,
 		AllowPRs:      a.AllowPRs,
@@ -45,6 +51,7 @@ func (j storeAgentJSON) toConfig() config.AgentDef {
 	return config.AgentDef{
 		Name:          j.Name,
 		Backend:       j.Backend,
+		Model:         j.Model,
 		Skills:        nilSafeStrings(j.Skills),
 		Prompt:        j.Prompt,
 		AllowPRs:      j.AllowPRs,
@@ -62,11 +69,20 @@ type storeSkillJSON struct {
 type storeBackendJSON struct {
 	Name             string            `json:"name"`
 	Command          string            `json:"command"`
+	Version          string            `json:"version,omitempty"`
+	Models           []string          `json:"models,omitempty"`
+	Healthy          bool              `json:"healthy"`
+	HealthDetail     string            `json:"health_detail,omitempty"`
+	LocalModelURL    string            `json:"local_model_url,omitempty"`
 	Args             []string          `json:"args"`
 	Env              map[string]string `json:"env"`
 	TimeoutSeconds   int               `json:"timeout_seconds"`
 	MaxPromptChars   int               `json:"max_prompt_chars"`
 	RedactionSaltEnv string            `json:"redaction_salt_env"`
+}
+
+type localBackendRequest struct {
+	URL string `json:"url"`
 }
 
 func backendToStoreJSON(name string, b config.AIBackendConfig) storeBackendJSON {
@@ -81,6 +97,11 @@ func backendToStoreJSON(name string, b config.AIBackendConfig) storeBackendJSON 
 	return storeBackendJSON{
 		Name:             name,
 		Command:          b.Command,
+		Version:          b.Version,
+		Models:           nilSafeStrings(b.Models),
+		Healthy:          b.Healthy,
+		HealthDetail:     b.HealthDetail,
+		LocalModelURL:    b.LocalModelURL,
 		Args:             nilSafeStrings(b.Args),
 		Env:              redactedEnv,
 		TimeoutSeconds:   b.TimeoutSeconds,
@@ -92,6 +113,11 @@ func backendToStoreJSON(name string, b config.AIBackendConfig) storeBackendJSON 
 func (j storeBackendJSON) toConfig() config.AIBackendConfig {
 	return config.AIBackendConfig{
 		Command:          j.Command,
+		Version:          j.Version,
+		Models:           nilSafeStrings(j.Models),
+		Healthy:          j.Healthy,
+		HealthDetail:     j.HealthDetail,
+		LocalModelURL:    j.LocalModelURL,
 		Args:             nilSafeStrings(j.Args),
 		Env:              j.Env,
 		TimeoutSeconds:   j.TimeoutSeconds,
@@ -497,6 +523,103 @@ func (s *Server) handleStoreBackends(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// handleBackendsStatus serves GET /backends/status with live diagnostics.
+func (s *Server) handleBackendsStatus(w http.ResponseWriter, r *http.Request) {
+	existing, err := store.ReadBackends(s.db)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("read backends: %v", err), http.StatusInternalServerError)
+		return
+	}
+	diag := backends.RunDiagnostics(r.Context(), existing)
+	writeJSON(w, http.StatusOK, diag)
+}
+
+// handleBackendsDiscover serves POST /backends/discover. It reruns discovery,
+// persists backend metadata, and hot-reloads the in-memory config.
+func (s *Server) handleBackendsDiscover(w http.ResponseWriter, r *http.Request) {
+	s.storeMu.Lock()
+	diag, err := backends.DiscoverAndPersist(r.Context(), s.db)
+	if err == nil {
+		err = s.reloadCron()
+	}
+	s.storeMu.Unlock()
+	if err != nil {
+		status := storeErrStatus(err)
+		s.logger.Error().Err(err).Msg("backend discovery failed")
+		http.Error(w, fmt.Sprintf("backend discovery: %v", err), status)
+		return
+	}
+	writeJSON(w, http.StatusOK, diag)
+}
+
+// handleBackendsLocal serves POST /backends/local. It creates or updates the
+// special claude_local backend by wiring the discovered Claude CLI to a local
+// OpenAI-compatible URL via ANTHROPIC_BASE_URL.
+func (s *Server) handleBackendsLocal(w http.ResponseWriter, r *http.Request) {
+	var req localBackendRequest
+	if !decodeBody(w, r, s.loadCfg().Daemon.HTTP.MaxBodyBytes, &req) {
+		return
+	}
+	req.URL = strings.TrimSpace(req.URL)
+	if req.URL == "" {
+		http.Error(w, "url is required", http.StatusBadRequest)
+		return
+	}
+	if _, err := url.ParseRequestURI(req.URL); err != nil {
+		http.Error(w, fmt.Sprintf("invalid url: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	s.storeMu.Lock()
+	existing, err := store.ReadBackends(s.db)
+	if err != nil {
+		s.storeMu.Unlock()
+		http.Error(w, fmt.Sprintf("read backends: %v", err), http.StatusInternalServerError)
+		return
+	}
+	base, ok := existing[backends.ClaudeName]
+	if !ok || strings.TrimSpace(base.Command) == "" {
+		s.storeMu.Unlock()
+		http.Error(w, "claude backend must be discovered first", http.StatusBadRequest)
+		return
+	}
+
+	local := existing[backends.ClaudeLocalName]
+	local.Command = base.Command
+	local.LocalModelURL = req.URL
+
+	diagMap := map[string]config.AIBackendConfig{
+		backends.ClaudeName:      base,
+		backends.ClaudeLocalName: local,
+	}
+	diag := backends.RunDiagnostics(context.Background(), diagMap)
+	for _, b := range diag.Backends {
+		if b.Name != backends.ClaudeLocalName {
+			continue
+		}
+		local.Version = b.Version
+		local.Models = b.Models
+		local.Healthy = b.Healthy
+		local.HealthDetail = b.HealthDetail
+		local.Command = b.Command
+		local.LocalModelURL = b.LocalModelURL
+		break
+	}
+
+	err = store.UpsertBackend(s.db, backends.ClaudeLocalName, local)
+	if err == nil {
+		err = s.reloadCron()
+	}
+	s.storeMu.Unlock()
+	if err != nil {
+		status := storeErrStatus(err)
+		s.logger.Error().Err(err).Msg("local backend upsert failed")
+		http.Error(w, fmt.Sprintf("local backend upsert or cron reload: %v", err), status)
+		return
+	}
+	writeJSON(w, http.StatusOK, backendToStoreJSON(backends.ClaudeLocalName, local))
+}
+
 // handleStoreBackend serves GET and DELETE /api/store/backends/{name}.
 func (s *Server) handleStoreBackend(w http.ResponseWriter, r *http.Request) {
 	name := config.NormalizeBackendName(mux.Vars(r)["name"])
@@ -619,10 +742,10 @@ func (s *Server) handleStoreRepo(w http.ResponseWriter, r *http.Request) {
 // four CRUD-mutable sections; daemon-level config (HTTP, log, proxy) is
 // intentionally excluded — it is not managed by the write API.
 type exportYAML struct {
-	Skills map[string]config.SkillDef        `yaml:"skills,omitempty"`
-	Agents []config.AgentDef                 `yaml:"agents,omitempty"`
-	Repos  []config.RepoDef                  `yaml:"repos,omitempty"`
-	Daemon *exportDaemonYAML                 `yaml:"daemon,omitempty"`
+	Skills map[string]config.SkillDef `yaml:"skills,omitempty"`
+	Agents []config.AgentDef          `yaml:"agents,omitempty"`
+	Repos  []config.RepoDef           `yaml:"repos,omitempty"`
+	Daemon *exportDaemonYAML          `yaml:"daemon,omitempty"`
 }
 
 type exportDaemonYAML struct {

--- a/internal/webhook/crud.go
+++ b/internal/webhook/crud.go
@@ -1,7 +1,6 @@
 package webhook
 
 import (
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -73,8 +72,6 @@ type storeBackendJSON struct {
 	Healthy          bool              `json:"healthy"`
 	HealthDetail     string            `json:"health_detail,omitempty"`
 	LocalModelURL    string            `json:"local_model_url,omitempty"`
-	Args             []string          `json:"args"`
-	Env              map[string]string `json:"env"`
 	TimeoutSeconds   int               `json:"timeout_seconds"`
 	MaxPromptChars   int               `json:"max_prompt_chars"`
 	RedactionSaltEnv string            `json:"redaction_salt_env"`
@@ -91,14 +88,6 @@ type backendRuntimeSettingsJSON struct {
 }
 
 func backendToStoreJSON(name string, b config.AIBackendConfig) storeBackendJSON {
-	// Redact env values: backend env entries are expected to hold secrets
-	// (API keys, base URLs, etc.). Preserve the key names so operators can
-	// identify which environment variables are configured, but never expose
-	// the resolved values — consistent with how /api/config handles backends.
-	redactedEnv := make(map[string]string, len(b.Env))
-	for k := range b.Env {
-		redactedEnv[k] = "[redacted]"
-	}
 	return storeBackendJSON{
 		Name:             name,
 		Command:          b.Command,
@@ -107,8 +96,6 @@ func backendToStoreJSON(name string, b config.AIBackendConfig) storeBackendJSON 
 		Healthy:          b.Healthy,
 		HealthDetail:     b.HealthDetail,
 		LocalModelURL:    b.LocalModelURL,
-		Args:             nilSafeStrings(b.Args),
-		Env:              redactedEnv,
 		TimeoutSeconds:   b.TimeoutSeconds,
 		MaxPromptChars:   b.MaxPromptChars,
 		RedactionSaltEnv: b.RedactionSaltEnv,
@@ -123,8 +110,6 @@ func (j storeBackendJSON) toConfig() config.AIBackendConfig {
 		Healthy:          j.Healthy,
 		HealthDetail:     j.HealthDetail,
 		LocalModelURL:    j.LocalModelURL,
-		Args:             nilSafeStrings(j.Args),
-		Env:              j.Env,
 		TimeoutSeconds:   j.TimeoutSeconds,
 		MaxPromptChars:   j.MaxPromptChars,
 		RedactionSaltEnv: j.RedactionSaltEnv,
@@ -174,45 +159,6 @@ func (j storeRepoJSON) toConfig() config.RepoDef {
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
-
-// restoreRedactedEnv resolves any "[redacted]" sentinel values in env that were
-// echoed back from the list API. For each such key the real stored value is
-// substituted; if the key does not exist in the stored backend the entry is
-// removed so that a phantom "[redacted]" is never written to the database.
-// env is mutated in place. Calling this before UpsertBackend prevents a no-op
-// edit from overwriting real secrets with the literal string "[redacted]".
-func restoreRedactedEnv(db *sql.DB, name string, env map[string]string) error {
-	// Fast path: nothing to do when no sentinel values are present.
-	needRestore := false
-	for _, v := range env {
-		if v == "[redacted]" {
-			needRestore = true
-			break
-		}
-	}
-	if !needRestore {
-		return nil
-	}
-	existing, err := store.ReadBackends(db)
-	if err != nil {
-		return err
-	}
-	stored, ok := existing[config.NormalizeBackendName(name)]
-	for k, v := range env {
-		if v != "[redacted]" {
-			continue
-		}
-		if ok {
-			if sv, found := stored.Env[k]; found {
-				env[k] = sv
-				continue
-			}
-		}
-		// Key not present in the stored backend — drop the sentinel.
-		delete(env, k)
-	}
-	return nil
-}
 
 func nilSafeStrings(s []string) []string {
 	if s == nil {
@@ -497,18 +443,7 @@ func (s *Server) handleStoreBackends(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "name is required", http.StatusBadRequest)
 			return
 		}
-		if req.Env == nil {
-			req.Env = map[string]string{}
-		}
-		// restoreRedactedEnv must run inside the lock so that the read of the
-		// stored backend and the subsequent UpsertBackend write are atomic with
-		// respect to other concurrent backend edits.
 		s.storeMu.Lock()
-		if err := restoreRedactedEnv(s.db, req.Name, req.Env); err != nil {
-			s.storeMu.Unlock()
-			http.Error(w, fmt.Sprintf("read backends: %v", err), http.StatusInternalServerError)
-			return
-		}
 		err := store.UpsertBackend(s.db, req.Name, req.toConfig())
 		if err == nil {
 			err = s.reloadCron()

--- a/internal/webhook/crud_test.go
+++ b/internal/webhook/crud_test.go
@@ -366,6 +366,160 @@ func TestStoreCRUDBackendPostPreservesRedactedEnv(t *testing.T) {
 	}
 }
 
+func TestStoreCRUDBackendPatchRuntimeSettings(t *testing.T) {
+	t.Parallel()
+	s := openCRUDTestServer(t)
+
+	if rr := doCRUDRequest(t, s, http.MethodPost, "/backends", map[string]any{
+		"name":             "claude",
+		"command":          "claude",
+		"args":             []string{"--legacy-arg"},
+		"env":              map[string]string{"ANTHROPIC_API_KEY": "sk-secret"},
+		"timeout_seconds":  600,
+		"max_prompt_chars": 12000,
+	}); rr.Code != http.StatusOK {
+		t.Fatalf("POST backend: got %d — %s", rr.Code, rr.Body.String())
+	}
+
+	rr := doCRUDRequest(t, s, http.MethodPatch, "/backends/claude", map[string]any{
+		"timeout_seconds":  900,
+		"max_prompt_chars": 45000,
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("PATCH /backends/claude: got %d — %s", rr.Code, rr.Body.String())
+	}
+
+	var out storeBackendJSON
+	if err := json.NewDecoder(rr.Body).Decode(&out); err != nil {
+		t.Fatalf("decode patch response: %v", err)
+	}
+	if out.TimeoutSeconds != 900 {
+		t.Fatalf("response timeout_seconds = %d, want 900", out.TimeoutSeconds)
+	}
+	if out.MaxPromptChars != 45000 {
+		t.Fatalf("response max_prompt_chars = %d, want 45000", out.MaxPromptChars)
+	}
+
+	backends, err := store.ReadBackends(s.db)
+	if err != nil {
+		t.Fatalf("ReadBackends: %v", err)
+	}
+	b, ok := backends["claude"]
+	if !ok {
+		t.Fatal("backend 'claude' not found after patch")
+	}
+	if b.TimeoutSeconds != 900 || b.MaxPromptChars != 45000 {
+		t.Fatalf("runtime settings = (%d, %d), want (900, 45000)", b.TimeoutSeconds, b.MaxPromptChars)
+	}
+	if b.Command != "claude" {
+		t.Fatalf("command changed unexpectedly: got %q", b.Command)
+	}
+	if len(b.Args) != 1 || b.Args[0] != "--legacy-arg" {
+		t.Fatalf("args changed unexpectedly: got %v", b.Args)
+	}
+	if got := b.Env["ANTHROPIC_API_KEY"]; got != "sk-secret" {
+		t.Fatalf("env changed unexpectedly: got %q", got)
+	}
+}
+
+func TestStoreCRUDBackendPatchRuntimeSettingsValidation(t *testing.T) {
+	t.Parallel()
+	s := openCRUDTestServer(t)
+
+	if rr := doCRUDRequest(t, s, http.MethodPatch, "/backends/missing", map[string]any{
+		"timeout_seconds": 10,
+	}); rr.Code != http.StatusNotFound {
+		t.Fatalf("PATCH missing backend: got %d, want 404", rr.Code)
+	}
+
+	if rr := doCRUDRequest(t, s, http.MethodPatch, "/backends/claude", map[string]any{}); rr.Code != http.StatusBadRequest {
+		t.Fatalf("PATCH empty payload: got %d, want 400", rr.Code)
+	}
+
+	if rr := doCRUDRequest(t, s, http.MethodPost, "/backends", map[string]any{
+		"name":    "claude",
+		"command": "claude",
+		"args":    []string{},
+		"env":     map[string]string{},
+	}); rr.Code != http.StatusOK {
+		t.Fatalf("POST backend: got %d — %s", rr.Code, rr.Body.String())
+	}
+
+	if rr := doCRUDRequest(t, s, http.MethodPatch, "/backends/claude", map[string]any{
+		"timeout_seconds": 0,
+	}); rr.Code != http.StatusBadRequest {
+		t.Fatalf("PATCH timeout_seconds=0: got %d, want 400", rr.Code)
+	}
+	if rr := doCRUDRequest(t, s, http.MethodPatch, "/backends/claude", map[string]any{
+		"max_prompt_chars": -1,
+	}); rr.Code != http.StatusBadRequest {
+		t.Fatalf("PATCH max_prompt_chars=-1: got %d, want 400", rr.Code)
+	}
+}
+
+func TestBackendsLocalCreateNamedAndDelete(t *testing.T) {
+	t.Parallel()
+	s := openCRUDTestServer(t)
+
+	// Local backend creation requires a discovered claude backend.
+	if err := store.UpsertBackend(s.db, "claude", config.AIBackendConfig{
+		Command: "/bin/sh",
+		Args:    []string{},
+		Env:     map[string]string{},
+	}); err != nil {
+		t.Fatalf("seed claude backend: %v", err)
+	}
+
+	rr := doCRUDRequest(t, s, http.MethodPost, "/backends/local", map[string]any{
+		"name": "qwen_local",
+		"url":  "http://localhost:18000/v1/messages",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("POST /backends/local: got %d — %s", rr.Code, rr.Body.String())
+	}
+	var created storeBackendJSON
+	if err := json.NewDecoder(rr.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if created.Name != "qwen_local" {
+		t.Fatalf("created backend name: got %q, want %q", created.Name, "qwen_local")
+	}
+	if created.LocalModelURL != "http://localhost:18000/v1/messages" {
+		t.Fatalf("local_model_url: got %q", created.LocalModelURL)
+	}
+
+	rr = doCRUDRequest(t, s, http.MethodGet, "/backends/qwen_local", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET /backends/qwen_local: got %d — %s", rr.Code, rr.Body.String())
+	}
+
+	rr = doCRUDRequest(t, s, http.MethodDelete, "/backends/qwen_local", nil)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("DELETE /backends/qwen_local: got %d — %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestBackendsLocalRejectReservedName(t *testing.T) {
+	t.Parallel()
+	s := openCRUDTestServer(t)
+
+	if err := store.UpsertBackend(s.db, "claude", config.AIBackendConfig{
+		Command: "/bin/sh",
+		Args:    []string{},
+		Env:     map[string]string{},
+	}); err != nil {
+		t.Fatalf("seed claude backend: %v", err)
+	}
+
+	rr := doCRUDRequest(t, s, http.MethodPost, "/backends/local", map[string]any{
+		"name": "claude",
+		"url":  "http://localhost:18000/v1/messages",
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("POST /backends/local with reserved name: got %d — %s", rr.Code, rr.Body.String())
+	}
+}
+
 // ── /repos ──────────────────────────────────────────────────────────
 
 func TestStoreCRUDRepoCreateAndDelete(t *testing.T) {
@@ -1669,4 +1823,3 @@ repos:
 		t.Errorf("existing-repo missing after failed replace import: %s", repos.Body.String())
 	}
 }
-

--- a/internal/webhook/crud_test.go
+++ b/internal/webhook/crud_test.go
@@ -41,7 +41,7 @@ func openCRUDTestServer(t *testing.T) *Server {
 // so that subsequent agent upserts that reference it pass cross-ref validation.
 func seedStoreBackend(t *testing.T, s *Server, name string) {
 	t.Helper()
-	b := config.AIBackendConfig{Command: name, Args: []string{}, Env: map[string]string{}}
+	b := config.AIBackendConfig{Command: name}
 	if err := store.UpsertBackend(s.db, name, b); err != nil {
 		t.Fatalf("seedStoreBackend %s: %v", name, err)
 	}
@@ -295,13 +295,8 @@ func TestStoreCRUDBackendGetRedactsEnv(t *testing.T) {
 	if len(list) != 1 {
 		t.Fatalf("want 1 backend, got %d", len(list))
 	}
-	for k, v := range list[0].Env {
-		if v != "[redacted]" {
-			t.Errorf("GET /backends: env[%q] = %q, want \"[redacted]\"", k, v)
-		}
-	}
 
-	// GET single — same redaction requirement.
+	// GET single.
 	rr = doCRUDRequest(t, s, http.MethodGet, "/backends/claude", nil)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("GET backend/claude: got %d", rr.Code)
@@ -310,61 +305,8 @@ func TestStoreCRUDBackendGetRedactsEnv(t *testing.T) {
 	if err := json.NewDecoder(rr.Body).Decode(&single); err != nil {
 		t.Fatalf("decode single: %v", err)
 	}
-	for k, v := range single.Env {
-		if v != "[redacted]" {
-			t.Errorf("GET /backends/claude: env[%q] = %q, want \"[redacted]\"", k, v)
-		}
-	}
 }
 
-// TestStoreCRUDBackendPostPreservesRedactedEnv verifies that POSTing a backend
-// with "[redacted]" env values (the sentinel echoed by the list API) does not
-// overwrite the real stored secret with the literal string "[redacted]".
-// This models the UI edit flow: GET list → seed form → POST back unchanged.
-func TestStoreCRUDBackendPostPreservesRedactedEnv(t *testing.T) {
-	t.Parallel()
-	s := openCRUDTestServer(t)
-
-	// Create backend with a real secret.
-	if rr := doCRUDRequest(t, s, http.MethodPost, "/backends", map[string]any{
-		"name":    "claude",
-		"command": "claude",
-		"args":    []string{},
-		"env":     map[string]string{"ANTHROPIC_API_KEY": "sk-real-secret"},
-	}); rr.Code != http.StatusOK {
-		t.Fatalf("POST backend (create): got %d — %s", rr.Code, rr.Body.String())
-	}
-
-	// Simulate the UI edit flow: POST back with the "[redacted]" sentinel that
-	// the list API returns, changing only a non-secret field.
-	if rr := doCRUDRequest(t, s, http.MethodPost, "/backends", map[string]any{
-		"name":            "claude",
-		"command":         "claude",
-		"args":            []string{"--dangerously-skip-permissions"},
-		"env":             map[string]string{"ANTHROPIC_API_KEY": "[redacted]"},
-		"timeout_seconds": 900,
-	}); rr.Code != http.StatusOK {
-		t.Fatalf("POST backend (edit with redacted sentinel): got %d — %s", rr.Code, rr.Body.String())
-	}
-
-	// Read back via the store directly (unredacted) and confirm the real secret
-	// was preserved, not overwritten with the literal string "[redacted]".
-	backends, err := store.ReadBackends(s.db)
-	if err != nil {
-		t.Fatalf("ReadBackends: %v", err)
-	}
-	b, ok := backends["claude"]
-	if !ok {
-		t.Fatal("backend 'claude' not found in store after edit")
-	}
-	if got, want := b.Env["ANTHROPIC_API_KEY"], "sk-real-secret"; got != want {
-		t.Errorf("stored env[ANTHROPIC_API_KEY] = %q, want %q (secret must not be overwritten by [redacted] sentinel)", got, want)
-	}
-	// The non-secret field change must have been applied.
-	if b.TimeoutSeconds != 900 {
-		t.Errorf("timeout_seconds = %d, want 900", b.TimeoutSeconds)
-	}
-}
 
 func TestStoreCRUDBackendPatchRuntimeSettings(t *testing.T) {
 	t.Parallel()
@@ -373,8 +315,6 @@ func TestStoreCRUDBackendPatchRuntimeSettings(t *testing.T) {
 	if rr := doCRUDRequest(t, s, http.MethodPost, "/backends", map[string]any{
 		"name":             "claude",
 		"command":          "claude",
-		"args":             []string{"--legacy-arg"},
-		"env":              map[string]string{"ANTHROPIC_API_KEY": "sk-secret"},
 		"timeout_seconds":  600,
 		"max_prompt_chars": 12000,
 	}); rr.Code != http.StatusOK {
@@ -414,12 +354,6 @@ func TestStoreCRUDBackendPatchRuntimeSettings(t *testing.T) {
 	if b.Command != "claude" {
 		t.Fatalf("command changed unexpectedly: got %q", b.Command)
 	}
-	if len(b.Args) != 1 || b.Args[0] != "--legacy-arg" {
-		t.Fatalf("args changed unexpectedly: got %v", b.Args)
-	}
-	if got := b.Env["ANTHROPIC_API_KEY"]; got != "sk-secret" {
-		t.Fatalf("env changed unexpectedly: got %q", got)
-	}
 }
 
 func TestStoreCRUDBackendPatchRuntimeSettingsValidation(t *testing.T) {
@@ -439,8 +373,6 @@ func TestStoreCRUDBackendPatchRuntimeSettingsValidation(t *testing.T) {
 	if rr := doCRUDRequest(t, s, http.MethodPost, "/backends", map[string]any{
 		"name":    "claude",
 		"command": "claude",
-		"args":    []string{},
-		"env":     map[string]string{},
 	}); rr.Code != http.StatusOK {
 		t.Fatalf("POST backend: got %d — %s", rr.Code, rr.Body.String())
 	}
@@ -464,8 +396,6 @@ func TestBackendsLocalCreateNamedAndDelete(t *testing.T) {
 	// Local backend creation requires a discovered claude backend.
 	if err := store.UpsertBackend(s.db, "claude", config.AIBackendConfig{
 		Command: "/bin/sh",
-		Args:    []string{},
-		Env:     map[string]string{},
 	}); err != nil {
 		t.Fatalf("seed claude backend: %v", err)
 	}
@@ -505,8 +435,6 @@ func TestBackendsLocalRejectReservedName(t *testing.T) {
 
 	if err := store.UpsertBackend(s.db, "claude", config.AIBackendConfig{
 		Command: "/bin/sh",
-		Args:    []string{},
-		Env:     map[string]string{},
 	}); err != nil {
 		t.Fatalf("seed claude backend: %v", err)
 	}
@@ -1280,15 +1208,6 @@ func TestStoreCRUDPostReturnsCanonicalForm(t *testing.T) {
 	if mp, ok := backend["max_prompt_chars"].(float64); !ok || mp == 0 {
 		t.Errorf("backend max_prompt_chars: got %v, want non-zero default", backend["max_prompt_chars"])
 	}
-	// Env values must be redacted.
-	if env, ok := backend["env"].(map[string]any); ok {
-		if env["ANTHROPIC_API_KEY"] != "[redacted]" {
-			t.Errorf("backend env value not redacted: got %q", env["ANTHROPIC_API_KEY"])
-		}
-	} else {
-		t.Errorf("backend env missing or wrong type: %v", backend["env"])
-	}
-
 	// ── agent ────────────────────────────────────────────────────────────────
 	// POST with mixed-case name and extra whitespace; response must have
 	// lowercase name and trimmed prompt.

--- a/internal/webhook/orphans.go
+++ b/internal/webhook/orphans.go
@@ -1,0 +1,168 @@
+package webhook
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/store"
+)
+
+// OrphanedAgent describes an agent whose pinned model no longer exists in the
+// backend model catalog stored in the database snapshot.
+type OrphanedAgent struct {
+	Name            string   `json:"name"`
+	Backend         string   `json:"backend"`
+	Model           string   `json:"model"`
+	Repos           []string `json:"repos,omitempty"`
+	AvailableModels []string `json:"available_models,omitempty"`
+}
+
+// OrphanedAgentsSnapshot is the cached orphan-check result used by /status and
+// /agents/orphans/status.
+type OrphanedAgentsSnapshot struct {
+	GeneratedAt time.Time       `json:"generated_at"`
+	Count       int             `json:"count"`
+	Agents      []OrphanedAgent `json:"agents"`
+}
+
+func (s *Server) handleAgentsOrphans(w http.ResponseWriter, _ *http.Request) {
+	snapshot := s.orphanedAgentsSnapshot()
+	if fresh, err := s.refreshOrphanedAgentsFromDB(); err == nil {
+		snapshot = fresh
+	} else {
+		s.logger.Warn().Err(err).Msg("orphan status: falling back to cached snapshot")
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(snapshot)
+}
+
+func (s *Server) refreshOrphanedAgents(cfg *config.Config) {
+	snapshot := OrphanedAgentsSnapshot{
+		GeneratedAt: time.Now().UTC(),
+		Agents:      computeOrphanedAgents(cfg),
+	}
+	snapshot.Count = len(snapshot.Agents)
+
+	s.orphanMu.Lock()
+	s.orphanCache = snapshot
+	s.orphanMu.Unlock()
+}
+
+func (s *Server) orphanedAgentsSnapshot() OrphanedAgentsSnapshot {
+	s.orphanMu.RLock()
+	defer s.orphanMu.RUnlock()
+
+	out := s.orphanCache
+	out.Agents = append([]OrphanedAgent(nil), s.orphanCache.Agents...)
+	return out
+}
+
+func (s *Server) refreshOrphanedAgentsFromDB() (OrphanedAgentsSnapshot, error) {
+	if s.db == nil {
+		return s.orphanedAgentsSnapshot(), nil
+	}
+	agents, repos, skills, backends, err := store.ReadSnapshot(s.db)
+	if err != nil {
+		return OrphanedAgentsSnapshot{}, fmt.Errorf("read config snapshot: %w", err)
+	}
+
+	baseCfg := s.loadCfg()
+	cfg := *baseCfg
+	cfg.Agents = agents
+	cfg.Repos = repos
+	cfg.Skills = skills
+	cfg.Daemon.AIBackends = backends
+
+	s.refreshOrphanedAgents(&cfg)
+	return s.orphanedAgentsSnapshot(), nil
+}
+
+func computeOrphanedAgents(cfg *config.Config) []OrphanedAgent {
+	if cfg == nil {
+		return nil
+	}
+
+	reposByAgent := make(map[string]map[string]struct{})
+	for _, repo := range cfg.Repos {
+		if !repo.Enabled {
+			continue
+		}
+		for _, binding := range repo.Use {
+			if !binding.IsEnabled() {
+				continue
+			}
+			set := reposByAgent[binding.Agent]
+			if set == nil {
+				set = make(map[string]struct{})
+				reposByAgent[binding.Agent] = set
+			}
+			set[repo.Name] = struct{}{}
+		}
+	}
+
+	orphans := make([]OrphanedAgent, 0)
+	for _, agent := range cfg.Agents {
+		backendName := cfg.ResolveBackend(agent.Backend)
+		if backendName == "" {
+			continue
+		}
+		backend, ok := cfg.Daemon.AIBackends[backendName]
+		if !ok || !config.IsPinnedModelUnavailable(agent.Model, backend) {
+			continue
+		}
+		orphans = append(orphans, OrphanedAgent{
+			Name:            agent.Name,
+			Backend:         backendName,
+			Model:           strings.TrimSpace(agent.Model),
+			Repos:           sortedSetKeys(reposByAgent[agent.Name]),
+			AvailableModels: canonicalModels(backend.Models),
+		})
+	}
+
+	sort.Slice(orphans, func(i, j int) bool {
+		if orphans[i].Backend != orphans[j].Backend {
+			return orphans[i].Backend < orphans[j].Backend
+		}
+		return orphans[i].Name < orphans[j].Name
+	})
+	return orphans
+}
+
+func sortedSetKeys(in map[string]struct{}) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(in))
+	for k := range in {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func canonicalModels(models []string) []string {
+	if len(models) == 0 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(models))
+	out := make([]string, 0, len(models))
+	for _, model := range models {
+		model = strings.TrimSpace(model)
+		if model == "" {
+			continue
+		}
+		if _, exists := set[model]; exists {
+			continue
+		}
+		set[model] = struct{}{}
+		out = append(out, model)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/webhook/orphans_test.go
+++ b/internal/webhook/orphans_test.go
@@ -1,0 +1,106 @@
+package webhook
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/eloylp/agents/internal/config"
+)
+
+func TestComputeOrphanedAgents(t *testing.T) {
+	t.Parallel()
+
+	cfg := testCfg(func(c *config.Config) {
+		c.Daemon.AIBackends = map[string]config.AIBackendConfig{
+			"claude": {
+				Command: "claude",
+				Models:  []string{"claude-3.7", "claude-4"},
+			},
+		}
+		c.Agents = []config.AgentDef{
+			{Name: "coder", Backend: "claude", Model: "claude-3.5", Prompt: "x"},
+			{Name: "reviewer", Backend: "claude", Model: "claude-4", Prompt: "x"},
+			{Name: "defaulted", Backend: "claude", Prompt: "x"},
+		}
+		enabled := true
+		c.Repos = []config.RepoDef{
+			{
+				Name:    "owner/repo",
+				Enabled: true,
+				Use: []config.Binding{
+					{Agent: "coder", Labels: []string{"ai:fix"}, Enabled: &enabled},
+				},
+			},
+		}
+	})
+
+	orphans := computeOrphanedAgents(cfg)
+	if len(orphans) != 1 {
+		t.Fatalf("len(orphans) = %d, want 1", len(orphans))
+	}
+	if orphans[0].Name != "coder" {
+		t.Fatalf("orphan name = %q, want %q", orphans[0].Name, "coder")
+	}
+	if orphans[0].Backend != "claude" {
+		t.Fatalf("orphan backend = %q, want %q", orphans[0].Backend, "claude")
+	}
+	if len(orphans[0].AvailableModels) != 2 {
+		t.Fatalf("available_models len = %d, want 2", len(orphans[0].AvailableModels))
+	}
+	if len(orphans[0].Repos) != 1 || orphans[0].Repos[0] != "owner/repo" {
+		t.Fatalf("repos = %v, want [owner/repo]", orphans[0].Repos)
+	}
+}
+
+func TestAgentsOrphansEndpointAndStatusSummary(t *testing.T) {
+	t.Parallel()
+
+	cfg := testCfg(func(c *config.Config) {
+		c.Daemon.AIBackends = map[string]config.AIBackendConfig{
+			"claude": {
+				Command: "claude",
+				Models:  []string{"claude-4"},
+			},
+		}
+		c.Agents = []config.AgentDef{
+			{Name: "coder", Backend: "claude", Model: "claude-3.5", Prompt: "x"},
+		}
+	})
+	srv, _ := newTestServer(cfg)
+	h := srv.buildHandler()
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/agents/orphans/status", nil)
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET /agents/orphans/status: got %d", rr.Code)
+	}
+
+	var snapshot OrphanedAgentsSnapshot
+	if err := json.NewDecoder(rr.Body).Decode(&snapshot); err != nil {
+		t.Fatalf("decode /agents/orphans/status: %v", err)
+	}
+	if snapshot.Count != 1 || len(snapshot.Agents) != 1 {
+		t.Fatalf("orphan snapshot count=%d agents=%d, want 1/1", snapshot.Count, len(snapshot.Agents))
+	}
+
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/status", nil)
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET /status: got %d", rr.Code)
+	}
+	var status struct {
+		OrphanedAgents struct {
+			Count int `json:"count"`
+		} `json:"orphaned_agents"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&status); err != nil {
+		t.Fatalf("decode /status: %v", err)
+	}
+	if status.OrphanedAgents.Count != 1 {
+		t.Fatalf("status orphaned_agents.count = %d, want 1", status.OrphanedAgents.Count)
+	}
+}

--- a/internal/webhook/server.go
+++ b/internal/webhook/server.go
@@ -106,6 +106,11 @@ type Server struct {
 	// (HTTP, proxy, log) is never replaced after startup, but since the entire
 	// pointer is swapped on reload the lock is required for all accesses.
 	cfgMu sync.RWMutex
+	// orphanMu protects orphanCache, which is updated on config reloads and
+	// read by /status and /agents/orphans/status endpoints.
+	orphanMu sync.RWMutex
+	// orphanCache stores the latest DB-only orphaned-agent snapshot.
+	orphanCache OrphanedAgentsSnapshot
 }
 
 // WithUI attaches an fs.FS containing the pre-built static UI assets to the
@@ -155,6 +160,7 @@ func NewServer(cfg *config.Config, delivery *DeliveryStore, channels EventQueue,
 		dispatchStats: dispatchStats,
 		startTime:     time.Now(),
 	}
+	s.refreshOrphanedAgents(cfg)
 	if cfg.Daemon.Proxy.Enabled {
 		up := cfg.Daemon.Proxy.Upstream
 		s.proxy = anthropicproxy.NewHandler(anthropicproxy.UpstreamConfig{
@@ -209,6 +215,7 @@ func (s *Server) buildHandler() http.Handler {
 
 	// Fleet view (GET) + CRUD (POST) merged on a single path.
 	router.Handle("/agents", withTimeout(http.HandlerFunc(s.handleAgents))).Methods(http.MethodGet, http.MethodPost)
+	router.Handle("/agents/orphans/status", withTimeout(http.HandlerFunc(s.handleAgentsOrphans))).Methods(http.MethodGet)
 	router.Handle("/agents/{name}", withTimeout(http.HandlerFunc(s.handleStoreAgent))).Methods(http.MethodGet, http.MethodDelete)
 
 	router.Handle("/skills", withTimeout(http.HandlerFunc(s.handleStoreSkills))).Methods(http.MethodGet, http.MethodPost)
@@ -218,7 +225,9 @@ func (s *Server) buildHandler() http.Handler {
 	router.Handle("/backends/status", withTimeout(http.HandlerFunc(s.handleBackendsStatus))).Methods(http.MethodGet)
 	router.Handle("/backends/discover", withTimeout(http.HandlerFunc(s.handleBackendsDiscover))).Methods(http.MethodPost)
 	router.Handle("/backends/local", withTimeout(http.HandlerFunc(s.handleBackendsLocal))).Methods(http.MethodPost)
-	router.Handle("/backends/{name}", withTimeout(http.HandlerFunc(s.handleStoreBackend))).Methods(http.MethodGet, http.MethodDelete)
+	router.Handle("/backends/{name}", withTimeout(http.HandlerFunc(s.handleStoreBackendGet))).Methods(http.MethodGet)
+	router.Handle("/backends/{name}", withTimeout(http.HandlerFunc(s.handleStoreBackendPatch))).Methods(http.MethodPatch)
+	router.Handle("/backends/{name}", withTimeout(http.HandlerFunc(s.handleStoreBackendDelete))).Methods(http.MethodDelete)
 
 	router.Handle("/repos", withTimeout(http.HandlerFunc(s.handleStoreRepos))).Methods(http.MethodGet, http.MethodPost)
 	router.Handle("/repos/{owner}/{repo}", withTimeout(http.HandlerFunc(s.handleStoreRepo))).Methods(http.MethodGet, http.MethodDelete)
@@ -315,12 +324,17 @@ func (s *Server) handleStatus(w http.ResponseWriter, _ *http.Request) {
 		Buffered int `json:"buffered"`
 		Capacity int `json:"capacity"`
 	}
+	type orphanedAgentsSummaryJSON struct {
+		Count     int        `json:"count"`
+		UpdatedAt *time.Time `json:"updated_at,omitempty"`
+	}
 	type statusJSON struct {
-		Status        string                  `json:"status"`
-		UptimeSeconds int64                   `json:"uptime_seconds"`
-		Queues        map[string]queueJSON    `json:"queues"`
-		Agents        []AgentStatus           `json:"agents"`
-		Dispatch      *workflow.DispatchStats `json:"dispatch,omitempty"`
+		Status         string                    `json:"status"`
+		UptimeSeconds  int64                     `json:"uptime_seconds"`
+		Queues         map[string]queueJSON      `json:"queues"`
+		Agents         []AgentStatus             `json:"agents"`
+		Dispatch       *workflow.DispatchStats   `json:"dispatch,omitempty"`
+		OrphanedAgents orphanedAgentsSummaryJSON `json:"orphaned_agents"`
 	}
 
 	agents := []AgentStatus{}
@@ -338,11 +352,25 @@ func (s *Server) handleStatus(w http.ResponseWriter, _ *http.Request) {
 		},
 		Agents: agents,
 	}
+	orphaned := s.orphanedAgentsSnapshot()
+	if fresh, err := s.refreshOrphanedAgentsFromDB(); err == nil {
+		orphaned = fresh
+	} else {
+		s.logger.Warn().Err(err).Msg("status: orphan snapshot refresh failed")
+	}
+	resp.OrphanedAgents = orphanedAgentsSummaryJSON{
+		Count: orphaned.Count,
+	}
+	if !orphaned.GeneratedAt.IsZero() {
+		at := orphaned.GeneratedAt
+		resp.OrphanedAgents.UpdatedAt = &at
+	}
 	if s.dispatchStats != nil {
 		stats := s.dispatchStats.DispatchStats()
 		resp.Dispatch = &stats
 	}
 
+	w.Header().Set("Cache-Control", "no-store")
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(resp)
 }

--- a/internal/webhook/server.go
+++ b/internal/webhook/server.go
@@ -52,7 +52,6 @@ type DispatchStatsProvider interface {
 	DispatchStats() workflow.DispatchStats
 }
 
-
 // RuntimeStateProvider reports whether a named agent currently has an in-flight run.
 // The implementation is optional; passing nil causes all agents to report "idle".
 type RuntimeStateProvider interface {
@@ -216,21 +215,24 @@ func (s *Server) buildHandler() http.Handler {
 	router.Handle("/skills/{name}", withTimeout(http.HandlerFunc(s.handleStoreSkill))).Methods(http.MethodGet, http.MethodDelete)
 
 	router.Handle("/backends", withTimeout(http.HandlerFunc(s.handleStoreBackends))).Methods(http.MethodGet, http.MethodPost)
+	router.Handle("/backends/status", withTimeout(http.HandlerFunc(s.handleBackendsStatus))).Methods(http.MethodGet)
+	router.Handle("/backends/discover", withTimeout(http.HandlerFunc(s.handleBackendsDiscover))).Methods(http.MethodPost)
+	router.Handle("/backends/local", withTimeout(http.HandlerFunc(s.handleBackendsLocal))).Methods(http.MethodPost)
 	router.Handle("/backends/{name}", withTimeout(http.HandlerFunc(s.handleStoreBackend))).Methods(http.MethodGet, http.MethodDelete)
 
 	router.Handle("/repos", withTimeout(http.HandlerFunc(s.handleStoreRepos))).Methods(http.MethodGet, http.MethodPost)
 	router.Handle("/repos/{owner}/{repo}", withTimeout(http.HandlerFunc(s.handleStoreRepo))).Methods(http.MethodGet, http.MethodDelete)
 
 	router.Handle("/events", withTimeout(http.HandlerFunc(s.handleAPIEvents))).Methods(http.MethodGet)
-	router.HandleFunc("/events/stream", s.handleAPIEventsStream)           // SSE — no timeout
+	router.HandleFunc("/events/stream", s.handleAPIEventsStream) // SSE — no timeout
 	router.Handle("/traces", withTimeout(http.HandlerFunc(s.handleAPITraces))).Methods(http.MethodGet)
-	router.HandleFunc("/traces/stream", s.handleAPITracesStream)                                                        // SSE — no timeout
+	router.HandleFunc("/traces/stream", s.handleAPITracesStream) // SSE — no timeout
 	router.Handle("/traces/{root_event_id}", withTimeout(http.HandlerFunc(s.handleAPITrace))).Methods(http.MethodGet)
 	router.Handle("/traces/{span_id}/steps", withTimeout(http.HandlerFunc(s.handleAPITraceSteps))).Methods(http.MethodGet)
 	router.Handle("/graph", withTimeout(http.HandlerFunc(s.handleAPIGraph))).Methods(http.MethodGet)
 	router.Handle("/dispatches", withTimeout(http.HandlerFunc(s.handleAPIDispatches))).Methods(http.MethodGet)
 	router.Handle("/memory/{agent}/{repo}", withTimeout(http.HandlerFunc(s.handleAPIMemory))).Methods(http.MethodGet)
-	router.HandleFunc("/memory/stream", s.handleAPIMemoryStream)           // SSE — no timeout
+	router.HandleFunc("/memory/stream", s.handleAPIMemoryStream) // SSE — no timeout
 	router.Handle("/config", withTimeout(http.HandlerFunc(s.handleAPIConfig))).Methods(http.MethodGet)
 	router.Handle("/export", withTimeout(http.HandlerFunc(s.handleStoreExport))).Methods(http.MethodGet)
 	router.Handle("/import", withTimeout(http.HandlerFunc(s.handleStoreImport))).Methods(http.MethodPost)
@@ -487,11 +489,11 @@ type webhookReview struct {
 func (s *Server) handleIssuesEvent(ctx context.Context, w http.ResponseWriter, body []byte, deliveryID string) {
 	cfg := s.loadCfg()
 	var payload struct {
-		Action     string             `json:"action"`
-		Label      webhookLabel       `json:"label"`
-		Issue      webhookIssue       `json:"issue"`
-		Repository webhookRepository  `json:"repository"`
-		Sender     webhookSender      `json:"sender"`
+		Action     string            `json:"action"`
+		Label      webhookLabel      `json:"label"`
+		Issue      webhookIssue      `json:"issue"`
+		Repository webhookRepository `json:"repository"`
+		Sender     webhookSender     `json:"sender"`
 	}
 	if err := json.Unmarshal(body, &payload); err != nil {
 		http.Error(w, "invalid payload", http.StatusBadRequest)

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -56,9 +56,9 @@ type StepRecorder interface {
 // the runners just execute the resulting prompt.
 type Engine struct {
 	cfg           *config.Config
-	cfgMu         sync.RWMutex         // protects cfg during hot-reload
+	cfgMu         sync.RWMutex // protects cfg during hot-reload
 	runners       map[string]ai.Runner
-	runnersMu     sync.RWMutex         // protects runners during hot-reload
+	runnersMu     sync.RWMutex // protects runners during hot-reload
 	dispatcher    *Dispatcher
 	maxConcurrent int
 	logger        zerolog.Logger
@@ -562,6 +562,7 @@ func (e *Engine) runAgent(ctx context.Context, ev Event, agent config.AgentDef, 
 		Workflow: workflow,
 		Repo:     ev.Repo.FullName,
 		Number:   ev.Number,
+		Model:    agent.Model,
 		System:   rendered.System,
 		User:     rendered.User,
 	})

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -498,6 +498,14 @@ func (e *Engine) runAgent(ctx context.Context, ev Event, agent config.AgentDef, 
 	if backend == "" {
 		return fmt.Errorf("agent %q: no runner available for backend %q", agent.Name, agent.Backend)
 	}
+	if backendCfg, ok := cfg.Daemon.AIBackends[backend]; ok && config.IsPinnedModelUnavailable(agent.Model, backendCfg) {
+		return fmt.Errorf(
+			"agent %q: configured model %q is not available for backend %q; run backend discovery and update the agent model",
+			agent.Name,
+			agent.Model,
+			backend,
+		)
+	}
 	runner, ok := runners[backend]
 	if !ok {
 		return fmt.Errorf("agent %q: no runner for backend %q", agent.Name, backend)


### PR DESCRIPTION
## Summary

- Adds `model` field to `AgentDef` (config, SQLite migration 006, CRUD wire types, fleet snapshot, config API) so each agent can target a specific model
- Injects `--model` flag in `buildClaudeDelivery` and `buildCodexDelivery` when the agent specifies a model (respects existing `--model` in static args)
- New `internal/discovery` package: probes installed CLIs (`which` + `--version`) and discovers available models (`claude models list`) at startup
- Augments `/backends` GET response with `available`, `version`, and `models` fields from discovery
- UI agent editor shows a model dropdown populated from discovered models, falling back to a freeform text input when none are discovered

## Test plan

- [ ] `go test ./... -race` passes (CI)
- [ ] `TestBuildDeliveryModelInjection` covers claude/codex with model, without model, and static --model not being overridden
- [ ] `TestUpsertAgentModelRoundtrip` covers model field persistence in SQLite
- [ ] `TestImportLoad` updated to verify model roundtrip through import/load
- [ ] `TestProbe_unavailableCLI` and `TestProbe_availableCLI` cover discovery for missing and present CLIs
- [ ] Manual: verify `/backends` response includes `available`, `version`, `models` fields
- [ ] Manual: verify agent editor shows model dropdown when models are discovered

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)