### PR TITLE
refactor(mcp): use boolPtrArg for enabled in binding tools

### DIFF
--- a/internal/mcp/tools_crud.go
+++ b/internal/mcp/tools_crud.go
@@ -384,12 +384,10 @@ func toolCreateBinding(deps Deps) server.ToolHandlerFunc {
 			Events: req.GetStringSlice("events", nil),
 			Cron:   req.GetString("cron", ""),
 		}
-		if v, ok := req.GetArguments()["enabled"]; ok && v != nil {
-			enabled, ok := v.(bool)
-			if !ok {
-				return mcpgo.NewToolResultError("enabled must be a boolean"), nil
-			}
-			b.Enabled = &enabled
+		if v, ok, errMsg := boolPtrArg(req.GetArguments(), "enabled"); ok {
+			b.Enabled = v
+		} else if errMsg != "" {
+			return mcpgo.NewToolResultError(errMsg), nil
 		}
 		persisted, err := deps.BindingWrite.CreateBinding(repo, b)
 		if err != nil {
@@ -426,12 +424,10 @@ func toolUpdateBinding(deps Deps) server.ToolHandlerFunc {
 			Events: req.GetStringSlice("events", nil),
 			Cron:   req.GetString("cron", ""),
 		}
-		if v, ok := req.GetArguments()["enabled"]; ok && v != nil {
-			enabled, ok := v.(bool)
-			if !ok {
-				return mcpgo.NewToolResultError("enabled must be a boolean"), nil
-			}
-			b.Enabled = &enabled
+		if v, ok, errMsg := boolPtrArg(req.GetArguments(), "enabled"); ok {
+			b.Enabled = v
+		} else if errMsg != "" {
+			return mcpgo.NewToolResultError(errMsg), nil
 		}
 		updated, uerr := deps.BindingWrite.UpdateBinding(repo, int64(id), b)
 		if uerr != nil {


### PR DESCRIPTION
## Summary

`toolCreateBinding` and `toolUpdateBinding` expanded the optional `enabled` field inline with a 5-line type-assertion block each, while every other optional-bool field across the MCP tools (`allow_prs`, `allow_dispatch`, `healthy`) uses `boolPtrArg`. This inconsistency means the same logic exists twice in diverging form.

Both binding tools now use `boolPtrArg`, matching the pattern already established in `toolUpdateAgent` and `toolUpdateBackend`. No behaviour change — `boolPtrArg` produces the same `(*bool, present, errMsg)` semantics.

## Test plan

- [ ] CI `go test ./... -race` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)