### PR TITLE
docs: fix local-models backend config — env: field does not exist, use local_model_url

### DIFF
--- a/docs/local-models.md
+++ b/docs/local-models.md
@@ -43,7 +43,7 @@ Two moving pieces inside the daemon:
 
 1. **The proxy** (`internal/anthropic_proxy/`) — an HTTP handler mounted on the daemon's existing server at `/v1/messages` and `/v1/models`. Accepts Anthropic Messages format, translates to OpenAI Chat Completions, forwards to your configured upstream, translates the response back. Text, system messages, tool-use / tool-result round-trips, streaming (fake-streaming via SSE, token-by-token streaming coming). Covered by unit tests.
 
-2. **Per-backend env override** (`AIBackendConfig.env`) — lets you have *two* backends that both run the `claude` CLI but route to different endpoints. One hits hosted Anthropic (default), one hits the local proxy. You pick per-agent.
+2. **Per-backend `local_model_url`** (`AIBackendConfig.local_model_url`) — set this on a backend entry and the daemon injects `ANTHROPIC_BASE_URL=<url>` into the subprocess environment, routing that backend's `claude` CLI through the local proxy. You can have two backends that both run `claude` — one hitting hosted Anthropic (no `local_model_url`), one hitting the proxy. You pick per-agent.
 
 Nothing else changes. Same agents, same prompts, same config.
 
@@ -105,17 +105,12 @@ daemon:
   ai_backends:
     claude:                               # default: hosted Anthropic
       command: claude
-      args: [-p, --dangerously-skip-permissions]
       timeout_seconds: 3600
       max_prompt_chars: 12000
 
-    claude_local:                         # second entry, same binary, different env
+    claude_local:                         # same binary, routed through the daemon proxy
       command: claude
-      args: [-p, --dangerously-skip-permissions]
-      env:
-        ANTHROPIC_BASE_URL: http://localhost:8080    # the daemon proxies itself
-        ANTHROPIC_API_KEY: sk-not-needed             # dummy; proxy ignores
-        ANTHROPIC_MODEL: qwen
+      local_model_url: http://localhost:8080    # daemon injects ANTHROPIC_BASE_URL
       timeout_seconds: 3600
       max_prompt_chars: 12000
 ```
@@ -249,7 +244,7 @@ The `claude` CLI's Task tool can spawn sub-agents whose conversations build up t
 
 ### "Invalid API key" on every run
 
-You're missing `ANTHROPIC_BASE_URL` / `ANTHROPIC_MODEL` in the backend's `env` block, or your build does not include the current allowlist in `internal/ai/cmdrunner.go`.
+`ANTHROPIC_BASE_URL` is not reaching the subprocess. Check that `local_model_url` is set on the `claude_local` backend in your daemon config — the daemon injects `ANTHROPIC_BASE_URL` from that field. `ANTHROPIC_API_KEY` must still be present in the container environment (any non-empty value works; the local endpoint ignores it). Set it in your `.env` file or compose `environment:` block.
 
 Verify with:
 


### PR DESCRIPTION
## Summary

`docs/local-models.md` shows a `claude_local` backend with an `env:` block:

```yaml
claude_local:
  command: claude
  args: [-p, --dangerously-skip-permissions]
  env:
    ANTHROPIC_BASE_URL: http://localhost:8080
    ANTHROPIC_API_KEY: sk-not-needed
    ANTHROPIC_MODEL: qwen
```

`AIBackendConfig` has no `env` field — the YAML parser silently drops that block. A user following the doc would configure the backend, restart the daemon, and the `claude` CLI would still hit hosted Anthropic because `ANTHROPIC_BASE_URL` was never injected.

The correct mechanism is `local_model_url`. In `cmd/agents/main.go`, `backendEnvOverrides` reads that field and injects `ANTHROPIC_BASE_URL=<url>` into the subprocess:

```go
func backendEnvOverrides(b config.AIBackendConfig) map[string]string {
    if b.LocalModelURL == "" {
        return nil
    }
    return map[string]string{"ANTHROPIC_BASE_URL": b.LocalModelURL}
}
```

**Three fixes in `docs/local-models.md`:**

1. **Architecture section** — `AIBackendConfig.env` → `AIBackendConfig.local_model_url` with an accurate description of what the field does.

2. **Step 2 daemon config snippet** — Remove the `env:` block from `claude_local`; replace with `local_model_url: http://localhost:8080`. Also remove `args:` (not a real `AIBackendConfig` field; args are hardcoded in `buildClaudeDelivery`).

3. **Troubleshooting "Invalid API key"** — Update the explanation to point at `local_model_url` rather than the non-existent `env` block; note that `ANTHROPIC_API_KEY` still needs to be in the container environment.

## Test plan

- [ ] Architecture section now says `AIBackendConfig.local_model_url` and describes env injection correctly
- [ ] Step 2 `claude_local` backend uses `local_model_url: http://localhost:8080` (no `env:` block)
- [ ] Troubleshooting "Invalid API key" points at `local_model_url`, not `env`
- [ ] Cross-check `AIBackendConfig` in `internal/config/config.go` — confirmed no `env` or `args` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)