### PR TITLE
docs: document Graph page edit-wiring mode in README and dispatch guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The daemon ships an embedded web dashboard at `/ui/` with real-time views of you
 |------|---------------|
 | **Events** | Live webhook event firehose with SSE streaming |
 | **Traces** | Agent run traces with timing, status, and drill-down to tool-loop transcripts |
-| **Graph** | Visual dispatch graph -- which agents invoke which, with edge counts |
+| **Graph** | Visual dispatch graph -- which agents invoke which, with edge counts. Toggle "Edit wiring" to add or remove dispatch connections by drag-and-drop |
 | **Agents** | Fleet snapshot -- per-agent status, skills, bindings, dispatch wiring. Create, edit, and delete agents |
 | **Skills** | Manage reusable guidance blocks -- create, edit, delete |
 | **Backends and tools** | Backend discovery status (including per-backend GitHub MCP connectivity), runtime limits, local backend URL management, and orphaned-model remediation |

--- a/docs/dispatch.md
+++ b/docs/dispatch.md
@@ -37,7 +37,7 @@ The dispatched agent receives an `agent.dispatch` event with these payload field
 ## Safety limits (`daemon.processor.dispatch`)
 
 | Field | Default | Meaning |
-|-------|---------|---------|
+|-------|---------|----------|
 | `max_depth` | 3 | Maximum dispatch chain length. Requests that would exceed this are dropped with a warning. |
 | `max_fanout` | 4 | Maximum number of dispatches a single agent run may enqueue. Additional requests are dropped. |
 | `dedup_window_seconds` | 300 | Suppress duplicate `(target, repo, number)` dispatch requests within this window (seconds). |
@@ -79,3 +79,12 @@ agents:
     prompt: |
       Review the change for security risks and unsafe assumptions.
 ```
+
+## UI wiring editor
+
+The **Graph** page in the web dashboard (`/ui/`) has an "Edit wiring" toggle. When active:
+
+- **Add a connection**: drag from any agent node to another. The daemon writes the source agent's `can_dispatch` list and enables `allow_dispatch` on the target via `PATCH /agents`.
+- **Remove a connection**: click an existing edge to open a confirmation modal. The daemon removes the target from the source agent's `can_dispatch` list; the target's `allow_dispatch` flag is left alone, since other agents may still dispatch to it.
+
+Self-dispatch and duplicate edges are rejected before any network call. Config-level constraints (`description` required on dispatch targets, no self-reference) still apply — the UI enforces them before writing.


### PR DESCRIPTION
## Summary

The "Edit wiring" toggle on the Graph page shipped in commit `cac44d2` (closed #246) but was never mentioned in any documentation. The README dashboard table described Graph as a read-only view, and `docs/dispatch.md` had no reference to the UI editor at all.

**Changes:**

- **README.md** (`Web dashboard` table, Graph row): extend the description to mention the drag-and-drop wiring editor.
- **docs/dispatch.md** (new `## UI wiring editor` section): explain the two interactions — adding a connection by dragging between nodes, and removing one by clicking an edge — including what the daemon writes on each action (`PATCH /agents` to update `can_dispatch` / `allow_dispatch`).

## Test plan

- [ ] README.md Graph row mentions "Edit wiring" and drag-and-drop
- [ ] `docs/dispatch.md` new section accurately describes the add-connection (drag) and remove-connection (click edge) flows
- [ ] No other sections of either file changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)