### PR TITLE
feat(mcp): add create_agent and delete_agent tools

### DIFF
--- a/cmd/agents/main.go
+++ b/cmd/agents/main.go
@@ -165,6 +165,7 @@ func run() error {
 		Memory:        &sqliteMcpReader{db: db},
 		ConfigBytes:   server,
 		ConfigImport:  server,
+		AgentWrite:    server,
 		Logger:        logger,
 	}))
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -15,8 +15,10 @@
 //   - list_events, list_traces, get_trace, get_trace_steps — agent activity
 //   - get_graph, get_dispatches, get_memory               — dispatch + memory
 //   - get_config, export_config, import_config            — config snapshots / write
+//   - create_agent, delete_agent                          — agent CRUD writes
 //
-// CRUD writes (create/delete) are tracked as follow-up work on #227.
+// Remaining CRUD writes (skill/backend/repo create/delete) are tracked as
+// follow-up work on #227.
 package mcp
 
 import (
@@ -105,15 +107,27 @@ type ConfigImporter interface {
 	ImportYAML(body []byte, mode string) (map[string]int, error)
 }
 
+// AgentWriter writes a single agent definition into the store and removes
+// existing ones. Returns the canonical (normalized) form the store persisted
+// so callers can show the same shape REST clients see in the POST /agents
+// response.
+//
+// Implementations must hold the store mutex while writing and reload cron
+// schedules afterwards so MCP writes stay consistent with the REST path.
+type AgentWriter interface {
+	UpsertAgent(a config.AgentDef) (config.AgentDef, error)
+	DeleteAgent(name string, cascade bool) error
+}
+
 // Deps bundles the dependencies the MCP server needs. Each tool handler
 // depends on a small subset of this struct; bundling them keeps the
 // registration site in tools.go short.
 //
 // Config, Queue, Status, and Logger are always required. Observe,
-// DispatchStats, Memory, ConfigBytes, and ConfigImport are optional: the
-// observability, config-read, and config-write tools are only registered when
-// the corresponding dependency is supplied, so tests can exercise the core
-// fleet surface without wiring the full stack.
+// DispatchStats, Memory, ConfigBytes, ConfigImport, and AgentWrite are
+// optional: the observability, config-read/write, and CRUD-write tools are
+// only registered when the corresponding dependency is supplied, so tests can
+// exercise the core fleet surface without wiring the full stack.
 type Deps struct {
 	Config        ConfigProvider
 	Queue         EventQueue
@@ -123,6 +137,7 @@ type Deps struct {
 	Memory        MemoryReader
 	ConfigBytes   ConfigReader
 	ConfigImport  ConfigImporter
+	AgentWrite    AgentWriter
 	Logger        zerolog.Logger
 }
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -200,6 +200,57 @@ func registerTools(srv *server.MCPServer, deps Deps) {
 			toolImportConfig(deps),
 		)
 	}
+	if deps.AgentWrite != nil {
+		srv.AddTool(
+			mcpgo.NewTool("create_agent",
+				mcpgo.WithDescription("Create or update an agent. Upsert semantics: a write to an existing name overwrites it. Returns the canonical (normalized) agent persisted by the store. Same path as POST /agents."),
+				mcpgo.WithString("name",
+					mcpgo.Required(),
+					mcpgo.Description("Agent name. Lowercased and trimmed by the store."),
+				),
+				mcpgo.WithString("backend",
+					mcpgo.Description("AI backend name (must exist in the fleet). Required for runnable agents."),
+				),
+				mcpgo.WithString("model",
+					mcpgo.Description("Optional model identifier; must be present in the backend's model catalog."),
+				),
+				mcpgo.WithString("prompt",
+					mcpgo.Description("Agent prompt body."),
+				),
+				mcpgo.WithString("description",
+					mcpgo.Description("Short human-readable description shown in the dispatch roster."),
+				),
+				mcpgo.WithArray("skills",
+					mcpgo.Description("Optional list of skill names to compose into the agent's system prompt."),
+					mcpgo.Items(map[string]any{"type": "string"}),
+				),
+				mcpgo.WithArray("can_dispatch",
+					mcpgo.Description("Optional whitelist of agent names this agent may dispatch to."),
+					mcpgo.Items(map[string]any{"type": "string"}),
+				),
+				mcpgo.WithBoolean("allow_prs",
+					mcpgo.Description("Allow this agent to open or edit pull requests. Defaults to false."),
+				),
+				mcpgo.WithBoolean("allow_dispatch",
+					mcpgo.Description("Allow other agents to dispatch this agent. Defaults to false."),
+				),
+			),
+			toolCreateAgent(deps),
+		)
+		srv.AddTool(
+			mcpgo.NewTool("delete_agent",
+				mcpgo.WithDescription("Delete an agent by name. Without cascade=true the call fails with a conflict error if any repo binding still references the agent. Same path as DELETE /agents/{name}."),
+				mcpgo.WithString("name",
+					mcpgo.Required(),
+					mcpgo.Description("Agent name (case-insensitive; matched after lowercasing)."),
+				),
+				mcpgo.WithBoolean("cascade",
+					mcpgo.Description("When true, also remove repo bindings that reference the agent. Defaults to false."),
+				),
+			),
+			toolDeleteAgent(deps),
+		)
+	}
 }
 
 // toolListAgents serialises every agent definition as JSON. Uses the same
