### PR TITLE
feat(ui): cascade agent deletion with binding confirmation modal

### DIFF
--- a/internal/store/crud.go
+++ b/internal/store/crud.go
@@ -124,11 +124,29 @@ func UpsertAgent(db *sql.DB, a config.AgentDef) error {
 // delete a name that does not exist. Returns an error if the agent is still
 // referenced by any repo binding or can_dispatch list, or if it is the last agent.
 func DeleteAgent(db *sql.DB, name string) error {
+	return deleteAgent(db, name, false)
+}
+
+// DeleteAgentCascade removes the agent and all repo bindings that reference it
+// in a single transaction. It still fails if removing the agent would leave
+// zero agents, or if any other agent's can_dispatch list still references it
+// (cascading across agent relationships would silently reshape the dispatch
+// graph; the user should opt in explicitly).
+func DeleteAgentCascade(db *sql.DB, name string) error {
+	return deleteAgent(db, name, true)
+}
+
+func deleteAgent(db *sql.DB, name string, cascade bool) error {
 	tx, err := db.Begin()
 	if err != nil {
 		return fmt.Errorf("store: delete agent %s: begin: %w", name, err)
 	}
 	defer tx.Rollback()
+	if cascade {
+		if _, err := tx.Exec("DELETE FROM bindings WHERE agent=?", name); err != nil {
+			return fmt.Errorf("store: delete agent %s: cascade bindings: %w", name, err)
+		}
+	}
 	res, err := tx.Exec("DELETE FROM agents WHERE name=?", name)
 	if err != nil {
 		return fmt.Errorf("store: delete agent %s: %w", name, err)

--- a/internal/store/crud.go
+++ b/internal/store/crud.go
@@ -146,6 +146,13 @@ func deleteAgent(db *sql.DB, name string, cascade bool) error {
 		if _, err := tx.Exec("DELETE FROM bindings WHERE agent=?", name); err != nil {
 			return fmt.Errorf("store: delete agent %s: cascade bindings: %w", name, err)
 		}
+	} else if refs, err := bindingsReferencing(tx, name); err != nil {
+		return fmt.Errorf("store: delete agent %s: check bindings: %w", name, err)
+	} else if len(refs) > 0 {
+		// Surface this as an ErrConflict rather than letting the raw FK
+		// constraint fire. Callers can show the referenced repos and
+		// offer a cascade without parsing SQLite error strings.
+		return &ErrConflict{Msg: fmt.Sprintf("store: delete agent %s: still referenced by %d binding(s) across %d repo(s); use cascade to remove them", name, len(refs), countDistinctRepos(refs))}
 	}
 	res, err := tx.Exec("DELETE FROM agents WHERE name=?", name)
 	if err != nil {
@@ -160,6 +167,34 @@ func deleteAgent(db *sql.DB, name string, cascade bool) error {
 		}
 	}
 	return tx.Commit()
+}
+
+// bindingsReferencing returns the repo names of every binding that points at
+// the given agent. Used by the non-cascade delete path to produce a typed
+// conflict error instead of a raw FK failure.
+func bindingsReferencing(q querier, agentName string) ([]string, error) {
+	rows, err := q.Query("SELECT repo FROM bindings WHERE agent=?", agentName)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var r string
+		if err := rows.Scan(&r); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+func countDistinctRepos(repos []string) int {
+	seen := make(map[string]struct{}, len(repos))
+	for _, r := range repos {
+		seen[r] = struct{}{}
+	}
+	return len(seen)
 }
 
 // ──── Skills ─────────────────────────────────────────────────────────────────

--- a/internal/store/crud_test.go
+++ b/internal/store/crud_test.go
@@ -2,6 +2,7 @@ package store_test
 
 import (
 	"database/sql"
+	"errors"
 	"maps"
 	"slices"
 	"strings"
@@ -620,9 +621,19 @@ func TestDeleteAgentRejectedWhenBindingReferences(t *testing.T) {
 		t.Fatalf("UpsertRepo: %v", err)
 	}
 
-	// Non-cascade delete must fail while a binding references the agent.
-	if err := store.DeleteAgent(db, "coder"); err == nil {
+	// Non-cascade delete must fail while a binding references the agent. The
+	// error must be ErrConflict so the HTTP layer can return 409 rather than
+	// leaking a raw FK constraint as 500.
+	err := store.DeleteAgent(db, "coder")
+	if err == nil {
 		t.Fatal("DeleteAgent with live bindings: want error, got nil")
+	}
+	var conflict *store.ErrConflict
+	if !errors.As(err, &conflict) {
+		t.Errorf("DeleteAgent with live bindings: want *store.ErrConflict, got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "still referenced") {
+		t.Errorf("error message should explain the blocker: %v", err)
 	}
 
 	// Agent must still be present.

--- a/internal/store/crud_test.go
+++ b/internal/store/crud_test.go
@@ -599,6 +599,142 @@ func TestDeleteSkillRejectedWhenAgentReferences(t *testing.T) {
 	}
 }
 
+func TestDeleteAgentRejectedWhenBindingReferences(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+
+	seedBackend(t, db, "claude")
+	for _, name := range []string{"coder", "reviewer"} {
+		if err := store.UpsertAgent(db, config.AgentDef{
+			Name: name, Backend: "claude", Prompt: "p", Skills: []string{}, CanDispatch: []string{},
+		}); err != nil {
+			t.Fatalf("UpsertAgent %s: %v", name, err)
+		}
+	}
+	enabled := true
+	if err := store.UpsertRepo(db, config.RepoDef{
+		Name:    "owner/repo",
+		Enabled: true,
+		Use:     []config.Binding{{Agent: "coder", Labels: []string{"ai:fix"}, Enabled: &enabled}},
+	}); err != nil {
+		t.Fatalf("UpsertRepo: %v", err)
+	}
+
+	// Non-cascade delete must fail while a binding references the agent.
+	if err := store.DeleteAgent(db, "coder"); err == nil {
+		t.Fatal("DeleteAgent with live bindings: want error, got nil")
+	}
+
+	// Agent must still be present.
+	agents, err := store.ReadAgents(db)
+	if err != nil {
+		t.Fatalf("ReadAgents: %v", err)
+	}
+	if len(agents) != 2 {
+		t.Errorf("agent count after rejected delete: got %d, want 2", len(agents))
+	}
+}
+
+func TestDeleteAgentCascadeRemovesBindings(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+
+	seedBackend(t, db, "claude")
+	for _, name := range []string{"coder", "reviewer"} {
+		if err := store.UpsertAgent(db, config.AgentDef{
+			Name: name, Backend: "claude", Prompt: "p", Skills: []string{}, CanDispatch: []string{},
+		}); err != nil {
+			t.Fatalf("UpsertAgent %s: %v", name, err)
+		}
+	}
+	enabled := true
+	// Repo keeps a binding for "reviewer" so the cascade path does not wipe
+	// the repo entirely; only bindings referencing "coder" should disappear.
+	if err := store.UpsertRepo(db, config.RepoDef{
+		Name:    "owner/repo",
+		Enabled: true,
+		Use: []config.Binding{
+			{Agent: "coder", Labels: []string{"ai:fix"}, Enabled: &enabled},
+			{Agent: "coder", Events: []string{"issues.opened"}, Enabled: &enabled},
+			{Agent: "reviewer", Labels: []string{"ai:review"}, Enabled: &enabled},
+		},
+	}); err != nil {
+		t.Fatalf("UpsertRepo: %v", err)
+	}
+
+	if err := store.DeleteAgentCascade(db, "coder"); err != nil {
+		t.Fatalf("DeleteAgentCascade: %v", err)
+	}
+
+	agents, err := store.ReadAgents(db)
+	if err != nil {
+		t.Fatalf("ReadAgents: %v", err)
+	}
+	if len(agents) != 1 || agents[0].Name != "reviewer" {
+		t.Errorf("agents after cascade: got %v, want [reviewer]", agents)
+	}
+
+	repos, err := store.ReadRepos(db)
+	if err != nil {
+		t.Fatalf("ReadRepos: %v", err)
+	}
+	if len(repos) != 1 {
+		t.Fatalf("repos after cascade: got %d, want 1", len(repos))
+	}
+	if len(repos[0].Use) != 1 {
+		t.Fatalf("bindings after cascade: got %d, want 1", len(repos[0].Use))
+	}
+	if repos[0].Use[0].Agent != "reviewer" {
+		t.Errorf("surviving binding agent: got %q, want %q", repos[0].Use[0].Agent, "reviewer")
+	}
+}
+
+func TestDeleteAgentCascadeStillRejectsLastAgent(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+
+	seedBackend(t, db, "claude")
+	if err := store.UpsertAgent(db, config.AgentDef{
+		Name: "coder", Backend: "claude", Prompt: "p", Skills: []string{}, CanDispatch: []string{},
+	}); err != nil {
+		t.Fatalf("UpsertAgent: %v", err)
+	}
+
+	err := store.DeleteAgentCascade(db, "coder")
+	if err == nil {
+		t.Fatal("DeleteAgentCascade last agent: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "at least one agent") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestDeleteAgentCascadeStillRejectsWhenInCanDispatch(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+
+	seedBackend(t, db, "claude")
+	if err := store.UpsertAgent(db, config.AgentDef{
+		Name: "target", Backend: "claude", Prompt: "p", Description: "a dispatchable target",
+		Skills: []string{}, CanDispatch: []string{},
+	}); err != nil {
+		t.Fatalf("UpsertAgent target: %v", err)
+	}
+	if err := store.UpsertAgent(db, config.AgentDef{
+		Name: "dispatcher", Backend: "claude", Prompt: "p",
+		Skills: []string{}, CanDispatch: []string{"target"},
+	}); err != nil {
+		t.Fatalf("UpsertAgent dispatcher: %v", err)
+	}
+
+	// Cascade is scoped to bindings; dangling can_dispatch references must
+	// still block the delete so callers cannot silently reshape the dispatch
+	// graph by deleting a referenced target.
+	if err := store.DeleteAgentCascade(db, "target"); err == nil {
+		t.Fatal("DeleteAgentCascade referenced by can_dispatch: want error, got nil")
+	}
+}
+
 func TestDeleteAgentRejectedWhenDispatchListReferences(t *testing.T) {
 	t.Parallel()
 	db := openTestDB(t)

--- a/internal/ui/src/app/page.tsx
+++ b/internal/ui/src/app/page.tsx
@@ -298,7 +298,7 @@ export default function FleetPage() {
 
   const [modal, setModal] = useState<'create' | 'edit' | 'delete' | null>(null)
   const [selected, setSelected] = useState<StoreAgent>(emptyForm)
-  const [deleteTarget, setDeleteTarget] = useState('')
+  const [deleteTarget, setDeleteTarget] = useState<{ name: string; bindings: Binding[] }>({ name: '', bindings: [] })
   const [saving, setSaving] = useState(false)
   const [saveError, setSaveError] = useState('')
 
@@ -399,14 +399,18 @@ export default function FleetPage() {
   }
 
   const confirmDelete = (name: string) => {
-    setDeleteTarget(name)
+    const a = agents.find(agent => agent.name === name)
+    setDeleteTarget({ name, bindings: a?.bindings ?? [] })
+    setSaveError('')
     setModal('delete')
   }
 
   const deleteAgent = async () => {
     setSaving(true)
     try {
-      const res = await fetch(`/agents/${encodeURIComponent(deleteTarget)}`, { method: 'DELETE' })
+      const cascade = deleteTarget.bindings.length > 0
+      const url = `/agents/${encodeURIComponent(deleteTarget.name)}${cascade ? '?cascade=true' : ''}`
+      const res = await fetch(url, { method: 'DELETE' })
       if (!res.ok && res.status !== 204) {
         const msg = await res.text()
         setSaveError(msg || 'Delete failed')
@@ -420,6 +424,13 @@ export default function FleetPage() {
       setSaveError(String(e))
     }
     setSaving(false)
+  }
+
+  const bindingTriggerLabel = (b: Binding): string => {
+    if (b.cron) return `cron: ${b.cron}`
+    if (b.labels && b.labels.length > 0) return `labels: ${b.labels.join(', ')}`
+    if (b.events && b.events.length > 0) return `events: ${b.events.join(', ')}`
+    return '—'
   }
 
   return (
@@ -482,22 +493,43 @@ export default function FleetPage() {
         </Modal>
       )}
 
-      {modal === 'delete' && (
-        <Modal title="Delete agent" onClose={() => setModal(null)}>
-          <p style={{ color: 'var(--text)', fontSize: '0.9rem', marginBottom: '1.25rem' }}>
-            Delete <strong>{deleteTarget}</strong>? This cannot be undone.
-          </p>
-          {saveError && <p style={{ color: 'var(--text-danger)', fontSize: '0.8rem', marginBottom: '0.75rem' }}>{saveError}</p>}
-          <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'flex-end' }}>
-            <button onClick={() => setModal(null)} style={{ padding: '6px 16px', borderRadius: '6px', border: '1px solid var(--border)', background: 'var(--bg-card)', cursor: 'pointer', fontSize: '0.875rem', color: 'var(--text-muted)' }}>
-              Cancel
-            </button>
-            <button onClick={deleteAgent} disabled={saving} style={{ padding: '6px 16px', borderRadius: '6px', border: '1px solid var(--border-danger)', background: '#dc2626', color: '#fff', cursor: saving ? 'wait' : 'pointer', fontSize: '0.875rem', fontWeight: 600 }}>
-              {saving ? 'Deleting…' : 'Delete'}
-            </button>
-          </div>
-        </Modal>
-      )}
+      {modal === 'delete' && (() => {
+        const bindings = deleteTarget.bindings
+        const repoCount = new Set(bindings.map(b => b.repo)).size
+        const hasBindings = bindings.length > 0
+        return (
+          <Modal title="Delete agent" onClose={() => setModal(null)}>
+            <p style={{ color: 'var(--text)', fontSize: '0.9rem', marginBottom: hasBindings ? '0.75rem' : '1.25rem' }}>
+              Delete <strong>{deleteTarget.name}</strong>? This cannot be undone.
+            </p>
+            {hasBindings && (
+              <div style={{ marginBottom: '1.25rem' }}>
+                <p style={{ color: 'var(--text-danger)', fontSize: '0.85rem', fontWeight: 600, marginBottom: '0.5rem' }}>
+                  ⚠ This will also remove {bindings.length} binding{bindings.length !== 1 ? 's' : ''} from {repoCount} repo{repoCount !== 1 ? 's' : ''}:
+                </p>
+                <div style={{ border: '1px solid var(--border)', borderRadius: '6px', background: 'var(--bg-input)', padding: '0.5rem 0.75rem', maxHeight: '12rem', overflowY: 'auto' }}>
+                  {bindings.map((b, i) => (
+                    <div key={i} style={{ fontSize: '0.8rem', color: 'var(--text-muted)', padding: '2px 0', display: 'flex', gap: '0.6rem' }}>
+                      <span style={{ color: 'var(--text)', fontWeight: 500 }}>{b.repo}</span>
+                      <span style={{ color: 'var(--text-faint)' }}>{bindingTriggerLabel(b)}</span>
+                      {b.enabled === false && <span style={{ color: 'var(--text-faint)', fontSize: '0.7rem' }}>(off)</span>}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+            {saveError && <p style={{ color: 'var(--text-danger)', fontSize: '0.8rem', marginBottom: '0.75rem' }}>{saveError}</p>}
+            <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'flex-end' }}>
+              <button onClick={() => setModal(null)} style={{ padding: '6px 16px', borderRadius: '6px', border: '1px solid var(--border)', background: 'var(--bg-card)', cursor: 'pointer', fontSize: '0.875rem', color: 'var(--text-muted)' }}>
+                Cancel
+              </button>
+              <button onClick={deleteAgent} disabled={saving} style={{ padding: '6px 16px', borderRadius: '6px', border: '1px solid var(--border-danger)', background: '#dc2626', color: '#fff', cursor: saving ? 'wait' : 'pointer', fontSize: '0.875rem', fontWeight: 600 }}>
+                {saving ? 'Deleting…' : hasBindings ? `Delete agent + ${bindings.length} binding${bindings.length !== 1 ? 's' : ''}` : 'Delete'}
+              </button>
+            </div>
+          </Modal>
+        )
+      })()}
     </div>
   )
 }

--- a/internal/webhook/crud.go
+++ b/internal/webhook/crud.go
@@ -322,8 +322,14 @@ func (s *Server) handleStoreAgent(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 
 	case http.MethodDelete:
+		cascade := r.URL.Query().Get("cascade") == "true"
 		s.storeMu.Lock()
-		err := store.DeleteAgent(s.db, name)
+		var err error
+		if cascade {
+			err = store.DeleteAgentCascade(s.db, name)
+		} else {
+			err = store.DeleteAgent(s.db, name)
+		}
 		if err == nil {
 			err = s.reloadCron()
 		}

--- a/internal/webhook/crud_test.go
+++ b/internal/webhook/crud_test.go
@@ -197,6 +197,94 @@ func TestStoreCRUDAgentDelete(t *testing.T) {
 	}
 }
 
+func TestStoreCRUDAgentDeleteBlockedByBindings(t *testing.T) {
+	t.Parallel()
+	s := openCRUDTestServer(t)
+
+	seedStoreBackend(t, s, "claude")
+	for _, name := range []string{"coder", "reviewer"} {
+		if rr := doCRUDRequest(t, s, http.MethodPost, "/agents", map[string]any{
+			"name": name, "backend": "claude", "prompt": "p",
+			"skills": []string{}, "can_dispatch": []string{},
+		}); rr.Code != http.StatusOK {
+			t.Fatalf("seed agent %s: got %d — %s", name, rr.Code, rr.Body.String())
+		}
+	}
+	if rr := doCRUDRequest(t, s, http.MethodPost, "/repos", map[string]any{
+		"name": "owner/repo", "enabled": true,
+		"bindings": []map[string]any{
+			{"agent": "coder", "labels": []string{"ai:fix"}, "enabled": true},
+		},
+	}); rr.Code != http.StatusOK {
+		t.Fatalf("seed repo: got %d — %s", rr.Code, rr.Body.String())
+	}
+
+	// Plain DELETE must be blocked while the binding references "coder".
+	rr := doCRUDRequest(t, s, http.MethodDelete, "/agents/coder", nil)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("DELETE without cascade: got %d, want 409", rr.Code)
+	}
+
+	// Agent must still be present.
+	rr = doCRUDRequest(t, s, http.MethodGet, "/agents/coder", nil)
+	if rr.Code != http.StatusOK {
+		t.Errorf("GET after blocked delete: got %d, want 200", rr.Code)
+	}
+}
+
+func TestStoreCRUDAgentDeleteCascadeRemovesBindings(t *testing.T) {
+	t.Parallel()
+	s := openCRUDTestServer(t)
+
+	seedStoreBackend(t, s, "claude")
+	for _, name := range []string{"coder", "reviewer"} {
+		if rr := doCRUDRequest(t, s, http.MethodPost, "/agents", map[string]any{
+			"name": name, "backend": "claude", "prompt": "p",
+			"skills": []string{}, "can_dispatch": []string{},
+		}); rr.Code != http.StatusOK {
+			t.Fatalf("seed agent %s: got %d — %s", name, rr.Code, rr.Body.String())
+		}
+	}
+	if rr := doCRUDRequest(t, s, http.MethodPost, "/repos", map[string]any{
+		"name": "owner/repo", "enabled": true,
+		"bindings": []map[string]any{
+			{"agent": "coder", "labels": []string{"ai:fix"}, "enabled": true},
+			{"agent": "reviewer", "labels": []string{"ai:review"}, "enabled": true},
+		},
+	}); rr.Code != http.StatusOK {
+		t.Fatalf("seed repo: got %d — %s", rr.Code, rr.Body.String())
+	}
+
+	rr := doCRUDRequest(t, s, http.MethodDelete, "/agents/coder?cascade=true", nil)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("DELETE ?cascade=true: got %d, want 204 — %s", rr.Code, rr.Body.String())
+	}
+
+	// Agent is gone.
+	rr = doCRUDRequest(t, s, http.MethodGet, "/agents/coder", nil)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("GET after cascade: got %d, want 404", rr.Code)
+	}
+
+	// Repo survives with only the reviewer binding.
+	rr = doCRUDRequest(t, s, http.MethodGet, "/repos/owner/repo", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET repo after cascade: got %d, want 200", rr.Code)
+	}
+	var repo struct {
+		Name     string `json:"name"`
+		Bindings []struct {
+			Agent string `json:"agent"`
+		} `json:"bindings"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&repo); err != nil {
+		t.Fatalf("decode repo: %v", err)
+	}
+	if len(repo.Bindings) != 1 || repo.Bindings[0].Agent != "reviewer" {
+		t.Errorf("surviving bindings after cascade: got %+v, want [{reviewer}]", repo.Bindings)
+	}
+}
+
 func TestStoreCRUDAgentMissingName(t *testing.T) {
 	t.Parallel()
 	s := openCRUDTestServer(t)


### PR DESCRIPTION
Closes #252.

## Summary

Deleting an agent that had active bindings previously failed with a raw foreign-key error from the store, forcing the user to hunt every repo manually and strip bindings before retrying. This PR replaces that dead-end with an opt-in cascade triggered from a clear confirmation modal.

## Changes

**Backend**

- `store.DeleteAgentCascade(db, name)` — new function that deletes bindings referencing the agent in the same transaction as the agent row. The existing \"at least one agent\" and cross-reference checks still run afterwards, so invariants are preserved.
- `DELETE /agents/{name}?cascade=true` selects the cascade path; the plain endpoint continues to reject referenced deletes (no silent behaviour change for existing API consumers).
- `can_dispatch` references on other agents still block the delete — that would silently reshape the dispatch graph, and the scope of issue #252 is binding cleanup only. The user still gets an actionable error in that case.

**Frontend**

- Fleet delete modal now reads the agent's `bindings` from the already-available `/agents` snapshot. When any binding exists, the modal lists every `repo + trigger` pair, warns that the bindings will be removed, and labels the confirm button \`Delete agent + N bindings\`. On confirm, the client appends `?cascade=true`.
- Agents with zero bindings keep the existing minimal modal — no new friction.

## Tests

- `store.TestDeleteAgentRejectedWhenBindingReferences` — plain delete is still rejected when bindings reference the agent.
- `store.TestDeleteAgentCascadeRemovesBindings` — cascade strips only bindings for the deleted agent; bindings for other agents in the same repo survive.
- `store.TestDeleteAgentCascadeStillRejectsLastAgent` — cascade still refuses to leave zero agents.
- `store.TestDeleteAgentCascadeStillRejectsWhenInCanDispatch` — cascade refuses when another agent's \`can_dispatch\` lists the target.
- `webhook.TestStoreCRUDAgentDeleteBlockedByBindings` — HTTP layer returns 409 without `cascade=true`.
- `webhook.TestStoreCRUDAgentDeleteCascadeRemovesBindings` — HTTP layer returns 204 with `cascade=true` and the repo survives with only the other agent's bindings.

## Verification

- `npx tsc --noEmit` — clean
- `npx next build` — ✓ compiled, 11/11 static pages
- Go tests not runnable locally (no toolchain); CI covers \`go test ./... -race\`.

## Follow-up

The issue also suggests applying the same UX to delete-backend, delete-skill, and delete-repo. Those flows already produce non-cryptic `ErrConflict` errors rather than raw FK failures, so they're less urgent. Happy to open follow-ups per the maintainer's preference.