### PR TITLE
refactor(autonomous): replace interface{} with any in zerologCronLogger

### DIFF
--- a/internal/autonomous/scheduler.go
+++ b/internal/autonomous/scheduler.go
@@ -30,18 +30,18 @@ type zerologCronLogger struct {
 	logger zerolog.Logger
 }
 
-func (z zerologCronLogger) Info(msg string, keysAndValues ...interface{}) {
+func (z zerologCronLogger) Info(msg string, keysAndValues ...any) {
 	appendLogKV(z.logger.Info(), keysAndValues).Msg(msg)
 }
 
-func (z zerologCronLogger) Error(err error, msg string, keysAndValues ...interface{}) {
+func (z zerologCronLogger) Error(err error, msg string, keysAndValues ...any) {
 	appendLogKV(z.logger.Error().Err(err), keysAndValues).Msg(msg)
 }
 
 // appendLogKV attaches key-value pairs to a zerolog event. keysAndValues is a
 // flat alternating slice of [key, value, key, value, …]; odd-length tails are
 // silently ignored, matching cron.Logger convention.
-func appendLogKV(e *zerolog.Event, keysAndValues []interface{}) *zerolog.Event {
+func appendLogKV(e *zerolog.Event, keysAndValues []any) *zerolog.Event {
 	for i := 0; i+1 < len(keysAndValues); i += 2 {
 		e = e.Interface(fmt.Sprintf("%v", keysAndValues[i]), keysAndValues[i+1])
 	}


### PR DESCRIPTION
## Summary

`zerologCronLogger` in `internal/autonomous/scheduler.go` implements the `cron.Logger` interface using the pre-1.18 `interface{}` spelling in three places:

- `Info(msg string, keysAndValues ...interface{})`
- `Error(err error, msg string, keysAndValues ...interface{})`
- `appendLogKV(e *zerolog.Event, keysAndValues []interface{}) *zerolog.Event`

`any` is a predeclared alias for `interface{}` since Go 1.18 and is interchangeable at the type level — method signatures using `any` still satisfy interfaces declared with `interface{}`. The rest of the codebase already uses `any` exclusively; this aligns the one remaining outlier.

No behaviour change. No import changes.

## Test plan

- [ ] CI green (`go test -race ./internal/autonomous/...` — existing scheduler tests exercise both `Info` and `Error` paths through `SkipIfStillRunning`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)