### PR TITLE
refactor(webhook): replace sort pkg with slices in orphans.go; err-first idiom

### DIFF
--- a/internal/webhook/orphans.go
+++ b/internal/webhook/orphans.go
@@ -6,7 +6,6 @@ import (
 	"maps"
 	"net/http"
 	"slices"
-	"sort"
 	"strings"
 	"time"
 
@@ -34,10 +33,10 @@ type OrphanedAgentsSnapshot struct {
 
 func (s *Server) handleAgentsOrphans(w http.ResponseWriter, _ *http.Request) {
 	snapshot := s.orphanedAgentsSnapshot()
-	if fresh, err := s.refreshOrphanedAgentsFromDB(); err == nil {
-		snapshot = fresh
-	} else {
+	if fresh, err := s.refreshOrphanedAgentsFromDB(); err != nil {
 		s.logger.Warn().Err(err).Msg("orphan status: falling back to cached snapshot")
+	} else {
+		snapshot = fresh
 	}
 	w.Header().Set("Cache-Control", "no-store")
 	w.Header().Set("Content-Type", "application/json")
@@ -127,11 +126,11 @@ func computeOrphanedAgents(cfg *config.Config) []OrphanedAgent {
 		})
 	}
 
-	sort.Slice(orphan, func(i, j int) bool {
-		if orphan[i].Backend != orphan[j].Backend {
-			return orphan[i].Backend < orphan[j].Backend
+	slices.SortFunc(orphan, func(a, b OrphanedAgent) int {
+		if c := strings.Compare(a.Backend, b.Backend); c != 0 {
+			return c
 		}
-		return orphan[i].Name < orphan[j].Name
+		return strings.Compare(a.Name, b.Name)
 	})
 	return orphan
 }
@@ -146,6 +145,6 @@ func canonicalModels(models []string) []string {
 	if len(out) == 0 {
 		return nil
 	}
-	sort.Strings(out)
+	slices.Sort(out)
 	return slices.Compact(out)
 }


### PR DESCRIPTION
## Summary

Two non-idiomatic patterns in `internal/webhook/orphans.go`, both fixed in one pass:

**1. `sort` package → `slices` package**

The file already imported `slices` (for `slices.Compact` and `slices.Sorted`) but used the older `sort` package for two operations:

- `sort.Slice` in `computeOrphanedAgents` — replaced with `slices.SortFunc`, which takes named parameters and is type-safe (no index arithmetic)
- `sort.Strings` in `canonicalModels` — replaced with `slices.Sort`

The `sort` import is now unused and is removed.

**Before (`computeOrphanedAgents`):**
```go
sort.Slice(orphan, func(i, j int) bool {
    if orphan[i].Backend != orphan[j].Backend {
        return orphan[i].Backend < orphan[j].Backend
    }
    return orphan[i].Name < orphan[j].Name
})
```

**After:**
```go
slices.SortFunc(orphan, func(a, b OrphanedAgent) int {
    if c := strings.Compare(a.Backend, b.Backend); c != 0 {
        return c
    }
    return strings.Compare(a.Name, b.Name)
})
```

**2. `err == nil` → `err != nil` idiom in `handleAgentsOrphans`**

The same success-first anti-pattern fixed in `buildStatus` by PR #301 also existed in `handleAgentsOrphans`. Error branch now comes first, matching Go convention and every other error-handling pattern in the package.

**Before:**
```go
if fresh, err := s.refreshOrphanedAgentsFromDB(); err == nil {
    snapshot = fresh
} else {
    s.logger.Warn().Err(err).Msg("orphan status: falling back to cached snapshot")
}
```

**After:**
```go
if fresh, err := s.refreshOrphanedAgentsFromDB(); err != nil {
    s.logger.Warn().Err(err).Msg("orphan status: falling back to cached snapshot")
} else {
    snapshot = fresh
}
```

No behaviour change in either case — same sort order, same fallback-on-error logic.

## Test plan

- [ ] CI passes (existing `TestHandleAgentsOrphans` / `TestComputeOrphanedAgents` in `internal/webhook/orphans_test.go` cover both paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)