### PR TITLE
refactor(mcp): use repoJSON helper in list/get repo tools

### DIFF
--- a/internal/mcp/tools_fleet.go
+++ b/internal/mcp/tools_fleet.go
@@ -142,15 +142,7 @@ func toolListRepos(deps Deps) server.ToolHandlerFunc {
 		}
 		out := make([]map[string]any, 0, len(repos))
 		for _, r := range repos {
-			bindings := make([]map[string]any, 0, len(r.Use))
-			for _, b := range r.Use {
-				bindings = append(bindings, bindingJSON(b))
-			}
-			out = append(out, map[string]any{
-				"name":     r.Name,
-				"enabled":  r.Enabled,
-				"bindings": bindings,
-			})
+			out = append(out, repoJSON(r))
 		}
 		return jsonResult(out)
 	}
@@ -171,15 +163,7 @@ func toolGetRepo(deps Deps) server.ToolHandlerFunc {
 		key := config.NormalizeRepoName(name)
 		for _, r := range repos {
 			if r.Name == key {
-				bindings := make([]map[string]any, 0, len(r.Use))
-				for _, b := range r.Use {
-					bindings = append(bindings, bindingJSON(b))
-				}
-				return jsonResult(map[string]any{
-					"name":     r.Name,
-					"enabled":  r.Enabled,
-					"bindings": bindings,
-				})
+				return jsonResult(repoJSON(r))
 			}
 		}
 		return mcpgo.NewToolResultErrorf("repo %q not found", name), nil


### PR DESCRIPTION
## Summary

`repoJSON` already exists in `tools_crud.go` to serialise a `config.RepoDef` into the `{name, enabled, bindings}` wire shape used by `create_repo`. But `toolListRepos` and `toolGetRepo` in `tools_fleet.go` duplicate the same binding-expansion loop inline instead of calling it.

This PR removes the duplication: both functions now delegate to `repoJSON`, so all three repo-serialisation paths (list, get, create) share a single implementation. No behaviour change — the output shape is identical.

## Test plan

- [ ] CI `go test ./... -race` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)