### PR TITLE
fix(mcp): accept JSON-stringified array args at the tool boundary

### DIFF
--- a/internal/mcp/tools_arrays_test.go
+++ b/internal/mcp/tools_arrays_test.go
@@ -30,6 +30,7 @@ func TestStringSliceArgAcceptsShapes(t *testing.T) {
 		{"native []string", []string{"x"}, []string{"x"}, ""},
 		{"JSON-encoded array string", `["a","b"]`, []string{"a", "b"}, ""},
 		{"JSON-encoded empty array", `[]`, []string{}, ""},
+		{"JSON-encoded null decodes as nil slice", `null`, nil, ""},
 		{"JSON-encoded array with spaces", `[ "a" , "b" ]`, []string{"a", "b"}, ""},
 		{"non-array string is rejected", "ready", nil, "skills must be an array of strings"},
 		{"empty string is rejected", "", nil, "skills must be an array of strings"},
@@ -81,6 +82,7 @@ func TestStringSlicePtrArgAcceptsJSONString(t *testing.T) {
 		{"native array → ptr to slice", map[string]any{"skills": []any{"a"}}, true, 1, ""},
 		{"JSON-string array → ptr to slice", map[string]any{"skills": `["a","b"]`}, true, 2, ""},
 		{"JSON-string empty array → ptr to empty", map[string]any{"skills": `[]`}, true, 0, ""},
+		{"JSON-string null → ptr to nil slice (explicit clear)", map[string]any{"skills": `null`}, true, 0, ""},
 		{"bad shape → error", map[string]any{"skills": "ready"}, false, 0, "skills must be an array of strings"},
 	}
 
@@ -109,6 +111,53 @@ func TestStringSlicePtrArgAcceptsJSONString(t *testing.T) {
 			}
 			if got := len(*ptr); got != tc.wantLen {
 				t.Fatalf("len = %d, want %d", got, tc.wantLen)
+			}
+		})
+	}
+}
+
+// TestArrayOfAnyAcceptsShapes pins the shape contract for the helper that
+// decodes nested-object tool arguments (e.g. create_repo's "bindings"
+// payload). Mirrors TestStringSliceArgAcceptsShapes: native []any, JSON-
+// encoded array strings, and JSON-encoded null all succeed; non-array
+// inputs surface a clear "must be an array" error that names the field.
+func TestArrayOfAnyAcceptsShapes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		in      any
+		wantLen int
+		wantNil bool
+		wantErr string
+	}{
+		{"native []any passthrough", []any{map[string]any{"agent": "coder"}}, 1, false, ""},
+		{"native empty []any", []any{}, 0, false, ""},
+		{"JSON-encoded array of objects", `[{"agent":"coder"}]`, 1, false, ""},
+		{"JSON-encoded empty array", `[]`, 0, false, ""},
+		{"JSON-encoded null decodes as nil slice", `null`, 0, true, ""},
+		{"nil falls through to error", nil, 0, true, "bindings must be an array"},
+		{"non-array string rejected", "not-an-array", 0, true, "bindings must be an array"},
+		{"JSON-encoded number rejected", `123`, 0, true, "bindings must be an array"},
+		{"wrong scalar type rejected", 42, 0, true, "bindings must be an array"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, errMsg := arrayOfAny(tc.in, "bindings")
+			if errMsg != tc.wantErr {
+				t.Fatalf("err = %q, want %q", errMsg, tc.wantErr)
+			}
+			if tc.wantErr != "" {
+				return
+			}
+			if tc.wantNil && got != nil {
+				t.Fatalf("got = %v, want nil", got)
+			}
+			if len(got) != tc.wantLen {
+				t.Fatalf("len = %d, want %d", len(got), tc.wantLen)
 			}
 		})
 	}

