### PR TITLE
fix: drop 'at least one repo must be enabled' constraint (#302)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -847,8 +847,14 @@ func countBindingTriggers(b Binding) int {
 	return n
 }
 
+// validateRepos checks per-repo invariants: name presence, name uniqueness,
+// binding agent references, trigger exclusivity, and event-kind allow-list.
+// It does NOT enforce an "at least one enabled repo" minimum — disabling all
+// repos is a legitimate user action (fleet maintenance, evaluating prompts on
+// a different repo) and the daemon runs cleanly with zero enabled repos:
+// webhook events for disabled repos route through workflow_engine which logs
+// "no bindings matched event, skipping". See issue #302.
 func (c *Config) validateRepos() error {
-	enabledCount := 0
 	seen := make(map[string]struct{}, len(c.Repos))
 	for _, r := range c.Repos {
 		if r.Name == "" {
@@ -859,9 +865,6 @@ func (c *Config) validateRepos() error {
 			return fmt.Errorf("config: duplicate repo %q", r.Name)
 		}
 		seen[key] = struct{}{}
-		if r.Enabled {
-			enabledCount++
-		}
 		for i, b := range r.Use {
 			if b.Agent == "" {
 				return fmt.Errorf("config: repo %q: binding #%d has no agent", r.Name, i)
@@ -882,9 +885,6 @@ func (c *Config) validateRepos() error {
 				}
 			}
 		}
-	}
-	if len(c.Repos) > 0 && enabledCount == 0 {
-		return errors.New("config: at least one repo must be enabled")
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -237,18 +237,6 @@ repos:
 `,
 			errMsg: "unknown event kind",
 		},
-		{
-			name: "all repos disabled",
-			repo: `
-repos:
-  - name: "owner/repo"
-    enabled: false
-    use:
-      - agent: reviewer
-        labels: ["ai:review:reviewer"]
-`,
-			errMsg: "must be enabled",
-		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -258,6 +246,32 @@ repos:
 				t.Fatalf("expected error containing %q, got %v", tc.errMsg, err)
 			}
 		})
+	}
+}
+
+// TestLoadAcceptsAllReposDisabled verifies that a config with every repo
+// disabled loads successfully. Disabling all repos is a legitimate user action
+// (fleet maintenance, prompt evaluation on a different repo) and the daemon
+// must not crash-loop on the next restart. Regression for issue #302.
+func TestLoadAcceptsAllReposDisabled(t *testing.T) {
+	t.Setenv("TEST_SECRET", "s3cret")
+	repo := `
+repos:
+  - name: "owner/repo"
+    enabled: false
+    use:
+      - agent: reviewer
+        labels: ["ai:review:reviewer"]
+`
+	cfg, err := Load(writeConfig(t, minimalYAML(repo)))
+	if err != nil {
+		t.Fatalf("Load with all repos disabled: want success, got %v", err)
+	}
+	if len(cfg.Repos) != 1 {
+		t.Fatalf("repos: got %d, want 1", len(cfg.Repos))
+	}
+	if cfg.Repos[0].Enabled {
+		t.Errorf("repo enabled: got true, want false")
 	}
 }
 

--- a/internal/store/crud.go
+++ b/internal/store/crud.go
@@ -101,6 +101,11 @@ func requireAtLeastOne(q querier, countQuery, entity, zeroMsg string) error {
 // ImportAll and ReplaceAll: entity cross-references, minimum cardinality, and
 // cron-expression parseability. op ("import" or "replace") is used verbatim in
 // error messages.
+//
+// "At least one enabled repo" is intentionally NOT enforced here — disabling
+// all repos is a legitimate user action (fleet maintenance, evaluating prompts
+// on a different repo) and the daemon runs cleanly with zero enabled repos.
+// See issue #302.
 func validateFleetConstraints(q querier, op string, repos []config.RepoDef) error {
 	if err := validateFleet(q); err != nil {
 		return &ErrValidation{Msg: fmt.Sprintf("store: %s: %v", op, err)}
@@ -109,9 +114,6 @@ func validateFleetConstraints(q querier, op string, repos []config.RepoDef) erro
 		return &ErrValidation{Msg: fmt.Sprintf("store: %s: %v", op, err)}
 	}
 	if err := requireAtLeastOne(q, "SELECT COUNT(*) FROM backends", "backends", "config: at least one ai_backends entry is required"); err != nil {
-		return &ErrValidation{Msg: fmt.Sprintf("store: %s: %v", op, err)}
-	}
-	if err := requireAtLeastOne(q, "SELECT COUNT(*) FROM repos WHERE enabled=1", "enabled repos", "config: at least one repo must be enabled"); err != nil {
 		return &ErrValidation{Msg: fmt.Sprintf("store: %s: %v", op, err)}
 	}
 	return validateCronExpressions(repos)
@@ -764,8 +766,9 @@ func nilSafeStrings(s []string) []string {
 	return s
 }
 
-// DeleteRepo removes a repo and all of its bindings. Returns an error if the
-// deletion would leave no enabled repos.
+// DeleteRepo removes a repo and all of its bindings. Deleting the last enabled
+// (or only) repo is allowed — see issue #302; the daemon runs cleanly with zero
+// enabled repos.
 func DeleteRepo(db *sql.DB, name string) error {
 	tx, err := db.Begin()
 	if err != nil {
@@ -775,14 +778,8 @@ func DeleteRepo(db *sql.DB, name string) error {
 	if _, err := tx.Exec("DELETE FROM bindings WHERE repo=?", name); err != nil {
 		return fmt.Errorf("store: delete bindings for repo %s: %w", name, err)
 	}
-	res, err := tx.Exec("DELETE FROM repos WHERE name=?", name)
-	if err != nil {
+	if _, err := tx.Exec("DELETE FROM repos WHERE name=?", name); err != nil {
 		return fmt.Errorf("store: delete repo %s: %w", name, err)
-	}
-	if n, _ := res.RowsAffected(); n > 0 {
-		if err := requireAtLeastOne(tx, "SELECT COUNT(*) FROM repos WHERE enabled=1", "enabled repos", "config: at least one repo must be enabled"); err != nil {
-			return &ErrConflict{Msg: fmt.Sprintf("store: delete repo %s: %v", name, err)}
-		}
 	}
 	return tx.Commit()
 }

--- a/internal/store/crud_test.go
+++ b/internal/store/crud_test.go
@@ -962,7 +962,11 @@ func TestDeleteBackendRejectedAsLast(t *testing.T) {
 	}
 }
 
-func TestDeleteRepoRejectedAsLastEnabled(t *testing.T) {
+// TestDeleteRepoAllowsLastEnabled verifies that DeleteRepo succeeds even when
+// it removes the last (or only) enabled repo. Disabling/removing all repos is
+// a legitimate user action; the daemon runs cleanly with zero enabled repos.
+// Regression for issue #302.
+func TestDeleteRepoAllowsLastEnabled(t *testing.T) {
 	t.Parallel()
 	db := openTestDB(t)
 
@@ -980,21 +984,25 @@ func TestDeleteRepoRejectedAsLastEnabled(t *testing.T) {
 		t.Fatalf("UpsertRepo: %v", err)
 	}
 
-	err := store.DeleteRepo(db, "owner/repo")
-	if err == nil {
-		t.Fatal("DeleteRepo last enabled repo: want error, got nil")
-	}
-	if !strings.Contains(err.Error(), "at least one repo must be enabled") {
-		t.Errorf("unexpected error: %v", err)
+	if err := store.DeleteRepo(db, "owner/repo"); err != nil {
+		t.Fatalf("DeleteRepo last enabled repo: want nil, got %v", err)
 	}
 
-	// Repo must still be present.
-	repos, readErr := store.ReadRepos(db)
-	if readErr != nil {
-		t.Fatalf("ReadRepos: %v", readErr)
+	repos, err := store.ReadRepos(db)
+	if err != nil {
+		t.Fatalf("ReadRepos: %v", err)
 	}
-	if len(repos) != 1 {
-		t.Errorf("repo count after rejected delete: got %d, want 1", len(repos))
+	if len(repos) != 0 {
+		t.Errorf("repo count after delete: got %d, want 0", len(repos))
+	}
+
+	// Bindings for the deleted repo must also be gone.
+	var count int
+	if err := db.QueryRow("SELECT COUNT(*) FROM bindings WHERE repo='owner/repo'").Scan(&count); err != nil {
+		t.Fatalf("count bindings: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("orphan bindings after DeleteRepo: got %d, want 0", count)
 	}
 }
 

--- a/internal/webhook/crud_test.go
+++ b/internal/webhook/crud_test.go
@@ -1701,7 +1701,12 @@ func TestServerCfgUpdatedAfterCRUDWrite(t *testing.T) {
 	}
 }
 
-func TestStoreCRUDDeleteRepoRejectedAsLastEnabled(t *testing.T) {
+// TestStoreCRUDDeleteRepoAllowsLastEnabled verifies that the HTTP DELETE
+// /repos/{owner}/{repo} endpoint succeeds with 204 even when the target is the
+// last (or only) enabled repo. Disabling/removing all repos is a legitimate
+// user action; the daemon runs cleanly with zero enabled repos. Regression for
+// issue #302.
+func TestStoreCRUDDeleteRepoAllowsLastEnabled(t *testing.T) {
 	t.Parallel()
 	s := openCRUDTestServer(t)
 
@@ -1720,8 +1725,13 @@ func TestStoreCRUDDeleteRepoRejectedAsLastEnabled(t *testing.T) {
 	}
 
 	rr := doCRUDRequest(t, s, http.MethodDelete, "/repos/owner/repo", nil)
-	if rr.Code == http.StatusNoContent {
-		t.Error("DELETE last enabled repo: want non-204, got 204")
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("DELETE last enabled repo: want 204, got %d — %s", rr.Code, rr.Body.String())
+	}
+
+	// The repo must be gone from subsequent reads.
+	if rr := doCRUDRequest(t, s, http.MethodGet, "/repos/owner/repo", nil); rr.Code != http.StatusNotFound {
+		t.Errorf("GET deleted repo: want 404, got %d — %s", rr.Code, rr.Body.String())
 	}
 }
 


### PR DESCRIPTION
Closes #302.

## Summary

Disabling all repos via the dashboard or `PATCH /repos/{owner}/{repo}` succeeded but bricked the daemon on the next restart with a crash loop. Recovery required SQLite surgery — a hostile failure mode for a legitimate user action (fleet maintenance, prompt evaluation on a different repo).

The constraint was enforced at startup via `Config.validateRepos`, in the bulk import/replace path via `validateFleetConstraints`, and on the last-enabled-repo `DeleteRepo` path. The PATCH and per-item upsert paths silently allowed reaching the all-disabled state, so the only thing the check did was crash the daemon on legal config states and reject DELETE on the last enabled repo with HTTP 409.

This PR removes all three enforcement points:

1. **`internal/config/config.go` — `validateRepos`**: drop the `enabledCount` aggregate-minimum block. Per-repo invariants (name presence, name uniqueness, binding agent references, trigger exclusivity, event-kind allow-list) are unchanged.
2. **`internal/store/crud.go` — `validateFleetConstraints`**: drop the `requireAtLeastOne(... enabled=1 ...)` call. ImportAll/ReplaceAll continue to enforce the agents and ai_backends minimums (those ARE required for a runnable fleet).
3. **`internal/store/crud.go` — `DeleteRepo`**: drop the post-delete check. Deletes that empty the enabled-repo set now succeed (HTTP 204).

The daemon runs cleanly with zero enabled repos: webhook events for disabled repos are filtered through `workflow_engine` which logs `"no bindings matched event, skipping"` — the correct semantics.

## Tests

- **`internal/config/config_test.go`**: removed the "all repos disabled" rejection case from `TestLoadRejectsInvalidRepoConfig`; added `TestLoadAcceptsAllReposDisabled` asserting the previously-rejected config now loads cleanly.
- **`internal/store/crud_test.go`**: replaced `TestDeleteRepoRejectedAsLastEnabled` with `TestDeleteRepoAllowsLastEnabled` asserting `DeleteRepo` of the last enabled repo succeeds and cascades binding cleanup.

The other two minimum tests (`TestDeleteAgentRejectedAsLast`, `TestDeleteBackendRejectedAsLast`) are unchanged — those minimums remain in force.

## Test plan

- [ ] CI green (`go test -race ./...`)
- [ ] `TestLoadAcceptsAllReposDisabled` and `TestDeleteRepoAllowsLastEnabled` pass against the new code paths
- [ ] @pr-reviewer please review.