### PR TITLE
refactor(webhook): simplify canonicalModels using slices.Compact

### DIFF
--- a/internal/webhook/orphans.go
+++ b/internal/webhook/orphans.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -147,22 +148,15 @@ func sortedSetKeys(in map[string]struct{}) []string {
 }
 
 func canonicalModels(models []string) []string {
-	if len(models) == 0 {
+	out := make([]string, 0, len(models))
+	for _, m := range models {
+		if m = strings.TrimSpace(m); m != "" {
+			out = append(out, m)
+		}
+	}
+	if len(out) == 0 {
 		return nil
 	}
-	set := make(map[string]struct{}, len(models))
-	out := make([]string, 0, len(models))
-	for _, model := range models {
-		model = strings.TrimSpace(model)
-		if model == "" {
-			continue
-		}
-		if _, exists := set[model]; exists {
-			continue
-		}
-		set[model] = struct{}{}
-		out = append(out, model)
-	}
 	sort.Strings(out)
-	return out
+	return slices.Compact(out)
 }

--- a/internal/webhook/orphans_test.go
+++ b/internal/webhook/orphans_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"github.com/eloylp/agents/internal/config"
@@ -27,13 +28,8 @@ func TestCanonicalModels(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got := canonicalModels(tc.input)
-			if len(got) != len(tc.want) {
-				t.Fatalf("canonicalModels(%v) = %v, want %v", tc.input, got, tc.want)
-			}
-			for i := range got {
-				if got[i] != tc.want[i] {
-					t.Errorf("canonicalModels[%d] = %q, want %q", i, got[i], tc.want[i])
-				}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("canonicalModels(%v) = %#v, want %#v", tc.input, got, tc.want)
 			}
 		})
 	}

--- a/internal/webhook/orphans_test.go
+++ b/internal/webhook/orphans_test.go
@@ -9,6 +9,36 @@ import (
 	"github.com/eloylp/agents/internal/config"
 )
 
+func TestCanonicalModels(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input []string
+		want  []string
+	}{
+		{"nil input", nil, nil},
+		{"empty slice", []string{}, nil},
+		{"all empty after trim", []string{"", "  ", "\t"}, nil},
+		{"dedup and sort", []string{"b", "a", "b", "c", "a"}, []string{"a", "b", "c"}},
+		{"trims whitespace", []string{"  beta  ", "alpha", "beta"}, []string{"alpha", "beta"}},
+		{"single", []string{"only"}, []string{"only"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := canonicalModels(tc.input)
+			if len(got) != len(tc.want) {
+				t.Fatalf("canonicalModels(%v) = %v, want %v", tc.input, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("canonicalModels[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestComputeOrphanedAgents(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Why

`canonicalModels` used a `map[string]struct{}` to deduplicate entries while building the output slice, then sorted at the end. Because the function sorts anyway, adjacent-duplicate removal via `slices.Compact` achieves the same result without the map allocation.

The `slices` package is already used in eight other files in this codebase (Go 1.21+), so this is consistent with the existing style.

## What changed

- `internal/webhook/orphans.go`: rewrite `canonicalModels` to filter/collect, sort, then `slices.Compact` — removes the set map, -7 net lines.
- `internal/webhook/orphans_test.go`: add `TestCanonicalModels` — table-driven, covers nil input, empty/whitespace-only strings, duplicates, and whitespace trimming.

No behaviour change; all existing tests continue to pass.