### PR TITLE
refactor(mcp): replace collect-then-sort with slices.Sorted(maps.Keys(...))

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -3,7 +3,6 @@ package mcp
 import (
 	"encoding/json"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
@@ -424,8 +423,6 @@ func nilSafe(xs []string) []string {
 	}
 	return xs
 }
-
-func sortStrings(xs []string) { sort.Strings(xs) }
 
 // trimmedString reads a required string argument, trims whitespace, and
 // returns (value, true) only if the caller supplied a non-empty value.

--- a/internal/mcp/tools_fleet.go
+++ b/internal/mcp/tools_fleet.go
@@ -2,6 +2,8 @@ package mcp
 
 import (
 	"context"
+	"maps"
+	"slices"
 	"strings"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
@@ -58,12 +60,8 @@ func toolListSkills(deps Deps) server.ToolHandlerFunc {
 		if err != nil {
 			return mcpgo.NewToolResultErrorFromErr("list skills", err), nil
 		}
-		names := make([]string, 0, len(skills))
-		for n := range skills {
-			names = append(names, n)
-		}
-		sortStrings(names)
-		out := make([]map[string]any, 0, len(skills))
+		names := slices.Sorted(maps.Keys(skills))
+		out := make([]map[string]any, 0, len(names))
 		for _, n := range names {
 			s := skills[n]
 			out = append(out, map[string]any{
@@ -106,11 +104,7 @@ func toolListBackends(deps Deps) server.ToolHandlerFunc {
 		if err != nil {
 			return mcpgo.NewToolResultErrorFromErr("list backends", err), nil
 		}
-		names := make([]string, 0, len(backends))
-		for n := range backends {
-			names = append(names, n)
-		}
-		sortStrings(names)
+		names := slices.Sorted(maps.Keys(backends))
 		out := make([]map[string]any, 0, len(names))
 		for _, n := range names {
 			out = append(out, backendJSON(n, backends[n]))

--- a/internal/mcp/tools_observe.go
+++ b/internal/mcp/tools_observe.go
@@ -2,6 +2,8 @@ package mcp
 
 import (
 	"context"
+	"maps"
+	"slices"
 	"time"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
@@ -124,11 +126,7 @@ func toolGetGraph(deps Deps) server.ToolHandlerFunc {
 			seen[e.From] = struct{}{}
 			seen[e.To] = struct{}{}
 		}
-		names := make([]string, 0, len(seen))
-		for name := range seen {
-			names = append(names, name)
-		}
-		sortStrings(names)
+		names := slices.Sorted(maps.Keys(seen))
 		nodes := make([]mcpGraphNode, 0, len(names))
 		for _, name := range names {
 			nodes = append(nodes, mcpGraphNode{ID: name})


### PR DESCRIPTION
## Why

Three handlers in `internal/mcp/tools.go` used a 4-line pattern to collect map keys into a slice and then sort them:

\`\`\`go
names := make([]string, 0, len(m))
for n := range m {
    names = append(names, n)
}
sortStrings(names)
\`\`\`

The codebase already uses the idiomatic one-liner in `config.go` (`slices.Sorted(maps.Keys(m))`). This PR applies the same idiom to all three callsites in `tools.go`, removes the `sortStrings` one-liner wrapper (which was an unnecessary abstraction over `sort.Strings`), and drops the now-unused `"sort"` import.

No behaviour change.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)