### PR TITLE
docs: make shipped config and docker setup self-contained

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ Multi-stage build on `node:22-alpine` so the image includes Claude Code, Codex, 
   - `GET /graph` — agent interaction graph (dispatch edges + counts).
   - `GET /dispatches` — dispatch dedup store snapshot + counters.
   - `GET /memory/{agent}/{repo}` — raw agent memory markdown.
-  - `GET /memory/stream` — memory file change notifications (SSE).
+  - `GET /memory/stream` — memory change notifications (SSE).
   - `GET /config` — effective parsed config (secrets redacted).
   - `GET /ui/` — embedded web dashboard (Next.js static assets).
   - `GET|POST /{resource}` and `GET|DELETE /{resource}/{name}` — SQLite CRUD endpoints (always mounted). Resources for `GET` list: `skills`, `backends`, `repos` (repos use two-segment path: `repos/{owner}/{repo}`). Note: `GET /agents` always returns the live fleet snapshot — not the CRUD list. `POST /agents` and `GET|DELETE /agents/{name}` are CRUD endpoints for agents.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -5,9 +5,10 @@
 #
 #   ./agents --db agents.db --import config.yaml
 #
-# prompt_file: paths (in skills and agents sections) reference local files
-# that must exist at import time. Their content is read and stored in the
-# SQLite database — the files are not needed afterward.
+# This example is self-contained: every skill and agent prompt is inline, so
+# `cp config.example.yaml config.yaml` works without creating extra files.
+# You can still use `prompt_file:` for longer prompts; those paths must exist
+# at import time, and their content is copied into SQLite.
 #
 # For new setups, you can skip the YAML entirely and use the web dashboard
 # (GET /ui/) to create agents, skills, backends, and repo bindings directly.
@@ -110,29 +111,37 @@ daemon:
 # Each skill is a named chunk of guidance. Agents reference skills by
 # name; at runtime the guidance is concatenated into the agent's prompt.
 # Use `prompt:` for short inline guidance or `prompt_file:` to load from
-# a file (path relative to this config).
+# a file (path relative to this config). The shipping example keeps them
+# inline so it imports cleanly out of the box.
 # ──────────────────────────────────────────────
 skills:
   architect:
-    prompt_file: skills/architect.md
+    prompt: |
+      Focus on architecture boundaries, coupling, and maintainability risks.
   security:
-    prompt_file: skills/security.md
+    prompt: |
+      Focus on auth, secrets handling, trust boundaries, and unsafe defaults.
   testing:
-    prompt_file: skills/testing.md
+    prompt: |
+      Focus on behavioral regressions, missing tests, and weak assertions.
   devops:
-    prompt_file: skills/devops.md
+    prompt: |
+      Focus on deployment safety, observability, and operational failure modes.
   dx:
-    prompt_file: skills/dx.md
+    prompt: |
+      Focus on onboarding friction, naming, docs drift, and actionable errors.
   documentation:
-    prompt_file: skills/documentation.md
+    prompt: |
+      Keep docs accurate, easy to scan, and honest about caveats.
   product:
-    prompt_file: skills/product.md
+    prompt: |
+      Translate technical findings into user-facing impact, priorities, and tradeoffs.
 
 # ──────────────────────────────────────────────
 # agents — named capabilities
 #
 # Each agent is a capability definition: a name, a backend, the skills
-# it uses, and a prompt file. Agents don't run on their own — repos
+# it uses, and a prompt. Agents don't run on their own — repos
 # below decide when and where they run.
 #
 # backend: auto | claude | codex   ("auto" picks the default)
@@ -148,6 +157,8 @@ skills:
 #   Whitelist of agents this agent is allowed to dispatch. Entries must
 #   reference real agents in this config; self-reference is rejected.
 # prompt_file: path relative to the config file's directory.
+#   Use it when you want prompts in separate files; this example keeps
+#   prompts inline so it is importable as-is.
 #
 # Runtime "Available experts" roster
 # ──────────────────────────────────
@@ -181,14 +192,18 @@ agents:
     backend: auto
     description: "Surveys the codebase for issues worth tracking in the issue tracker"
     skills: &scout-skills [architect, dx]
-    prompt_file: prompts/codebase-scout-issues.md
+    prompt: |
+      Inspect the repository for user-visible bugs, stale docs, or maintenance gaps.
+      Open or update GitHub issues with concrete evidence and next steps.
     can_dispatch: [product-strategist]
 
   - name: scout-code
     backend: auto
     description: "Surveys the codebase for code-quality and architectural concerns"
     skills: *scout-skills
-    prompt_file: prompts/codebase-scout-code.md
+    prompt: |
+      Inspect the codebase for architectural debt, risky complexity, and weak invariants.
+      Capture findings as concrete GitHub issues with reproduction details when possible.
     can_dispatch: [product-strategist]
 
   # PR-authoring agents — require allow_prs: true.
