### PR TITLE
refactor(mcp): replace for-range search with slices.IndexFunc in toolGetAgent and toolGetRepo

### DIFF
--- a/internal/mcp/tools_fleet.go
+++ b/internal/mcp/tools_fleet.go
@@ -45,10 +45,8 @@ func toolGetAgent(deps Deps) server.ToolHandlerFunc {
 			return mcpgo.NewToolResultErrorFromErr("get agent", err), nil
 		}
 		key := config.NormalizeAgentName(name)
-		for _, a := range agents {
-			if a.Name == key {
-				return jsonResult(agentJSON(a))
-			}
+		if idx := slices.IndexFunc(agents, func(a config.AgentDef) bool { return a.Name == key }); idx != -1 {
+			return jsonResult(agentJSON(agents[idx]))
 		}
 		return mcpgo.NewToolResultErrorf("agent %q not found", name), nil
 	}
@@ -161,10 +159,8 @@ func toolGetRepo(deps Deps) server.ToolHandlerFunc {
 			return mcpgo.NewToolResultErrorFromErr("get repo", err), nil
 		}
 		key := config.NormalizeRepoName(name)
-		for _, r := range repos {
-			if r.Name == key {
-				return jsonResult(repoJSON(r))
-			}
+		if idx := slices.IndexFunc(repos, func(r config.RepoDef) bool { return r.Name == key }); idx != -1 {
+			return jsonResult(repoJSON(repos[idx]))
 		}
 		return mcpgo.NewToolResultErrorf("repo %q not found", name), nil
 	}


### PR DESCRIPTION
## Summary

`toolGetAgent` and `toolGetRepo` each contain a 4-line `for`+`if` loop that scans a slice for the first element whose `Name` matches a normalized key, then falls through to a not-found return:

```go
for _, a := range agents {
    if a.Name == key {
        return jsonResult(agentJSON(a))
    }
}
return mcpgo.NewToolResultErrorf("agent %q not found", name), nil
```

Go 1.21 introduced `slices.IndexFunc`, which expresses this intent as a single predicate call. Both functions become:

```go
if idx := slices.IndexFunc(agents, func(a config.AgentDef) bool { return a.Name == key }); idx != -1 {
    return jsonResult(agentJSON(agents[idx]))
}
return mcpgo.NewToolResultErrorf("agent %q not found", name), nil
```

- No behaviour change — `IndexFunc` returns the index of the first match or -1, identical semantics to the loop.
- `"slices"` is already imported in this file (used by `slices.Sorted` in `toolListSkills` and `toolListBackends`).
- No new imports.
- `-4` lines net.

The map-based lookups in `toolGetSkill` and `toolGetBackend` are already idiomatic and unchanged.

## Test plan

- [ ] CI green (`go test -race ./internal/mcp/...` — existing `TestToolGetAgent*` and `TestToolGetRepo*` tests cover both the found and not-found paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)