@@ -753,5 +804,58 @@ func toolImportConfig(deps Deps) server.ToolHandlerFunc {
 			return mcpgo.NewToolResultErrorFromErr("import config", err), nil
 		}
 		return jsonResult(counts)
+	}
+}
+
+// toolCreateAgent upserts an agent definition through the same path as POST
+// /agents. Returns the canonical (normalized) form so callers see the agent
+// the way the store actually persisted it. Empty names, unknown backends, and
+// model/skill validation failures surface as tool errors via the store's
+// *ErrValidation / *ErrConflict types.
+func toolCreateAgent(deps Deps) server.ToolHandlerFunc {
+	return func(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		name, err := req.RequireString("name")
+		if err != nil {
+			return mcpgo.NewToolResultError(err.Error()), nil
+		}
+		a := config.AgentDef{
+			Name:          name,
+			Backend:       req.GetString("backend", ""),
+			Model:         req.GetString("model", ""),
+			Prompt:        req.GetString("prompt", ""),
+			Description:   req.GetString("description", ""),
+			Skills:        req.GetStringSlice("skills", nil),
+			CanDispatch:   req.GetStringSlice("can_dispatch", nil),
+			AllowPRs:      req.GetBool("allow_prs", false),
+			AllowDispatch: req.GetBool("allow_dispatch", false),
+		}
+		canonical, err := deps.AgentWrite.UpsertAgent(a)
+		if err != nil {
+			return mcpgo.NewToolResultErrorFromErr("create agent", err), nil
+		}
+		return jsonResult(agentJSON(canonical))
+	}
+}
+
+// toolDeleteAgent removes an agent through the same path as DELETE
+// /agents/{name}. cascade=true also drops repo bindings that reference the
+// agent; without it, a referenced agent surfaces a *store.ErrConflict so
+// callers can prompt for cascade explicitly rather than silently mutating
+// repo bindings.
+func toolDeleteAgent(deps Deps) server.ToolHandlerFunc {
+	return func(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		name, ok := trimmedString(req, "name")
+		if !ok {
+			return mcpgo.NewToolResultError("name is required"), nil
+		}
+		cascade := req.GetBool("cascade", false)
+		if err := deps.AgentWrite.DeleteAgent(config.NormalizeAgentName(name), cascade); err != nil {
+			return mcpgo.NewToolResultErrorFromErr("delete agent", err), nil
+		}
+		return jsonResult(map[string]any{
+			"status":  "deleted",
+			"name":    config.NormalizeAgentName(name),
+			"cascade": cascade,
+		})
 	}
 }

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -1184,3 +1184,228 @@ func TestToolImportConfigPropagatesError(t *testing.T) {
 		t.Fatalf("expected IsError when importer fails, got %+v", res)
 	}
 }