@@ -196,7 +211,9 @@ agents:
     backend: claude
     description: "Implements fixes and features; opens pull requests"
     skills: [architect, testing]
-    prompt_file: prompts/coder.md
+    prompt: |
+      Implement the requested change end-to-end.
+      Run the narrowest meaningful tests and open a pull request when the work is ready.
     allow_prs: true
     allow_dispatch: true    # can be dispatched by pr-reviewer on REQUEST_CHANGES
     can_dispatch: [pr-reviewer]
@@ -205,7 +222,9 @@ agents:
     backend: claude
     description: "Refactors existing code for readability and maintainability"
     skills: [architect, testing, dx]
-    prompt_file: prompts/refactorer.md
+    prompt: |
+      Refactor code for clarity and maintainability without changing behavior.
+      Leave the repo in a state where tests still pass.
     allow_prs: true
 
   # Documentation agent — reviews code + git history, keeps docs accurate and readable.
@@ -213,7 +232,9 @@ agents:
     backend: claude
     description: "Keeps README, CLAUDE.md, AGENTS.md, and docs/*.md accurate and readable"
     skills: [documentation, dx]
-    prompt_file: prompts/docs-writer.md
+    prompt: |
+      Read the code before editing docs.
+      Keep README, CLAUDE.md, AGENTS.md, and docs/*.md aligned with shipped behavior.
     allow_prs: true
 
   # PR-reviewing agent — comments only, no PRs (default allow_prs: false).
@@ -221,7 +242,9 @@ agents:
     backend: codex
     description: "Reviews pull requests for quality, test coverage, and correctness"
     skills: [architect, testing, security]
-    prompt_file: prompts/pr-reviewer.md
+    prompt: |
+      Review pull requests for correctness, regressions, and missing tests.
+      Prefer concrete findings over broad summaries.
     allow_dispatch: true    # can be dispatched by coder when PR is ready
     can_dispatch: [coder, sec-reviewer]
 
@@ -229,7 +252,8 @@ agents:
     backend: claude
     description: "Translates technical findings into product-level insights and priorities"
     skills: [product, dx]
-    prompt_file: prompts/product-strategist.md
+    prompt: |
+      Convert technical findings into product priorities, tradeoffs, and sequencing advice.
     allow_dispatch: true    # scouts dispatch here with product-facing findings
 
   # Single-axis review agents, one per skill.
@@ -237,32 +261,37 @@ agents:
     backend: auto
     description: "Reviews architecture and design decisions"
     skills: [architect]
-    prompt_file: prompts/arch-reviewer.md
+    prompt: |
+      Review the change for architecture boundaries, coupling, and long-term maintainability.
 
   - name: sec-reviewer
     backend: auto
     description: "Reviews security concerns and potential vulnerabilities"
     skills: [security]
-    prompt_file: prompts/sec-reviewer.md
+    prompt: |
+      Review the change for security risks, trust-boundary violations, and unsafe defaults.
     allow_dispatch: true    # pr-reviewer escalates security smells here
 
   - name: test-reviewer
     backend: auto
     description: "Reviews test coverage and testing strategy"
     skills: [testing]
-    prompt_file: prompts/test-reviewer.md
+    prompt: |
+      Review the change for missing tests, brittle assertions, and blind spots in coverage.
 
   - name: ops-reviewer
     backend: auto
     description: "Reviews operational concerns: CI, deployment, observability"
     skills: [devops]
-    prompt_file: prompts/ops-reviewer.md
+    prompt: |
+      Review the change for CI reliability, deploy safety, and observability gaps.
 
   - name: dx-reviewer
     backend: auto
     description: "Reviews developer experience: docs, tooling, onboarding"
     skills: [dx]
-    prompt_file: prompts/dx-reviewer.md
+    prompt: |
+      Review the change for onboarding friction, confusing naming, and stale documentation.
 
 # ──────────────────────────────────────────────
 # repos — wiring: where and when agents run

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,8 +8,6 @@ services:
       - GITHUB_PAT_TOKEN=${GITHUB_PAT_TOKEN}
     volumes:
       - ./config.yaml:/etc/agents/config.yaml:ro
-      # Optional: required only when config uses prompt_file paths under agents_dir.
-      - ./agents:/etc/agents/agents:ro
       # Persists the SQLite database (config + agent memory) across restarts.
       - agents-data:/var/lib/agents
       - ~/.claude:/home/agents/.claude

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,7 +65,7 @@ skills:
       Focus on authn/authz, secrets exposure, injection vectors, and unsafe defaults.
 ```
 
-Skills are referenced by name from agents. You can also use `prompt_file: path/to/file.md` instead of inline `prompt`.
+Skills are referenced by name from agents. You can also use `prompt_file: path/to/file.md` instead of inline `prompt`. The shipping [`config.example.yaml`](../config.example.yaml) keeps prompts inline so a fresh clone imports without extra files.
 
 ## `agents` -- named capabilities
 
@@ -78,12 +78,13 @@ agents:
     prompt: |
       You are an architecture-focused PR reviewer. Post one high-signal review comment.
 
-  # Prompt loaded from a file (recommended for longer prompts)
-  # allow_prs: true lets this agent open pull requests
+  # PR-authoring agent
   - name: coder
     backend: claude
     skills: [architect, testing]
-    prompt_file: prompts/coder.md
+    prompt: |
+      Implement the requested change end-to-end.
+      Run focused tests and open a pull request when the work is ready.
     allow_prs: true            # required for agents that open PRs
 
   # Dispatch target -- can be invoked by pr-reviewer
@@ -91,19 +92,22 @@ agents:
     description: "Deep-dive security reviewer for risky changes"
     backend: claude
     allow_dispatch: true       # opt-in to being dispatched
-    prompt_file: prompts/sec-reviewer.md
+    prompt: |
+      Review the change for security risks and trust-boundary violations.
 
   # Agent that may dispatch to sec-reviewer
   - name: pr-reviewer
     backend: claude
     can_dispatch: [sec-reviewer]   # whitelist of agents this agent may dispatch
-    prompt_file: prompts/pr-reviewer.md
+    prompt: |
+      Review the pull request for correctness, regressions, and missing tests.
 ```
 
 Each agent is a pure capability definition: backend + skills + prompt. Agents don't run until a repo binds them to a trigger.
 
 - `backend: auto` picks the first configured backend in `daemon.ai_backends` (claude before codex).
 - `prompt_file` paths are resolved relative to the config file's directory.
+  Use them for your own longer prompts; the repo no longer ships a `prompts/` tree.
 - Agent names must be unique.
 - `allow_prs` (default `false`) -- when `false`, the scheduler prepends a hard instruction forbidding the agent from opening pull requests, regardless of what the prompt says. Set `allow_prs: true` only on agents that are explicitly meant to author PRs (e.g. coders, refactorers). Reviewer-only agents should leave this unset.
 - `allow_dispatch` (default `false`) -- opt-in gate. An agent must have `allow_dispatch: true` for any other agent to dispatch it. Agents without this flag silently drop any incoming dispatch requests.

--- a/docs/dispatch.md
+++ b/docs/dispatch.md
@@ -69,11 +69,13 @@ agents:
   - name: pr-reviewer
     backend: claude
     can_dispatch: [sec-reviewer]       # whitelist of targets
-    prompt_file: prompts/pr-reviewer.md
+    prompt: |
+      Review the pull request for correctness and escalate specialist concerns when needed.
 
   - name: sec-reviewer
     description: "Deep-dive security reviewer"
     backend: claude
     allow_dispatch: true               # opt-in to being dispatched
-    prompt_file: prompts/sec-reviewer.md
+    prompt: |
+      Review the change for security risks and unsafe assumptions.
 ```

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -21,12 +21,13 @@ The compose file expects:
 | Host path | Container path | Purpose |
 |---|---|---|
 | `config.yaml` | `/etc/agents/config.yaml` (read-only) | Daemon config (used for `--import` seeding; optional once DB is seeded) |
-| `./agents` | `/etc/agents/agents` (read-only) | Optional: source tree for agent and skill `prompt_file:` paths that reference this directory |
 | `~/.claude` | `/home/agents/.claude` | Claude Code session data |
 | `~/.claude.json` | `/home/agents/.claude.json` | Claude Code main config |
 | `~/.codex` | `/home/agents/.codex` | Codex configuration |
 | `~/.config/gh` | `/home/agents/.config/gh` (read-only) | GitHub CLI auth tokens |
 | `agents-data` (volume) | `/var/lib/agents` | SQLite database (config + agent memory) across restarts |
+
+If your own `config.yaml` uses `prompt_file:` paths, mount the directory that contains those files yourself. The shipping example config is inline-only, so no extra prompt mount is required.
 
 ## MCP server configuration
 

--- a/docs/local-models.md
+++ b/docs/local-models.md
@@ -127,12 +127,14 @@ agents:
   - name: pr-reviewer
     backend: claude_local                 # Qwen-backed
     skills: [architect, testing, security]
-    prompt_file: prompts/pr-reviewer.md
+    prompt: |
+      Review the pull request for correctness, regressions, and risky behavior.
 
   - name: coder
     backend: claude                       # hosted Anthropic (see caveats below)
     skills: [architect, testing]
-    prompt_file: prompts/coder.md
+    prompt: |
+      Implement the requested change end-to-end and open a pull request when ready.
     allow_prs: true
 ```
 


### PR DESCRIPTION
## Summary
- make `config.example.yaml` importable from a fresh clone by inlining the shipped skill and agent prompts
- update docs snippets that still pointed at removed `prompts/` files
- remove the stale `./agents` Docker mount and document how to add your own `prompt_file` mount when needed

## Verification
- verified all referenced paths and config fields against `origin/main`
- `git diff --check`
- could not run `go test ./...` or an import smoke test here because `go` is not installed in this environment