### PR TITLE
refactor(ai): extract hasBackendPrefix to deduplicate backend predicates

### DIFF
--- a/internal/ai/cmdrunner.go
+++ b/internal/ai/cmdrunner.go
@@ -236,16 +236,16 @@ func (r *CommandRunner) buildDelivery(req Request) (args []string, stdin string)
 	return nil, truncateString(combineSystemUser(req.System, req.User), r.maxPromptChars)
 }
 
-func (r *CommandRunner) isClaudeBackend() bool {
-	name := strings.ToLower(strings.TrimSpace(r.backendName))
-	cmd := strings.ToLower(filepath.Base(strings.TrimSpace(r.command)))
-	return strings.HasPrefix(name, "claude") || strings.HasPrefix(cmd, "claude")
-}
+func (r *CommandRunner) isClaudeBackend() bool { return r.hasBackendPrefix("claude") }
+func (r *CommandRunner) isCodexBackend() bool  { return r.hasBackendPrefix("codex") }
 
-func (r *CommandRunner) isCodexBackend() bool {
+// hasBackendPrefix reports whether the backend name or command basename starts
+// with prefix (case-insensitive). Centralises the name/command normalisation
+// so each new backend type only needs a one-liner predicate.
+func (r *CommandRunner) hasBackendPrefix(prefix string) bool {
 	name := strings.ToLower(strings.TrimSpace(r.backendName))
 	cmd := strings.ToLower(filepath.Base(strings.TrimSpace(r.command)))
-	return strings.HasPrefix(name, "codex") || strings.HasPrefix(cmd, "codex")
+	return strings.HasPrefix(name, prefix) || strings.HasPrefix(cmd, prefix)
 }
 
 // buildClaudeDelivery builds hardcoded Claude CLI args and delivers system

--- a/internal/ai/cmdrunner_test.go
+++ b/internal/ai/cmdrunner_test.go
@@ -835,3 +835,38 @@ func TestExtractToolResultText(t *testing.T) {
 		})
 	}
 }
+
+func TestHasBackendPrefix(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		beName  string
+		command string
+		prefix  string
+		want    bool
+	}{
+		{name: "exact name match", beName: "claude", command: "", prefix: "claude", want: true},
+		{name: "name with spaces", beName: "  claude-prod  ", command: "", prefix: "claude", want: true},
+		{name: "name uppercase", beName: "Claude", command: "", prefix: "claude", want: true},
+		{name: "command basename match", beName: "", command: "/usr/local/bin/claude", prefix: "claude", want: true},
+		{name: "command basename uppercase", beName: "", command: "/usr/bin/Claude", prefix: "claude", want: true},
+		{name: "command with spaces", beName: "", command: "  /usr/bin/claude  ", prefix: "claude", want: true},
+		{name: "no match", beName: "openai", command: "/usr/bin/gpt", prefix: "claude", want: false},
+		{name: "codex via name", beName: "codex-fast", command: "", prefix: "codex", want: true},
+		{name: "codex via command", beName: "", command: "/opt/bin/codex", prefix: "codex", want: true},
+		{name: "empty name and command", beName: "", command: "", prefix: "claude", want: false},
+		{name: "substring only — not a prefix", beName: "anthropic-claude", command: "/usr/bin/gpt", prefix: "claude", want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r := &CommandRunner{backendName: tc.beName, command: tc.command}
+			if got := r.hasBackendPrefix(tc.prefix); got != tc.want {
+				t.Errorf("hasBackendPrefix(%q) with name=%q command=%q = %v, want %v",
+					tc.prefix, tc.beName, tc.command, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why

`isClaudeBackend` and `isCodexBackend` contained the same 3-line normalization block (name `ToLower`+`TrimSpace`, command `Base`+`ToLower`) and differed only in the prefix string checked. The duplication meant that a change to the normalization strategy (e.g. dropping the command check, or switching to `strings.EqualFold`) would need to be applied in two places.

## What

Extract a private `hasBackendPrefix(prefix string) bool` helper that holds the shared logic once. The two predicate methods become one-liners:

```go
func (r *CommandRunner) isClaudeBackend() bool { return r.hasBackendPrefix("claude") }
func (r *CommandRunner) isCodexBackend() bool  { return r.hasBackendPrefix("codex") }
```

No behavior change. Existing `buildDelivery` tests cover both predicates indirectly.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)