+
+// stubAgentWriter records the agent definition / delete arguments it received
+// and returns canned values. The canonical agent returned from UpsertAgent is
+// what the create_agent tool serialises back to the caller, so tests pin both
+// the inputs the writer received and the outputs the tool surfaces.
+type stubAgentWriter struct {
+	gotUpsert     config.AgentDef
+	gotDeleteName string
+	gotCascade    bool
+	canonical     config.AgentDef
+	upsertErr     error
+	deleteErr     error
+}
+
+func (s *stubAgentWriter) UpsertAgent(a config.AgentDef) (config.AgentDef, error) {
+	s.gotUpsert = a
+	if s.upsertErr != nil {
+		return config.AgentDef{}, s.upsertErr
+	}
+	return s.canonical, nil
+}
+
+func (s *stubAgentWriter) DeleteAgent(name string, cascade bool) error {
+	s.gotDeleteName = name
+	s.gotCascade = cascade
+	return s.deleteErr
+}
+
+func TestToolCreateAgentForwardsAndReturnsCanonical(t *testing.T) {
+	t.Parallel()
+	canonical := config.AgentDef{
+		Name:          "linter",
+		Backend:       "claude",
+		Skills:        []string{"security"},
+		Prompt:        "audit",
+		AllowDispatch: true,
+		CanDispatch:   []string{"coder"},
+		Description:   "audits code",
+	}
+	w := &stubAgentWriter{canonical: canonical}
+	deps := Deps{
+		Config:     stubConfig{cfg: fixtureConfig()},
+		Queue:      &stubQueue{},
+		Status:     stubStatus{},
+		AgentWrite: w,
+		Logger:     zerolog.Nop(),
+	}
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"name":           "Linter",
+		"backend":        "claude",
+		"prompt":         "audit",
+		"description":    "audits code",
+		"skills":         []any{"security"},
+		"can_dispatch":   []any{"coder"},
+		"allow_dispatch": true,
+	}
+
+	res, err := toolCreateAgent(deps)(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("expected success, got error: %s", textOf(t, res))
+	}
+
+	if w.gotUpsert.Name != "Linter" || w.gotUpsert.Backend != "claude" || w.gotUpsert.Prompt != "audit" {
+		t.Errorf("forwarded agent missing fields: %+v", w.gotUpsert)
+	}
+	if !w.gotUpsert.AllowDispatch || len(w.gotUpsert.CanDispatch) != 1 || w.gotUpsert.CanDispatch[0] != "coder" {
+		t.Errorf("dispatch fields not forwarded: %+v", w.gotUpsert)
+	}
+	if len(w.gotUpsert.Skills) != 1 || w.gotUpsert.Skills[0] != "security" {
+		t.Errorf("skills slice not forwarded: %+v", w.gotUpsert.Skills)
+	}
+
+	var got map[string]any
+	decodeText(t, res, &got)
+	if got["name"] != "linter" {
+		t.Errorf("response should reflect canonical name, got %+v", got["name"])
+	}
+	if got["allow_dispatch"] != true {
+		t.Errorf("canonical allow_dispatch lost in response: %+v", got)
+	}
+}
+
+func TestToolCreateAgentRequiresName(t *testing.T) {
+	t.Parallel()
+	w := &stubAgentWriter{}
+	deps := Deps{
+		Config:     stubConfig{cfg: fixtureConfig()},
+		Queue:      &stubQueue{},
+		Status:     stubStatus{},
+		AgentWrite: w,
+		Logger:     zerolog.Nop(),
+	}
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"backend": "claude"}
+
+	res, err := toolCreateAgent(deps)(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected IsError when name missing, got %+v", res)
+	}
+	if w.gotUpsert.Name != "" {
+		t.Errorf("writer should not be invoked when name missing, got %+v", w.gotUpsert)
+	}
+}
+
+func TestToolCreateAgentPropagatesError(t *testing.T) {
+	t.Parallel()
+	w := &stubAgentWriter{upsertErr: errors.New("backend unknown")}
+	deps := Deps{
+		Config:     stubConfig{cfg: fixtureConfig()},
+		Queue:      &stubQueue{},
+		Status:     stubStatus{},
+		AgentWrite: w,
+		Logger:     zerolog.Nop(),
+	}
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"name": "linter", "backend": "ghost"}
+
+	res, err := toolCreateAgent(deps)(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected IsError on writer failure, got %+v", res)
+	}
+	if got := textOf(t, res); !strings.Contains(got, "backend unknown") {
+		t.Fatalf("error body want substring %q, got %q", "backend unknown", got)
+	}
+}
+
+func TestToolDeleteAgentNormalizesAndForwardsCascade(t *testing.T) {
+	t.Parallel()
+	w := &stubAgentWriter{}
+	deps := Deps{
+		Config:     stubConfig{cfg: fixtureConfig()},
+		Queue:      &stubQueue{},
+		Status:     stubStatus{},
+		AgentWrite: w,
+		Logger:     zerolog.Nop(),
+	}
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"name": "  Coder  ", "cascade": true}
+
+	res, err := toolDeleteAgent(deps)(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("expected success, got error: %s", textOf(t, res))
+	}
+	if w.gotDeleteName != "coder" {
+		t.Errorf("name should be normalized: got %q", w.gotDeleteName)
+	}
+	if !w.gotCascade {
+		t.Errorf("cascade should be forwarded as true")
+	}
+
+	var got map[string]any
+	decodeText(t, res, &got)
+	if got["status"] != "deleted" || got["name"] != "coder" || got["cascade"] != true {
+		t.Errorf("response shape: %+v", got)
+	}
+}
+
+func TestToolDeleteAgentRequiresName(t *testing.T) {
+	t.Parallel()
+	w := &stubAgentWriter{}
+	deps := Deps{
+		Config:     stubConfig{cfg: fixtureConfig()},
+		Queue:      &stubQueue{},
+		Status:     stubStatus{},
+		AgentWrite: w,
+		Logger:     zerolog.Nop(),
+	}
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"name": "   "}
+
+	res, err := toolDeleteAgent(deps)(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected IsError for blank name, got %+v", res)
+	}
+	if w.gotDeleteName != "" {
+		t.Errorf("writer should not be invoked for blank name, got %q", w.gotDeleteName)
+	}
+}
+
+func TestToolDeleteAgentPropagatesConflict(t *testing.T) {
+	t.Parallel()
+	w := &stubAgentWriter{deleteErr: errors.New("agent referenced by binding")}
+	deps := Deps{
+		Config:     stubConfig{cfg: fixtureConfig()},
+		Queue:      &stubQueue{},
+		Status:     stubStatus{},
+		AgentWrite: w,
+		Logger:     zerolog.Nop(),
+	}
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"name": "coder"}
+
+	res, err := toolDeleteAgent(deps)(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected IsError on writer failure, got %+v", res)
+	}
+	if got := textOf(t, res); !strings.Contains(got, "agent referenced by binding") {
+		t.Fatalf("error body want substring %q, got %q", "agent referenced by binding", got)
+	}
+}

