### PR TITLE
refactor(backends): inline isBuiltinBackendName, use slices.Sort in dedupeSorted

### DIFF
--- a/internal/backends/discovery.go
+++ b/internal/backends/discovery.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -98,7 +99,7 @@ func RunDiagnostics(ctx context.Context, existing map[string]config.AIBackendCon
 		})
 	}
 	for name, cfg := range existing {
-		if isBuiltinBackendName(name) || strings.TrimSpace(cfg.LocalModelURL) == "" {
+		if slices.Contains(builtinBackendNames, name) || strings.TrimSpace(cfg.LocalModelURL) == "" {
 			continue
 		}
 		targets = append(targets, backendTarget{
@@ -414,7 +415,7 @@ func dedupeSorted(in []string) []string {
 		seen[s] = struct{}{}
 		out = append(out, s)
 	}
-	sort.Strings(out)
+	slices.Sort(out)
 	return out
 }
 
@@ -471,13 +472,4 @@ func mergeEnv(base []string, override map[string]string) []string {
 		out = append(out, k+"="+v)
 	}
 	return out
-}
-
-func isBuiltinBackendName(name string) bool {
-	for _, builtin := range builtinBackendNames {
-		if name == builtin {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
## Summary

Two small idiom cleanups in `internal/backends/discovery.go`:

- **Inline `isBuiltinBackendName`** — 6-line helper with exactly one caller that does precisely what `slices.Contains` does. Removing the wrapper makes the intent explicit at the call site and eliminates a one-caller abstraction.
- **`dedupeSorted`: `sort.Strings` → `slices.Sort`** — `sort.Strings` is the pre-generics API; `slices.Sort` is the idiomatic equivalent since Go 1.21 and is already used in `tools_fleet.go`, `tools_observe.go`, `ai/prompt.go`, and `config/config.go`.

No behaviour change. `sort` stays imported (still needed for `sort.Slice` in `RunDiagnostics`).

## Test plan

- [ ] CI green (existing tests cover both functions via `RunDiagnostics` and `parseModels`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)