### PR TITLE
refactor(webhook): replace sortedSetKeys with slices.Sorted(maps.Keys(...))

### DIFF
--- a/internal/webhook/orphans.go
+++ b/internal/webhook/orphans.go
@@ -108,7 +108,7 @@ func computeOrphanedAgents(cfg *config.Config) []OrphanedAgent {
 		}
 	}
 
-	orphans := make([]OrphanedAgent, 0)
+	orphan := make([]OrphanedAgent, 0)
 	for _, agent := range cfg.Agents {
 		backendName := cfg.ResolveBackend(agent.Backend)
 		if backendName == "" {
@@ -118,7 +118,7 @@ func computeOrphanedAgents(cfg *config.Config) []OrphanedAgent {
 		if !ok || !config.IsPinnedModelUnavailable(agent.Model, backend) {
 			continue
 		}
-		orphans = append(orphans, OrphanedAgent{
+		orphan = append(orphan, OrphanedAgent{
 			Name:            agent.Name,
 			Backend:         backendName,
 			Model:           strings.TrimSpace(agent.Model),
@@ -127,13 +127,13 @@ func computeOrphanedAgents(cfg *config.Config) []OrphanedAgent {
 		})
 	}
 
-	sort.Slice(orphans, func(i, j int) bool {
-		if orphans[i].Backend != orphans[j].Backend {
-			return orphans[i].Backend < orphans[j].Backend
+	sort.Slice(orphan, func(i, j int) bool {
+		if orphan[i].Backend != orphan[j].Backend {
+			return orphan[i].Backend < orphan[j].Backend
 		}
-		return orphans[i].Name < orphans[j].Name
+		return orphan[i].Name < orphan[j].Name
 	})
-	return orphans
+	return orphan
 }
 
 func canonicalModels(models []string) []string {

--- a/internal/webhook/orphans.go
+++ b/internal/webhook/orphans.go
@@ -3,6 +3,7 @@ package webhook
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
 	"slices"
 	"sort"
@@ -107,7 +108,7 @@ func computeOrphanedAgents(cfg *config.Config) []OrphanedAgent {
 		}
 	}
 
-	orphans := make([]OrphanedAgent, 0)
+	orpans := make([]OrphanedAgent, 0)
 	for _, agent := range cfg.Agents {
 		backendName := cfg.ResolveBackend(agent.Backend)
 		if backendName == "" {
@@ -117,11 +118,11 @@ func computeOrphanedAgents(cfg *config.Config) []OrphanedAgent {
 		if !ok || !config.IsPinnedModelUnavailable(agent.Model, backend) {
 			continue
 		}
-		orphans = append(orphans, OrphanedAgent{
+		orpans = append(orphans, OrphanedAgent{
 			Name:            agent.Name,
 			Backend:         backendName,
 			Model:           strings.TrimSpace(agent.Model),
-			Repos:           sortedSetKeys(reposByAgent[agent.Name]),
+			Repos:           slices.Sorted(maps.Keys(reposByAgent[agent.Name])),
 			AvailableModels: canonicalModels(backend.Models),
 		})
 	}
@@ -133,18 +134,6 @@ func computeOrphanedAgents(cfg *config.Config) []OrphanedAgent {
 		return orphans[i].Name < orphans[j].Name
 	})
 	return orphans
-}
-
-func sortedSetKeys(in map[string]struct{}) []string {
-	if len(in) == 0 {
-		return nil
-	}
-	out := make([]string, 0, len(in))
-	for k := range in {
-		out = append(out, k)
-	}
-	sort.Strings(out)
-	return out
 }
 
 func canonicalModels(models []string) []string {

--- a/internal/webhook/orphans.go
+++ b/internal/webhook/orphans.go
@@ -108,7 +108,7 @@ func computeOrphanedAgents(cfg *config.Config) []OrphanedAgent {
 		}
 	}
 
-	orpans := make([]OrphanedAgent, 0)
+	orphans := make([]OrphanedAgent, 0)
 	for _, agent := range cfg.Agents {
 		backendName := cfg.ResolveBackend(agent.Backend)
 		if backendName == "" {
@@ -118,7 +118,7 @@ func computeOrphanedAgents(cfg *config.Config) []OrphanedAgent {
 		if !ok || !config.IsPinnedModelUnavailable(agent.Model, backend) {
 			continue
 		}
-		orpans = append(orphans, OrphanedAgent{
+		orphans = append(orphans, OrphanedAgent{
 			Name:            agent.Name,
 			Backend:         backendName,
 			Model:           strings.TrimSpace(agent.Model),


### PR DESCRIPTION
## Summary

`sortedSetKeys` in `internal/webhook/orphans.go` is a hand-rolled helper that converts `map[string]struct{}` to a sorted `[]string` using a manual append loop + `sort.Strings`. Go 1.23 stdlib covers this exactly with `slices.Sorted(maps.Keys(...))`.

- Inline the single call site (`computeOrphanedAgents`) with `slices.Sorted(maps.Keys(reposByAgent[agent.Name]))`
- Delete the 10-line `sortedSetKeys` function
- Add `"maps"` import; `"sort"` stays (still used by `sort.Slice` and `sort.Strings` in `canonicalModels`)

The pattern is already used in `tools_fleet.go`, `tools_observe.go`, `ai/prompt.go`, and `config/config.go`, so this makes `orphans.go` consistent with the rest of the codebase.

No behaviour change — `slices.Sorted` on an empty iterator returns nil (same as the old guard `if len(in) == 0 { return nil }`), and the `Repos` field carries `omitempty` so JSON output is identical either way.