### PR TITLE
refactor(config): collapse validateDispatchWiring from 4 passes to 2

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -814,33 +814,22 @@ func (c *Config) validateAgents() error {
 //   - can_dispatch must not include the agent itself
 //   - agents referenced in any can_dispatch list must have a description
 func (c *Config) validateDispatchWiring() error {
-	// Build set of all agent names for O(1) lookup.
-	agentNames := make(map[string]struct{}, len(c.Agents))
+	agentByName := make(map[string]AgentDef, len(c.Agents))
 	for _, a := range c.Agents {
-		agentNames[a.Name] = struct{}{}
-	}
-	// Build set of agents that appear in any can_dispatch list — these require
-	// a description so the roster is informative.
-	dispatchTargets := make(map[string]struct{})
-	for _, a := range c.Agents {
-		for _, t := range a.CanDispatch {
-			dispatchTargets[t] = struct{}{}
-		}
+		agentByName[a.Name] = a
 	}
 	for _, a := range c.Agents {
 		for _, t := range a.CanDispatch {
-			if _, ok := agentNames[t]; !ok {
+			target, ok := agentByName[t]
+			if !ok {
 				return fmt.Errorf("config: agent %q: can_dispatch references unknown agent %q", a.Name, t)
 			}
 			if t == a.Name {
 				return fmt.Errorf("config: agent %q: can_dispatch must not include itself", a.Name)
 			}
-		}
-	}
-	// Verify dispatch targets have descriptions.
-	for _, a := range c.Agents {
-		if _, isTarget := dispatchTargets[a.Name]; isTarget && a.Description == "" {
-			return fmt.Errorf("config: agent %q is in a can_dispatch list but has no description (description is required for dispatch targets)", a.Name)
+			if target.Description == "" {
+				return fmt.Errorf("config: agent %q is in a can_dispatch list but has no description (description is required for dispatch targets)", t)
+			}
 		}
 	}
 	return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -610,7 +610,7 @@ func TestDispatchWiringValidationErrors(t *testing.T) {
     prompt: "Review PRs."
     allow_dispatch: true
 `,
-			errMsg: "description",
+			errMsg: `agent "pr-reviewer" is in a can_dispatch list but has no description`,
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

- Collapses `validateDispatchWiring` from 4 passes to 2 by using the full `agentByName` (AgentDef values) instead of a separate `agentNames` set plus a `dispatchTargets` set.
- The description check now happens in the same inner loop as the reference check, eliminating two redundant iterations over `c.Agents`.
- The new shape mirrors `ValidateCrossRefs`, which already solves the same problem in two passes.

## Test plan

- [x] `go test ./... -race` (covered by CI)
- [x] Existing dispatch-validation tests cover both positive and error paths