### PR TITLE
feat(mcp): add import_config tool

### DIFF
--- a/cmd/agents/main.go
+++ b/cmd/agents/main.go
@@ -164,6 +164,7 @@ func run() error {
 		DispatchStats: engine,
 		Memory:        &sqliteMcpReader{db: db},
 		ConfigBytes:   server,
+		ConfigImport:  server,
 		Logger:        logger,
 	}))
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -6,7 +6,7 @@
 // foundation for conversational fleet management — tracked in issue #227.
 //
 // The current tool inventory covers fleet reads, on-demand runs, the
-// read-only observability surface, and read-only config export:
+// read-only observability surface, and config snapshots / import:
 //
 //   - list_agents, list_skills, list_backends, list_repos — fleet lists
 //   - get_agent, get_skill, get_backend, get_repo         — per-item reads
@@ -14,10 +14,9 @@
 //   - trigger_agent                                       — on-demand run
 //   - list_events, list_traces, get_trace, get_trace_steps — agent activity
 //   - get_graph, get_dispatches, get_memory               — dispatch + memory
-//   - get_config, export_config                           — config snapshots
+//   - get_config, export_config, import_config            — config snapshots / write
 //
-// CRUD writes (create/delete) and config import are tracked as follow-up work
-// on #227.
+// CRUD writes (create/delete) are tracked as follow-up work on #227.
 package mcp
 
 import (
@@ -95,15 +94,26 @@ type ConfigReader interface {
 	ExportYAML() ([]byte, error)
 }
 
+// ConfigImporter writes a YAML fragment (matching the export_config / GET
+// /export shape) into the store. mode is empty/"merge" (upsert-only) or
+// "replace" (prune entries not in the payload). Returns the per-section
+// counts of imported entities — the same map handleStoreImport ships as JSON.
+//
+// Implementations must hold the store mutex while writing and reload cron
+// schedules afterwards so MCP imports stay consistent with the REST path.
+type ConfigImporter interface {
+	ImportYAML(body []byte, mode string) (map[string]int, error)
+}
+
 // Deps bundles the dependencies the MCP server needs. Each tool handler
 // depends on a small subset of this struct; bundling them keeps the
 // registration site in tools.go short.
 //
 // Config, Queue, Status, and Logger are always required. Observe,
-// DispatchStats, Memory, and ConfigBytes are optional: the observability and
-// config tools are only registered when the corresponding dependency is
-// supplied, so tests can exercise the core fleet surface without wiring the
-// full stack.
+// DispatchStats, Memory, ConfigBytes, and ConfigImport are optional: the
+// observability, config-read, and config-write tools are only registered when
+// the corresponding dependency is supplied, so tests can exercise the core
+// fleet surface without wiring the full stack.
 type Deps struct {
 	Config        ConfigProvider
 	Queue         EventQueue
@@ -112,6 +122,7 @@ type Deps struct {
 	DispatchStats DispatchStatsSource
 	Memory        MemoryReader
 	ConfigBytes   ConfigReader
+	ConfigImport  ConfigImporter
 	Logger        zerolog.Logger
 }
 
@@ -162,7 +173,8 @@ single agent, skill, backend, repo, trace, or memory record.
 get_status returns daemon health. trigger_agent fires an on-demand run.
 Observability tools (list_events, list_traces, get_trace,
 get_trace_steps, get_graph, get_dispatches, get_memory) expose the same
-data the web dashboard shows. Config tools (get_config, export_config)
-return the redacted effective config and a YAML fragment of the
-CRUD-mutable sections. This server is the v3 foundation;
-additional CRUD writes and config import will land in follow-ups.`
+data the web dashboard shows. Config tools (get_config, export_config,
+import_config) return the redacted effective config, export the
+CRUD-mutable YAML fragment, and write a YAML payload back into the
+store. This server is the v3 foundation; additional CRUD writes will
+land in follow-ups.`

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -185,6 +185,21 @@ func registerTools(srv *server.MCPServer, deps Deps) {
 			toolExportConfig(deps),
 		)
 	}
+	if deps.ConfigImport != nil {
+		srv.AddTool(
+			mcpgo.NewTool("import_config",
+				mcpgo.WithDescription("Write a YAML config fragment (agents, skills, repos, ai_backends) into the store. mode=\"\" or \"merge\" upserts; mode=\"replace\" prunes entries not in the payload. Returns per-section counts. Same path as POST /import."),
+				mcpgo.WithString("yaml",
+					mcpgo.Required(),
+					mcpgo.Description("YAML body matching the export_config / GET /export shape."),
+				),
+				mcpgo.WithString("mode",
+					mcpgo.Description("\"\" or \"merge\" to upsert, \"replace\" to prune entries not in the payload."),
+				),
+			),
+			toolImportConfig(deps),
+		)
+	}
 }
 
 // toolListAgents serialises every agent definition as JSON. Uses the same
