### PR TITLE
refactor(store): extract validateFleetConstraints from ImportAll and ReplaceAll

### DIFF
--- a/internal/store/crud.go
+++ b/internal/store/crud.go
@@ -97,7 +97,27 @@ func requireAtLeastOne(q querier, countQuery, entity, zeroMsg string) error {
 	return nil
 }
 
-// ──── Agents ─────────────────────────────────────────────────────────────────
+// validateFleetConstraints runs all post-write invariant checks shared by
+// ImportAll and ReplaceAll: entity cross-references, minimum cardinality, and
+// cron-expression parseability. op ("import" or "replace") is used verbatim in
+// error messages.
+func validateFleetConstraints(q querier, op string, repos []config.RepoDef) error {
+	if err := validateFleet(q); err != nil {
+		return &ErrValidation{Msg: fmt.Sprintf("store: %s: %v", op, err)}
+	}
+	if err := requireAtLeastOne(q, "SELECT COUNT(*) FROM agents", "agents", "config: at least one agent is required"); err != nil {
+		return &ErrValidation{Msg: fmt.Sprintf("store: %s: %v", op, err)}
+	}
+	if err := requireAtLeastOne(q, "SELECT COUNT(*) FROM backends", "backends", "config: at least one ai_backends entry is required"); err != nil {
+		return &ErrValidation{Msg: fmt.Sprintf("store: %s: %v", op, err)}
+	}
+	if err := requireAtLeastOne(q, "SELECT COUNT(*) FROM repos WHERE enabled=1", "enabled repos", "config: at least one repo must be enabled"); err != nil {
+		return &ErrValidation{Msg: fmt.Sprintf("store: %s: %v", op, err)}
+	}
+	return validateCronExpressions(repos)
+}
+
+// ──── Agents ────────────────────────────────────────────────────────────────────────────────
 
 // ReadAgents returns all agents from the database, ordered by name.
 func ReadAgents(db *sql.DB) ([]config.AgentDef, error) {
@@ -205,7 +225,7 @@ func countDistinctRepos(repos []string) int {
 	return len(seen)
 }
 
-// ──── Skills ─────────────────────────────────────────────────────────────────
+// ──── Skills ─────────────────────────────────────────────────────────────────────────────
 
 // ReadSkills returns all skills from the database.
 func ReadSkills(db *sql.DB) (map[string]config.SkillDef, error) {
@@ -258,7 +278,7 @@ func DeleteSkill(db *sql.DB, name string) error {
 	return tx.Commit()
 }
 
-// ──── Backends ───────────────────────────────────────────────────────────────
+// ──── Backends ───────────────────────────────────────────────────────────────────────────
 
 // ReadBackends returns all AI backend configurations from the database.
 func ReadBackends(db *sql.DB) (map[string]config.AIBackendConfig, error) {
@@ -354,7 +374,7 @@ func ReadSnapshot(db *sql.DB) ([]config.AgentDef, []config.RepoDef, map[string]c
 	return cfg.Agents, cfg.Repos, cfg.Skills, cfg.Daemon.AIBackends, nil
 }
 
-// ──── Repos ──────────────────────────────────────────────────────────────────
+// ──── Repos ──────────────────────────────────────────────────────────────────────────────
 
 // ReadRepos returns all repos (with bindings) from the database.
 func ReadRepos(db *sql.DB) ([]config.RepoDef, error) {
@@ -445,19 +465,7 @@ func ImportAll(
 	if err := importBackends(tx, normalizedBackends); err != nil {
 		return err
 	}
-	if err := validateFleet(tx); err != nil {
-		return &ErrValidation{Msg: fmt.Sprintf("store: import: %v", err)}
-	}
-	if err := requireAtLeastOne(tx, "SELECT COUNT(*) FROM agents", "agents", "config: at least one agent is required"); err != nil {
-		return &ErrValidation{Msg: fmt.Sprintf("store: import: %v", err)}
-	}
-	if err := requireAtLeastOne(tx, "SELECT COUNT(*) FROM backends", "backends", "config: at least one ai_backends entry is required"); err != nil {
-		return &ErrValidation{Msg: fmt.Sprintf("store: import: %v", err)}
-	}
-	if err := requireAtLeastOne(tx, "SELECT COUNT(*) FROM repos WHERE enabled=1", "enabled repos", "config: at least one repo must be enabled"); err != nil {
-		return &ErrValidation{Msg: fmt.Sprintf("store: import: %v", err)}
-	}
-	if err := validateCronExpressions(repos); err != nil {
+	if err := validateFleetConstraints(tx, "import", repos); err != nil {
 		return err
 	}
 	return tx.Commit()
@@ -502,25 +510,13 @@ func ReplaceAll(
 	if err := importBackends(tx, normalizedBackends); err != nil {
 		return err
 	}
-	if err := validateFleet(tx); err != nil {
-		return &ErrValidation{Msg: fmt.Sprintf("store: replace: %v", err)}
-	}
-	if err := requireAtLeastOne(tx, "SELECT COUNT(*) FROM agents", "agents", "config: at least one agent is required"); err != nil {
-		return &ErrValidation{Msg: fmt.Sprintf("store: replace: %v", err)}
-	}
-	if err := requireAtLeastOne(tx, "SELECT COUNT(*) FROM backends", "backends", "config: at least one ai_backends entry is required"); err != nil {
-		return &ErrValidation{Msg: fmt.Sprintf("store: replace: %v", err)}
-	}
-	if err := requireAtLeastOne(tx, "SELECT COUNT(*) FROM repos WHERE enabled=1", "enabled repos", "config: at least one repo must be enabled"); err != nil {
-		return &ErrValidation{Msg: fmt.Sprintf("store: replace: %v", err)}
-	}
-	if err := validateCronExpressions(repos); err != nil {
+	if err := validateFleetConstraints(tx, "replace", repos); err != nil {
 		return err
 	}
 	return tx.Commit()
 }
 
-// ──── Bindings (atomic per-item CRUD) ────────────────────────────────────────
+// ──── Bindings (atomic per-item CRUD) ────────────────────────────────────────────
 
 // validateBindingShape checks the trigger-exclusivity and event-kind invariants
 // for a single binding, without requiring a full repo context. Returns an


### PR DESCRIPTION
## Summary

`ImportAll` and `ReplaceAll` each close with an identical 20-line validation block:

```go
if err := validateFleet(tx); err != nil {
    return &ErrValidation{Msg: fmt.Sprintf("store: import: %v", err)}
}
if err := requireAtLeastOne(tx, "SELECT COUNT(*) FROM agents", "agents", "config: at least one agent is required"); err != nil {
    return &ErrValidation{Msg: fmt.Sprintf("store: import: %v", err)}
}
if err := requireAtLeastOne(tx, "SELECT COUNT(*) FROM backends", "backends", "config: at least one ai_backends entry is required"); err != nil {
    return &ErrValidation{Msg: fmt.Sprintf("store: import: %v", err)}
}
if err := requireAtLeastOne(tx, "SELECT COUNT(*) FROM repos WHERE enabled=1", "enabled repos", "config: at least one repo must be enabled"); err != nil {
    return &ErrValidation{Msg: fmt.Sprintf("store: import: %v", err)}
}
if err := validateCronExpressions(repos); err != nil {
    return err
}
```

The only difference between the two copies is `"import"` vs `"replace"` in the error prefix. Extract into `validateFleetConstraints(q querier, op string, repos []config.RepoDef) error` so each function calls one helper instead of repeating the same five checks.

- No behaviour change — the helper is a mechanical extraction of the shared block.
- Return convention matches the surrounding helpers: non-nil error on the first failing check.