### PR TITLE
refactor: remove dead if branch from validateAgentModel

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -916,14 +916,11 @@ func IsPinnedModelUnavailable(model string, backend AIBackendConfig) bool {
 	return !slices.Contains(backend.Models, model)
 }
 
-func validateAgentModel(_ string, model string, backend AIBackendConfig) error {
+func validateAgentModel(_ string, _ string, _ AIBackendConfig) error {
 	// Model/backend mismatches are intentionally allowed at config validation
 	// time so discovery can persist backend model changes even if agents become
 	// temporarily orphaned. Runtime paths enforce this strictly before invoking
 	// a backend, and UI surfaces orphan remediation flows.
-	if IsPinnedModelUnavailable(model, backend) {
-		return nil
-	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

`validateAgentModel` in `internal/config/config.go` contained a dead `if` branch where both the true and false paths returned `nil`:

```go
// before
func validateAgentModel(_ string, model string, backend AIBackendConfig) error {
    if IsPinnedModelUnavailable(model, backend) {
        return nil
    }
    return nil
}
```

`IsPinnedModelUnavailable` was called but its result was ignored — the function always returned `nil` regardless. The existing comment already documents the intentional permissiveness at config-validation time. The cleanup makes that intent immediately obvious without having to trace through the branch.

```go
// after
func validateAgentModel(_ string, _ string, _ AIBackendConfig) error {
    // Model/backend mismatches are intentionally allowed at config validation
    // time so discovery can persist backend model changes even if agents become
    // temporarily orphaned. Runtime paths enforce this strictly before invoking
    // a backend, and UI surfaces orphan remediation flows.
    return nil
}
```

Unused parameters are blanked to `_`; the function signature is kept so callers (`validateAgents`, `ValidateCrossRefs`, `ValidateEntities`) need no changes.

## Test plan
- [ ] CI passes (no behavior change, pure dead-code removal)