### PR TITLE
refactor(mcp): generalise nilSafe to nilSafe[T any], drop redundant nil checks

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -596,9 +596,9 @@ func jsonResult(v any) (*mcpgo.CallToolResult, error) {
 // nilSafe normalises a nil slice to an empty slice so JSON output is a
 // predictable [] rather than null. Consumers — especially LLMs — parse the
 // two differently, and we already follow the same convention in REST handlers.
-func nilSafe(xs []string) []string {
+func nilSafe[T any](xs []T) []T {
 	if xs == nil {
-		return []string{}
+		return []T{}
 	}
 	return xs
 }

--- a/internal/mcp/tools_observe.go
+++ b/internal/mcp/tools_observe.go
@@ -9,9 +9,7 @@ import (
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
-	"github.com/eloylp/agents/internal/observe"
 	"github.com/eloylp/agents/internal/store"
-	"github.com/eloylp/agents/internal/workflow"
 )
 
 // mcpGraphNode mirrors the node payload used by GET /graph so consumers
@@ -49,11 +47,7 @@ func toolListEvents(deps Deps) server.ToolHandlerFunc {
 				since = t
 			}
 		}
-		events := deps.Observe.ListEvents(since)
-		if events == nil {
-			events = []observe.TimestampedEvent{}
-		}
-		return jsonResult(events)
+		return jsonResult(nilSafe(deps.Observe.ListEvents(since)))
 	}
 }
 
@@ -62,11 +56,7 @@ func toolListEvents(deps Deps) server.ToolHandlerFunc {
 // the same decoder.
 func toolListTraces(deps Deps) server.ToolHandlerFunc {
 	return func(_ context.Context, _ mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
-		spans := deps.Observe.ListTraces()
-		if spans == nil {
-			spans = []observe.Span{}
-		}
-		return jsonResult(spans)
+		return jsonResult(nilSafe(deps.Observe.ListTraces()))
 	}
 }
 
@@ -97,11 +87,7 @@ func toolGetTraceSteps(deps Deps) server.ToolHandlerFunc {
 		if !ok {
 			return mcpgo.NewToolResultError("span_id is required"), nil
 		}
-		steps := deps.Observe.ListSteps(id)
-		if steps == nil {
-			steps = []workflow.TraceStep{}
-		}
-		return jsonResult(steps)
+		return jsonResult(nilSafe(deps.Observe.ListSteps(id)))
 	}
 }
 
@@ -200,4 +186,3 @@ func toolGetMemory(deps Deps) server.ToolHandlerFunc {
 		return jsonResult(out)
 	}
 }
-


### PR DESCRIPTION
## Summary

- Make `nilSafe` generic (`nilSafe[T any](xs []T) []T`) so it works for any slice type, not just `[]string`
- Replace three manual nil-guard blocks in `tools_observe.go` with `nilSafe(...)` calls
- Drop the now-unused `observe` and `workflow` imports from `tools_observe.go`

## Motivation

Three functions in `tools_observe.go` each had a 4–5 line nil-guard pattern:

```go
xs := deps.Observe.ListXxx(...)
if xs == nil {
    xs = []SomeType{}
}
return jsonResult(xs)
```

These are the same nil→empty-slice coercion that `nilSafe` already handles for `[]string` callers in the same package. Generalising `nilSafe` to a type parameter collapses each block to one line and removes the need to name the `observe` and `workflow` types explicitly in `tools_observe.go`, which in turn allows dropping both imports.

All existing `nilSafe` call sites (`nilSafe(a.Skills)`, `nilSafe(a.CanDispatch)`, etc.) continue to compile unchanged via Go type inference.

## Test plan

- [ ] CI passes (existing unit + integration tests)
- [ ] `nilSafe` callers in `tools.go` still compile (type inference, no explicit type param needed)
- [ ] `tools_observe.go` imports compile without `observe` or `workflow`