--- a/internal/mcp/tools_arrays_test.go
+++ b/internal/mcp/tools_arrays_test.go
@@ -1,0 +1,348 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/rs/zerolog"
+
+	"github.com/eloylp/agents/internal/config"
+)
+
+// TestStringSliceArgAcceptsShapes pins the shape contract for the
+// transport-permissive helper introduced for issue #278: native []any,
+// native []string, and JSON-encoded array strings all decode the same way,
+// while bogus inputs produce a clear "must be an array of strings" error
+// that names the offending field.
+func TestStringSliceArgAcceptsShapes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		in      any
+		want    []string
+		wantErr string
+	}{
+		{"nil yields nil with no error", nil, nil, ""},
+		{"native []any of strings", []any{"a", "b"}, []string{"a", "b"}, ""},
+		{"native []string", []string{"x"}, []string{"x"}, ""},
+		{"JSON-encoded array string", `["a","b"]`, []string{"a", "b"}, ""},
+		{"JSON-encoded empty array", `[]`, []string{}, ""},
+		{"JSON-encoded array with spaces", `[ "a" , "b" ]`, []string{"a", "b"}, ""},
+		{"non-array string is rejected", "ready", nil, "skills must be an array of strings"},
+		{"empty string is rejected", "", nil, "skills must be an array of strings"},
+		{"wrong scalar type is rejected", 42, nil, "skills must be an array of strings"},
+		{"wrong element type points at index", []any{"a", 2}, nil, "skills[1] must be a string"},
+		{"JSON-encoded number rejected", `123`, nil, "skills must be an array of strings"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, errMsg := stringSliceArg(tc.in, "skills")
+			if errMsg != tc.wantErr {
+				t.Fatalf("err = %q, want %q", errMsg, tc.wantErr)
+			}
+			if tc.wantErr != "" {
+				return
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("len = %d, want %d (got=%v)", len(got), len(tc.want), got)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestStringSlicePtrArgAcceptsJSONString pins that PATCH-style helpers also
+// accept JSON-encoded array strings. The pointer return distinguishes
+// "absent" (preserve) from "explicit empty" (clear); both shapes must reach
+// the same outcome regardless of whether the client sent a native array or
+// a stringified one.
+func TestStringSlicePtrArgAcceptsJSONString(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		args    map[string]any
+		wantPtr bool
+		wantLen int
+		wantErr string
+	}{
+		{"absent → nil ptr, no error", map[string]any{}, false, 0, ""},
+		{"null → nil ptr, no error", map[string]any{"skills": nil}, false, 0, ""},
+		{"native array → ptr to slice", map[string]any{"skills": []any{"a"}}, true, 1, ""},
+		{"JSON-string array → ptr to slice", map[string]any{"skills": `["a","b"]`}, true, 2, ""},
+		{"JSON-string empty array → ptr to empty", map[string]any{"skills": `[]`}, true, 0, ""},
+		{"bad shape → error", map[string]any{"skills": "ready"}, false, 0, "skills must be an array of strings"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ptr, ok, errMsg := stringSlicePtrArg(tc.args, "skills")
+			if errMsg != tc.wantErr {
+				t.Fatalf("err = %q, want %q", errMsg, tc.wantErr)
+			}
+			if tc.wantErr != "" {
+				return
+			}
+			if ok != tc.wantPtr {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantPtr)
+			}
+			if !tc.wantPtr {
+				if ptr != nil {
+					t.Fatalf("ptr = %v, want nil", *ptr)
+				}
+				return
+			}
+			if ptr == nil {
+				t.Fatal("ptr = nil, want non-nil")
+			}
+			if got := len(*ptr); got != tc.wantLen {
+				t.Fatalf("len = %d, want %d", got, tc.wantLen)
+			}
+		})
+	}
+}
+
+// TestToolUpdateAgentAcceptsJSONStringSkills is the regression test for the
+// issue's primary repro: an MCP client that delivers `skills` as a
+// JSON-encoded string must not be rejected with "skills must be an array of
+// strings". The decoded slice must reach the writer with the expected
+// elements so the patch lands as the caller intended.
+func TestToolUpdateAgentAcceptsJSONStringSkills(t *testing.T) {
+	t.Parallel()
+	canonical := config.AgentDef{Name: "coder", Backend: "codex", Prompt: "p"}
+	w := &stubAgentWriter{patchCanonical: canonical}
+	deps := Deps{
+		DB: testDB(t), Config: stubConfig{cfg: fixtureConfig()},
+		Queue: &stubQueue{}, Status: stubStatus{},
+		AgentWrite: w, Logger: zerolog.Nop(),
+	}
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"name":         "coder",
+		"skills":       `["architect","go-testing"]`,
+		"can_dispatch": `["pr-reviewer"]`,
+	}
+	res, err := toolUpdateAgent(deps)(context.Background(), req)
+	if err != nil || res.IsError {
+		t.Fatalf("update_agent failed: err=%v body=%s", err, textOf(t, res))
+	}
+	if w.gotPatch.Skills == nil || len(*w.gotPatch.Skills) != 2 {
+		t.Fatalf("skills patch not forwarded: %+v", w.gotPatch.Skills)
+	}
+	if (*w.gotPatch.Skills)[0] != "architect" || (*w.gotPatch.Skills)[1] != "go-testing" {
+		t.Errorf("skills contents wrong: %+v", *w.gotPatch.Skills)
+	}
+	if w.gotPatch.CanDispatch == nil || len(*w.gotPatch.CanDispatch) != 1 ||
+		(*w.gotPatch.CanDispatch)[0] != "pr-reviewer" {
+		t.Errorf("can_dispatch patch not forwarded: %+v", w.gotPatch.CanDispatch)
+	}
+}
+
+// TestToolUpdateBackendAcceptsJSONStringModels mirrors the agent test for
+// the backend tool — same transport bug, same fix, different field. Pins
+// that the relief is uniform across the CRUD surface.
+func TestToolUpdateBackendAcceptsJSONStringModels(t *testing.T) {
+	t.Parallel()
+	w := &stubBackendWriter{
+		patchCanonicalName:   "claude",
+		patchCanonicalConfig: config.AIBackendConfig{Command: "/bin/claude"},
+	}
+	deps := Deps{
+		DB: testDB(t), Config: stubConfig{cfg: fixtureConfig()},
+		Queue: &stubQueue{}, Status: stubStatus{},
+		BackendWrite: w, Logger: zerolog.Nop(),
+	}
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"name":   "claude",
+		"models": `["opus","sonnet"]`,
+	}
+	res, err := toolUpdateBackend(deps)(context.Background(), req)
+	if err != nil || res.IsError {
+		t.Fatalf("update_backend failed: err=%v body=%s", err, textOf(t, res))
+	}
+	if w.gotPatch.Models == nil || len(*w.gotPatch.Models) != 2 {
+		t.Fatalf("models patch not forwarded: %+v", w.gotPatch.Models)
+	}
+	if (*w.gotPatch.Models)[0] != "opus" || (*w.gotPatch.Models)[1] != "sonnet" {
+		t.Errorf("models contents wrong: %+v", *w.gotPatch.Models)
+	}
+}
+
+// TestToolCreateAgentAcceptsJSONStringSlices pins that POST-style handlers
+// also accept JSON-encoded arrays. Today these go through req.GetStringSlice
+// which silently drops bad shapes; the issue's acceptance criterion is that
+// the same JSON-string relief applies across CRUD tools.
+func TestToolCreateAgentAcceptsJSONStringSlices(t *testing.T) {
+	t.Parallel()
+	canonical := config.AgentDef{Name: "linter", Backend: "claude", Skills: []string{"security"}}
+	w := &stubAgentWriter{canonical: canonical}
+	deps := Deps{
+		DB: testDB(t), Config: stubConfig{cfg: fixtureConfig()},
+		Queue: &stubQueue{}, Status: stubStatus{},
+		AgentWrite: w, Logger: zerolog.Nop(),
+	}
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"name":         "linter",
+		"backend":      "claude",
+		"skills":       `["security","compliance"]`,
+		"can_dispatch": `["coder"]`,
+	}
+	res, err := toolCreateAgent(deps)(context.Background(), req)
+	if err != nil || res.IsError {
+		t.Fatalf("create_agent failed: err=%v body=%s", err, textOf(t, res))
+	}
+	if len(w.gotUpsert.Skills) != 2 ||
+		w.gotUpsert.Skills[0] != "security" || w.gotUpsert.Skills[1] != "compliance" {
+		t.Errorf("skills not forwarded from JSON-string: %+v", w.gotUpsert.Skills)
+	}
+	if len(w.gotUpsert.CanDispatch) != 1 || w.gotUpsert.CanDispatch[0] != "coder" {
+		t.Errorf("can_dispatch not forwarded from JSON-string: %+v", w.gotUpsert.CanDispatch)
+	}
+}
+
+// TestToolCreateBindingAcceptsJSONStringSlices pins that labels/events on
+// create_binding also flow through the JSON-string path. The binding tools
+// are the highest-traffic surface for parallel MCP calls (the original
+// repro), so the relief must reach them too.
+func TestToolCreateBindingAcceptsJSONStringSlices(t *testing.T) {
+	t.Parallel()
+	w := &stubBindingWriter{
+		createResult: config.Binding{ID: 1, Agent: "coder"},
+	}
+	deps := Deps{
+		DB: testDB(t), Config: stubConfig{cfg: fixtureConfig()},
+		Queue: &stubQueue{}, Status: stubStatus{},
+		BindingWrite: w, Logger: zerolog.Nop(),
+	}
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"repo":   "owner/repo",
+		"agent":  "coder",
+		"labels": `["ai:fix","ready"]`,
+		"events": `["push","pull_request"]`,
+	}
+	res, err := toolCreateBinding(deps)(context.Background(), req)
+	if err != nil || res.IsError {
+		t.Fatalf("create_binding failed: err=%v body=%s", err, textOf(t, res))
+	}
+	if got := w.gotCreateBinding.Labels; len(got) != 2 || got[0] != "ai:fix" || got[1] != "ready" {
+		t.Errorf("labels not forwarded from JSON-string: %+v", got)
+	}
+	if got := w.gotCreateBinding.Events; len(got) != 2 || got[0] != "push" || got[1] != "pull_request" {
+		t.Errorf("events not forwarded from JSON-string: %+v", got)
+	}
+}
+
+// TestToolUpdateBindingAcceptsJSONStringSlices is the PUT-replace mirror of
+// the create_binding test — same fields, same shape contract.
+func TestToolUpdateBindingAcceptsJSONStringSlices(t *testing.T) {
+	t.Parallel()
+	w := &stubBindingWriter{
+		updateResult: config.Binding{ID: 5, Agent: "coder"},
+	}
+	deps := Deps{
+		DB: testDB(t), Config: stubConfig{cfg: fixtureConfig()},
+		Queue: &stubQueue{}, Status: stubStatus{},
+		BindingWrite: w, Logger: zerolog.Nop(),
+	}
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"id":     float64(5),
+		"repo":   "owner/repo",
+		"agent":  "coder",
+		"labels": `["ready"]`,
+		"events": `["push"]`,
+	}
+	res, err := toolUpdateBinding(deps)(context.Background(), req)
+	if err != nil || res.IsError {
+		t.Fatalf("update_binding failed: err=%v body=%s", err, textOf(t, res))
+	}
+	if got := w.gotUpdateBinding.Labels; len(got) != 1 || got[0] != "ready" {
+		t.Errorf("labels not forwarded from JSON-string: %+v", got)
+	}
+	if got := w.gotUpdateBinding.Events; len(got) != 1 || got[0] != "push" {
+		t.Errorf("events not forwarded from JSON-string: %+v", got)
+	}
+}
+
+// TestToolCreateRepoAcceptsJSONStringBindings pins that the nested
+// "bindings" payload also accepts a JSON-encoded array string at the top
+// level — the same MCP-transport quirk surfaces here too because the
+// argument is itself an array.
+func TestToolCreateRepoAcceptsJSONStringBindings(t *testing.T) {
+	t.Parallel()
+	w := &stubRepoWriter{canonical: config.RepoDef{Name: "owner/repo", Enabled: true}}
+	deps := Deps{
+		DB: testDB(t), Config: stubConfig{cfg: fixtureConfig()},
+		Queue: &stubQueue{}, Status: stubStatus{},
+		RepoWrite: w, Logger: zerolog.Nop(),
+	}
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"name":     "owner/repo",
+		"enabled":  true,
+		"bindings": `[{"agent":"coder","labels":["ready"]}]`,
+	}
+	res, err := toolCreateRepo(deps)(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("expected success, got error: %s", textOf(t, res))
+	}
+	if len(w.gotUpsert.Use) != 1 {
+		t.Fatalf("bindings: want 1, got %d", len(w.gotUpsert.Use))
+	}
+	b := w.gotUpsert.Use[0]
+	if b.Agent != "coder" {
+		t.Errorf("agent: got %q, want %q", b.Agent, "coder")
+	}
+	if len(b.Labels) != 1 || b.Labels[0] != "ready" {
+		t.Errorf("labels: got %+v, want [ready]", b.Labels)
+	}
+}
+
+// TestToolUpdateAgentRejectsBogusSkills pins the "still rejects garbage"
+// half of the fix: a non-array, non-stringified-array input must surface
+// the clear array-of-strings error rather than silently slipping through.
+func TestToolUpdateAgentRejectsBogusSkills(t *testing.T) {
+	t.Parallel()
+	w := &stubAgentWriter{}
+	deps := Deps{
+		DB: testDB(t), Config: stubConfig{cfg: fixtureConfig()},
+		Queue: &stubQueue{}, Status: stubStatus{},
+		AgentWrite: w, Logger: zerolog.Nop(),
+	}
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"name":   "coder",
+		"skills": "not-an-array",
+	}
+	res, err := toolUpdateAgent(deps)(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("expected IsError for bogus skills")
+	}
+	if got := textOf(t, res); !strings.Contains(got, "skills must be an array of strings") {
+		t.Fatalf("error body want %q, got %q", "skills must be an array of strings", got)
+	}
+	if w.gotPatchName != "" {
+		t.Errorf("writer must not be invoked on validation failure, got name=%q", w.gotPatchName)
+	}
+}