@@ -719,5 +734,24 @@ func toolExportConfig(deps Deps) server.ToolHandlerFunc {
 			return mcpgo.NewToolResultErrorFromErr("export config", err), nil
 		}
 		return mcpgo.NewToolResultText(string(body)), nil
+	}
+}
+
+// toolImportConfig writes a YAML payload into the store using the same code
+// path as POST /import. Validation, store, and cron-reload errors are
+// surfaced to the caller as tool errors; on success the per-section counts
+// are returned as JSON.
+func toolImportConfig(deps Deps) server.ToolHandlerFunc {
+	return func(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		body, err := req.RequireString("yaml")
+		if err != nil {
+			return mcpgo.NewToolResultError(err.Error()), nil
+		}
+		mode, _ := trimmedStringOptional(req, "mode")
+		counts, err := deps.ConfigImport.ImportYAML([]byte(body), mode)
+		if err != nil {
+			return mcpgo.NewToolResultErrorFromErr("import config", err), nil
+		}
+		return jsonResult(counts)
 	}
 }

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -1056,3 +1056,131 @@ func TestToolExportConfigPropagatesError(t *testing.T) {
 		t.Fatalf("error body want substring %q, got %q", "db closed", got)
 	}
 }
+
+// stubConfigImporter records the YAML body and mode it received and returns a
+// canned counts map / error. Used by the import_config tool tests so they stay
+// independent of the real webhook.Server.
+type stubConfigImporter struct {
+	gotBody []byte
+	gotMode string
+	counts  map[string]int
+	err     error
+}
+
+func (s *stubConfigImporter) ImportYAML(body []byte, mode string) (map[string]int, error) {
+	s.gotBody = body
+	s.gotMode = mode
+	return s.counts, s.err
+}
+
+func TestToolImportConfigPassesYAMLAndMode(t *testing.T) {
+	t.Parallel()
+	imp := &stubConfigImporter{counts: map[string]int{
+		"agents": 2, "skills": 1, "repos": 3, "backends": 1,
+	}}
+	deps := Deps{
+		Config:       stubConfig{cfg: fixtureConfig()},
+		Queue:        &stubQueue{},
+		Status:       stubStatus{},
+		ConfigImport: imp,
+		Logger:       zerolog.Nop(),
+	}
+
+	body := "agents:\n  - name: coder\n    backend: claude\n    prompt: x\n"
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"yaml": body, "mode": "replace"}
+
+	res, err := toolImportConfig(deps)(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("expected success, got error result: %+v", res)
+	}
+	if string(imp.gotBody) != body {
+		t.Errorf("body forwarded: want %q, got %q", body, string(imp.gotBody))
+	}
+	if imp.gotMode != "replace" {
+		t.Errorf("mode forwarded: want replace, got %q", imp.gotMode)
+	}
+	var got map[string]int
+	decodeText(t, res, &got)
+	if got["agents"] != 2 || got["skills"] != 1 || got["repos"] != 3 || got["backends"] != 1 {
+		t.Errorf("counts wire shape: got %+v", got)
+	}
+}
+
+func TestToolImportConfigDefaultsMode(t *testing.T) {
+	t.Parallel()
+	imp := &stubConfigImporter{counts: map[string]int{}}
+	deps := Deps{
+		Config:       stubConfig{cfg: fixtureConfig()},
+		Queue:        &stubQueue{},
+		Status:       stubStatus{},
+		ConfigImport: imp,
+		Logger:       zerolog.Nop(),
+	}
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"yaml": "skills: {}\n"}
+
+	res, err := toolImportConfig(deps)(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("expected success, got error result: %+v", res)
+	}
+	if imp.gotMode != "" {
+		t.Errorf("missing mode should default to empty, got %q", imp.gotMode)
+	}
+}
+
+func TestToolImportConfigRequiresYAML(t *testing.T) {
+	t.Parallel()
+	imp := &stubConfigImporter{counts: map[string]int{}}
+	deps := Deps{
+		Config:       stubConfig{cfg: fixtureConfig()},
+		Queue:        &stubQueue{},
+		Status:       stubStatus{},
+		ConfigImport: imp,
+		Logger:       zerolog.Nop(),
+	}
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{}
+
+	res, err := toolImportConfig(deps)(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected IsError when yaml argument missing, got %+v", res)
+	}
+	if imp.gotBody != nil {
+		t.Errorf("importer should not be called when yaml is missing, got body=%q", string(imp.gotBody))
+	}
+}
+
+func TestToolImportConfigPropagatesError(t *testing.T) {
+	t.Parallel()
+	imp := &stubConfigImporter{err: errors.New("invalid mode")}
+	deps := Deps{
+		Config:       stubConfig{cfg: fixtureConfig()},
+		Queue:        &stubQueue{},
+		Status:       stubStatus{},
+		ConfigImport: imp,
+		Logger:       zerolog.Nop(),
+	}
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"yaml": "x", "mode": "replce"}
+
+	res, err := toolImportConfig(deps)(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected IsError when importer fails, got %+v", res)
+	}
+}

