### PR TITLE
docs: add missing internal packages to code maps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Agents can also invoke each other at runtime via the **reactive inter-agent disp
 Key numbers:
 - Language: **Go 1.25** (check `go.mod`).
 - Binary entrypoint: `cmd/agents/main.go`.
-- Single-binary deployment; no required runtime dependencies beyond the AI CLI and `gh`.
+- Single-binary deployment; no required runtime dependencies beyond the AI CLIs (GitHub access flows through the GitHub MCP server configured on each AI CLI).
 
 ## Quick commands
 
@@ -35,9 +35,12 @@ internal/
   anthropic_proxy/              # built-in Anthropic Messages ↔ OpenAI Chat Completions translation
   observe/                      # observability store: events, traces, dispatch graph, SSE hubs
   autonomous/                   # cron scheduler + agent memory (SQLite-backed)
+  backends/                     # backend discovery: CLI probing, GitHub MCP health checks, orphan detection
   store/                        # SQLite-backed config store: Open, Import, Load, CRUD
   workflow/                     # event routing engine (single event queue), processor, dispatcher
+  server/                       # shared HTTP server types (cross-cutting interfaces, error sentinels)
   webhook/                      # HTTP server, HMAC signature verification, delivery dedupe, CRUD API handlers
+  mcp/                          # MCP server exposing fleet-management tools at /mcp
   ui/                           # embedded Next.js web dashboard (static assets served at /ui/)
   setup/                        # interactive first-time setup command
   logging/                      # zerolog configuration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,10 @@ internal/
   anthropic_proxy/          # Built-in Anthropic↔OpenAI Chat Completions translation proxy
   observe/                  # Observability store: events, traces, dispatch graph, SSE hubs
   autonomous/               # Cron scheduler + agent memory (SQLite-backed)
+  backends/                 # Backend discovery: CLI probing, GitHub MCP health checks, orphan detection
   store/                    # SQLite-backed config store: Open, Import, Load, CRUD
   workflow/                 # Event routing engine, single event queue, processor, dispatcher
+  server/                   # Shared HTTP server types (cross-cutting interfaces, error sentinels)
   webhook/                  # HTTP server, HMAC verification, delivery dedupe, CRUD API handlers
   ui/                       # Embedded Next.js web dashboard (served at /ui/)
   setup/                    # Interactive first-time setup command

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,9 +19,9 @@ internal/
   workflow/                 # Event routing engine, single event queue, processor, dispatcher
   server/                   # Shared HTTP server types (cross-cutting interfaces, error sentinels)
   webhook/                  # HTTP server, HMAC verification, delivery dedupe, CRUD API handlers
+  mcp/                      # MCP server exposing fleet-management tools at /mcp
   ui/                       # Embedded Next.js web dashboard (served at /ui/)
   setup/                    # Interactive first-time setup command
-  mcp/                      # MCP (Model Context Protocol) server exposing fleet tools at /mcp
   logging/                  # zerolog setup
 docs/                       # Long-form docs: configuration, events, dispatch, API, docker, local-models, security
 ```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Define your agents once. Wire them to repos with labels, cron schedules, or even
 
 - **Self-hosted, no SaaS** -- your code and prompts stay on your infrastructure.
 - **Multi-backend** -- Claude, Codex, and named local backends. Mix backends per agent.
-- **Discovery + diagnostics** -- daemon detects backend/tools, validates CLI health (`gh`, MCP connectivity, models), and persists discovery snapshots.
+- **Discovery + diagnostics** -- daemon detects backend/tools, validates CLI health (MCP connectivity, models), and persists discovery snapshots.
 - **Local model support** -- built-in Anthropic-to-OpenAI translation proxy routes the fleet through `llama.cpp`, Ollama, vLLM, or any OpenAI-compatible endpoint. Zero vendor lock-in.
 - **One agent model, many triggers** -- label events, cron schedules, GitHub event subscriptions, on-demand API calls. Same agent, wired however you want.
 - **Composable skills** -- reusable guidance blocks (architecture, security, testing, DX, ...) merged into any agent.
@@ -188,9 +188,12 @@ internal/
   anthropic_proxy/          # Built-in Anthropic-to-OpenAI translation proxy (opt-in)
   observe/                  # Observability store (events, traces, dispatch graph, SSE hubs)
   autonomous/               # Cron scheduler + agent memory (SQLite-backed)
+  backends/                 # Backend discovery: CLI probing, GitHub MCP health checks, orphan detection
   store/                    # SQLite-backed config store: schema migrations, CRUD helpers
   workflow/                 # Event routing engine, single event queue, processor, inter-agent dispatcher
+  server/                   # Shared HTTP server types (cross-cutting interfaces, error sentinels)
   webhook/                  # HTTP server, signature verification, delivery dedupe, CRUD API handlers
+  mcp/                      # MCP server exposing fleet-management tools at /mcp
   ui/                       # Embedded Next.js web dashboard (served at /ui/)
   setup/                    # Interactive first-time setup command
   logging/                  # zerolog setup


### PR DESCRIPTION
## Summary

Three packages existed in `internal/` but were absent from all code maps (README, CLAUDE.md, AGENTS.md):

- `internal/backends/` — backend discovery: CLI probing, GitHub MCP health checks, orphan detection
- `internal/server/` — shared cross-cutting HTTP server types, extracted from `internal/webhook/` in #276
- `internal/mcp/` — MCP server introduced in the #227 chain

Also drops two stale `gh` references that survived the #249 cleanup (commit `0bb233d`):

- README Features: "validates CLI health (`gh`, MCP connectivity, models)" → removes the `` `gh` `` entry since the gh CLI health check was removed
- AGENTS.md Key numbers: "beyond the AI CLI and `gh`" → "beyond the AI CLIs (GitHub access flows through the GitHub MCP server configured on each AI CLI)"

No behavior change; docs only.

## Test plan

- [ ] Verify `internal/backends/`, `internal/server/`, `internal/mcp/` directories exist at the paths described
- [ ] Grep for any remaining stale `gh` CLI references in docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)