--- a/internal/webhook/crud.go
+++ b/internal/webhook/crud.go
@@ -279,28 +279,43 @@ func (s *Server) handleStoreAgents(w http.ResponseWriter, r *http.Request) {
 		if !decodeBody(w, r, s.loadCfg().Daemon.HTTP.MaxBodyBytes, &req) {
 			return
 		}
-		if req.Name == "" {
-			http.Error(w, "name is required", http.StatusBadRequest)
-			return
-		}
-		s.storeMu.Lock()
-		err := store.UpsertAgent(s.db, req.toConfig())
-		if err == nil {
-			err = s.reloadCron()
-		}
-		s.storeMu.Unlock()
+		canonical, err := s.UpsertAgent(req.toConfig())
 		if err != nil {
 			status := storeErrStatus(err)
 			s.logger.Error().Err(err).Msg("store crud: agent upsert or cron reload failed")
 			http.Error(w, fmt.Sprintf("agent upsert or cron reload: %v", err), status)
 			return
 		}
-		// Return the canonical persisted form so clients see normalized values
-		// (lowercase name, trimmed prompt, etc.) rather than the raw request.
-		a := req.toConfig()
-		config.NormalizeAgentDef(&a)
-		writeJSON(w, http.StatusOK, agentToStoreJSON(a))
+		writeJSON(w, http.StatusOK, agentToStoreJSON(canonical))
 	}
+}
+
+// UpsertAgent writes a single agent definition into the store and reloads the
+// cron scheduler. Returns the canonical (normalized) form that was persisted
+// so callers can surface the same shape REST clients see in the POST response
+// — lowercase name, trimmed prompt, etc.
+//
+// Empty/whitespace names are rejected as *store.ErrValidation so callers can
+// map them to HTTP 400 / MCP user errors via storeErrStatus, mirroring the
+// behaviour of POST /agents.
+//
+// Exposed so non-HTTP surfaces (e.g. the MCP create_agent tool) can run the
+// same upsert path as POST /agents without going through the router.
+func (s *Server) UpsertAgent(a config.AgentDef) (config.AgentDef, error) {
+	if strings.TrimSpace(a.Name) == "" {
+		return config.AgentDef{}, &store.ErrValidation{Msg: "name is required"}
+	}
+	s.storeMu.Lock()
+	err := store.UpsertAgent(s.db, a)
+	if err == nil {
+		err = s.reloadCron()
+	}
+	s.storeMu.Unlock()
+	if err != nil {
+		return config.AgentDef{}, err
+	}
+	config.NormalizeAgentDef(&a)
+	return a, nil
 }
 
 // handleStoreAgent serves GET and DELETE /api/store/agents/{name}.