--- a/internal/mcp/tools_crud.go
+++ b/internal/mcp/tools_crud.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
@@ -21,14 +22,23 @@ func toolCreateAgent(deps Deps) server.ToolHandlerFunc {
 		if err != nil {
 			return mcpgo.NewToolResultError(err.Error()), nil
 		}
+		args := req.GetArguments()
+		skills, errMsg := stringSliceArg(args["skills"], "skills")
+		if errMsg != "" {
+			return mcpgo.NewToolResultError(errMsg), nil
+		}
+		canDispatch, errMsg := stringSliceArg(args["can_dispatch"], "can_dispatch")
+		if errMsg != "" {
+			return mcpgo.NewToolResultError(errMsg), nil
+		}
 		a := config.AgentDef{
 			Name:          name,
 			Backend:       req.GetString("backend", ""),
 			Model:         req.GetString("model", ""),
 			Prompt:        req.GetString("prompt", ""),
 			Description:   req.GetString("description", ""),
-			Skills:        req.GetStringSlice("skills", nil),
-			CanDispatch:   req.GetStringSlice("can_dispatch", nil),
+			Skills:        skills,
+			CanDispatch:   canDispatch,
 			AllowPRs:      req.GetBool("allow_prs", false),
 			AllowDispatch: req.GetBool("allow_dispatch", false),
 		}
@@ -204,9 +214,13 @@ func toolCreateBackend(deps Deps) server.ToolHandlerFunc {
 		if err != nil {
 			return mcpgo.NewToolResultError(err.Error()), nil
 		}
+		models, errMsg := stringSliceArg(req.GetArguments()["models"], "models")
+		if errMsg != "" {
+			return mcpgo.NewToolResultError(errMsg), nil
+		}
 		b := config.AIBackendConfig{
 			Command:          req.GetString("command", ""),
-			Models:           req.GetStringSlice("models", nil),
+			Models:           models,
 			LocalModelURL:    req.GetString("local_model_url", ""),
 			TimeoutSeconds:   req.GetInt("timeout_seconds", 0),
 			MaxPromptChars:   req.GetInt("max_prompt_chars", 0),
@@ -378,13 +392,22 @@ func toolCreateBinding(deps Deps) server.ToolHandlerFunc {
 		if !ok {
 			return mcpgo.NewToolResultError("agent is required"), nil
 		}
+		args := req.GetArguments()
+		labels, errMsg := stringSliceArg(args["labels"], "labels")
+		if errMsg != "" {
+			return mcpgo.NewToolResultError(errMsg), nil
+		}
+		events, errMsg := stringSliceArg(args["events"], "events")
+		if errMsg != "" {
+			return mcpgo.NewToolResultError(errMsg), nil
+		}
 		b := config.Binding{
 			Agent:  agent,
-			Labels: req.GetStringSlice("labels", nil),
-			Events: req.GetStringSlice("events", nil),
+			Labels: labels,
+			Events: events,
 			Cron:   req.GetString("cron", ""),
 		}
-		if v, ok, errMsg := boolPtrArg(req.GetArguments(), "enabled"); ok {
+		if v, ok, errMsg := boolPtrArg(args, "enabled"); ok {
 			b.Enabled = v
 		} else if errMsg != "" {
 			return mcpgo.NewToolResultError(errMsg), nil
@@ -418,13 +441,22 @@ func toolUpdateBinding(deps Deps) server.ToolHandlerFunc {
 		if !ok {
 			return mcpgo.NewToolResultError("agent is required"), nil
 		}
+		args := req.GetArguments()
+		labels, errMsg := stringSliceArg(args["labels"], "labels")
+		if errMsg != "" {
+			return mcpgo.NewToolResultError(errMsg), nil
+		}
+		events, errMsg := stringSliceArg(args["events"], "events")
+		if errMsg != "" {
+			return mcpgo.NewToolResultError(errMsg), nil
+		}
 		b := config.Binding{
 			Agent:  agent,
-			Labels: req.GetStringSlice("labels", nil),
-			Events: req.GetStringSlice("events", nil),
+			Labels: labels,
+			Events: events,
 			Cron:   req.GetString("cron", ""),
 		}
-		if v, ok, errMsg := boolPtrArg(req.GetArguments(), "enabled"); ok {
+		if v, ok, errMsg := boolPtrArg(args, "enabled"); ok {
 			b.Enabled = v
 		} else if errMsg != "" {
 			return mcpgo.NewToolResultError(errMsg), nil
@@ -516,13 +548,17 @@ func repoJSON(r config.RepoDef) map[string]any {
 // Binding.Enabled stays nil when the caller omits the key (the "default
 // enabled" case config.Binding.IsEnabled relies on). A literal false/true sets
 // the pointer so downstream validation sees the user's intent preserved.
+//
+// The top-level value is also accepted as a JSON-encoded array string — see
+// stringSliceArg for the same MCP-transport rationale (some clients
+// stringify array params at the JSON-RPC boundary).
 func parseBindings(v any) ([]config.Binding, string) {
 	if v == nil {
 		return nil, ""
 	}
-	raw, ok := v.([]any)
-	if !ok {
-		return nil, "bindings must be an array"
+	raw, errMsg := arrayOfAny(v, "bindings")
+	if errMsg != "" {
+		return nil, errMsg
 	}
 	out := make([]config.Binding, 0, len(raw))
 	for i, item := range raw {
@@ -545,12 +581,12 @@ func parseBindings(v any) ([]config.Binding, string) {
 			}
 			b.Cron = s
 		}
-		labels, lErr := stringSliceFromAny(m["labels"], fmt.Sprintf("bindings[%d].labels", i))
+		labels, lErr := stringSliceArg(m["labels"], fmt.Sprintf("bindings[%d].labels", i))
 		if lErr != "" {
 			return nil, lErr
 		}
 		b.Labels = labels
-		events, eErr := stringSliceFromAny(m["events"], fmt.Sprintf("bindings[%d].events", i))
+		events, eErr := stringSliceArg(m["events"], fmt.Sprintf("bindings[%d].events", i))
 		if eErr != "" {
 			return nil, eErr
 		}
@@ -626,46 +662,86 @@ func intPtrArg(args map[string]any, key string) (*int, bool, string) {
 // stringSlicePtrArg reads an optional []string field. Returns (&slice, true,
 // "") when the key is present and well-typed, including an explicit empty
 // array (so callers can clear the list). Missing keys return (nil, false, "").
+// Wrong-shape values surface (nil, false, errMsg) so PATCH callers can reject
+// rather than silently treat a typo as "preserve".
+//
+// Accepts the same input shapes as stringSliceArg, including JSON-encoded
+// array strings (see that helper for the rationale).
 func stringSlicePtrArg(args map[string]any, key string) (*[]string, bool, string) {
 	v, ok := args[key]
 	if !ok || v == nil {
 		return nil, false, ""
 	}
-	raw, ok := v.([]any)
-	if !ok {
-		return nil, false, fmt.Sprintf("%s must be an array of strings", key)
-	}
-	out := make([]string, 0, len(raw))
-	for i, item := range raw {
-		s, ok := item.(string)
-		if !ok {
-			return nil, false, fmt.Sprintf("%s[%d] must be a string", key, i)
-		}
-		out = append(out, s)
+	out, errMsg := stringSliceArg(v, key)
+	if errMsg != "" {
+		return nil, false, errMsg
 	}
 	return &out, true, ""
 }
 
-// stringSliceFromAny decodes a JSON array of strings for the given field
-// path. A nil/missing value yields nil. A non-array argument or a non-string
-// element is reported via the returned error string using the supplied path
-// prefix so callers get `bindings[i].labels[j] must be a string` rather than
-// a silent drop.
-func stringSliceFromAny(v any, path string) ([]string, string) {
+// stringSliceArg coerces v into []string for a tool argument.
+//
+// Returns (nil, "") when v is nil/missing — callers that need to distinguish
+// absence from an explicit empty array should use stringSlicePtrArg instead.
+// Returns ([]string, "") on success and (nil, errMsg) when v is the wrong
+// shape (e.g. a number, a non-string element, or a non-array string that
+// doesn't decode as a JSON array).
+//
+// Accepts:
+//   - native []any with string elements (the standard JSON-decoded shape)
+//   - native []string (defensive, for callers that pre-decoded)
+//   - a JSON-encoded array string (e.g. `["a","b"]`)
+//
+// The JSON-string path exists because some MCP clients — observed with
+// mark3labs/mcp-go when batching tool calls into a single JSON-RPC message —
+// stringify array parameters at the transport boundary. Decoding here keeps
+// the server permissive without requiring clients to know about the quirk.
+//
+// keyForErr is used in error messages, e.g. "skills" produces
+// "skills must be an array of strings" or "skills[1] must be a string".
+func stringSliceArg(v any, keyForErr string) ([]string, string) {
 	if v == nil {
 		return nil, ""
 	}
-	raw, ok := v.([]any)
-	if !ok {
-		return nil, fmt.Sprintf("%s must be an array", path)
-	}
-	out := make([]string, 0, len(raw))
-	for i, item := range raw {
-		s, ok := item.(string)
-		if !ok {
-			return nil, fmt.Sprintf("%s[%d] must be a string", path, i)
+	switch raw := v.(type) {
+	case []any:
+		out := make([]string, 0, len(raw))
+		for i, item := range raw {
+			s, ok := item.(string)
+			if !ok {
+				return nil, fmt.Sprintf("%s[%d] must be a string", keyForErr, i)
+			}
+			out = append(out, s)
 		}
-		out = append(out, s)
+		return out, ""
+	case []string:
+		cp := make([]string, len(raw))
+		copy(cp, raw)
+		return cp, ""
+	case string:
+		var decoded []string
+		if err := json.Unmarshal([]byte(raw), &decoded); err == nil {
+			return decoded, ""
+		}
+		return nil, fmt.Sprintf("%s must be an array of strings", keyForErr)
+	default:
+		return nil, fmt.Sprintf("%s must be an array of strings", keyForErr)
 	}
-	return out, ""
+}
+
+// arrayOfAny coerces v into []any for nested-object tool arguments such as
+// the create_repo "bindings" payload. Accepts a native []any and a
+// JSON-encoded array string for the same MCP-transport reason as
+// stringSliceArg. Returns (nil, errMsg) for any other shape.
+func arrayOfAny(v any, keyForErr string) ([]any, string) {
+	switch raw := v.(type) {
+	case []any:
+		return raw, ""
+	case string:
+		var decoded []any
+		if err := json.Unmarshal([]byte(raw), &decoded); err == nil {
+			return decoded, ""
+		}
+	}
+	return nil, fmt.Sprintf("%s must be an array", keyForErr)
 }


### PR DESCRIPTION
Closes #278.

## Summary

Some MCP clients — observed with `mark3labs/mcp-go` when batching tool calls into a single JSON-RPC message — stringify array parameters at the transport boundary, so `skills: ["a","b"]` arrives as the literal string `"[\"a\",\"b\"]"`. Today every fleet CRUD tool that takes an array argument (`skills`, `can_dispatch`, `models`, `events`, `labels`, `bindings`) rejects that shape with a misleading `"must be an array of strings"` error, breaking parallel writes over MCP — exactly the high-traffic pattern the fleet is designed to support.

## What changed

- New helper `stringSliceArg(v, key) ([]string, errMsg)` accepts native `[]any`, native `[]string`, **and** JSON-encoded array strings. Returns a clear field-named error for any other shape.
- New helper `arrayOfAny(v, key) ([]any, errMsg)` does the same coercion for `parseBindings`'s top-level argument.
- `stringSlicePtrArg` now delegates to `stringSliceArg`, so PATCH callers (`update_agent`, `update_backend`) inherit the relief.
- Tool handlers that previously used `req.GetStringSlice` for relaxed fields — `toolCreateAgent` (`skills`, `can_dispatch`), `toolCreateBackend` (`models`), `toolCreateBinding` and `toolUpdateBinding` (`labels`, `events`) — now use `stringSliceArg` so the transport relief reaches every CRUD tool, not just the PATCH ones. Bogus inputs still surface a clear `<field> must be an array of strings` error and never reach the writer.
- `parseBindings` accepts a stringified `bindings` array at the top level via `arrayOfAny`. Nested `labels`/`events` flow through `stringSliceArg` and get the same JSON-string relief.
- REST behaviour is unchanged — this is an MCP-layer relaxation only.

## Acceptance criteria coverage

- [x] `update_agent` succeeds when `skills` is supplied as a JSON-encoded string — covered by `TestToolUpdateAgentAcceptsJSONStringSkills`.
- [x] Same relief applies to `can_dispatch`, `models`, `events`, `labels` across all CRUD tools — covered by `TestToolUpdateBackendAcceptsJSONStringModels`, `TestToolCreateAgentAcceptsJSONStringSlices`, `TestToolCreateBindingAcceptsJSONStringSlices`, `TestToolUpdateBindingAcceptsJSONStringSlices`, and `TestToolCreateRepoAcceptsJSONStringBindings`.
- [x] Non-array, non-stringified-array inputs still return a clear `must be an array of strings` error — covered by `TestStringSliceArgAcceptsShapes`, `TestStringSlicePtrArgAcceptsJSONString`, and `TestToolUpdateAgentRejectsBogusSkills`.
- [x] Unit tests in `internal/mcp/tools_arrays_test.go` cover both native-array and stringified-array inputs for at least one agent tool and one backend tool (in fact every relaxed tool).
- [x] REST behaviour unchanged — only `internal/mcp/tools_crud.go` is touched.

## Test plan

- [ ] CI green on `-race`.
- [ ] Existing `TestToolCreateRepoRejectsBadBindingsShape` and `TestToolCreateRepoRejectsBadBindingFieldTypes` still pass — substring assertions remain satisfied because the new error string is a superset of the old one (`"must be an array"` is a prefix of `"must be an array of strings"`).