--- a/internal/webhook/crud.go
+++ b/internal/webhook/crud.go
@@ -829,21 +829,37 @@ func (s *Server) handleStoreImport(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("read request: %v", err), http.StatusBadRequest)
 		return
 	}
+	counts, err := s.ImportYAML(body, r.URL.Query().Get("mode"))
+	if err != nil {
+		http.Error(w, err.Error(), storeErrStatus(err))
+		return
+	}
+	writeJSON(w, http.StatusOK, counts)
+}
+
+// ImportYAML parses a YAML payload in handleStoreExport's format and writes it
+// to the store. mode controls upsert semantics: empty or "merge" preserves
+// existing records, "replace" prunes anything not present in the payload.
+//
+// On success it returns the per-section counts that handleStoreImport ships in
+// its JSON response. Validation failures (bad mode, malformed YAML, store-level
+// invariants) are returned as *store.ErrValidation so callers can map them to
+// HTTP 400 / MCP user errors via storeErrStatus.
+//
+// Exposed so non-HTTP surfaces (e.g. the MCP import_config tool) can run the
+// same import path as POST /import without going through the router.
+func (s *Server) ImportYAML(body []byte, mode string) (map[string]int, error) {
+	if mode != "" && mode != "merge" && mode != "replace" {
+		return nil, &store.ErrValidation{Msg: fmt.Sprintf("invalid mode %q: must be empty, \"merge\", or \"replace\"", mode)}
+	}
 	var payload exportYAML
 	if err := yaml.Unmarshal(body, &payload); err != nil {
-		http.Error(w, fmt.Sprintf("parse yaml: %v", err), http.StatusBadRequest)
-		return
+		return nil, &store.ErrValidation{Msg: fmt.Sprintf("parse yaml: %v", err)}
 	}
 
 	backends := map[string]config.AIBackendConfig{}
 	if payload.Daemon != nil {
 		backends = payload.Daemon.AIBackends
-	}
-
-	mode := r.URL.Query().Get("mode")
-	if mode != "" && mode != "merge" && mode != "replace" {
-		http.Error(w, fmt.Sprintf("invalid mode %q: must be empty, \"merge\", or \"replace\"", mode), http.StatusBadRequest)
-		return
 	}
 
 	s.storeMu.Lock()
@@ -856,23 +872,17 @@ func (s *Server) handleStoreImport(w http.ResponseWriter, r *http.Request) {
 		importErr = store.ImportAll(s.db, payload.Agents, payload.Repos, payload.Skills, backends)
 	}
 	if importErr != nil {
-		http.Error(w, fmt.Sprintf("import: %v", importErr), storeErrStatus(importErr))
-		return
+		return nil, fmt.Errorf("import: %w", importErr)
 	}
 	if err := s.reloadCron(); err != nil {
 		s.logger.Error().Err(err).Msg("store import: cron reload failed")
-		http.Error(w, fmt.Sprintf("cron reload: %v", err), http.StatusInternalServerError)
-		return
+		return nil, fmt.Errorf("cron reload: %w", err)
 	}
 
-	backendsCount := 0
-	if payload.Daemon != nil {
-		backendsCount = len(payload.Daemon.AIBackends)
-	}
-	writeJSON(w, http.StatusOK, map[string]int{
+	return map[string]int{
 		"agents":   len(payload.Agents),
 		"skills":   len(payload.Skills),
 		"repos":    len(payload.Repos),
-		"backends": backendsCount,
-	})
+		"backends": len(backends),
+	}, nil
 }


### PR DESCRIPTION
## Summary

- Adds `import_config` MCP tool that writes a YAML config fragment (agents/skills/repos/ai_backends) into the store, mirroring `POST /import`.
- Refactors `handleStoreImport` to delegate to a new `Server.ImportYAML(body, mode)` method so REST and MCP both run through the same path (storeMu held, store mutation, cron reload).
- Validation failures (bad mode, malformed YAML) are surfaced as `*store.ErrValidation` so `storeErrStatus` maps them uniformly to HTTP 400 / MCP user-error.
- Tool only registers when `Deps.ConfigImport` is wired — matches the optional-dep pattern used by the other config / observability tools.

Stacked on #268 (`feat/227-mcp-config-tools`). Once #268 lands, the diff against main collapses to just the import-tool slice.

## Test plan

- [x] New unit tests in `internal/mcp/tools_test.go`:
  - argument forwarding (yaml + mode reach the importer verbatim)
  - default mode (omitted `mode` arg → `""` passed to importer)
  - missing `yaml` arg returns user error without invoking importer
  - importer errors propagate to a tool error result
- [x] Existing `internal/webhook/crud_test.go` import suites still cover the round-trip / replace / invalid-mode / empty-fleet HTTP paths through the refactored handler.
- [ ] CI (`go test ./... -race`) — relying on Actions; no local Go toolchain in this environment.

Refs #227.