@@ -323,18 +338,7 @@ func (s *Server) handleStoreAgent(w http.ResponseWriter, r *http.Request) {
 
 	case http.MethodDelete:
 		cascade := r.URL.Query().Get("cascade") == "true"
-		s.storeMu.Lock()
-		var err error
-		if cascade {
-			err = store.DeleteAgentCascade(s.db, name)
-		} else {
-			err = store.DeleteAgent(s.db, name)
-		}
-		if err == nil {
-			err = s.reloadCron()
-		}
-		s.storeMu.Unlock()
-		if err != nil {
+		if err := s.DeleteAgent(name, cascade); err != nil {
 			status := storeErrStatus(err)
 			s.logger.Error().Err(err).Msg("store crud: agent delete or cron reload failed")
 			http.Error(w, fmt.Sprintf("agent delete or cron reload: %v", err), status)
@@ -342,6 +346,28 @@ func (s *Server) handleStoreAgent(w http.ResponseWriter, r *http.Request) {
 		}
 		w.WriteHeader(http.StatusNoContent)
 	}
+}
+
+// DeleteAgent removes an agent from the store and reloads the cron scheduler.
+// When cascade is true, repo bindings referencing the agent are also removed;
+// otherwise a *store.ErrConflict is returned if any binding still references
+// the agent (HTTP 409 / MCP user error via storeErrStatus).
+//
+// Exposed so non-HTTP surfaces (e.g. the MCP delete_agent tool) can run the
+// same delete path as DELETE /agents/{name} without going through the router.
+func (s *Server) DeleteAgent(name string, cascade bool) error {
+	s.storeMu.Lock()
+	defer s.storeMu.Unlock()
+	var err error
+	if cascade {
+		err = store.DeleteAgentCascade(s.db, name)
+	} else {
+		err = store.DeleteAgent(s.db, name)
+	}
+	if err != nil {
+		return err
+	}
+	return s.reloadCron()
 }
 
 // ── /api/store/skills ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds two new MCP tools for agent CRUD writes: `create_agent` and `delete_agent`. Closes the per-agent CRUD gap on #227.
- Refactors `handleStoreAgents` POST and `handleStoreAgent` DELETE in `internal/webhook/crud.go` into reusable methods on `*webhook.Server`:
  - `UpsertAgent(a config.AgentDef) (config.AgentDef, error)` — returns the canonical (normalized) agent the store persisted.
  - `DeleteAgent(name string, cascade bool) error`.
  Both hold `storeMu` and call `reloadCron()` so MCP writes stay consistent with the REST path. The HTTP handlers now delegate to these methods.
- New `mcp.AgentWriter` interface bundles the two methods and is wired through `Deps.AgentWrite` in `cmd/agents/main.go`. Tools register conditionally so tests can exercise the core fleet surface without wiring the full stack — same pattern as `ConfigImport`.
- Empty/whitespace names are now surfaced as `*store.ErrValidation` so `storeErrStatus` maps both REST + MCP uniformly to HTTP 400 / MCP user errors.

Stacked on #269 (`feat/227-mcp-import-config`).

## Test plan

- [ ] CI green
- [ ] `TestToolCreateAgentForwardsAndReturnsCanonical` — verifies the writer receives all fields (skills, can_dispatch, allow_dispatch) and the response uses the canonical (normalized) agent.
- [ ] `TestToolCreateAgentRequiresName` — missing `name` argument surfaces as a tool error and the writer is not invoked.
- [ ] `TestToolCreateAgentPropagatesError` — store / cron-reload errors are wrapped in `IsError` and the original message survives.
- [ ] `TestToolDeleteAgentNormalizesAndForwardsCascade` — `"  Coder  "` → `"coder"`, `cascade=true` forwarded.
- [ ] `TestToolDeleteAgentRequiresName` — blank name short-circuits before invoking the writer.
- [ ] `TestToolDeleteAgentPropagatesConflict` — referenced-by-binding errors wrap into `IsError` with the message preserved.
- [ ] Existing `TestStoreCRUDAgent*` HTTP tests continue to pass (they now flow through the refactored methods).

🤖 Generated with [Claude Code](https://claude.com/claude-code)