### PR TITLE
refactor(mcp): fix misplaced doc comment on toolGetBinding

### DIFF
--- a/internal/mcp/tools_crud.go
+++ b/internal/mcp/tools_crud.go
@@ -441,8 +441,8 @@ func toolUpdateBinding(deps Deps) server.ToolHandlerFunc {
 	}
 }
 
-// toolDeleteBinding removes a binding by ID through the same path as DELETE
-// /repos/{owner}/{repo}/bindings/{id}.
+// toolGetBinding fetches one binding by ID, verifying it belongs to the given
+// repo. Same path as GET /repos/{owner}/{repo}/bindings/{id}.
 func toolGetBinding(deps Deps) server.ToolHandlerFunc {
 	return func(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 		id, err := req.RequireInt("id")
@@ -464,6 +464,8 @@ func toolGetBinding(deps Deps) server.ToolHandlerFunc {
 	}
 }
 
+// toolDeleteBinding removes a binding by ID through the same path as DELETE
+// /repos/{owner}/{repo}/bindings/{id}.
 func toolDeleteBinding(deps Deps) server.ToolHandlerFunc {
 	return func(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 		id, err := req.RequireInt("id")


### PR DESCRIPTION
## Summary

In `tools_crud.go` the `// toolDeleteBinding removes...` doc comment was attached to `toolGetBinding` — leaving `toolGetBinding` with no doc comment of its own and the wrong function identity, while `toolDeleteBinding` had no comment at all.

The fix moves each comment to its correct function:

- `toolGetBinding` now carries `// toolGetBinding fetches one binding by ID, verifying it belongs to the given repo...`
- `toolDeleteBinding` now carries `// toolDeleteBinding removes a binding by ID through the same path as DELETE /repos/{owner}/{repo}/bindings/{id}.`

No behaviour change — comment-only edit.

## Test plan

- [ ] CI `go test ./... -race` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)