### PR TITLE
refactor(backends): drop stale pre-Go 1.22 loop captures

### DIFF
--- a/internal/backends/discovery.go
+++ b/internal/backends/discovery.go
@@ -128,7 +128,6 @@ func RunDiagnostics(ctx context.Context, existing map[string]config.AIBackendCon
 	}()
 
 	for _, target := range targets {
-		target := target
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/internal/backends/discovery_test.go
+++ b/internal/backends/discovery_test.go
@@ -53,7 +53,6 @@ github  https://api.githubcopilot.com/mcp/  GITHUB_PAT_TOKEN      enabled  Beare
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			found, online := parseGitHubMCPStatus(tc.output)


### PR DESCRIPTION
## Why

`internal/backends/discovery.go` and its test file both contain `x := x`
shadow assignments inside `for ... range` loops — a guard against the
old pre-Go 1.22 loop-variable capture bug where all goroutine closures
shared the same variable.

The module is on **Go 1.25** (`go.mod`), where each loop iteration already
gets its own variable, making these lines dead code that only adds noise.

## What changed

- Removed `target := target` in `RunDiagnostics` (production goroutine loop)
- Removed `tc := tc` in `TestParseGitHubMCPStatus` (parallel subtest loop)

All existing tests pass (`go test ./...`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)