### PR TITLE
refactor(ai): move roster and no-PR guard into System for prompt caching

### DIFF
--- a/internal/ai/prompt.go
+++ b/internal/ai/prompt.go
@@ -47,19 +47,24 @@ type PromptContext struct {
 // RenderedPrompt with two parts:
 //
 //   - System: stable content that is identical across every run of the same
-//     agent — concatenated skill guidance followed by the agent's own prompt
-//     body. Backends that support a native system channel (e.g. Claude's
+//     agent on the same repo — no-PR guard (when allow_prs=false), concatenated
+//     skill guidance, the agent's own prompt body, and the available-experts
+//     roster. Backends that support a native system channel (e.g. Claude's
 //     --append-system-prompt) can deliver this part separately to benefit from
 //     prompt caching.
 //
 //   - User: per-run content — the ## Runtime context block containing the
-//     repo, event, actor, payload, memory, and roster. This changes every run
-//     and must travel as the user turn.
+//     repo, event, actor, payload, and memory. This changes every run and must
+//     travel as the user turn.
 //
 // No Go templates, no {{.Field}} substitution — just text composition. The
 // agent's prompt is expected to be self-contained.
 func RenderAgentPrompt(agent config.AgentDef, skills map[string]config.SkillDef, ctx PromptContext) (RenderedPrompt, error) {
 	var sys strings.Builder
+
+	if !agent.AllowPRs {
+		sys.WriteString("Do not open or create pull requests under any circumstances.\n")
+	}
 
 	for _, skillName := range agent.Skills {
 		skill, ok := skills[skillName]
@@ -78,6 +83,13 @@ func RenderAgentPrompt(agent config.AgentDef, skills map[string]config.SkillDef,
 		sys.WriteString(agentPrompt)
 	}
 
+	if roster := renderRoster(ctx.Roster); roster != "" {
+		if sys.Len() > 0 {
+			sys.WriteString("\n\n")
+		}
+		sys.WriteString(roster)
+	}
+
 	var usr strings.Builder
 	runtime := renderRuntimeContext(ctx)
 	if runtime != "" {
@@ -89,6 +101,32 @@ func RenderAgentPrompt(agent config.AgentDef, skills map[string]config.SkillDef,
 		System: strings.TrimRight(sys.String(), "\n"),
 		User:   strings.TrimRight(usr.String(), "\n"),
 	}, nil
+}
+
+func renderRoster(roster []RosterEntry) string {
+	if len(roster) == 0 {
+		return ""
+	}
+	sorted := slices.Clone(roster)
+	slices.SortFunc(sorted, func(a, b RosterEntry) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+	var b strings.Builder
+	b.WriteString("## Available experts\n\n")
+	for _, r := range sorted {
+		fmt.Fprintf(&b, "- **%s**", r.Name)
+		if r.Description != "" {
+			fmt.Fprintf(&b, ": %s", r.Description)
+		}
+		if len(r.Skills) > 0 {
+			fmt.Fprintf(&b, " (skills: %s)", strings.Join(r.Skills, ", "))
+		}
+		if r.AllowDispatch {
+			b.WriteString(" [dispatchable]")
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
 }
 
 func renderRuntimeContext(ctx PromptContext) string {
@@ -136,27 +174,6 @@ func renderRuntimeContext(ctx PromptContext) string {
 			b.WriteString("Existing memory: (empty)\n")
 		} else {
 			fmt.Fprintf(&b, "Existing memory:\n%s\n", mem)
-		}
-	}
-	if len(ctx.Roster) > 0 {
-		b.WriteString("\n## Available experts\n\n")
-		// Sort roster by name for deterministic output.
-		roster := slices.Clone(ctx.Roster)
-		slices.SortFunc(roster, func(a, b RosterEntry) int {
-			return strings.Compare(a.Name, b.Name)
-		})
-		for _, r := range roster {
-			fmt.Fprintf(&b, "- **%s**", r.Name)
-			if r.Description != "" {
-				fmt.Fprintf(&b, ": %s", r.Description)
-			}
-			if len(r.Skills) > 0 {
-				fmt.Fprintf(&b, " (skills: %s)", strings.Join(r.Skills, ", "))
-			}
-			if r.AllowDispatch {
-				b.WriteString(" [dispatchable]")
-			}
-			b.WriteString("\n")
 		}
 	}
 	return b.String()

--- a/internal/ai/prompt_test.go
+++ b/internal/ai/prompt_test.go
@@ -219,9 +219,9 @@ func TestRenderAgentPromptMultilinePayloadBodyIsIndented(t *testing.T) {
 	}
 }
 
-func TestRenderAgentPromptRosterInUser(t *testing.T) {
+func TestRenderAgentPromptRosterInSystem(t *testing.T) {
 	t.Parallel()
-	agent := config.AgentDef{Prompt: "Do work."}
+	agent := config.AgentDef{Prompt: "Do work.", AllowPRs: true}
 	ctx := ai.PromptContext{
 		Repo: "owner/repo",
 		Roster: []ai.RosterEntry{
@@ -234,49 +234,90 @@ func TestRenderAgentPromptRosterInUser(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RenderAgentPrompt: %v", err)
 	}
-	usr := got.User
-	if !strings.Contains(usr, "## Available experts") {
-		t.Errorf("missing experts section in User:\n%s", usr)
+	sys := got.System
+	if !strings.Contains(sys, "## Available experts") {
+		t.Errorf("missing experts section in System:\n%s", sys)
 	}
-	// Roster must not bleed into System.
-	if strings.Contains(got.System, "Available experts") {
-		t.Errorf("roster section must not appear in System:\n%s", got.System)
+	// Roster must not bleed into User.
+	if strings.Contains(got.User, "Available experts") {
+		t.Errorf("roster section must not appear in User:\n%s", got.User)
 	}
-	archIdx := strings.Index(usr, "arch-reviewer")
-	prIdx := strings.Index(usr, "pr-reviewer")
-	secIdx := strings.Index(usr, "sec-reviewer")
+	archIdx := strings.Index(sys, "arch-reviewer")
+	prIdx := strings.Index(sys, "pr-reviewer")
+	secIdx := strings.Index(sys, "sec-reviewer")
 	if !(archIdx < prIdx && prIdx < secIdx) {
 		t.Errorf("roster not alphabetical: arch=%d pr=%d sec=%d", archIdx, prIdx, secIdx)
 	}
-	if !strings.Contains(usr, "pr-reviewer") || !strings.Contains(usr, "[dispatchable]") {
-		t.Errorf("dispatchable marker missing:\n%s", usr)
+	if !strings.Contains(sys, "pr-reviewer") || !strings.Contains(sys, "[dispatchable]") {
+		t.Errorf("dispatchable marker missing:\n%s", sys)
 	}
-	if strings.Contains(usr, "arch-reviewer: Reviews arch (skills: architect) [dispatchable]") {
+	if strings.Contains(sys, "arch-reviewer: Reviews arch (skills: architect) [dispatchable]") {
 		t.Errorf("non-dispatchable agent should not have [dispatchable] marker")
 	}
 }
 
-func TestRenderAgentPromptRosterExcludesSelfFromRoster(t *testing.T) {
+func TestRenderAgentPromptRosterAppendsAfterAgentPrompt(t *testing.T) {
 	t.Parallel()
-	agent := config.AgentDef{Name: "coder", Prompt: "Code."}
+	agent := config.AgentDef{Name: "coder", Prompt: "Write code.", AllowPRs: true}
 	ctx := ai.PromptContext{
 		Repo: "owner/repo",
 		Roster: []ai.RosterEntry{
 			{Name: "pr-reviewer", Description: "Reviews PRs"},
 		},
 	}
-	usr := renderUser(t, agent, nil, ctx)
-	if strings.Contains(usr, "**coder**") {
-		t.Errorf("current agent should not appear in roster:\n%s", usr)
+	sys := renderSystem(t, agent, nil, ctx)
+	promptIdx := strings.Index(sys, "Write code.")
+	rosterIdx := strings.Index(sys, "## Available experts")
+	if promptIdx < 0 || rosterIdx < 0 {
+		t.Fatalf("prompt body and roster must both appear in System:\n%s", sys)
+	}
+	if promptIdx >= rosterIdx {
+		t.Errorf("roster must come after the agent prompt; prompt=%d roster=%d", promptIdx, rosterIdx)
 	}
 }
 
 func TestRenderAgentPromptRosterOmittedWhenEmpty(t *testing.T) {
 	t.Parallel()
-	agent := config.AgentDef{Prompt: "Do X."}
-	usr := renderUser(t, agent, nil, ai.PromptContext{Repo: "owner/repo"})
-	if strings.Contains(usr, "## Available experts") {
-		t.Errorf("empty roster should not produce the experts section:\n%s", usr)
+	agent := config.AgentDef{Prompt: "Do X.", AllowPRs: true}
+	got, err := ai.RenderAgentPrompt(agent, nil, ai.PromptContext{Repo: "owner/repo"})
+	if err != nil {
+		t.Fatalf("RenderAgentPrompt: %v", err)
+	}
+	if strings.Contains(got.System, "## Available experts") {
+		t.Errorf("empty roster should not produce the experts section in System:\n%s", got.System)
+	}
+	if strings.Contains(got.User, "## Available experts") {
+		t.Errorf("empty roster should not produce the experts section in User:\n%s", got.User)
+	}
+}
+
+func TestRenderAgentPromptNoPRGuardInSystem(t *testing.T) {
+	t.Parallel()
+	const guard = "Do not open or create pull requests under any circumstances."
+	tests := []struct {
+		name      string
+		allowPRs  bool
+		wantGuard bool
+	}{
+		{name: "guard present when allow_prs=false", allowPRs: false, wantGuard: true},
+		{name: "guard absent when allow_prs=true", allowPRs: true, wantGuard: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			agent := config.AgentDef{Name: "reviewer", Prompt: "Review.", AllowPRs: tc.allowPRs}
+			got, err := ai.RenderAgentPrompt(agent, nil, ai.PromptContext{Repo: "owner/repo"})
+			if err != nil {
+				t.Fatalf("RenderAgentPrompt: %v", err)
+			}
+			hasGuard := strings.HasPrefix(got.System, guard)
+			if hasGuard != tc.wantGuard {
+				t.Errorf("guard present=%v, want %v; System:\n%s", hasGuard, tc.wantGuard, got.System)
+			}
+			if strings.Contains(got.User, guard) {
+				t.Errorf("no-PR guard must not appear in User:\n%s", got.User)
+			}
+		})
 	}
 }
 

--- a/internal/ai/prompt_test.go
+++ b/internal/ai/prompt_test.go
@@ -321,6 +321,49 @@ func TestRenderAgentPromptNoPRGuardInSystem(t *testing.T) {
 	}
 }
 
+// TestRenderAgentPromptSystemSectionOrdering pins the full ordering of blocks
+// in System when every optional section is present at once. Without this test,
+// a bug that interleaved the no-PR guard with the roster (or placed the roster
+// before skills / prompt body) could pass the entire suite, since the
+// per-section tests exercise each block in isolation. Caching depends on this
+// ordering being stable across runs.
+func TestRenderAgentPromptSystemSectionOrdering(t *testing.T) {
+	t.Parallel()
+	skills := map[string]config.SkillDef{
+		"testing": {Prompt: "Focus on tests."},
+	}
+	agent := config.AgentDef{
+		Name:     "reviewer",
+		Skills:   []string{"testing"},
+		Prompt:   "You review PRs.",
+		AllowPRs: false,
+	}
+	ctx := ai.PromptContext{
+		Repo: "owner/repo",
+		Roster: []ai.RosterEntry{
+			{Name: "pr-reviewer", Description: "Reviews PRs", AllowDispatch: true},
+		},
+	}
+	sys := renderSystem(t, agent, skills, ctx)
+
+	guardIdx := strings.Index(sys, "Do not open or create pull requests")
+	skillsIdx := strings.Index(sys, "Focus on tests.")
+	promptIdx := strings.Index(sys, "You review PRs.")
+	rosterIdx := strings.Index(sys, "## Available experts")
+
+	for name, idx := range map[string]int{
+		"guard": guardIdx, "skills": skillsIdx, "prompt": promptIdx, "roster": rosterIdx,
+	} {
+		if idx < 0 {
+			t.Fatalf("missing %s block in System:\n%s", name, sys)
+		}
+	}
+	if !(guardIdx < skillsIdx && skillsIdx < promptIdx && promptIdx < rosterIdx) {
+		t.Errorf("wrong section ordering; guard=%d skills=%d prompt=%d roster=%d\nSystem:\n%s",
+			guardIdx, skillsIdx, promptIdx, rosterIdx, sys)
+	}
+}
+
 func TestRenderAgentPromptDispatchContextInUser(t *testing.T) {
 	t.Parallel()
 	agent := config.AgentDef{Prompt: "React to dispatch."}

--- a/internal/autonomous/scheduler.go
+++ b/internal/autonomous/scheduler.go
@@ -450,9 +450,6 @@ func (s *Scheduler) executeAgentRun(ctx context.Context, repo string, agent conf
 		}
 		return fmt.Errorf("render prompt: %w", err)
 	}
-	if !agent.AllowPRs {
-		rendered.System = "Do not open or create pull requests under any circumstances.\n" + rendered.System
-	}
 
 	logger.Info().Msg("running autonomous pass")
 	spanStart := time.Now()

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -554,9 +554,6 @@ func (e *Engine) runAgent(ctx context.Context, ev Event, agent config.AgentDef, 
 	if invokedBy != "" {
 		logger = logger.With().Str("invoked_by", invokedBy).Logger()
 	}
-	if !agent.AllowPRs {
-		rendered.System = "Do not open or create pull requests under any circumstances.\n" + rendered.System
-	}
 	logger.Info().Str("workflow", workflow).Msg("invoking ai agent")
 
 	if e.runTracker != nil {


### PR DESCRIPTION
## Summary

- Closes #257.
- Moves the `## Available experts` roster from the per-run User section into the stable System section of the rendered prompt. The roster changes only when the (agent, repo) binding configuration changes — not per run — so it belongs in the cacheable System block.
- Moves the `Do not open or create pull requests under any circumstances.` guard into `RenderAgentPrompt` itself. Previously both `internal/workflow/engine.go` and `internal/autonomous/scheduler.go` prepended it to `rendered.System` by hand; consolidating it keeps all stable-content composition in one place.

## Impact

- **Claude backends** (`--append-system-prompt` delivery): System is now identical across every run of the same agent on the same repo, unlocking Claude's prompt caching for skills, agent prompt, roster, and the no-PR guard.
- **Codex / OpenAI-compatible backends**: System and User are still concatenated on stdin, so the total delivered prompt text is unchanged.

## Test plan

- [x] New tests in `internal/ai/prompt_test.go`:
  - `TestRenderAgentPromptRosterInSystem` (replaces the prior `*InUser` test): roster appears in `got.System`, not in `got.User`; entries are alphabetical; `[dispatchable]` markers render only on dispatchable agents.
  - `TestRenderAgentPromptRosterAppendsAfterAgentPrompt`: pins that the roster appears after the agent prompt body in System (not before it).
  - `TestRenderAgentPromptRosterOmittedWhenEmpty`: asserts no `## Available experts` section in either System or User when the roster is empty.
  - `TestRenderAgentPromptNoPRGuardInSystem`: table-driven — guard prepended to System when `allow_prs=false`, absent when `allow_prs=true`; never leaks into User.
- [x] Existing caller-side tests still pass:
  - `TestEngineAllowPRsFalseInjectsNoPRGuard` (engine_test.go) — inspects `req.System` delivered to the runner.
  - `TestSchedulerAllowPRsPromptPrefixing` (scheduler_test.go) — same pattern via `promptCapturingRunner`.
- [x] CI runs `go test ./... -race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)