### PR TITLE
refactor: extract domain entities to internal/fleet, drop *Def suffix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ internal/ui/node_modules/
 internal/ui/.next/
 internal/ui/dist/*
 !internal/ui/dist/.gitkeep
+internal/ui/tsconfig.tsbuildinfo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,8 @@ docker compose up -d                            # containerised run
 ```
 cmd/agents/main.go              # wires config, logger, runners, scheduler, webhook server, proxy
 internal/
-  config/                       # YAML parsing, defaults, validation, prompt/skill file resolution
+  fleet/                        # domain entities: Agent, Repo, Skill, Backend, Binding (zero deps)
+  config/                       # YAML parsing, defaults, validation, prompt/skill file resolution (uses fleet)
   ai/                           # prompt composition + CLI runner (hardcoded backend args + schema enforcement)
   anthropic_proxy/              # built-in Anthropic Messages ↔ OpenAI Chat Completions translation
   observe/                      # observability store: events, traces, dispatch graph, SSE hubs
@@ -93,7 +94,8 @@ When making common classes of changes, update all of these at once:
 
 | Change | Update |
 |---|---|
-| Config schema (types in `internal/config/config.go`) | Validation, `normalize()`, defaults, `config.example.yaml`, README, tests in `internal/config/config_test.go` |
+| Domain entities (`internal/fleet/`: Agent, Repo, Skill, Backend, Binding) | The struct itself, the SQLite store columns, the YAML tags, all CRUD wire shapes, tests |
+| Config schema (top-level `Config`, `Daemon*` in `internal/config/config.go`) | Validation, `normalize()`, defaults, `config.example.yaml`, README, tests in `internal/config/config_test.go` |
 | New webhook event kind | Decoder in `internal/webhook/server.go`, acceptance in `internal/workflow/engine.go`, README event table, validation in `internal/config/config.go` |
 | New AI backend behavior | `internal/ai/cmdrunner.go`, allowlist if new env vars, backend registration in `cmd/agents/main.go`, config example |
 | Agent prompt contract | Prompts in SQLite (edit via UI or CRUD API), runner parser in `internal/ai/cmdrunner.go`, `internal/ai/types.go`, `internal/ai/response-schema.json`, AGENTS.md runner-contract section, tests |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,8 @@
 ```
 cmd/agents/main.go          # Daemon entry point + --run-agent / --db / --import modes
 internal/
-  config/                   # YAML parsing, prompt/skill file resolution, validation
+  fleet/                    # Domain entities: Agent, Repo, Skill, Backend, Binding (zero deps)
+  config/                   # YAML parsing, prompt/skill file resolution, validation (uses fleet)
   ai/                       # Prompt composition + command-based CLI runner (per-backend env)
   anthropic_proxy/          # Built-in Anthropic↔OpenAI Chat Completions translation proxy
   observe/                  # Observability store: events, traces, dispatch graph, SSE hubs

--- a/cmd/agents/main.go
+++ b/cmd/agents/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/eloylp/agents/internal/autonomous"
 	"github.com/eloylp/agents/internal/backends"
 	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/fleet"
 	"github.com/eloylp/agents/internal/logging"
 	mcpserver "github.com/eloylp/agents/internal/mcp"
 	"github.com/eloylp/agents/internal/observe"
@@ -72,7 +73,7 @@ func run() error {
 	// Wire the runner factory so that hot-reloaded backend definitions produce
 	// live runners without a restart. The same factory is used for the initial
 	// setup, so the two paths stay in sync automatically.
-	scheduler.WithRunnerBuilder(func(name string, b config.AIBackendConfig) ai.Runner {
+	scheduler.WithRunnerBuilder(func(name string, b fleet.Backend) ai.Runner {
 		return ai.NewCommandRunner(
 			name, "command", b.Command, backendEnvOverrides(b),
 			b.TimeoutSeconds, b.MaxPromptChars, b.RedactionSaltEnv,
@@ -227,7 +228,7 @@ func setupRunners(cfg *config.Config, logger zerolog.Logger) map[string]ai.Runne
 	return runners
 }
 
-func backendEnvOverrides(b config.AIBackendConfig) map[string]string {
+func backendEnvOverrides(b fleet.Backend) map[string]string {
 	if b.LocalModelURL == "" {
 		return nil
 	}

--- a/cmd/agents/main_test.go
+++ b/cmd/agents/main_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/eloylp/agents/internal/ai"
 	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/fleet"
 	"github.com/eloylp/agents/internal/workflow"
 )
 
@@ -35,18 +36,18 @@ func newMinimalEngine(queue workflow.EventEnqueuer) *workflow.Engine {
 	cfg := &config.Config{
 		Daemon: config.DaemonConfig{
 			Processor: config.ProcessorConfig{MaxConcurrentAgents: 1},
-			AIBackends: map[string]config.AIBackendConfig{
+			AIBackends: map[string]fleet.Backend{
 				"claude": {Command: "claude"},
 			},
 		},
-		Agents: []config.AgentDef{
+		Agents: []fleet.Agent{
 			{Name: "worker", Backend: "claude", Prompt: "Do work."},
 		},
-		Repos: []config.RepoDef{
+		Repos: []fleet.Repo{
 			{
 				Name:    "owner/repo",
 				Enabled: true,
-				Use:     []config.Binding{{Agent: "worker", Labels: []string{"run"}}},
+				Use:     []fleet.Binding{{Agent: "worker", Labels: []string{"run"}}},
 			},
 		},
 	}
@@ -105,19 +106,19 @@ func TestDrainDispatchesPropagatesHandleEventError(t *testing.T) {
 	cfg := &config.Config{
 		Daemon: config.DaemonConfig{
 			Processor: config.ProcessorConfig{MaxConcurrentAgents: 1},
-			AIBackends: map[string]config.AIBackendConfig{
+			AIBackends: map[string]fleet.Backend{
 				"claude": {Command: "claude"},
 			},
 		},
-		Agents: []config.AgentDef{
+		Agents: []fleet.Agent{
 			{Name: "worker", Backend: "claude", Prompt: "Do work."},
 		},
-		Repos: []config.RepoDef{
+		Repos: []fleet.Repo{
 			{
 				Name:    "owner/repo",
 				Enabled: true,
 				// "push" events match this binding so the worker agent is invoked.
-				Use: []config.Binding{{Agent: "worker", Events: []string{"push"}}},
+				Use: []fleet.Binding{{Agent: "worker", Events: []string{"push"}}},
 			},
 		},
 	}
@@ -165,18 +166,18 @@ func TestDrainDispatchesDrainsChainedEvents(t *testing.T) {
 	cfg := &config.Config{
 		Daemon: config.DaemonConfig{
 			Processor: config.ProcessorConfig{MaxConcurrentAgents: 1},
-			AIBackends: map[string]config.AIBackendConfig{
+			AIBackends: map[string]fleet.Backend{
 				"claude": {Command: "claude"},
 			},
 		},
-		Agents: []config.AgentDef{
+		Agents: []fleet.Agent{
 			{Name: "worker", Backend: "claude", Prompt: "Do work."},
 		},
-		Repos: []config.RepoDef{
+		Repos: []fleet.Repo{
 			{
 				Name:    "owner/repo",
 				Enabled: true,
-				Use:     []config.Binding{{Agent: "worker", Events: []string{"push"}}},
+				Use:     []fleet.Binding{{Agent: "worker", Events: []string{"push"}}},
 			},
 		},
 	}

--- a/internal/ai/prompt.go
+++ b/internal/ai/prompt.go
@@ -7,7 +7,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/fleet"
 )
 
 // RosterEntry describes a peer agent visible to the current agent via the
@@ -59,7 +59,7 @@ type PromptContext struct {
 //
 // No Go templates, no {{.Field}} substitution — just text composition. The
 // agent's prompt is expected to be self-contained.
-func RenderAgentPrompt(agent config.AgentDef, skills map[string]config.SkillDef, ctx PromptContext) (RenderedPrompt, error) {
+func RenderAgentPrompt(agent fleet.Agent, skills map[string]fleet.Skill, ctx PromptContext) (RenderedPrompt, error) {
 	var sys strings.Builder
 
 	if !agent.AllowPRs {

--- a/internal/ai/prompt_test.go
+++ b/internal/ai/prompt_test.go
@@ -5,12 +5,12 @@ import (
 	"testing"
 
 	"github.com/eloylp/agents/internal/ai"
-	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/fleet"
 )
 
 // renderSystem is a test helper that returns the System part of a rendered
 // prompt or fails the test if rendering fails.
-func renderSystem(t *testing.T, agent config.AgentDef, skills map[string]config.SkillDef, ctx ai.PromptContext) string {
+func renderSystem(t *testing.T, agent fleet.Agent, skills map[string]fleet.Skill, ctx ai.PromptContext) string {
 	t.Helper()
 	got, err := ai.RenderAgentPrompt(agent, skills, ctx)
 	if err != nil {
@@ -21,7 +21,7 @@ func renderSystem(t *testing.T, agent config.AgentDef, skills map[string]config.
 
 // renderUser is a test helper that returns the User part of a rendered prompt
 // or fails the test if rendering fails.
-func renderUser(t *testing.T, agent config.AgentDef, skills map[string]config.SkillDef, ctx ai.PromptContext) string {
+func renderUser(t *testing.T, agent fleet.Agent, skills map[string]fleet.Skill, ctx ai.PromptContext) string {
 	t.Helper()
 	got, err := ai.RenderAgentPrompt(agent, skills, ctx)
 	if err != nil {
@@ -32,11 +32,11 @@ func renderUser(t *testing.T, agent config.AgentDef, skills map[string]config.Sk
 
 func TestRenderAgentPromptSkillsAndPromptInSystem(t *testing.T) {
 	t.Parallel()
-	skills := map[string]config.SkillDef{
+	skills := map[string]fleet.Skill{
 		"architect": {Prompt: "Focus on architecture."},
 		"testing":   {Prompt: "Focus on tests."},
 	}
-	agent := config.AgentDef{
+	agent := fleet.Agent{
 		Name:   "reviewer",
 		Skills: []string{"architect", "testing"},
 		Prompt: "You review PRs.",
@@ -76,10 +76,10 @@ func TestRenderAgentPromptSystemAndUserAreSeparate(t *testing.T) {
 	t.Parallel()
 	// Skills and agent prompt must only appear in System; runtime context must
 	// only appear in User.
-	skills := map[string]config.SkillDef{
+	skills := map[string]fleet.Skill{
 		"sec": {Prompt: "Check security."},
 	}
-	agent := config.AgentDef{Name: "sec-reviewer", Skills: []string{"sec"}, Prompt: "Audit the code."}
+	agent := fleet.Agent{Name: "sec-reviewer", Skills: []string{"sec"}, Prompt: "Audit the code."}
 	got, err := ai.RenderAgentPrompt(agent, skills, ai.PromptContext{
 		Repo: "owner/repo", Number: 7, EventKind: "issues.labeled", Actor: "bot",
 	})
@@ -107,7 +107,7 @@ func TestRenderAgentPromptSystemAndUserAreSeparate(t *testing.T) {
 
 func TestRenderAgentPromptWithMemory(t *testing.T) {
 	t.Parallel()
-	agent := config.AgentDef{
+	agent := fleet.Agent{
 		Name:   "autonomous",
 		Prompt: "Do your job.",
 	}
@@ -126,7 +126,7 @@ func TestRenderAgentPromptWithMemory(t *testing.T) {
 
 func TestRenderAgentPromptEmptyMemoryFormattedExplicitly(t *testing.T) {
 	t.Parallel()
-	agent := config.AgentDef{Prompt: "Go."}
+	agent := fleet.Agent{Prompt: "Go."}
 	usr := renderUser(t, agent, nil, ai.PromptContext{
 		Repo:         "owner/repo",
 		HasMemory: true,
@@ -138,7 +138,7 @@ func TestRenderAgentPromptEmptyMemoryFormattedExplicitly(t *testing.T) {
 
 func TestRenderAgentPromptMemoryOmittedForEventDrivenRuns(t *testing.T) {
 	t.Parallel()
-	agent := config.AgentDef{Prompt: "Review this PR."}
+	agent := fleet.Agent{Prompt: "Review this PR."}
 	usr := renderUser(t, agent, nil, ai.PromptContext{
 		Repo:   "owner/repo",
 		Number: 42,
@@ -152,12 +152,12 @@ func TestRenderAgentPromptMemoryOmittedForEventDrivenRuns(t *testing.T) {
 
 func TestRenderAgentPromptUnknownSkillErrors(t *testing.T) {
 	t.Parallel()
-	agent := config.AgentDef{
+	agent := fleet.Agent{
 		Name:   "bad",
 		Skills: []string{"missing"},
 		Prompt: "hi",
 	}
-	_, err := ai.RenderAgentPrompt(agent, map[string]config.SkillDef{}, ai.PromptContext{})
+	_, err := ai.RenderAgentPrompt(agent, map[string]fleet.Skill{}, ai.PromptContext{})
 	if err == nil || !strings.Contains(err.Error(), "unknown skill") {
 		t.Fatalf("expected unknown-skill error, got %v", err)
 	}
@@ -165,7 +165,7 @@ func TestRenderAgentPromptUnknownSkillErrors(t *testing.T) {
 
 func TestRenderAgentPromptOmitsUserWhenContextEmpty(t *testing.T) {
 	t.Parallel()
-	agent := config.AgentDef{Prompt: "Do X."}
+	agent := fleet.Agent{Prompt: "Do X."}
 	got, err := ai.RenderAgentPrompt(agent, nil, ai.PromptContext{})
 	if err != nil {
 		t.Fatalf("RenderAgentPrompt: %v", err)
@@ -180,7 +180,7 @@ func TestRenderAgentPromptOmitsUserWhenContextEmpty(t *testing.T) {
 
 func TestRenderAgentPromptIncludesEventContextInUser(t *testing.T) {
 	t.Parallel()
-	agent := config.AgentDef{Prompt: "React to comments."}
+	agent := fleet.Agent{Prompt: "React to comments."}
 	usr := renderUser(t, agent, nil, ai.PromptContext{
 		Repo:      "owner/repo",
 		Number:    3,
@@ -201,7 +201,7 @@ func TestRenderAgentPromptIncludesEventContextInUser(t *testing.T) {
 
 func TestRenderAgentPromptMultilinePayloadBodyIsIndented(t *testing.T) {
 	t.Parallel()
-	agent := config.AgentDef{Prompt: "React to comments."}
+	agent := fleet.Agent{Prompt: "React to comments."}
 	body := "first line\nsecond line\nthird line"
 	usr := renderUser(t, agent, nil, ai.PromptContext{
 		Repo:      "owner/repo",
@@ -221,7 +221,7 @@ func TestRenderAgentPromptMultilinePayloadBodyIsIndented(t *testing.T) {
 
 func TestRenderAgentPromptRosterInSystem(t *testing.T) {
 	t.Parallel()
-	agent := config.AgentDef{Prompt: "Do work.", AllowPRs: true}
+	agent := fleet.Agent{Prompt: "Do work.", AllowPRs: true}
 	ctx := ai.PromptContext{
 		Repo: "owner/repo",
 		Roster: []ai.RosterEntry{
@@ -258,7 +258,7 @@ func TestRenderAgentPromptRosterInSystem(t *testing.T) {
 
 func TestRenderAgentPromptRosterAppendsAfterAgentPrompt(t *testing.T) {
 	t.Parallel()
-	agent := config.AgentDef{Name: "coder", Prompt: "Write code.", AllowPRs: true}
+	agent := fleet.Agent{Name: "coder", Prompt: "Write code.", AllowPRs: true}
 	ctx := ai.PromptContext{
 		Repo: "owner/repo",
 		Roster: []ai.RosterEntry{
@@ -278,7 +278,7 @@ func TestRenderAgentPromptRosterAppendsAfterAgentPrompt(t *testing.T) {
 
 func TestRenderAgentPromptRosterOmittedWhenEmpty(t *testing.T) {
 	t.Parallel()
-	agent := config.AgentDef{Prompt: "Do X.", AllowPRs: true}
+	agent := fleet.Agent{Prompt: "Do X.", AllowPRs: true}
 	got, err := ai.RenderAgentPrompt(agent, nil, ai.PromptContext{Repo: "owner/repo"})
 	if err != nil {
 		t.Fatalf("RenderAgentPrompt: %v", err)
@@ -305,7 +305,7 @@ func TestRenderAgentPromptNoPRGuardInSystem(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			agent := config.AgentDef{Name: "reviewer", Prompt: "Review.", AllowPRs: tc.allowPRs}
+			agent := fleet.Agent{Name: "reviewer", Prompt: "Review.", AllowPRs: tc.allowPRs}
 			got, err := ai.RenderAgentPrompt(agent, nil, ai.PromptContext{Repo: "owner/repo"})
 			if err != nil {
 				t.Fatalf("RenderAgentPrompt: %v", err)
@@ -329,10 +329,10 @@ func TestRenderAgentPromptNoPRGuardInSystem(t *testing.T) {
 // ordering being stable across runs.
 func TestRenderAgentPromptSystemSectionOrdering(t *testing.T) {
 	t.Parallel()
-	skills := map[string]config.SkillDef{
+	skills := map[string]fleet.Skill{
 		"testing": {Prompt: "Focus on tests."},
 	}
-	agent := config.AgentDef{
+	agent := fleet.Agent{
 		Name:     "reviewer",
 		Skills:   []string{"testing"},
 		Prompt:   "You review PRs.",
@@ -366,7 +366,7 @@ func TestRenderAgentPromptSystemSectionOrdering(t *testing.T) {
 
 func TestRenderAgentPromptDispatchContextInUser(t *testing.T) {
 	t.Parallel()
-	agent := config.AgentDef{Prompt: "React to dispatch."}
+	agent := fleet.Agent{Prompt: "React to dispatch."}
 	usr := renderUser(t, agent, nil, ai.PromptContext{
 		Repo:          "owner/repo",
 		InvokedBy:     "coder",
@@ -388,7 +388,7 @@ func TestRenderAgentPromptDispatchContextInUser(t *testing.T) {
 
 func TestRenderAgentPromptDispatchContextOmittedWhenNotDispatched(t *testing.T) {
 	t.Parallel()
-	agent := config.AgentDef{Prompt: "Normal run."}
+	agent := fleet.Agent{Prompt: "Normal run."}
 	usr := renderUser(t, agent, nil, ai.PromptContext{Repo: "owner/repo"})
 	for _, unwanted := range []string{"Invoked by:", "Dispatch reason:", "Dispatch depth:"} {
 		if strings.Contains(usr, unwanted) {
@@ -422,10 +422,10 @@ func TestNormalizeTokenSanitizesForFilesystemUse(t *testing.T) {
 // the split. This is the regression guard required by the issue.
 func TestRenderAgentPromptTotalContentPreserved(t *testing.T) {
 	t.Parallel()
-	skills := map[string]config.SkillDef{
+	skills := map[string]fleet.Skill{
 		"arch": {Prompt: "Architecture guidance."},
 	}
-	agent := config.AgentDef{Name: "coder", Skills: []string{"arch"}, Prompt: "Write code."}
+	agent := fleet.Agent{Name: "coder", Skills: []string{"arch"}, Prompt: "Write code."}
 	ctx := ai.PromptContext{
 		Repo:      "owner/repo",
 		Number:    5,

--- a/internal/autonomous/scheduler.go
+++ b/internal/autonomous/scheduler.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/eloylp/agents/internal/ai"
 	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/fleet"
 	"github.com/eloylp/agents/internal/workflow"
 )
 
@@ -73,7 +74,7 @@ type lastRunRecord struct {
 // RunnerBuilder constructs a new ai.Runner for a given backend name and its
 // config. It is used by Reload to keep the in-process runner map consistent
 // with SQLite when ai_backend definitions change via the CRUD API.
-type RunnerBuilder func(name string, cfg config.AIBackendConfig) ai.Runner
+type RunnerBuilder func(name string, cfg fleet.Backend) ai.Runner
 
 // HotReloadSink is implemented by components that share config and runner
 // state with the Scheduler and must be notified when a CRUD-triggered Reload
@@ -250,7 +251,7 @@ func (s *Scheduler) makeCronJob(repo string, agentName string) func() {
 		// Snapshot cfg+runners at execution time under the same lock so that
 		// the agent definition, backends, and runner set all come from the same
 		// config epoch. Resolving the agent by name here (rather than capturing
-		// a config.AgentDef by value at registration time) ensures that a cron
+		// a fleet.Agent by value at registration time) ensures that a cron
 		// closure that was dequeued just before a Reload completes will still
 		// execute with the post-reload definition once it acquires the read lock.
 		s.bindMu.RLock()
@@ -359,7 +360,7 @@ func (s *Scheduler) TriggerAgent(ctx context.Context, agentName, repo string) er
 	}
 	// The agent must actually be bound to this repo (any trigger kind is
 	// sufficient for on-demand execution).
-	if !slices.ContainsFunc(repoDef.Use, func(b config.Binding) bool {
+	if !slices.ContainsFunc(repoDef.Use, func(b fleet.Binding) bool {
 		return b.Agent == agentName && b.IsEnabled()
 	}) {
 		return fmt.Errorf("agent %q is not bound to repo %q", agentName, repo)
@@ -371,7 +372,7 @@ func (s *Scheduler) TriggerAgent(ctx context.Context, agentName, repo string) er
 // provided by the caller. Both must come from the same atomic snapshot (taken
 // under bindMu.RLock) so that backend resolution and roster building operate
 // on a single consistent epoch without racing against a concurrent Reload.
-func (s *Scheduler) executeAgentRun(ctx context.Context, repo string, agent config.AgentDef, cfg *config.Config, runners map[string]ai.Runner) error {
+func (s *Scheduler) executeAgentRun(ctx context.Context, repo string, agent fleet.Agent, cfg *config.Config, runners map[string]ai.Runner) error {
 	// Atomically check whether a dispatch has already claimed the
 	// (agent, repo, 0) slot and, if not, write the cron mark. This single
 	// lock-protected operation eliminates the TOCTOU race where the old split
@@ -567,7 +568,7 @@ func (s *Scheduler) executeAgentRun(ctx context.Context, repo string, agent conf
 // removed and the config pointer updated. If registration fails, the old
 // entries remain active and the old config is preserved, so the scheduler
 // stays in a consistent state and the caller receives an error.
-func (s *Scheduler) Reload(repos []config.RepoDef, agents []config.AgentDef, skills map[string]config.SkillDef, backends map[string]config.AIBackendConfig) error {
+func (s *Scheduler) Reload(repos []fleet.Repo, agents []fleet.Agent, skills map[string]fleet.Skill, backends map[string]fleet.Backend) error {
 	s.bindMu.Lock()
 
 	// Save old state for rollback.

--- a/internal/autonomous/scheduler_test.go
+++ b/internal/autonomous/scheduler_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/eloylp/agents/internal/ai"
 	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/fleet"
 	"github.com/eloylp/agents/internal/workflow"
 )
 
@@ -85,21 +86,21 @@ func (r *errorRunner) Run(_ context.Context, _ ai.Request) (ai.Response, error) 
 func baseCfg(modify func(*config.Config)) *config.Config {
 	cfg := &config.Config{
 		Daemon: config.DaemonConfig{
-			AIBackends: map[string]config.AIBackendConfig{
+			AIBackends: map[string]fleet.Backend{
 				"claude": {Command: "claude"},
 			},
 		},
-		Skills: map[string]config.SkillDef{
+		Skills: map[string]fleet.Skill{
 			"architect": {Prompt: "Focus on architecture."},
 		},
-		Agents: []config.AgentDef{
+		Agents: []fleet.Agent{
 			{Name: "reviewer", Backend: "claude", Skills: []string{"architect"}, Prompt: "Review PRs."},
 		},
-		Repos: []config.RepoDef{
+		Repos: []fleet.Repo{
 			{
 				Name:    "owner/repo",
 				Enabled: true,
-				Use: []config.Binding{
+				Use: []fleet.Binding{
 					{Agent: "reviewer", Cron: "* * * * *"},
 				},
 			},
@@ -138,7 +139,7 @@ func TestNewSchedulerEntryRegistration(t *testing.T) {
 		{
 			name: "skips label-only binding",
 			mutate: func(c *config.Config) {
-				c.Repos[0].Use[0] = config.Binding{Agent: "reviewer", Labels: []string{"ai:review"}}
+				c.Repos[0].Use[0] = fleet.Binding{Agent: "reviewer", Labels: []string{"ai:review"}}
 			},
 			wantCount: 0,
 		},
@@ -190,7 +191,7 @@ func TestTriggerAgentRejections(t *testing.T) {
 		{
 			name: "unbound agent",
 			mutateCfg: func(c *config.Config) {
-				c.Agents = append(c.Agents, config.AgentDef{Name: "orphan", Backend: "claude", Prompt: "x"})
+				c.Agents = append(c.Agents, fleet.Agent{Name: "orphan", Backend: "claude", Prompt: "x"})
 			},
 			agent:   "orphan",
 			wantErr: "not bound",
@@ -329,7 +330,7 @@ func (q *fakeQueue) popped() []workflow.Event {
 // "notifier" and "notifier" has allow_dispatch: true.
 func dispatchCfgForTest() *config.Config {
 	return baseCfg(func(c *config.Config) {
-		c.Agents = []config.AgentDef{
+		c.Agents = []fleet.Agent{
 			{
 				Name:        "reviewer",
 				Backend:     "claude",
@@ -343,7 +344,7 @@ func dispatchCfgForTest() *config.Config {
 				AllowDispatch: true,
 			},
 		}
-		c.Repos[0].Use = []config.Binding{
+		c.Repos[0].Use = []fleet.Binding{
 			{Agent: "reviewer", Cron: "* * * * *"},
 			{Agent: "notifier", Cron: "0 0 * * *"},
 		}
@@ -360,7 +361,7 @@ func TestSchedulerDispatchesEnqueuedWhenDispatcherAttached(t *testing.T) {
 		},
 	}
 	q := &fakeQueue{}
-	agentMap := map[string]config.AgentDef{
+	agentMap := map[string]fleet.Agent{
 		"reviewer": cfg.Agents[0],
 		"notifier": cfg.Agents[1],
 	}
@@ -407,7 +408,7 @@ func TestSchedulerAutonomousDispatchCarriesNonEmptyRootEventID(t *testing.T) {
 		},
 	}
 	q := &fakeQueue{}
-	agentMap := map[string]config.AgentDef{
+	agentMap := map[string]fleet.Agent{
 		"reviewer": cfg.Agents[0],
 		"notifier": cfg.Agents[1],
 	}
@@ -474,7 +475,7 @@ func TestSchedulerCronRunSkippedWhenAlreadySeenInDedup(t *testing.T) {
 
 	runner := &stubRunner{}
 	q := &fakeQueue{}
-	agentMap := map[string]config.AgentDef{
+	agentMap := map[string]fleet.Agent{
 		"reviewer": cfg.Agents[0],
 		"notifier": cfg.Agents[1],
 	}
@@ -535,7 +536,7 @@ func TestCronRunBlockedByPendingDispatchClaim(t *testing.T) {
 	cfg := dispatchCfgForTest()
 
 	notifierRunner := &stubRunner{}
-	agentMap := map[string]config.AgentDef{
+	agentMap := map[string]fleet.Agent{
 		"reviewer": cfg.Agents[0],
 		"notifier": cfg.Agents[1],
 	}
@@ -600,7 +601,7 @@ func TestSchedulerCronRunNotSuppressedByPriorCronRun(t *testing.T) {
 
 	runner := &stubRunner{}
 	q := &fakeQueue{}
-	agentMap := map[string]config.AgentDef{
+	agentMap := map[string]fleet.Agent{
 		"reviewer": cfg.Agents[0],
 		"notifier": cfg.Agents[1],
 	}
@@ -658,7 +659,7 @@ func TestSchedulerCronMarkNotWrittenOnRunFailure(t *testing.T) {
 			// "notifier" can dispatch to "reviewer"; "reviewer" has allow_dispatch so
 			// whitelist and opt-in checks pass and we can isolate the cron-mark behavior.
 			cfg := baseCfg(func(c *config.Config) {
-				c.Agents = []config.AgentDef{
+				c.Agents = []fleet.Agent{
 					{
 						Name:          "reviewer",
 						Backend:       "claude",
@@ -672,14 +673,14 @@ func TestSchedulerCronMarkNotWrittenOnRunFailure(t *testing.T) {
 						CanDispatch: []string{"reviewer"},
 					},
 				}
-				c.Repos[0].Use = []config.Binding{
+				c.Repos[0].Use = []fleet.Binding{
 					{Agent: "reviewer", Cron: "* * * * *"},
 					{Agent: "notifier", Cron: "0 0 * * *"},
 				}
 			})
 
 			q := &fakeQueue{}
-			agentMap := map[string]config.AgentDef{
+			agentMap := map[string]fleet.Agent{
 				"reviewer": cfg.Agents[0],
 				"notifier": cfg.Agents[1],
 			}
@@ -727,7 +728,7 @@ func TestSchedulerDispatchEnqueueFailurePropagates(t *testing.T) {
 	}
 	queueErr := errors.New("queue full")
 	q := &fakeQueue{err: queueErr}
-	agentMap := map[string]config.AgentDef{
+	agentMap := map[string]fleet.Agent{
 		"reviewer": cfg.Agents[0],
 		"notifier": cfg.Agents[1],
 	}
@@ -765,7 +766,7 @@ func TestSchedulerDispatchEnqueueFailureRecordsErrorSpan(t *testing.T) {
 	}
 	queueErr := errors.New("queue full")
 	q := &fakeQueue{err: queueErr}
-	agentMap := map[string]config.AgentDef{
+	agentMap := map[string]fleet.Agent{
 		"reviewer": cfg.Agents[0],
 		"notifier": cfg.Agents[1],
 	}
@@ -813,7 +814,7 @@ func TestSchedulerCronMarkKeptAfterSuccessfulRunWithDispatchEnqueueFailure(t *te
 	}
 	queueErr := errors.New("queue full")
 	q := &fakeQueue{err: queueErr}
-	agentMap := map[string]config.AgentDef{
+	agentMap := map[string]fleet.Agent{
 		"reviewer": cfg.Agents[0],
 		"notifier": cfg.Agents[1],
 	}
@@ -866,7 +867,7 @@ func TestSchedulerCronRefcountDecrementedOnPostRunEnqueueFailure(t *testing.T) {
 	}
 	queueErr := errors.New("queue full")
 	q := &fakeQueue{err: queueErr}
-	agentMap := map[string]config.AgentDef{
+	agentMap := map[string]fleet.Agent{
 		"reviewer": cfg.Agents[0],
 		"notifier": cfg.Agents[1],
 	}
@@ -908,7 +909,7 @@ func TestSchedulerCronRefcountDecrementedOnPostRunEnqueueFailure(t *testing.T) {
 	// so the cron mark is at ("reviewer", "owner/repo", 0). To test that this mark
 	// no longer blocks dispatches to "reviewer", we need reviewer to have
 	// AllowDispatch: true. Add a local config that grants this.
-	agentMapWithAllowDispatch := map[string]config.AgentDef{
+	agentMapWithAllowDispatch := map[string]fleet.Agent{
 		"reviewer": {
 			Name:          "reviewer",
 			Backend:       "claude",
@@ -948,7 +949,7 @@ func TestSchedulerCronRefcountDecrementedOnPostRunEnqueueFailure(t *testing.T) {
 func TestSchedulerPostRunDispatchSuppressedWithinDedupWindow(t *testing.T) {
 	t.Parallel()
 	cfg := baseCfg(func(c *config.Config) {
-		c.Agents = []config.AgentDef{
+		c.Agents = []fleet.Agent{
 			{
 				Name:          "notifier",
 				Backend:       "claude",
@@ -962,7 +963,7 @@ func TestSchedulerPostRunDispatchSuppressedWithinDedupWindow(t *testing.T) {
 				CanDispatch: []string{"notifier"},
 			},
 		}
-		c.Repos[0].Use = []config.Binding{
+		c.Repos[0].Use = []fleet.Binding{
 			{Agent: "notifier", Cron: "* * * * *"},
 			{Agent: "reviewer", Cron: "0 0 * * *"},
 		}
@@ -970,7 +971,7 @@ func TestSchedulerPostRunDispatchSuppressedWithinDedupWindow(t *testing.T) {
 
 	runner := &stubRunner{}
 	q := &fakeQueue{}
-	agentMap := map[string]config.AgentDef{
+	agentMap := map[string]fleet.Agent{
 		"notifier": cfg.Agents[0],
 		"reviewer": cfg.Agents[1],
 	}
@@ -1032,7 +1033,7 @@ func TestSchedulerAllowPRsPromptPrefixing(t *testing.T) {
 			t.Parallel()
 			runner := &promptCapturingRunner{}
 			cfg := baseCfg(func(c *config.Config) {
-				c.Agents = []config.AgentDef{
+				c.Agents = []fleet.Agent{
 					{Name: "reviewer", Backend: "claude", Skills: []string{"architect"}, Prompt: tc.prompt, AllowPRs: tc.allowPRs},
 				}
 			})
@@ -1068,7 +1069,7 @@ func TestSchedulerCronMarkBlocksDispatchDuringInFlightRun(t *testing.T) {
 	t.Parallel()
 
 	cfg := baseCfg(func(c *config.Config) {
-		c.Agents = []config.AgentDef{
+		c.Agents = []fleet.Agent{
 			{
 				Name:          "reviewer",
 				Backend:       "claude",
@@ -1082,7 +1083,7 @@ func TestSchedulerCronMarkBlocksDispatchDuringInFlightRun(t *testing.T) {
 				CanDispatch: []string{"reviewer"},
 			},
 		}
-		c.Repos[0].Use = []config.Binding{
+		c.Repos[0].Use = []fleet.Binding{
 			{Agent: "reviewer", Cron: "* * * * *"},
 			{Agent: "notifier", Cron: "0 0 * * *"},
 		}
@@ -1092,7 +1093,7 @@ func TestSchedulerCronMarkBlocksDispatchDuringInFlightRun(t *testing.T) {
 	block := make(chan struct{})
 	runner := &blockingRunner{ready: ready, block: block}
 	q := &fakeQueue{}
-	agentMap := map[string]config.AgentDef{
+	agentMap := map[string]fleet.Agent{
 		"reviewer": cfg.Agents[0],
 		"notifier": cfg.Agents[1],
 	}
@@ -1155,7 +1156,7 @@ func TestCronDispatchCrossNamespaceRaceOnlyOneWins(t *testing.T) {
 	ctx := context.Background()
 
 	cfg := dispatchCfgForTest()
-	agentMap := map[string]config.AgentDef{
+	agentMap := map[string]fleet.Agent{
 		"reviewer": cfg.Agents[0],
 		"notifier": cfg.Agents[1],
 	}
@@ -1223,17 +1224,17 @@ func TestSchedulerReload(t *testing.T) {
 	}
 
 	// Reload with a completely different agent and repo.
-	newAgents := []config.AgentDef{
+	newAgents := []fleet.Agent{
 		{Name: "scanner", Backend: "claude", Skills: []string{}, Prompt: "scan"},
 	}
-	newRepos := []config.RepoDef{
+	newRepos := []fleet.Repo{
 		{
 			Name:    "owner/other",
 			Enabled: true,
-			Use:     []config.Binding{{Agent: "scanner", Cron: "* * * * *"}},
+			Use:     []fleet.Binding{{Agent: "scanner", Cron: "* * * * *"}},
 		},
 	}
-	if err := s.Reload(newRepos, newAgents, cfg.Skills, map[string]config.AIBackendConfig{"claude": {Command: "claude"}}); err != nil {
+	if err := s.Reload(newRepos, newAgents, cfg.Skills, map[string]fleet.Backend{"claude": {Command: "claude"}}); err != nil {
 		t.Fatalf("Reload: %v", err)
 	}
 
@@ -1261,10 +1262,10 @@ func TestSchedulerReloadUpdatesSkillsAndBackends(t *testing.T) {
 		t.Fatalf("NewScheduler: %v", err)
 	}
 
-	newSkills := map[string]config.SkillDef{
+	newSkills := map[string]fleet.Skill{
 		"security": {Prompt: "Think about security."},
 	}
-	newBackends := map[string]config.AIBackendConfig{
+	newBackends := map[string]fleet.Backend{
 		"claude": {Command: "claude", TimeoutSeconds: 120},
 	}
 
@@ -1293,7 +1294,7 @@ func TestSchedulerReloadClearsAllBindings(t *testing.T) {
 	}
 
 	// Reload with repos that have no cron bindings.
-	if err := s.Reload([]config.RepoDef{{Name: "owner/repo", Enabled: true, Use: []config.Binding{
+	if err := s.Reload([]fleet.Repo{{Name: "owner/repo", Enabled: true, Use: []fleet.Binding{
 		{Agent: "reviewer", Labels: []string{"ai:fix"}},
 	}}}, cfg.Agents, cfg.Skills, cfg.Daemon.AIBackends); err != nil {
 		t.Fatalf("Reload: %v", err)
@@ -1324,12 +1325,12 @@ func TestSchedulerReloadRollsBackOnFailure(t *testing.T) {
 	}
 
 	// Attempt a reload where the binding references an agent not in the agents slice.
-	badRepos := []config.RepoDef{{
+	badRepos := []fleet.Repo{{
 		Name:    "owner/repo",
 		Enabled: true,
-		Use:     []config.Binding{{Agent: "ghost", Cron: "* * * * *"}},
+		Use:     []fleet.Binding{{Agent: "ghost", Cron: "* * * * *"}},
 	}}
-	badAgents := []config.AgentDef{} // "ghost" not in this list → registerJobs will fail
+	badAgents := []fleet.Agent{} // "ghost" not in this list → registerJobs will fail
 
 	if err := s.Reload(badRepos, badAgents, cfg.Skills, cfg.Daemon.AIBackends); err == nil {
 		t.Fatal("Reload: expected error for unknown agent binding, got nil")
@@ -1382,14 +1383,14 @@ func TestSchedulerReloadRebuildsRunners(t *testing.T) {
 
 	// Register a builder that returns a new distinct stub for each backend.
 	buildCalls := map[string]*stubRunner{}
-	s.WithRunnerBuilder(func(name string, _ config.AIBackendConfig) ai.Runner {
+	s.WithRunnerBuilder(func(name string, _ fleet.Backend) ai.Runner {
 		r := &stubRunner{}
 		buildCalls[name] = r
 		return r
 	})
 
 	// Reload with a new "codex" backend added and "claude" retained.
-	newBackends := map[string]config.AIBackendConfig{
+	newBackends := map[string]fleet.Backend{
 		"claude": {Command: "claude"},
 		"codex":  {Command: "codex"},
 	}
@@ -1476,7 +1477,7 @@ func TestSchedulerReloadConfigCopyOnWrite(t *testing.T) {
 		t.Fatalf("NewScheduler: %v", err)
 	}
 
-	newRepos := []config.RepoDef{{Name: "owner/new-repo", Enabled: true, Use: []config.Binding{{Agent: "reviewer", Cron: "* * * * *"}}}}
+	newRepos := []fleet.Repo{{Name: "owner/new-repo", Enabled: true, Use: []fleet.Binding{{Agent: "reviewer", Cron: "* * * * *"}}}}
 	if err := s.Reload(newRepos, cfg.Agents, cfg.Skills, cfg.Daemon.AIBackends); err != nil {
 		t.Fatalf("Reload: %v", err)
 	}
@@ -1508,7 +1509,7 @@ func TestSchedulerReloadRaceWithConcurrentRun(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewScheduler: %v", err)
 	}
-	s.WithRunnerBuilder(func(name string, _ config.AIBackendConfig) ai.Runner { return runner })
+	s.WithRunnerBuilder(func(name string, _ fleet.Backend) ai.Runner { return runner })
 	s.WithHotReloadSink(&testHotReloadSink{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -1560,7 +1561,7 @@ func TestSchedulerReloadReleasesMuBeforeSinkCall(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewScheduler: %v", err)
 	}
-	s.WithRunnerBuilder(func(_ string, _ config.AIBackendConfig) ai.Runner { return runner })
+	s.WithRunnerBuilder(func(_ string, _ fleet.Backend) ai.Runner { return runner })
 
 	// Sink that signals when UpdateConfigAndRunners is entered, then blocks
 	// until released. This lets us assert that bindMu is NOT held during the
@@ -1629,7 +1630,7 @@ func TestSchedulerCronJobUsesPostReloadAgentDef(t *testing.T) {
 	preReloadJob := s.cron.Entry(s.agentEntries[0].cronID).WrappedJob
 
 	// Reload with an updated prompt for the same agent.
-	updatedAgents := []config.AgentDef{
+	updatedAgents := []fleet.Agent{
 		{Name: "reviewer", Backend: "claude", Skills: []string{"architect"}, Prompt: "Updated review prompt."},
 	}
 	if err := s.Reload(cfg.Repos, updatedAgents, cfg.Skills, cfg.Daemon.AIBackends); err != nil {
@@ -1723,7 +1724,7 @@ func TestSchedulerWriteMemoryFailureFailsRun(t *testing.T) {
 	// notices the error and re-dispatches "reviewer" to recover lost memory.
 	cfg := baseCfg(func(c *config.Config) {
 		c.Agents[0].AllowDispatch = true // reviewer can receive dispatches
-		c.Agents = append(c.Agents, config.AgentDef{
+		c.Agents = append(c.Agents, fleet.Agent{
 			Name:        "notifier",
 			Backend:     "claude",
 			Prompt:      "Notify.",
@@ -1734,7 +1735,7 @@ func TestSchedulerWriteMemoryFailureFailsRun(t *testing.T) {
 	mem := &errMemory{inner: newMapMemory(), err: writeErr}
 
 	q := &fakeQueue{}
-	agentMap := map[string]config.AgentDef{
+	agentMap := map[string]fleet.Agent{
 		"reviewer": cfg.Agents[0],
 		"notifier": cfg.Agents[1],
 	}

--- a/internal/backends/discovery.go
+++ b/internal/backends/discovery.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/fleet"
 	"github.com/eloylp/agents/internal/store"
 )
 
@@ -80,7 +81,7 @@ func DiscoverAndPersist(ctx context.Context, db *sql.DB) (Diagnostics, error) {
 }
 
 // RunDiagnostics executes live discovery checks without mutating the store.
-func RunDiagnostics(ctx context.Context, existing map[string]config.AIBackendConfig) Diagnostics {
+func RunDiagnostics(ctx context.Context, existing map[string]fleet.Backend) Diagnostics {
 	diag := Diagnostics{GeneratedAt: time.Now().UTC()}
 	type backendTarget struct {
 		name             string
@@ -131,7 +132,7 @@ func RunDiagnostics(ctx context.Context, existing map[string]config.AIBackendCon
 	return diag
 }
 
-func persistDiagnostics(db *sql.DB, existing map[string]config.AIBackendConfig, diag Diagnostics) error {
+func persistDiagnostics(db *sql.DB, existing map[string]fleet.Backend, diag Diagnostics) error {
 	for _, b := range diag.Backends {
 		prev, hadPrev := existing[b.Name]
 		if !b.Detected && !hadPrev {

--- a/internal/config/allow_memory_test.go
+++ b/internal/config/allow_memory_test.go
@@ -1,16 +1,17 @@
 package config
 
 import (
+	"github.com/eloylp/agents/internal/fleet"
 	"strings"
 	"testing"
 )
 
-// TestAgentIsAllowMemoryDefaultsTrue confirms that an AgentDef with no
+// TestAgentIsAllowMemoryDefaultsTrue confirms that an fleet.Agent with no
 // AllowMemory field set (the YAML "absent" case) reports true so existing
 // agents authored before the field existed keep their previous behaviour.
 func TestAgentIsAllowMemoryDefaultsTrue(t *testing.T) {
 	t.Parallel()
-	a := AgentDef{Name: "reviewer"}
+	a := fleet.Agent{Name: "reviewer"}
 	if !a.IsAllowMemory() {
 		t.Errorf("AllowMemory nil should report true, got false")
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/eloylp/agents/internal/fleet"
 )
 
 // validAIBackendNames is the canonical list of supported AI backend names.
@@ -74,9 +76,9 @@ const (
 // Config is the root configuration loaded from YAML.
 type Config struct {
 	Daemon DaemonConfig        `yaml:"daemon"`
-	Skills map[string]SkillDef `yaml:"skills"`
-	Agents []AgentDef          `yaml:"agents"`
-	Repos  []RepoDef           `yaml:"repos"`
+	Skills map[string]fleet.Skill `yaml:"skills"`
+	Agents []fleet.Agent          `yaml:"agents"`
+	Repos  []fleet.Repo           `yaml:"repos"`
 
 	// configDir is the directory containing the config file, used to resolve
 	// prompt_file paths.
@@ -89,7 +91,7 @@ type DaemonConfig struct {
 	Log        LogConfig                  `yaml:"log"`
 	HTTP       HTTPConfig                 `yaml:"http"`
 	Processor  ProcessorConfig            `yaml:"processor"`
-	AIBackends map[string]AIBackendConfig `yaml:"ai_backends"`
+	AIBackends map[string]fleet.Backend `yaml:"ai_backends"`
 	Proxy      ProxyConfig                `yaml:"proxy"`
 }
 
@@ -158,115 +160,6 @@ type DispatchConfig struct {
 	DedupWindowSeconds int `yaml:"dedup_window_seconds"`
 }
 
-// AIBackendConfig describes how to invoke a CLI-based AI backend.
-//
-// LocalModelURL, when set, routes the CLI through the built-in translation
-// proxy by injecting ANTHROPIC_BASE_URL into the subprocess environment.
-type AIBackendConfig struct {
-	Command          string   `yaml:"command"`
-	Version          string   `yaml:"version"`
-	Models           []string `yaml:"models"`
-	Healthy          bool     `yaml:"healthy"`
-	HealthDetail     string   `yaml:"health_detail"`
-	LocalModelURL    string   `yaml:"local_model_url"`
-	TimeoutSeconds   int      `yaml:"timeout_seconds"`
-	MaxPromptChars   int      `yaml:"max_prompt_chars"`
-	RedactionSaltEnv string   `yaml:"redaction_salt_env"`
-}
-
-// SkillDef is a reusable block of guidance that agents can compose.
-// After loading, Prompt always contains the resolved guidance text; PromptFile
-// is retained only for debugging/logging.
-type SkillDef struct {
-	Prompt     string `yaml:"prompt"`
-	PromptFile string `yaml:"prompt_file"`
-}
-
-// AgentDef is a named capability: a backend, a set of skills, and a prompt.
-// Agents are pure definitions — they don't run on their own. Repos bind them
-// to triggers.
-type AgentDef struct {
-	Name       string   `yaml:"name"`
-	Backend    string   `yaml:"backend"`
-	Model      string   `yaml:"model"`
-	Skills     []string `yaml:"skills"`
-	Prompt     string   `yaml:"prompt"`
-	PromptFile string   `yaml:"prompt_file"`
-	// AllowPRs controls whether the agent is permitted to open pull requests.
-	// Defaults to false; the scheduler prepends a hard no-PR instruction when
-	// false so the gate is code-level rather than relying on prompt wording.
-	AllowPRs bool `yaml:"allow_prs"`
-
-	// Description is a short human-readable summary of what this agent does.
-	// Required when the agent appears in any other agent's can_dispatch list.
-	Description string `yaml:"description"`
-
-	// AllowDispatch opts this agent in as a dispatch target. Default false.
-	// Other agents may only dispatch to this agent when this is true.
-	AllowDispatch bool `yaml:"allow_dispatch"`
-
-	// CanDispatch is the whitelist of agent names this agent is allowed to
-	// dispatch. Validated: entries must reference real agents in the same
-	// config and must not include the agent itself.
-	CanDispatch []string `yaml:"can_dispatch"`
-
-	// AllowMemory controls whether the autonomous (cron) scheduler loads and
-	// persists this agent's memory across runs. Stored as a pointer so absence
-	// can be distinguished from explicit false: when nil (the YAML/JSON
-	// "absent" case), IsAllowMemory reports true so existing autonomous agents
-	// keep their behaviour without an explicit opt-in. Set to a non-nil false
-	// to disable memory load+persist for this agent across all run kinds.
-	AllowMemory *bool `yaml:"allow_memory,omitempty"`
-}
-
-// IsAllowMemory reports whether this agent's memory should be loaded into the
-// prompt and persisted from the response. Default (nil pointer) is true, so
-// agents authored before this field existed retain their previous behaviour.
-func (a AgentDef) IsAllowMemory() bool {
-	return a.AllowMemory == nil || *a.AllowMemory
-}
-
-// RepoDef describes a single GitHub repo the daemon operates on and the
-// agents bound to it.
-type RepoDef struct {
-	Name    string    `yaml:"name"`
-	Enabled bool      `yaml:"enabled"`
-	Use     []Binding `yaml:"use"`
-}
-
-// Binding wires an agent to one or more triggers on a specific repo.
-// An agent can appear multiple times in a repo's Use list with different
-// triggers.
-//
-// ID is the SQLite AUTOINCREMENT primary key of the binding row. It is not
-// present in YAML (zero for entries loaded from a YAML file) and is populated
-// by the store when loaded. Atomic per-binding CRUD endpoints address a row
-// by its ID so UI edits can target one binding without replacing the whole
-// repo.
-type Binding struct {
-	ID      int64    `yaml:"-" json:"id,omitempty"`
-	Agent   string   `yaml:"agent"`
-	Labels  []string `yaml:"labels"`
-	Cron    string   `yaml:"cron"`
-	Events  []string `yaml:"events"`
-	Enabled *bool    `yaml:"enabled"`
-}
-
-// IsEnabled reports whether this binding should be active. Absent =
-// enabled; only explicit `enabled: false` disables.
-func (b Binding) IsEnabled() bool {
-	return b.Enabled == nil || *b.Enabled
-}
-
-// IsCron reports whether this binding is cron-triggered.
-func (b Binding) IsCron() bool { return strings.TrimSpace(b.Cron) != "" }
-
-// IsLabel reports whether this binding is label-triggered.
-func (b Binding) IsLabel() bool { return len(b.Labels) > 0 }
-
-// IsEvent reports whether this binding is event-triggered (via the events: field).
-func (b Binding) IsEvent() bool { return len(b.Events) > 0 }
-
 // ValidateCrossRefs checks cross-entity reference consistency across the four
 // mutable entity sets. It is called by the SQLite CRUD layer after each write
 // (within the same transaction) so that invalid fleet configurations cannot be
@@ -276,8 +169,8 @@ func (b Binding) IsEvent() bool { return len(b.Events) > 0 }
 //   - every agent references a known backend and known skills
 //   - dispatch wiring (can_dispatch) references existing agents with descriptions
 //   - every repo binding references a known agent
-func ValidateCrossRefs(agents []AgentDef, repos []RepoDef, skills map[string]SkillDef, backends map[string]AIBackendConfig) error {
-	agentByName := make(map[string]AgentDef, len(agents))
+func ValidateCrossRefs(agents []fleet.Agent, repos []fleet.Repo, skills map[string]fleet.Skill, backends map[string]fleet.Backend) error {
+	agentByName := make(map[string]fleet.Agent, len(agents))
 	for _, a := range agents {
 		agentByName[a.Name] = a
 	}
@@ -338,12 +231,12 @@ func ValidateCrossRefs(agents []AgentDef, repos []RepoDef, skills map[string]Ski
 // The intent is that every CRUD write on the SQLite store passes ValidateEntities
 // so that SQLite is never left in a state that would fail LoadAndValidate on
 // restart due to locally invalid entity fields.
-func ValidateEntities(agents []AgentDef, repos []RepoDef, skills map[string]SkillDef, backends map[string]AIBackendConfig) error {
+func ValidateEntities(agents []fleet.Agent, repos []fleet.Repo, skills map[string]fleet.Skill, backends map[string]fleet.Backend) error {
 	if backends == nil {
-		backends = map[string]AIBackendConfig{}
+		backends = map[string]fleet.Backend{}
 	}
 	if skills == nil {
-		skills = map[string]SkillDef{}
+		skills = map[string]fleet.Skill{}
 	}
 
 	// Backend field checks (without "at least one" aggregate check).
@@ -488,26 +381,26 @@ func Load(path string) (*Config, error) {
 
 // RepoByName returns the repo definition with the given full name
 // (case-insensitive).
-func (c *Config) RepoByName(name string) (RepoDef, bool) {
+func (c *Config) RepoByName(name string) (fleet.Repo, bool) {
 	name = strings.ToLower(strings.TrimSpace(name))
 	for _, r := range c.Repos {
 		if strings.ToLower(r.Name) == name {
 			return r, true
 		}
 	}
-	return RepoDef{}, false
+	return fleet.Repo{}, false
 }
 
 // AgentByName returns the agent definition with the given name
 // (case-insensitive).
-func (c *Config) AgentByName(name string) (AgentDef, bool) {
+func (c *Config) AgentByName(name string) (fleet.Agent, bool) {
 	name = strings.ToLower(strings.TrimSpace(name))
 	for _, a := range c.Agents {
 		if a.Name == name {
 			return a, true
 		}
 	}
-	return AgentDef{}, false
+	return fleet.Agent{}, false
 }
 
 // ResolveBackend returns the concrete backend name for the given agent
@@ -568,7 +461,7 @@ func (c *Config) applyDefaults() {
 func (c *Config) normalize() {
 	// Lowercase backend keys for case-insensitive matching.
 	if len(c.Daemon.AIBackends) > 0 {
-		lower := make(map[string]AIBackendConfig, len(c.Daemon.AIBackends))
+		lower := make(map[string]fleet.Backend, len(c.Daemon.AIBackends))
 		for name, backend := range c.Daemon.AIBackends {
 			key := strings.ToLower(strings.TrimSpace(name))
 			backend.Command = strings.TrimSpace(backend.Command)
@@ -585,7 +478,7 @@ func (c *Config) normalize() {
 
 	// Lowercase skill keys.
 	if len(c.Skills) > 0 {
-		lower := make(map[string]SkillDef, len(c.Skills))
+		lower := make(map[string]fleet.Skill, len(c.Skills))
 		for name, skill := range c.Skills {
 			key := strings.ToLower(strings.TrimSpace(name))
 			skill.Prompt = strings.TrimSpace(skill.Prompt)
@@ -826,7 +719,7 @@ func (c *Config) validateAgents() error {
 //   - can_dispatch must not include the agent itself
 //   - agents referenced in any can_dispatch list must have a description
 func (c *Config) validateDispatchWiring() error {
-	agentByName := make(map[string]AgentDef, len(c.Agents))
+	agentByName := make(map[string]fleet.Agent, len(c.Agents))
 	for _, a := range c.Agents {
 		agentByName[a.Name] = a
 	}
@@ -848,7 +741,7 @@ func (c *Config) validateDispatchWiring() error {
 }
 
 // countBindingTriggers returns the number of trigger types (labels, events, cron) set on b.
-func countBindingTriggers(b Binding) int {
+func countBindingTriggers(b fleet.Binding) int {
 	n := 0
 	if b.IsLabel() {
 		n++
@@ -908,7 +801,7 @@ func isValidBackendName(name string) bool {
 	return slices.Contains(validAIBackendNames, name)
 }
 
-func isSupportedBackend(name string, backend AIBackendConfig) bool {
+func isSupportedBackend(name string, backend fleet.Backend) bool {
 	if isValidBackendName(name) {
 		return true
 	}
@@ -920,7 +813,7 @@ func isSupportedBackend(name string, backend AIBackendConfig) bool {
 //
 // If backend.Models is empty, availability is treated as unknown (returns
 // false) so callers can avoid blocking on missing catalog metadata.
-func IsPinnedModelUnavailable(model string, backend AIBackendConfig) bool {
+func IsPinnedModelUnavailable(model string, backend fleet.Backend) bool {
 	model = strings.TrimSpace(model)
 	if model == "" {
 		return false
@@ -931,7 +824,7 @@ func IsPinnedModelUnavailable(model string, backend AIBackendConfig) bool {
 	return !slices.Contains(backend.Models, model)
 }
 
-func validateAgentModel(_ string, _ string, _ AIBackendConfig) error {
+func validateAgentModel(_ string, _ string, _ fleet.Backend) error {
 	// Model/backend mismatches are intentionally allowed at config validation
 	// time so discovery can persist backend model changes even if agents become
 	// temporarily orphaned. Runtime paths enforce this strictly before invoking
@@ -943,7 +836,7 @@ func validateAgentModel(_ string, _ string, _ AIBackendConfig) error {
 // that Load / FinishLoad apply at startup. Callers that persist a backend via
 // the CRUD API should call this before writing so that the stored values match
 // what the daemon would derive from those zeros on the next restart.
-func ApplyBackendDefaults(b *AIBackendConfig) {
+func ApplyBackendDefaults(b *fleet.Backend) {
 	setDefaultInt(&b.TimeoutSeconds, defaultAITimeoutSeconds)
 	setDefaultInt(&b.MaxPromptChars, defaultMaxPromptChars)
 }
@@ -953,7 +846,7 @@ func ApplyBackendDefaults(b *AIBackendConfig) {
 // are empty after trimming. CRUD callers must invoke this before persisting a
 // backend so that the stored values match the canonical form the daemon derives
 // at boot, preventing live behavior from diverging until a restart.
-func NormalizeBackendConfig(b *AIBackendConfig) {
+func NormalizeBackendConfig(b *fleet.Backend) {
 	b.Command = strings.TrimSpace(b.Command)
 	b.Version = strings.TrimSpace(b.Version)
 	b.HealthDetail = strings.TrimSpace(b.HealthDetail)
@@ -967,7 +860,7 @@ func NormalizeBackendConfig(b *AIBackendConfig) {
 // performs on skill values at startup: it trims Prompt and PromptFile.
 // CRUD callers must invoke this before persisting a skill so that the stored
 // values match the canonical form the daemon derives at boot.
-func NormalizeSkillDef(s *SkillDef) {
+func NormalizeSkillDef(s *fleet.Skill) {
 	s.Prompt = strings.TrimSpace(s.Prompt)
 	s.PromptFile = strings.TrimSpace(s.PromptFile)
 }
@@ -977,7 +870,7 @@ func NormalizeSkillDef(s *SkillDef) {
 // CRUD callers must invoke this before writing an agent to SQLite so the stored
 // values are already in the canonical form that AgentByName and registerJobs
 // expect, preventing live behavior from diverging until the next restart.
-func NormalizeAgentDef(a *AgentDef) {
+func NormalizeAgentDef(a *fleet.Agent) {
 	a.Name = strings.ToLower(strings.TrimSpace(a.Name))
 	a.Backend = strings.ToLower(strings.TrimSpace(a.Backend))
 	a.Model = strings.TrimSpace(a.Model)
@@ -1024,7 +917,7 @@ func NormalizeRepoName(name string) string {
 // repo entries: lowercase+trim the repo name, and lowercase+trim each binding
 // agent name, cron, and event strings. CRUD callers must invoke this before
 // writing a repo.
-func NormalizeRepoDef(r *RepoDef) {
+func NormalizeRepoDef(r *fleet.Repo) {
 	r.Name = NormalizeRepoName(r.Name)
 	for i := range r.Use {
 		r.Use[i].Agent = strings.ToLower(strings.TrimSpace(r.Use[i].Agent))

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"github.com/eloylp/agents/internal/fleet"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -341,7 +342,7 @@ repos:
 
 func TestBindingIsEnabledDefaultsTrue(t *testing.T) {
 	t.Parallel()
-	var b Binding
+	var b fleet.Binding
 	if !b.IsEnabled() {
 		t.Errorf("expected enabled by default")
 	}
@@ -356,7 +357,7 @@ func TestResolveBackend(t *testing.T) {
 	t.Parallel()
 	cfg := &Config{
 		Daemon: DaemonConfig{
-			AIBackends: map[string]AIBackendConfig{
+			AIBackends: map[string]fleet.Backend{
 				"claude": {Command: "claude"},
 			},
 		},

--- a/internal/fleet/agent.go
+++ b/internal/fleet/agent.go
@@ -1,0 +1,47 @@
+package fleet
+
+// Agent is a named capability: a backend, a set of skills, and a prompt.
+// Agents are pure definitions — they don't run on their own. Repos bind them
+// to triggers.
+type Agent struct {
+	Name       string   `yaml:"name"`
+	Backend    string   `yaml:"backend"`
+	Model      string   `yaml:"model"`
+	Skills     []string `yaml:"skills"`
+	Prompt     string   `yaml:"prompt"`
+	PromptFile string   `yaml:"prompt_file"`
+	// AllowPRs controls whether the agent is permitted to open pull requests.
+	// Defaults to false; the scheduler prepends a hard no-PR instruction when
+	// false so the gate is code-level rather than relying on prompt wording.
+	AllowPRs bool `yaml:"allow_prs"`
+
+	// Description is a short human-readable summary of what this agent does.
+	// Required when the agent appears in any other agent's can_dispatch list.
+	Description string `yaml:"description"`
+
+	// AllowDispatch opts this agent in as a dispatch target. Default false.
+	// Other agents may only dispatch to this agent when this is true.
+	AllowDispatch bool `yaml:"allow_dispatch"`
+
+	// CanDispatch is the whitelist of agent names this agent is allowed to
+	// dispatch. Validated: entries must reference real agents in the same
+	// config and must not include the agent itself.
+	CanDispatch []string `yaml:"can_dispatch"`
+
+	// AllowMemory controls whether the daemon loads existing memory into the
+	// prompt and persists the agent's returned memory after the run. Stored as
+	// a pointer so absence can be distinguished from explicit false: when nil
+	// (the YAML/JSON "absent" case), IsAllowMemory reports true so existing
+	// agents authored before this field existed retain their previous behaviour.
+	// Set to a non-nil false to disable memory load+persist for this agent
+	// across every trigger surface (cron, --run-agent, webhook events,
+	// dispatch, POST /run, MCP trigger_agent).
+	AllowMemory *bool `yaml:"allow_memory,omitempty"`
+}
+
+// IsAllowMemory reports whether this agent's memory should be loaded into the
+// prompt and persisted from the response. Default (nil pointer) is true, so
+// agents authored before this field existed retain their previous behaviour.
+func (a Agent) IsAllowMemory() bool {
+	return a.AllowMemory == nil || *a.AllowMemory
+}

--- a/internal/fleet/backend.go
+++ b/internal/fleet/backend.go
@@ -1,0 +1,28 @@
+// Package fleet defines the domain entities the daemon orchestrates: agents,
+// skills, backends, repos, and the bindings that wire agents to repos. Other
+// packages (config, store, mcp, webhook, workflow, autonomous) consume these
+// types; this package depends on none of them.
+//
+// The types here are loaded from YAML by the config package, persisted by the
+// store package, and surfaced over REST and MCP. They are pure data plus
+// per-entity invariants and helpers (e.g. Binding.IsCron, Agent.IsAllowMemory).
+// Cross-entity validation (agents that reference unknown skills, dispatch
+// wiring that points at agents that do not exist) lives in the config
+// package because it needs the full Config snapshot.
+package fleet
+
+// Backend is one AI CLI runner the daemon can dispatch agents through.
+// "claude" and "codex" are built-in names; any other key in the daemon's
+// AIBackends map is a custom backend, typically routed through a local LLM
+// via LocalModelURL.
+type Backend struct {
+	Command          string   `yaml:"command"`
+	Version          string   `yaml:"version"`
+	Models           []string `yaml:"models"`
+	Healthy          bool     `yaml:"healthy"`
+	HealthDetail     string   `yaml:"health_detail"`
+	LocalModelURL    string   `yaml:"local_model_url"`
+	TimeoutSeconds   int      `yaml:"timeout_seconds"`
+	MaxPromptChars   int      `yaml:"max_prompt_chars"`
+	RedactionSaltEnv string   `yaml:"redaction_salt_env"`
+}

--- a/internal/fleet/binding.go
+++ b/internal/fleet/binding.go
@@ -1,0 +1,36 @@
+package fleet
+
+import "strings"
+
+// Binding wires an agent to one or more triggers on a specific repo.
+// An agent can appear multiple times in a repo's Use list with different
+// triggers.
+//
+// ID is the SQLite AUTOINCREMENT primary key of the binding row. It is not
+// present in YAML (zero for entries loaded from a YAML file) and is populated
+// by the store when loaded. Atomic per-binding CRUD endpoints address a row
+// by its ID so UI edits can target one binding without replacing the whole
+// repo.
+type Binding struct {
+	ID      int64    `yaml:"-" json:"id,omitempty"`
+	Agent   string   `yaml:"agent"`
+	Labels  []string `yaml:"labels"`
+	Cron    string   `yaml:"cron"`
+	Events  []string `yaml:"events"`
+	Enabled *bool    `yaml:"enabled"`
+}
+
+// IsEnabled reports whether this binding should be active. Absent =
+// enabled; only explicit `enabled: false` disables.
+func (b Binding) IsEnabled() bool {
+	return b.Enabled == nil || *b.Enabled
+}
+
+// IsCron reports whether this binding is cron-triggered.
+func (b Binding) IsCron() bool { return strings.TrimSpace(b.Cron) != "" }
+
+// IsLabel reports whether this binding is label-triggered.
+func (b Binding) IsLabel() bool { return len(b.Labels) > 0 }
+
+// IsEvent reports whether this binding is event-triggered (via the events: field).
+func (b Binding) IsEvent() bool { return len(b.Events) > 0 }

--- a/internal/fleet/repo.go
+++ b/internal/fleet/repo.go
@@ -1,0 +1,9 @@
+package fleet
+
+// Repo describes a single GitHub repository the daemon operates on and the
+// agent bindings declared for it.
+type Repo struct {
+	Name    string    `yaml:"name"`
+	Enabled bool      `yaml:"enabled"`
+	Use     []Binding `yaml:"use"`
+}

--- a/internal/fleet/skill.go
+++ b/internal/fleet/skill.go
@@ -1,0 +1,9 @@
+package fleet
+
+// Skill is a reusable block of guidance that agents can compose.
+// After loading, Prompt always contains the resolved guidance text; PromptFile
+// is retained only for debugging/logging.
+type Skill struct {
+	Prompt     string `yaml:"prompt"`
+	PromptFile string `yaml:"prompt_file"`
+}

--- a/internal/mcp/allow_memory_test.go
+++ b/internal/mcp/allow_memory_test.go
@@ -7,7 +7,7 @@ import (
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/rs/zerolog"
 
-	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/fleet"
 	"github.com/eloylp/agents/internal/store"
 )
 
@@ -17,7 +17,7 @@ import (
 // memory disabled" from the documented default.
 func TestToolCreateAgentForwardsAllowMemoryFalse(t *testing.T) {
 	t.Parallel()
-	canonical := config.AgentDef{Name: "linter", Backend: "claude", Prompt: "audit"}
+	canonical := fleet.Agent{Name: "linter", Backend: "claude", Prompt: "audit"}
 	w := &stubAgentWriter{canonical: canonical}
 	deps := Deps{
 		DB:         testDB(t),
@@ -53,7 +53,7 @@ func TestToolCreateAgentForwardsAllowMemoryFalse(t *testing.T) {
 // returns the documented default of true downstream.
 func TestToolCreateAgentLeavesAllowMemoryNilWhenAbsent(t *testing.T) {
 	t.Parallel()
-	canonical := config.AgentDef{Name: "linter", Backend: "claude", Prompt: "audit"}
+	canonical := fleet.Agent{Name: "linter", Backend: "claude", Prompt: "audit"}
 	w := &stubAgentWriter{canonical: canonical}
 	deps := Deps{
 		DB:         testDB(t),
@@ -85,7 +85,7 @@ func TestToolCreateAgentLeavesAllowMemoryNilWhenAbsent(t *testing.T) {
 // what the webhook adapter expects to merge over an existing AgentDef.
 func TestToolUpdateAgentForwardsAllowMemoryPatch(t *testing.T) {
 	t.Parallel()
-	canonical := config.AgentDef{Name: "coder", Backend: "claude", Prompt: "p"}
+	canonical := fleet.Agent{Name: "coder", Backend: "claude", Prompt: "p"}
 	w := &stubAgentWriter{patchCanonical: canonical}
 	deps := Deps{
 		DB:         testDB(t),
@@ -149,7 +149,7 @@ func TestToolGetAgentSurfacesAllowMemory(t *testing.T) {
 	t.Parallel()
 	cfg := fixtureConfig()
 	ff := false
-	cfg.Agents = []config.AgentDef{
+	cfg.Agents = []fleet.Agent{
 		{Name: "coder", Backend: "claude", Prompt: "p"},
 		{Name: "stateless", Backend: "claude", Prompt: "p", AllowMemory: &ff},
 	}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -35,6 +35,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/fleet"
 	"github.com/eloylp/agents/internal/observe"
 	"github.com/eloylp/agents/internal/workflow"
 )
@@ -137,8 +138,8 @@ type AgentPatch struct {
 // Implementations must hold the store mutex while writing and reload cron
 // schedules afterwards so MCP writes stay consistent with the REST path.
 type AgentWriter interface {
-	UpsertAgent(a config.AgentDef) (config.AgentDef, error)
-	UpdateAgentPatch(name string, patch AgentPatch) (config.AgentDef, error)
+	UpsertAgent(a fleet.Agent) (fleet.Agent, error)
+	UpdateAgentPatch(name string, patch AgentPatch) (fleet.Agent, error)
 	DeleteAgent(name string, cascade bool) error
 }
 
@@ -158,8 +159,8 @@ type SkillPatch struct {
 // Implementations must hold the store mutex while writing and reload cron
 // schedules afterwards so MCP writes stay consistent with the REST path.
 type SkillWriter interface {
-	UpsertSkill(name string, sk config.SkillDef) (string, config.SkillDef, error)
-	UpdateSkillPatch(name string, patch SkillPatch) (string, config.SkillDef, error)
+	UpsertSkill(name string, sk fleet.Skill) (string, fleet.Skill, error)
+	UpdateSkillPatch(name string, patch SkillPatch) (string, fleet.Skill, error)
 	DeleteSkill(name string) error
 }
 
@@ -189,8 +190,8 @@ type BackendPatch struct {
 // Implementations must hold the store mutex while writing and reload cron
 // schedules afterwards so MCP writes stay consistent with the REST path.
 type BackendWriter interface {
-	UpsertBackend(name string, b config.AIBackendConfig) (string, config.AIBackendConfig, error)
-	UpdateBackendPatch(name string, patch BackendPatch) (string, config.AIBackendConfig, error)
+	UpsertBackend(name string, b fleet.Backend) (string, fleet.Backend, error)
+	UpdateBackendPatch(name string, patch BackendPatch) (string, fleet.Backend, error)
 	DeleteBackend(name string) error
 }
 
@@ -203,7 +204,7 @@ type BackendWriter interface {
 // Implementations must hold the store mutex while writing and reload cron
 // schedules afterwards so MCP writes stay consistent with the REST path.
 type RepoWriter interface {
-	UpsertRepo(r config.RepoDef) (config.RepoDef, error)
+	UpsertRepo(r fleet.Repo) (fleet.Repo, error)
 	DeleteRepo(name string) error
 }
 
@@ -216,9 +217,9 @@ type RepoWriter interface {
 // Implementations must hold the store mutex while writing and reload cron
 // schedules afterwards so MCP writes stay consistent with the REST path.
 type BindingWriter interface {
-	CreateBinding(repoName string, b config.Binding) (config.Binding, error)
-	ReadBinding(repoName string, id int64) (config.Binding, error)
-	UpdateBinding(repoName string, id int64, b config.Binding) (config.Binding, error)
+	CreateBinding(repoName string, b fleet.Binding) (fleet.Binding, error)
+	ReadBinding(repoName string, id int64) (fleet.Binding, error)
+	UpdateBinding(repoName string, id int64, b fleet.Binding) (fleet.Binding, error)
 	DeleteBinding(repoName string, id int64) error
 }
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -8,7 +8,7 @@ import (
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
-	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/fleet"
 )
 
 // registerTools wires the core tool set onto the MCP server. Handlers read
@@ -536,9 +536,9 @@ func registerTools(srv *server.MCPServer, deps Deps) {
 	}
 }
 
-// agentJSON converts a config.AgentDef to the snake_case map shape used by
+// agentJSON converts a fleet.Agent to the snake_case map shape used by
 // the REST API, so the MCP and HTTP surfaces stay aligned.
-func agentJSON(a config.AgentDef) map[string]any {
+func agentJSON(a fleet.Agent) map[string]any {
 	return map[string]any{
 		"name":           a.Name,
 		"backend":        a.Backend,
@@ -555,7 +555,7 @@ func agentJSON(a config.AgentDef) map[string]any {
 
 // backendJSON renders one AI backend entry in the snake_case shape shared
 // between list_backends and get_backend.
-func backendJSON(name string, b config.AIBackendConfig) map[string]any {
+func backendJSON(name string, b fleet.Backend) map[string]any {
 	return map[string]any{
 		"name":               name,
 		"command":            b.Command,
@@ -575,7 +575,7 @@ func backendJSON(name string, b config.AIBackendConfig) map[string]any {
 // for consumers; unused triggers appear as empty values. The id field is
 // included only when > 0 (unset for bindings that haven't yet been persisted
 // to the store, matching the omitempty behaviour on the REST side).
-func bindingJSON(b config.Binding) map[string]any {
+func bindingJSON(b fleet.Binding) map[string]any {
 	out := map[string]any{
 		"agent":   b.Agent,
 		"labels":  nilSafe(b.Labels),

--- a/internal/mcp/tools_arrays_test.go
+++ b/internal/mcp/tools_arrays_test.go
@@ -8,7 +8,7 @@ import (
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/rs/zerolog"
 
-	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/fleet"
 )
 
 // TestStringSliceArgAcceptsShapes pins the shape contract for the
@@ -170,7 +170,7 @@ func TestArrayOfAnyAcceptsShapes(t *testing.T) {
 // elements so the patch lands as the caller intended.
 func TestToolUpdateAgentAcceptsJSONStringSkills(t *testing.T) {
 	t.Parallel()
-	canonical := config.AgentDef{Name: "coder", Backend: "codex", Prompt: "p"}
+	canonical := fleet.Agent{Name: "coder", Backend: "codex", Prompt: "p"}
 	w := &stubAgentWriter{patchCanonical: canonical}
 	deps := Deps{
 		DB: testDB(t), Config: stubConfig{cfg: fixtureConfig()},
@@ -206,7 +206,7 @@ func TestToolUpdateBackendAcceptsJSONStringModels(t *testing.T) {
 	t.Parallel()
 	w := &stubBackendWriter{
 		patchCanonicalName:   "claude",
-		patchCanonicalConfig: config.AIBackendConfig{Command: "/bin/claude"},
+		patchCanonicalConfig: fleet.Backend{Command: "/bin/claude"},
 	}
 	deps := Deps{
 		DB: testDB(t), Config: stubConfig{cfg: fixtureConfig()},
@@ -236,7 +236,7 @@ func TestToolUpdateBackendAcceptsJSONStringModels(t *testing.T) {
 // the same JSON-string relief applies across CRUD tools.
 func TestToolCreateAgentAcceptsJSONStringSlices(t *testing.T) {
 	t.Parallel()
-	canonical := config.AgentDef{Name: "linter", Backend: "claude", Skills: []string{"security"}}
+	canonical := fleet.Agent{Name: "linter", Backend: "claude", Skills: []string{"security"}}
 	w := &stubAgentWriter{canonical: canonical}
 	deps := Deps{
 		DB: testDB(t), Config: stubConfig{cfg: fixtureConfig()},
@@ -270,7 +270,7 @@ func TestToolCreateAgentAcceptsJSONStringSlices(t *testing.T) {
 func TestToolCreateBindingAcceptsJSONStringSlices(t *testing.T) {
 	t.Parallel()
 	w := &stubBindingWriter{
-		createResult: config.Binding{ID: 1, Agent: "coder"},
+		createResult: fleet.Binding{ID: 1, Agent: "coder"},
 	}
 	deps := Deps{
 		DB: testDB(t), Config: stubConfig{cfg: fixtureConfig()},
@@ -301,7 +301,7 @@ func TestToolCreateBindingAcceptsJSONStringSlices(t *testing.T) {
 func TestToolUpdateBindingAcceptsJSONStringSlices(t *testing.T) {
 	t.Parallel()
 	w := &stubBindingWriter{
-		updateResult: config.Binding{ID: 5, Agent: "coder"},
+		updateResult: fleet.Binding{ID: 5, Agent: "coder"},
 	}
 	deps := Deps{
 		DB: testDB(t), Config: stubConfig{cfg: fixtureConfig()},
@@ -334,7 +334,7 @@ func TestToolUpdateBindingAcceptsJSONStringSlices(t *testing.T) {
 // argument is itself an array.
 func TestToolCreateRepoAcceptsJSONStringBindings(t *testing.T) {
 	t.Parallel()
-	w := &stubRepoWriter{canonical: config.RepoDef{Name: "owner/repo", Enabled: true}}
+	w := &stubRepoWriter{canonical: fleet.Repo{Name: "owner/repo", Enabled: true}}
 	deps := Deps{
 		DB: testDB(t), Config: stubConfig{cfg: fixtureConfig()},
 		Queue: &stubQueue{}, Status: stubStatus{},

--- a/internal/mcp/tools_crud.go
+++ b/internal/mcp/tools_crud.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 
 	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/fleet"
 )
 
 // toolCreateAgent upserts an agent definition through the same path as POST
@@ -31,7 +32,7 @@ func toolCreateAgent(deps Deps) server.ToolHandlerFunc {
 		if errMsg != "" {
 			return mcpgo.NewToolResultError(errMsg), nil
 		}
-		a := config.AgentDef{
+		a := fleet.Agent{
 			Name:          name,
 			Backend:       req.GetString("backend", ""),
 			Model:         req.GetString("model", ""),
@@ -158,7 +159,7 @@ func toolCreateSkill(deps Deps) server.ToolHandlerFunc {
 		if err != nil {
 			return mcpgo.NewToolResultError(err.Error()), nil
 		}
-		sk := config.SkillDef{Prompt: req.GetString("prompt", "")}
+		sk := fleet.Skill{Prompt: req.GetString("prompt", "")}
 		canonicalName, canonical, err := deps.SkillWrite.UpsertSkill(name, sk)
 		if err != nil {
 			return mcpgo.NewToolResultErrorFromErr("create skill", err), nil
@@ -233,7 +234,7 @@ func toolCreateBackend(deps Deps) server.ToolHandlerFunc {
 		if errMsg != "" {
 			return mcpgo.NewToolResultError(errMsg), nil
 		}
-		b := config.AIBackendConfig{
+		b := fleet.Backend{
 			Command:          req.GetString("command", ""),
 			Models:           models,
 			LocalModelURL:    req.GetString("local_model_url", ""),
@@ -357,7 +358,7 @@ func toolCreateRepo(deps Deps) server.ToolHandlerFunc {
 		if bErr != "" {
 			return mcpgo.NewToolResultError(bErr), nil
 		}
-		r := config.RepoDef{
+		r := fleet.Repo{
 			Name:    name,
 			Enabled: req.GetBool("enabled", false),
 			Use:     bindings,
@@ -480,20 +481,20 @@ func toolDeleteBinding(deps Deps) server.ToolHandlerFunc {
 	}
 }
 
-// bindingFromReq builds a config.Binding from the MCP request fields shared
+// bindingFromReq builds a fleet.Binding from the MCP request fields shared
 // by create_binding and update_binding. Returns a non-empty error string when
 // a field is present but the wrong type.
-func bindingFromReq(req mcpgo.CallToolRequest, agent string) (config.Binding, string) {
+func bindingFromReq(req mcpgo.CallToolRequest, agent string) (fleet.Binding, string) {
 	args := req.GetArguments()
 	labels, errMsg := stringSliceArg(args["labels"], "labels")
 	if errMsg != "" {
-		return config.Binding{}, errMsg
+		return fleet.Binding{}, errMsg
 	}
 	events, errMsg := stringSliceArg(args["events"], "events")
 	if errMsg != "" {
-		return config.Binding{}, errMsg
+		return fleet.Binding{}, errMsg
 	}
-	b := config.Binding{
+	b := fleet.Binding{
 		Agent:  agent,
 		Labels: labels,
 		Events: events,
@@ -502,7 +503,7 @@ func bindingFromReq(req mcpgo.CallToolRequest, agent string) (config.Binding, st
 	if v, ok, errMsg := boolPtrArg(args, "enabled"); ok {
 		b.Enabled = v
 	} else if errMsg != "" {
-		return config.Binding{}, errMsg
+		return fleet.Binding{}, errMsg
 	}
 	return b, ""
 }
@@ -510,7 +511,7 @@ func bindingFromReq(req mcpgo.CallToolRequest, agent string) (config.Binding, st
 // repoJSON renders a RepoDef in the same wire shape as an element of the
 // list_repos / get_repo responses, so create_repo/delete_repo callers consume
 // one schema regardless of whether they are reading or writing.
-func repoJSON(r config.RepoDef) map[string]any {
+func repoJSON(r fleet.Repo) map[string]any {
 	bindings := make([]map[string]any, 0, len(r.Use))
 	for _, b := range r.Use {
 		bindings = append(bindings, bindingJSON(b))
@@ -523,7 +524,7 @@ func repoJSON(r config.RepoDef) map[string]any {
 }
 
 // parseBindings decodes the create_repo "bindings" argument into a slice of
-// config.Binding. The MCP-go request helpers expose string/bool/number
+// fleet.Binding. The MCP-go request helpers expose string/bool/number
 // primitives directly but not nested objects, so we read the raw argument and
 // destructure it here. A nil/missing value yields an empty binding list.
 //
@@ -535,13 +536,13 @@ func repoJSON(r config.RepoDef) map[string]any {
 // caller's intended disablement.
 //
 // Binding.Enabled stays nil when the caller omits the key (the "default
-// enabled" case config.Binding.IsEnabled relies on). A literal false/true sets
+// enabled" case fleet.Binding.IsEnabled relies on). A literal false/true sets
 // the pointer so downstream validation sees the user's intent preserved.
 //
 // The top-level value is also accepted as a JSON-encoded array string — see
 // stringSliceArg for the same MCP-transport rationale (some clients
 // stringify array params at the JSON-RPC boundary).
-func parseBindings(v any) ([]config.Binding, string) {
+func parseBindings(v any) ([]fleet.Binding, string) {
 	if v == nil {
 		return nil, ""
 	}
@@ -549,13 +550,13 @@ func parseBindings(v any) ([]config.Binding, string) {
 	if errMsg != "" {
 		return nil, errMsg
 	}
-	out := make([]config.Binding, 0, len(raw))
+	out := make([]fleet.Binding, 0, len(raw))
 	for i, item := range raw {
 		m, ok := item.(map[string]any)
 		if !ok {
 			return nil, fmt.Sprintf("bindings[%d]: must be an object", i)
 		}
-		var b config.Binding
+		var b fleet.Binding
 		if v, ok := m["agent"]; ok && v != nil {
 			s, ok := v.(string)
 			if !ok {

--- a/internal/mcp/tools_fleet.go
+++ b/internal/mcp/tools_fleet.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 
 	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/fleet"
 	"github.com/eloylp/agents/internal/store"
 	"github.com/eloylp/agents/internal/workflow"
 )
@@ -45,7 +46,7 @@ func toolGetAgent(deps Deps) server.ToolHandlerFunc {
 			return mcpgo.NewToolResultErrorFromErr("get agent", err), nil
 		}
 		key := config.NormalizeAgentName(name)
-		if idx := slices.IndexFunc(agents, func(a config.AgentDef) bool { return a.Name == key }); idx != -1 {
+		if idx := slices.IndexFunc(agents, func(a fleet.Agent) bool { return a.Name == key }); idx != -1 {
 			return jsonResult(agentJSON(agents[idx]))
 		}
 		return mcpgo.NewToolResultErrorf("agent %q not found", name), nil
@@ -159,7 +160,7 @@ func toolGetRepo(deps Deps) server.ToolHandlerFunc {
 			return mcpgo.NewToolResultErrorFromErr("get repo", err), nil
 		}
 		key := config.NormalizeRepoName(name)
-		if idx := slices.IndexFunc(repos, func(r config.RepoDef) bool { return r.Name == key }); idx != -1 {
+		if idx := slices.IndexFunc(repos, func(r fleet.Repo) bool { return r.Name == key }); idx != -1 {
 			return jsonResult(repoJSON(repos[idx]))
 		}
 		return mcpgo.NewToolResultErrorf("repo %q not found", name), nil

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/fleet"
 	"github.com/eloylp/agents/internal/observe"
 	"github.com/eloylp/agents/internal/store"
 	"github.com/eloylp/agents/internal/workflow"
@@ -66,21 +67,21 @@ func (s stubStatus) StatusJSON() ([]byte, error) {
 func fixtureConfig() *config.Config {
 	return &config.Config{
 		Daemon: config.DaemonConfig{
-			AIBackends: map[string]config.AIBackendConfig{
+			AIBackends: map[string]fleet.Backend{
 				"claude": {Command: "claude", Models: []string{"opus", "sonnet"}, Healthy: true, TimeoutSeconds: 60},
 				"codex":  {Command: "codex", Healthy: false},
 			},
 		},
-		Skills: map[string]config.SkillDef{
+		Skills: map[string]fleet.Skill{
 			"testing":  {Prompt: "write good tests"},
 			"security": {Prompt: "audit inputs"},
 		},
-		Agents: []config.AgentDef{
+		Agents: []fleet.Agent{
 			{Name: "coder", Backend: "claude", Skills: []string{"testing"}, Description: "writes code"},
 			{Name: "reviewer", Backend: "claude", AllowDispatch: true},
 		},
-		Repos: []config.RepoDef{
-			{Name: "owner/one", Enabled: true, Use: []config.Binding{
+		Repos: []fleet.Repo{
+			{Name: "owner/one", Enabled: true, Use: []fleet.Binding{
 				{Agent: "coder", Labels: []string{"bug"}},
 				{Agent: "reviewer", Cron: "@hourly"},
 			}},
@@ -100,22 +101,22 @@ func testDB(t *testing.T) *sql.DB {
 	t.Cleanup(func() { db.Close() })
 	if err := store.ImportAll(
 		db,
-		[]config.AgentDef{
+		[]fleet.Agent{
 			{Name: "coder", Backend: "claude", Skills: []string{"testing"}, Prompt: "code", Description: "writes code", CanDispatch: []string{}},
 			{Name: "reviewer", Backend: "claude", Prompt: "review", AllowDispatch: true, Skills: []string{}, CanDispatch: []string{}},
 		},
-		[]config.RepoDef{
-			{Name: "owner/one", Enabled: true, Use: []config.Binding{
+		[]fleet.Repo{
+			{Name: "owner/one", Enabled: true, Use: []fleet.Binding{
 				{Agent: "coder", Labels: []string{"bug"}},
 				{Agent: "reviewer", Cron: "0 * * * *"},
 			}},
-			{Name: "owner/two", Enabled: false, Use: []config.Binding{}},
+			{Name: "owner/two", Enabled: false, Use: []fleet.Binding{}},
 		},
-		map[string]config.SkillDef{
+		map[string]fleet.Skill{
 			"testing":  {Prompt: "write good tests"},
 			"security": {Prompt: "audit inputs"},
 		},
-		map[string]config.AIBackendConfig{
+		map[string]fleet.Backend{
 			"claude": {Command: "claude", Models: []string{"opus", "sonnet"}, Healthy: true, TimeoutSeconds: 60},
 			"codex":  {Command: "codex"},
 		},
@@ -1255,31 +1256,31 @@ func TestToolImportConfigPropagatesError(t *testing.T) {
 // what the create_agent tool serialises back to the caller, so tests pin both
 // the inputs the writer received and the outputs the tool surfaces.
 type stubAgentWriter struct {
-	gotUpsert      config.AgentDef
+	gotUpsert      fleet.Agent
 	gotDeleteName  string
 	gotCascade     bool
 	gotPatchName   string
 	gotPatch       AgentPatch
-	canonical      config.AgentDef
-	patchCanonical config.AgentDef
+	canonical      fleet.Agent
+	patchCanonical fleet.Agent
 	upsertErr      error
 	deleteErr      error
 	patchErr       error
 }
 
-func (s *stubAgentWriter) UpsertAgent(a config.AgentDef) (config.AgentDef, error) {
+func (s *stubAgentWriter) UpsertAgent(a fleet.Agent) (fleet.Agent, error) {
 	s.gotUpsert = a
 	if s.upsertErr != nil {
-		return config.AgentDef{}, s.upsertErr
+		return fleet.Agent{}, s.upsertErr
 	}
 	return s.canonical, nil
 }
 
-func (s *stubAgentWriter) UpdateAgentPatch(name string, patch AgentPatch) (config.AgentDef, error) {
+func (s *stubAgentWriter) UpdateAgentPatch(name string, patch AgentPatch) (fleet.Agent, error) {
 	s.gotPatchName = name
 	s.gotPatch = patch
 	if s.patchErr != nil {
-		return config.AgentDef{}, s.patchErr
+		return fleet.Agent{}, s.patchErr
 	}
 	return s.patchCanonical, nil
 }
@@ -1292,7 +1293,7 @@ func (s *stubAgentWriter) DeleteAgent(name string, cascade bool) error {
 
 func TestToolCreateAgentForwardsAndReturnsCanonical(t *testing.T) {
 	t.Parallel()
-	canonical := config.AgentDef{
+	canonical := fleet.Agent{
 		Name:          "linter",
 		Backend:       "claude",
 		Skills:        []string{"security"},
@@ -1501,31 +1502,31 @@ type stubSkillWriter struct {
 	gotPatchName        string
 	gotPatch            SkillPatch
 	patchCanonicalName  string
-	patchCanonicalSkill config.SkillDef
+	patchCanonicalSkill fleet.Skill
 	patchErr            error
 	gotUpsertName  string
-	gotUpsertSkill config.SkillDef
+	gotUpsertSkill fleet.Skill
 	gotDeleteName  string
 	canonicalName  string
-	canonical      config.SkillDef
+	canonical      fleet.Skill
 	upsertErr      error
 	deleteErr      error
 }
 
-func (s *stubSkillWriter) UpsertSkill(name string, sk config.SkillDef) (string, config.SkillDef, error) {
+func (s *stubSkillWriter) UpsertSkill(name string, sk fleet.Skill) (string, fleet.Skill, error) {
 	s.gotUpsertName = name
 	s.gotUpsertSkill = sk
 	if s.upsertErr != nil {
-		return "", config.SkillDef{}, s.upsertErr
+		return "", fleet.Skill{}, s.upsertErr
 	}
 	return s.canonicalName, s.canonical, nil
 }
 
-func (s *stubSkillWriter) UpdateSkillPatch(name string, patch SkillPatch) (string, config.SkillDef, error) {
+func (s *stubSkillWriter) UpdateSkillPatch(name string, patch SkillPatch) (string, fleet.Skill, error) {
 	s.gotPatchName = name
 	s.gotPatch = patch
 	if s.patchErr != nil {
-		return "", config.SkillDef{}, s.patchErr
+		return "", fleet.Skill{}, s.patchErr
 	}
 	return s.patchCanonicalName, s.patchCanonicalSkill, nil
 }
@@ -1539,7 +1540,7 @@ func TestToolCreateSkillForwardsAndReturnsCanonical(t *testing.T) {
 	t.Parallel()
 	w := &stubSkillWriter{
 		canonicalName: "security",
-		canonical:     config.SkillDef{Prompt: "audit inputs carefully"},
+		canonical:     fleet.Skill{Prompt: "audit inputs carefully"},
 	}
 	deps := Deps{
 		DB:            testDB(t),
@@ -1763,33 +1764,33 @@ func TestToolDeleteSkillPropagatesConflict(t *testing.T) {
 // canonical values the tool surfaces back to the caller.
 type stubBackendWriter struct {
 	gotUpsertName        string
-	gotUpsertBackend     config.AIBackendConfig
+	gotUpsertBackend     fleet.Backend
 	gotDeleteName        string
 	gotPatchName         string
 	gotPatch             BackendPatch
 	canonicalName        string
-	canonical            config.AIBackendConfig
+	canonical            fleet.Backend
 	patchCanonicalName   string
-	patchCanonicalConfig config.AIBackendConfig
+	patchCanonicalConfig fleet.Backend
 	upsertErr            error
 	deleteErr            error
 	patchErr             error
 }
 
-func (s *stubBackendWriter) UpsertBackend(name string, b config.AIBackendConfig) (string, config.AIBackendConfig, error) {
+func (s *stubBackendWriter) UpsertBackend(name string, b fleet.Backend) (string, fleet.Backend, error) {
 	s.gotUpsertName = name
 	s.gotUpsertBackend = b
 	if s.upsertErr != nil {
-		return "", config.AIBackendConfig{}, s.upsertErr
+		return "", fleet.Backend{}, s.upsertErr
 	}
 	return s.canonicalName, s.canonical, nil
 }
 
-func (s *stubBackendWriter) UpdateBackendPatch(name string, patch BackendPatch) (string, config.AIBackendConfig, error) {
+func (s *stubBackendWriter) UpdateBackendPatch(name string, patch BackendPatch) (string, fleet.Backend, error) {
 	s.gotPatchName = name
 	s.gotPatch = patch
 	if s.patchErr != nil {
-		return "", config.AIBackendConfig{}, s.patchErr
+		return "", fleet.Backend{}, s.patchErr
 	}
 	return s.patchCanonicalName, s.patchCanonicalConfig, nil
 }
@@ -1801,7 +1802,7 @@ func (s *stubBackendWriter) DeleteBackend(name string) error {
 
 func TestToolCreateBackendForwardsAndReturnsCanonical(t *testing.T) {
 	t.Parallel()
-	canonical := config.AIBackendConfig{
+	canonical := fleet.Backend{
 		Command:        "claude",
 		Models:         []string{"claude-opus-4-7"},
 		TimeoutSeconds: 600,
@@ -2041,17 +2042,17 @@ func TestToolDeleteBackendPropagatesConflict(t *testing.T) {
 // canned values. Tests pin both the raw inputs the writer observed and the
 // canonical repo the tool surfaces back to the caller.
 type stubRepoWriter struct {
-	gotUpsert     config.RepoDef
+	gotUpsert     fleet.Repo
 	gotDeleteName string
-	canonical     config.RepoDef
+	canonical     fleet.Repo
 	upsertErr     error
 	deleteErr     error
 }
 
-func (s *stubRepoWriter) UpsertRepo(r config.RepoDef) (config.RepoDef, error) {
+func (s *stubRepoWriter) UpsertRepo(r fleet.Repo) (fleet.Repo, error) {
 	s.gotUpsert = r
 	if s.upsertErr != nil {
-		return config.RepoDef{}, s.upsertErr
+		return fleet.Repo{}, s.upsertErr
 	}
 	return s.canonical, nil
 }
@@ -2064,10 +2065,10 @@ func (s *stubRepoWriter) DeleteRepo(name string) error {
 func TestToolCreateRepoForwardsAndReturnsCanonical(t *testing.T) {
 	t.Parallel()
 	disabled := false
-	canonical := config.RepoDef{
+	canonical := fleet.Repo{
 		Name:    "owner/repo",
 		Enabled: true,
-		Use: []config.Binding{
+		Use: []fleet.Binding{
 			{Agent: "coder", Labels: []string{"ready"}},
 			{Agent: "planner", Cron: "0 * * * *", Enabled: &disabled},
 		},
@@ -2380,11 +2381,11 @@ func TestToolCreateRepoRejectsBadBindingFieldTypes(t *testing.T) {
 
 // TestToolCreateRepoDefaultsBindingEnabledNil pins the default-enabled
 // contract: when a binding omits "enabled", the *bool must stay nil so
-// config.Binding.IsEnabled returns true. Setting it to a pointer-to-false
+// fleet.Binding.IsEnabled returns true. Setting it to a pointer-to-false
 // here would silently disable bindings on every round-trip through MCP.
 func TestToolCreateRepoDefaultsBindingEnabledNil(t *testing.T) {
 	t.Parallel()
-	w := &stubRepoWriter{canonical: config.RepoDef{Name: "owner/repo", Enabled: true}}
+	w := &stubRepoWriter{canonical: fleet.Repo{Name: "owner/repo", Enabled: true}}
 	deps := Deps{
 		DB:            testDB(t),
 		Config:    stubConfig{cfg: fixtureConfig()},
@@ -2511,19 +2512,19 @@ func TestToolDeleteRepoPropagatesNotFound(t *testing.T) {
 type stubBindingWriter struct {
 	// Create
 	gotCreateRepo    string
-	gotCreateBinding config.Binding
-	createResult     config.Binding
+	gotCreateBinding fleet.Binding
+	createResult     fleet.Binding
 	createErr        error
 	// Update
 	gotUpdateRepo    string
 	gotUpdateID      int64
-	gotUpdateBinding config.Binding
-	updateResult     config.Binding
+	gotUpdateBinding fleet.Binding
+	updateResult     fleet.Binding
 	updateErr        error
 	// Read
 	gotReadRepo string
 	gotReadID   int64
-	readResult  config.Binding
+	readResult  fleet.Binding
 	readErr     error
 	// Delete
 	gotDeleteRepo string
@@ -2531,30 +2532,30 @@ type stubBindingWriter struct {
 	deleteErr     error
 }
 
-func (s *stubBindingWriter) CreateBinding(repoName string, b config.Binding) (config.Binding, error) {
+func (s *stubBindingWriter) CreateBinding(repoName string, b fleet.Binding) (fleet.Binding, error) {
 	s.gotCreateRepo = repoName
 	s.gotCreateBinding = b
 	if s.createErr != nil {
-		return config.Binding{}, s.createErr
+		return fleet.Binding{}, s.createErr
 	}
 	return s.createResult, nil
 }
 
-func (s *stubBindingWriter) UpdateBinding(repoName string, id int64, b config.Binding) (config.Binding, error) {
+func (s *stubBindingWriter) UpdateBinding(repoName string, id int64, b fleet.Binding) (fleet.Binding, error) {
 	s.gotUpdateRepo = repoName
 	s.gotUpdateID = id
 	s.gotUpdateBinding = b
 	if s.updateErr != nil {
-		return config.Binding{}, s.updateErr
+		return fleet.Binding{}, s.updateErr
 	}
 	return s.updateResult, nil
 }
 
-func (s *stubBindingWriter) ReadBinding(repoName string, id int64) (config.Binding, error) {
+func (s *stubBindingWriter) ReadBinding(repoName string, id int64) (fleet.Binding, error) {
 	s.gotReadRepo = repoName
 	s.gotReadID = id
 	if s.readErr != nil {
-		return config.Binding{}, s.readErr
+		return fleet.Binding{}, s.readErr
 	}
 	return s.readResult, nil
 }
@@ -2568,7 +2569,7 @@ func (s *stubBindingWriter) DeleteBinding(repoName string, id int64) error {
 func TestToolCreateBindingForwardsAndReturnsID(t *testing.T) {
 	t.Parallel()
 	w := &stubBindingWriter{
-		createResult: config.Binding{ID: 42, Agent: "coder", Labels: []string{"ai:fix"}},
+		createResult: fleet.Binding{ID: 42, Agent: "coder", Labels: []string{"ai:fix"}},
 	}
 	deps := Deps{
 		DB:           testDB(t),
@@ -2631,7 +2632,7 @@ func TestToolUpdateBindingForwardsID(t *testing.T) {
 	t.Parallel()
 	disabled := false
 	w := &stubBindingWriter{
-		updateResult: config.Binding{ID: 7, Agent: "coder", Cron: "0 9 * * *", Enabled: &disabled},
+		updateResult: fleet.Binding{ID: 7, Agent: "coder", Cron: "0 9 * * *", Enabled: &disabled},
 	}
 	deps := Deps{
 		DB:           testDB(t),
@@ -2700,7 +2701,7 @@ func TestToolDeleteBindingForwardsID(t *testing.T) {
 
 func TestToolUpdateAgentForwardsPatch(t *testing.T) {
 	t.Parallel()
-	canonical := config.AgentDef{
+	canonical := fleet.Agent{
 		Name: "coder", Backend: "codex", Prompt: "p",
 	}
 	w := &stubAgentWriter{patchCanonical: canonical}
@@ -2763,7 +2764,7 @@ func TestToolUpdateSkillForwardsPatch(t *testing.T) {
 	t.Parallel()
 	w := &stubSkillWriter{
 		patchCanonicalName:  "security",
-		patchCanonicalSkill: config.SkillDef{Prompt: "audit"},
+		patchCanonicalSkill: fleet.Skill{Prompt: "audit"},
 	}
 	deps := Deps{
 		DB: testDB(t), Config: stubConfig{cfg: fixtureConfig()},
@@ -2810,7 +2811,7 @@ func TestToolUpdateBackendForwardsPatch(t *testing.T) {
 	t.Parallel()
 	w := &stubBackendWriter{
 		patchCanonicalName:   "claude",
-		patchCanonicalConfig: config.AIBackendConfig{Command: "/bin/claude", TimeoutSeconds: 900},
+		patchCanonicalConfig: fleet.Backend{Command: "/bin/claude", TimeoutSeconds: 900},
 	}
 	deps := Deps{
 		DB: testDB(t), Config: stubConfig{cfg: fixtureConfig()},

--- a/internal/server/observe/observe_test.go
+++ b/internal/server/observe/observe_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/fleet"
 	obstore "github.com/eloylp/agents/internal/observe"
 	"github.com/eloylp/agents/internal/server"
 	"github.com/eloylp/agents/internal/store"
@@ -425,7 +426,7 @@ func TestHandleGraphIncludesConfiguredAgentWithNoDispatches(t *testing.T) {
 	t.Parallel()
 	obs := newTestStore(t)
 	cfg := &stubConfig{cfg: &config.Config{
-		Agents: []config.AgentDef{{Name: "solo-agent", Backend: "claude"}},
+		Agents: []fleet.Agent{{Name: "solo-agent", Backend: "claude"}},
 	}}
 	h := New(obs, cfg, nil, nil, nil, nil)
 
@@ -455,7 +456,7 @@ func TestHandleGraphNodeStatusReflectsRuntimeState(t *testing.T) {
 	t.Parallel()
 	obs := newTestStore(t)
 	cfg := &stubConfig{cfg: &config.Config{
-		Agents: []config.AgentDef{
+		Agents: []fleet.Agent{
 			{Name: "runner", Backend: "claude"},
 			{Name: "idle-ok", Backend: "claude"},
 			{Name: "idle-err", Backend: "claude"},

--- a/internal/server/types.go
+++ b/internal/server/types.go
@@ -13,7 +13,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/fleet"
 	"github.com/eloylp/agents/internal/workflow"
 )
 
@@ -21,7 +21,7 @@ import (
 // repo, agent, skill, or backend write to update the scheduler's in-process
 // state without restarting the daemon.
 type CronReloader interface {
-	Reload(repos []config.RepoDef, agents []config.AgentDef, skills map[string]config.SkillDef, backends map[string]config.AIBackendConfig) error
+	Reload(repos []fleet.Repo, agents []fleet.Agent, skills map[string]fleet.Skill, backends map[string]fleet.Backend) error
 }
 
 // AgentStatus is the runtime state of one autonomous agent as reported by /status.

--- a/internal/store/allow_memory_test.go
+++ b/internal/store/allow_memory_test.go
@@ -3,7 +3,7 @@ package store_test
 import (
 	"testing"
 
-	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/fleet"
 	"github.com/eloylp/agents/internal/store"
 )
 
@@ -84,7 +84,7 @@ func TestUpsertAgentRoundTripsAllowMemoryFalse(t *testing.T) {
 	}
 
 	ff := false
-	if err := store.UpsertAgent(db, config.AgentDef{
+	if err := store.UpsertAgent(db, fleet.Agent{
 		Name:        "coder",
 		Backend:     "claude",
 		Prompt:      "You write code.",

--- a/internal/store/crud.go
+++ b/internal/store/crud.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/fleet"
 	"github.com/robfig/cron/v3"
 )
 
@@ -38,7 +39,7 @@ var cronParser = cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month 
 // validateCronExpressions checks that every cron binding in repos can be
 // parsed by the same parser the autonomous scheduler uses. Returns an
 // ErrValidation if any expression is malformed.
-func validateCronExpressions(repos []config.RepoDef) error {
+func validateCronExpressions(repos []fleet.Repo) error {
 	for _, r := range repos {
 		for _, b := range r.Use {
 			if !b.IsCron() {
@@ -74,11 +75,11 @@ func validateFleet(q querier) error {
 	}
 	backends := cfg.Daemon.AIBackends
 	if backends == nil {
-		backends = map[string]config.AIBackendConfig{}
+		backends = map[string]fleet.Backend{}
 	}
 	skills := cfg.Skills
 	if skills == nil {
-		skills = map[string]config.SkillDef{}
+		skills = map[string]fleet.Skill{}
 	}
 	return config.ValidateEntities(cfg.Agents, cfg.Repos, skills, backends)
 }
@@ -106,7 +107,7 @@ func requireAtLeastOne(q querier, countQuery, entity, zeroMsg string) error {
 // all repos is a legitimate user action (fleet maintenance, evaluating prompts
 // on a different repo) and the daemon runs cleanly with zero enabled repos.
 // See issue #302.
-func validateFleetConstraints(q querier, op string, repos []config.RepoDef) error {
+func validateFleetConstraints(q querier, op string, repos []fleet.Repo) error {
 	if err := validateFleet(q); err != nil {
 		return &ErrValidation{Msg: fmt.Sprintf("store: %s: %v", op, err)}
 	}
@@ -122,7 +123,7 @@ func validateFleetConstraints(q querier, op string, repos []config.RepoDef) erro
 // ──── Agents ────────────────────────────────────────────────────────────────────────────────────
 
 // ReadAgents returns all agents from the database, ordered by name.
-func ReadAgents(db *sql.DB) ([]config.AgentDef, error) {
+func ReadAgents(db *sql.DB) ([]fleet.Agent, error) {
 	var cfg config.Config
 	if err := loadAgents(db, &cfg); err != nil {
 		return nil, err
@@ -134,14 +135,14 @@ func ReadAgents(db *sql.DB) ([]config.AgentDef, error) {
 // The agent name and related fields are normalized (lowercase, trimmed) before
 // writing so the stored values match the canonical form that AgentByName and
 // registerJobs expect, keeping live behavior consistent with startup.
-func UpsertAgent(db *sql.DB, a config.AgentDef) error {
+func UpsertAgent(db *sql.DB, a fleet.Agent) error {
 	config.NormalizeAgentDef(&a)
 	tx, err := db.Begin()
 	if err != nil {
 		return fmt.Errorf("store: upsert agent %s: begin: %w", a.Name, err)
 	}
 	defer tx.Rollback()
-	if err := importAgents(tx, []config.AgentDef{a}); err != nil {
+	if err := importAgents(tx, []fleet.Agent{a}); err != nil {
 		return err
 	}
 	if err := validateFleet(tx); err != nil {
@@ -230,13 +231,13 @@ func countDistinctRepos(repos []string) int {
 // ──── Skills ─────────────────────────────────────────────────────────────────────────────────────
 
 // ReadSkills returns all skills from the database.
-func ReadSkills(db *sql.DB) (map[string]config.SkillDef, error) {
+func ReadSkills(db *sql.DB) (map[string]fleet.Skill, error) {
 	var cfg config.Config
 	if err := loadSkills(db, &cfg); err != nil {
 		return nil, err
 	}
 	if cfg.Skills == nil {
-		return map[string]config.SkillDef{}, nil
+		return map[string]fleet.Skill{}, nil
 	}
 	return cfg.Skills, nil
 }
@@ -246,7 +247,7 @@ func ReadSkills(db *sql.DB) (map[string]config.SkillDef, error) {
 // (Prompt, PromptFile) are trimmed before writing, matching the normalization
 // startup applies in normalize() so that the stored values are already in
 // canonical form and validation sees the same shape as after a restart.
-func UpsertSkill(db *sql.DB, name string, s config.SkillDef) error {
+func UpsertSkill(db *sql.DB, name string, s fleet.Skill) error {
 	name = config.NormalizeSkillName(name)
 	config.NormalizeSkillDef(&s)
 	tx, err := db.Begin()
@@ -254,7 +255,7 @@ func UpsertSkill(db *sql.DB, name string, s config.SkillDef) error {
 		return fmt.Errorf("store: upsert skill %s: begin: %w", name, err)
 	}
 	defer tx.Rollback()
-	if err := importSkills(tx, map[string]config.SkillDef{name: s}); err != nil {
+	if err := importSkills(tx, map[string]fleet.Skill{name: s}); err != nil {
 		return err
 	}
 	if err := validateFleet(tx); err != nil {
@@ -283,13 +284,13 @@ func DeleteSkill(db *sql.DB, name string) error {
 // ──── Backends ───────────────────────────────────────────────────────────────────────────────────────
 
 // ReadBackends returns all AI backend configurations from the database.
-func ReadBackends(db *sql.DB) (map[string]config.AIBackendConfig, error) {
+func ReadBackends(db *sql.DB) (map[string]fleet.Backend, error) {
 	var cfg config.Config
 	if err := loadBackends(db, &cfg); err != nil {
 		return nil, err
 	}
 	if cfg.Daemon.AIBackends == nil {
-		return map[string]config.AIBackendConfig{}, nil
+		return map[string]fleet.Backend{}, nil
 	}
 	return cfg.Daemon.AIBackends, nil
 }
@@ -301,7 +302,7 @@ func ReadBackends(db *sql.DB) (map[string]config.AIBackendConfig, error) {
 // defaults (timeout_seconds 0 → 600, max_prompt_chars 0 → 12000). This
 // ensures the stored values are already in canonical form so that live
 // behavior never diverges from a post-restart load.
-func UpsertBackend(db *sql.DB, name string, b config.AIBackendConfig) error {
+func UpsertBackend(db *sql.DB, name string, b fleet.Backend) error {
 	name = config.NormalizeBackendName(name)
 	config.NormalizeBackendConfig(&b)
 	config.ApplyBackendDefaults(&b)
@@ -310,7 +311,7 @@ func UpsertBackend(db *sql.DB, name string, b config.AIBackendConfig) error {
 		return fmt.Errorf("store: upsert backend %s: begin: %w", name, err)
 	}
 	defer tx.Rollback()
-	if err := importBackends(tx, map[string]config.AIBackendConfig{name: b}); err != nil {
+	if err := importBackends(tx, map[string]fleet.Backend{name: b}); err != nil {
 		return err
 	}
 	if err := validateFleet(tx); err != nil {
@@ -347,7 +348,7 @@ func DeleteBackend(db *sql.DB, name string) error {
 // This prevents the race where a concurrent /api/store write commits between
 // reads, producing a mixed snapshot that can cause spurious Reload failures or
 // agents that see new definitions with stale skill/backend maps.
-func ReadSnapshot(db *sql.DB) ([]config.AgentDef, []config.RepoDef, map[string]config.SkillDef, map[string]config.AIBackendConfig, error) {
+func ReadSnapshot(db *sql.DB) ([]fleet.Agent, []fleet.Repo, map[string]fleet.Skill, map[string]fleet.Backend, error) {
 	tx, err := db.Begin()
 	if err != nil {
 		return nil, nil, nil, nil, fmt.Errorf("store: begin snapshot: %w", err)
@@ -368,10 +369,10 @@ func ReadSnapshot(db *sql.DB) ([]config.AgentDef, []config.RepoDef, map[string]c
 		return nil, nil, nil, nil, err
 	}
 	if cfg.Skills == nil {
-		cfg.Skills = map[string]config.SkillDef{}
+		cfg.Skills = map[string]fleet.Skill{}
 	}
 	if cfg.Daemon.AIBackends == nil {
-		cfg.Daemon.AIBackends = map[string]config.AIBackendConfig{}
+		cfg.Daemon.AIBackends = map[string]fleet.Backend{}
 	}
 	return cfg.Agents, cfg.Repos, cfg.Skills, cfg.Daemon.AIBackends, nil
 }
@@ -379,7 +380,7 @@ func ReadSnapshot(db *sql.DB) ([]config.AgentDef, []config.RepoDef, map[string]c
 // ──── Repos ────────────────────────────────────────────────────────────────────────────────────────
 
 // ReadRepos returns all repos (with bindings) from the database.
-func ReadRepos(db *sql.DB) ([]config.RepoDef, error) {
+func ReadRepos(db *sql.DB) ([]fleet.Repo, error) {
 	var cfg config.Config
 	if err := loadRepos(db, &cfg); err != nil {
 		return nil, err
@@ -391,14 +392,14 @@ func ReadRepos(db *sql.DB) ([]config.RepoDef, error) {
 // replaced wholesale: any existing bindings for the repo are removed before
 // the new list is written. The repo name and binding agents/events are
 // normalized (trimmed / lowercased) before writing.
-func UpsertRepo(db *sql.DB, r config.RepoDef) error {
+func UpsertRepo(db *sql.DB, r fleet.Repo) error {
 	config.NormalizeRepoDef(&r)
 	tx, err := db.Begin()
 	if err != nil {
 		return fmt.Errorf("store: upsert repo %s: begin: %w", r.Name, err)
 	}
 	defer tx.Rollback()
-	if err := importRepos(tx, []config.RepoDef{r}); err != nil {
+	if err := importRepos(tx, []fleet.Repo{r}); err != nil {
 		return err
 	}
 	if err := validateFleet(tx); err != nil {
@@ -410,24 +411,24 @@ func UpsertRepo(db *sql.DB, r config.RepoDef) error {
 // normalizeFleet normalizes agents and repos in-place and returns new maps
 // with normalized skills and backends. Called by ImportAll and ReplaceAll.
 func normalizeFleet(
-	agents []config.AgentDef,
-	repos []config.RepoDef,
-	skills map[string]config.SkillDef,
-	backends map[string]config.AIBackendConfig,
-) (map[string]config.SkillDef, map[string]config.AIBackendConfig) {
+	agents []fleet.Agent,
+	repos []fleet.Repo,
+	skills map[string]fleet.Skill,
+	backends map[string]fleet.Backend,
+) (map[string]fleet.Skill, map[string]fleet.Backend) {
 	for i := range agents {
 		config.NormalizeAgentDef(&agents[i])
 	}
 	for i := range repos {
 		config.NormalizeRepoDef(&repos[i])
 	}
-	normalizedSkills := make(map[string]config.SkillDef, len(skills))
+	normalizedSkills := make(map[string]fleet.Skill, len(skills))
 	for name, s := range skills {
 		name = config.NormalizeSkillName(name)
 		config.NormalizeSkillDef(&s)
 		normalizedSkills[name] = s
 	}
-	normalizedBackends := make(map[string]config.AIBackendConfig, len(backends))
+	normalizedBackends := make(map[string]fleet.Backend, len(backends))
 	for name, b := range backends {
 		name = config.NormalizeBackendName(name)
 		config.NormalizeBackendConfig(&b)
@@ -443,10 +444,10 @@ func normalizeFleet(
 // consistent with the normalization the individual Upsert* helpers apply.
 func ImportAll(
 	db *sql.DB,
-	agents []config.AgentDef,
-	repos []config.RepoDef,
-	skills map[string]config.SkillDef,
-	backends map[string]config.AIBackendConfig,
+	agents []fleet.Agent,
+	repos []fleet.Repo,
+	skills map[string]fleet.Skill,
+	backends map[string]fleet.Backend,
 ) error {
 	normalizedSkills, normalizedBackends := normalizeFleet(agents, repos, skills, backends)
 
@@ -480,10 +481,10 @@ func ImportAll(
 // left unchanged.
 func ReplaceAll(
 	db *sql.DB,
-	agents []config.AgentDef,
-	repos []config.RepoDef,
-	skills map[string]config.SkillDef,
-	backends map[string]config.AIBackendConfig,
+	agents []fleet.Agent,
+	repos []fleet.Repo,
+	skills map[string]fleet.Skill,
+	backends map[string]fleet.Backend,
 ) error {
 	normalizedSkills, normalizedBackends := normalizeFleet(agents, repos, skills, backends)
 
@@ -523,7 +524,7 @@ func ReplaceAll(
 // validateBindingShape checks the trigger-exclusivity and event-kind invariants
 // for a single binding, without requiring a full repo context. Returns an
 // *ErrValidation on failure so HTTP handlers can map it to 400 Bad Request.
-func validateBindingShape(b config.Binding) error {
+func validateBindingShape(b fleet.Binding) error {
 	if strings.TrimSpace(b.Agent) == "" {
 		return &ErrValidation{Msg: "agent is required"}
 	}
@@ -553,7 +554,7 @@ func validateBindingShape(b config.Binding) error {
 
 // normalizeBinding lowercases/trims agent and event names so writes match the
 // canonical form the daemon derives at boot (see normalize() in config.go).
-func normalizeBinding(b *config.Binding) {
+func normalizeBinding(b *fleet.Binding) {
 	b.Agent = strings.ToLower(strings.TrimSpace(b.Agent))
 	b.Cron = strings.TrimSpace(b.Cron)
 	for i := range b.Events {
@@ -569,41 +570,41 @@ func normalizeBinding(b *config.Binding) {
 // Validation failures surface as *ErrValidation (HTTP 400). Missing repo/agent
 // references surface as *ErrNotFound (HTTP 404). The caller is responsible for
 // holding the store mutex and reloading cron schedules after success.
-func CreateBinding(db *sql.DB, repoName string, b config.Binding) (int64, config.Binding, error) {
+func CreateBinding(db *sql.DB, repoName string, b fleet.Binding) (int64, fleet.Binding, error) {
 	repoName = config.NormalizeRepoName(repoName)
 	normalizeBinding(&b)
 	if err := validateBindingShape(b); err != nil {
-		return 0, config.Binding{}, err
+		return 0, fleet.Binding{}, err
 	}
 	tx, err := db.Begin()
 	if err != nil {
-		return 0, config.Binding{}, fmt.Errorf("store: create binding: begin: %w", err)
+		return 0, fleet.Binding{}, fmt.Errorf("store: create binding: begin: %w", err)
 	}
 	defer tx.Rollback()
 
 	// Verify the repo exists so the FK violation surfaces as a typed error.
 	var repoExists bool
 	if err := tx.QueryRow("SELECT EXISTS(SELECT 1 FROM repos WHERE name=?)", repoName).Scan(&repoExists); err != nil {
-		return 0, config.Binding{}, fmt.Errorf("store: create binding: lookup repo: %w", err)
+		return 0, fleet.Binding{}, fmt.Errorf("store: create binding: lookup repo: %w", err)
 	}
 	if !repoExists {
-		return 0, config.Binding{}, &ErrNotFound{Msg: fmt.Sprintf("repo %q not found", repoName)}
+		return 0, fleet.Binding{}, &ErrNotFound{Msg: fmt.Sprintf("repo %q not found", repoName)}
 	}
 	var agentExists bool
 	if err := tx.QueryRow("SELECT EXISTS(SELECT 1 FROM agents WHERE name=?)", b.Agent).Scan(&agentExists); err != nil {
-		return 0, config.Binding{}, fmt.Errorf("store: create binding: lookup agent: %w", err)
+		return 0, fleet.Binding{}, fmt.Errorf("store: create binding: lookup agent: %w", err)
 	}
 	if !agentExists {
-		return 0, config.Binding{}, &ErrValidation{Msg: fmt.Sprintf("unknown agent %q", b.Agent)}
+		return 0, fleet.Binding{}, &ErrValidation{Msg: fmt.Sprintf("unknown agent %q", b.Agent)}
 	}
 
 	labels, err := json.Marshal(nilSafeStrings(b.Labels))
 	if err != nil {
-		return 0, config.Binding{}, fmt.Errorf("store: create binding: marshal labels: %w", err)
+		return 0, fleet.Binding{}, fmt.Errorf("store: create binding: marshal labels: %w", err)
 	}
 	events, err := json.Marshal(nilSafeStrings(b.Events))
 	if err != nil {
-		return 0, config.Binding{}, fmt.Errorf("store: create binding: marshal events: %w", err)
+		return 0, fleet.Binding{}, fmt.Errorf("store: create binding: marshal events: %w", err)
 	}
 	enabled := bindingEnabledInt(b.Enabled)
 	res, err := tx.Exec(
@@ -611,17 +612,17 @@ func CreateBinding(db *sql.DB, repoName string, b config.Binding) (int64, config
 		repoName, b.Agent, string(labels), string(events), b.Cron, enabled,
 	)
 	if err != nil {
-		return 0, config.Binding{}, fmt.Errorf("store: create binding: insert: %w", err)
+		return 0, fleet.Binding{}, fmt.Errorf("store: create binding: insert: %w", err)
 	}
 	id, err := res.LastInsertId()
 	if err != nil {
-		return 0, config.Binding{}, fmt.Errorf("store: create binding: last insert id: %w", err)
+		return 0, fleet.Binding{}, fmt.Errorf("store: create binding: last insert id: %w", err)
 	}
 	if err := validateFleet(tx); err != nil {
-		return 0, config.Binding{}, &ErrValidation{Msg: fmt.Sprintf("store: create binding: %v", err)}
+		return 0, fleet.Binding{}, &ErrValidation{Msg: fmt.Sprintf("store: create binding: %v", err)}
 	}
 	if err := tx.Commit(); err != nil {
-		return 0, config.Binding{}, fmt.Errorf("store: create binding: commit: %w", err)
+		return 0, fleet.Binding{}, fmt.Errorf("store: create binding: commit: %w", err)
 	}
 	b.ID = id
 	return id, b, nil
@@ -633,32 +634,32 @@ func CreateBinding(db *sql.DB, repoName string, b config.Binding) (int64, config
 // unknown agent refs.
 //
 // Callers hold the store mutex and reload cron afterwards.
-func UpdateBinding(db *sql.DB, id int64, b config.Binding) (config.Binding, error) {
+func UpdateBinding(db *sql.DB, id int64, b fleet.Binding) (fleet.Binding, error) {
 	normalizeBinding(&b)
 	if err := validateBindingShape(b); err != nil {
-		return config.Binding{}, err
+		return fleet.Binding{}, err
 	}
 	tx, err := db.Begin()
 	if err != nil {
-		return config.Binding{}, fmt.Errorf("store: update binding: begin: %w", err)
+		return fleet.Binding{}, fmt.Errorf("store: update binding: begin: %w", err)
 	}
 	defer tx.Rollback()
 
 	var agentExists bool
 	if err := tx.QueryRow("SELECT EXISTS(SELECT 1 FROM agents WHERE name=?)", b.Agent).Scan(&agentExists); err != nil {
-		return config.Binding{}, fmt.Errorf("store: update binding: lookup agent: %w", err)
+		return fleet.Binding{}, fmt.Errorf("store: update binding: lookup agent: %w", err)
 	}
 	if !agentExists {
-		return config.Binding{}, &ErrValidation{Msg: fmt.Sprintf("unknown agent %q", b.Agent)}
+		return fleet.Binding{}, &ErrValidation{Msg: fmt.Sprintf("unknown agent %q", b.Agent)}
 	}
 
 	labels, err := json.Marshal(nilSafeStrings(b.Labels))
 	if err != nil {
-		return config.Binding{}, fmt.Errorf("store: update binding: marshal labels: %w", err)
+		return fleet.Binding{}, fmt.Errorf("store: update binding: marshal labels: %w", err)
 	}
 	events, err := json.Marshal(nilSafeStrings(b.Events))
 	if err != nil {
-		return config.Binding{}, fmt.Errorf("store: update binding: marshal events: %w", err)
+		return fleet.Binding{}, fmt.Errorf("store: update binding: marshal events: %w", err)
 	}
 	enabled := bindingEnabledInt(b.Enabled)
 	res, err := tx.Exec(
@@ -666,26 +667,26 @@ func UpdateBinding(db *sql.DB, id int64, b config.Binding) (config.Binding, erro
 		b.Agent, string(labels), string(events), b.Cron, enabled, id,
 	)
 	if err != nil {
-		return config.Binding{}, fmt.Errorf("store: update binding: %w", err)
+		return fleet.Binding{}, fmt.Errorf("store: update binding: %w", err)
 	}
 	n, err := res.RowsAffected()
 	if err != nil {
-		return config.Binding{}, fmt.Errorf("store: update binding: rows affected: %w", err)
+		return fleet.Binding{}, fmt.Errorf("store: update binding: rows affected: %w", err)
 	}
 	if n == 0 {
-		return config.Binding{}, &ErrNotFound{Msg: fmt.Sprintf("binding id=%d not found", id)}
+		return fleet.Binding{}, &ErrNotFound{Msg: fmt.Sprintf("binding id=%d not found", id)}
 	}
 
 	var repoName string
 	if err := tx.QueryRow("SELECT repo FROM bindings WHERE id=?", id).Scan(&repoName); err != nil {
-		return config.Binding{}, fmt.Errorf("store: update binding: lookup repo: %w", err)
+		return fleet.Binding{}, fmt.Errorf("store: update binding: lookup repo: %w", err)
 	}
 
 	if err := validateFleet(tx); err != nil {
-		return config.Binding{}, &ErrValidation{Msg: fmt.Sprintf("store: update binding: %v", err)}
+		return fleet.Binding{}, &ErrValidation{Msg: fmt.Sprintf("store: update binding: %v", err)}
 	}
 	if err := tx.Commit(); err != nil {
-		return config.Binding{}, fmt.Errorf("store: update binding: commit: %w", err)
+		return fleet.Binding{}, fmt.Errorf("store: update binding: commit: %w", err)
 	}
 	b.ID = id
 	return b, nil
@@ -722,27 +723,27 @@ func DeleteBinding(db *sql.DB, id int64) error {
 // ReadBinding fetches a single binding by ID along with its parent repo name.
 // Returns found=false when the row does not exist; errors only reflect
 // unexpected I/O failures.
-func ReadBinding(db *sql.DB, id int64) (repoName string, b config.Binding, found bool, err error) {
+func ReadBinding(db *sql.DB, id int64) (repoName string, b fleet.Binding, found bool, err error) {
 	var labelsJSON, eventsJSON, cron, agent string
 	var enabled int
 	err = db.QueryRow(
 		"SELECT repo,agent,labels,events,cron,enabled FROM bindings WHERE id=?", id,
 	).Scan(&repoName, &agent, &labelsJSON, &eventsJSON, &cron, &enabled)
 	if errors.Is(err, sql.ErrNoRows) {
-		return "", config.Binding{}, false, nil
+		return "", fleet.Binding{}, false, nil
 	}
 	if err != nil {
-		return "", config.Binding{}, false, fmt.Errorf("store: read binding %d: %w", id, err)
+		return "", fleet.Binding{}, false, fmt.Errorf("store: read binding %d: %w", id, err)
 	}
 	var labels []string
 	if err := json.Unmarshal([]byte(labelsJSON), &labels); err != nil {
-		return "", config.Binding{}, false, fmt.Errorf("store: read binding %d: parse labels: %w", id, err)
+		return "", fleet.Binding{}, false, fmt.Errorf("store: read binding %d: parse labels: %w", id, err)
 	}
 	var events []string
 	if err := json.Unmarshal([]byte(eventsJSON), &events); err != nil {
-		return "", config.Binding{}, false, fmt.Errorf("store: read binding %d: parse events: %w", id, err)
+		return "", fleet.Binding{}, false, fmt.Errorf("store: read binding %d: parse events: %w", id, err)
 	}
-	b = config.Binding{
+	b = fleet.Binding{
 		ID:     id,
 		Agent:  agent,
 		Labels: labels,

--- a/internal/store/crud_test.go
+++ b/internal/store/crud_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/fleet"
 	"github.com/eloylp/agents/internal/store"
 )
 
@@ -16,7 +16,7 @@ import (
 // reference it pass cross-ref validation.
 func seedBackend(t *testing.T, db *sql.DB, name string) {
 	t.Helper()
-	b := config.AIBackendConfig{Command: name}
+	b := fleet.Backend{Command: name}
 	if err := store.UpsertBackend(db, name, b); err != nil {
 		t.Fatalf("seedBackend %s: %v", name, err)
 	}
@@ -26,7 +26,7 @@ func seedBackend(t *testing.T, db *sql.DB, name string) {
 // reference it pass cross-ref validation.
 func seedSkill(t *testing.T, db *sql.DB, name string) {
 	t.Helper()
-	if err := store.UpsertSkill(db, name, config.SkillDef{Prompt: "skill prompt"}); err != nil {
+	if err := store.UpsertSkill(db, name, fleet.Skill{Prompt: "skill prompt"}); err != nil {
 		t.Fatalf("seedSkill %s: %v", name, err)
 	}
 }
@@ -42,7 +42,7 @@ func TestUpsertAndReadAgents(t *testing.T) {
 
 	// "pr-reviewer" must exist (with a description) before "coder" can list it
 	// in can_dispatch.
-	if err := store.UpsertAgent(db, config.AgentDef{
+	if err := store.UpsertAgent(db, fleet.Agent{
 		Name:        "pr-reviewer",
 		Backend:     "claude",
 		Prompt:      "review code",
@@ -53,7 +53,7 @@ func TestUpsertAndReadAgents(t *testing.T) {
 		t.Fatalf("UpsertAgent pr-reviewer: %v", err)
 	}
 
-	a := config.AgentDef{
+	a := fleet.Agent{
 		Name:          "coder",
 		Backend:       "claude",
 		Skills:        []string{"architect"},
@@ -72,7 +72,7 @@ func TestUpsertAndReadAgents(t *testing.T) {
 		t.Fatalf("ReadAgents: %v", err)
 	}
 	// 2 agents: pr-reviewer (seeded for can_dispatch) + coder.
-	var got *config.AgentDef
+	var got *fleet.Agent
 	for i := range agents {
 		if agents[i].Name == "coder" {
 			got = &agents[i]
@@ -96,7 +96,7 @@ func TestUpsertAgentIsIdempotent(t *testing.T) {
 
 	seedBackend(t, db, "claude")
 
-	a := config.AgentDef{Name: "coder", Backend: "claude", Prompt: "v1", Skills: []string{}, CanDispatch: []string{}}
+	a := fleet.Agent{Name: "coder", Backend: "claude", Prompt: "v1", Skills: []string{}, CanDispatch: []string{}}
 	if err := store.UpsertAgent(db, a); err != nil {
 		t.Fatalf("first upsert: %v", err)
 	}
@@ -125,7 +125,7 @@ func TestDeleteAgent(t *testing.T) {
 
 	// Seed two agents so that deleting one still leaves the system valid.
 	for _, name := range []string{"coder", "reviewer"} {
-		if err := store.UpsertAgent(db, config.AgentDef{
+		if err := store.UpsertAgent(db, fleet.Agent{
 			Name: name, Backend: "claude", Prompt: "p", Skills: []string{}, CanDispatch: []string{},
 		}); err != nil {
 			t.Fatalf("UpsertAgent %s: %v", name, err)
@@ -161,7 +161,7 @@ func TestUpsertAndReadSkills(t *testing.T) {
 	t.Parallel()
 	db := openTestDB(t)
 
-	s := config.SkillDef{Prompt: "Focus on architecture."}
+	s := fleet.Skill{Prompt: "Focus on architecture."}
 	if err := store.UpsertSkill(db, "architect", s); err != nil {
 		t.Fatalf("UpsertSkill: %v", err)
 	}
@@ -181,7 +181,7 @@ func TestDeleteSkill(t *testing.T) {
 	t.Parallel()
 	db := openTestDB(t)
 
-	if err := store.UpsertSkill(db, "architect", config.SkillDef{Prompt: "p"}); err != nil {
+	if err := store.UpsertSkill(db, "architect", fleet.Skill{Prompt: "p"}); err != nil {
 		t.Fatalf("UpsertSkill: %v", err)
 	}
 	if err := store.DeleteSkill(db, "architect"); err != nil {
@@ -202,7 +202,7 @@ func TestUpsertAndReadBackends(t *testing.T) {
 	t.Parallel()
 	db := openTestDB(t)
 
-	b := config.AIBackendConfig{
+	b := fleet.Backend{
 		Command:        "claude",
 		TimeoutSeconds: 300,
 		MaxPromptChars: 8000,
@@ -233,7 +233,7 @@ func TestUpsertBackendAppliesDefaults(t *testing.T) {
 	// Persist a backend with zero numeric fields — the same payload that
 	// POST /api/store/backends would send when omitting timeout_seconds and
 	// max_prompt_chars from the request body.
-	b := config.AIBackendConfig{Command: "claude"}
+	b := fleet.Backend{Command: "claude"}
 	if err := store.UpsertBackend(db, "claude", b); err != nil {
 		t.Fatalf("UpsertBackend: %v", err)
 	}
@@ -257,7 +257,7 @@ func TestDeleteBackend(t *testing.T) {
 
 	// Seed two backends so that deleting one still leaves the system valid.
 	for _, name := range []string{"claude", "codex"} {
-		if err := store.UpsertBackend(db, name, config.AIBackendConfig{
+		if err := store.UpsertBackend(db, name, fleet.Backend{
 			Command: name,
 		}); err != nil {
 			t.Fatalf("UpsertBackend %s: %v", name, err)
@@ -287,17 +287,17 @@ func TestUpsertAndReadRepos(t *testing.T) {
 	seedBackend(t, db, "claude")
 
 	// UpsertRepo requires the agents referenced by bindings to exist.
-	if err := store.UpsertAgent(db, config.AgentDef{
+	if err := store.UpsertAgent(db, fleet.Agent{
 		Name: "coder", Backend: "claude", Prompt: "p", Skills: []string{}, CanDispatch: []string{},
 	}); err != nil {
 		t.Fatalf("UpsertAgent: %v", err)
 	}
 
 	enabled := true
-	r := config.RepoDef{
+	r := fleet.Repo{
 		Name:    "owner/repo",
 		Enabled: true,
-		Use: []config.Binding{
+		Use: []fleet.Binding{
 			{Agent: "coder", Labels: []string{"ai:fix"}, Enabled: &enabled},
 		},
 	}
@@ -336,16 +336,16 @@ func TestUpsertRepoReplacesBindings(t *testing.T) {
 
 	seedBackend(t, db, "claude")
 
-	if err := store.UpsertAgent(db, config.AgentDef{
+	if err := store.UpsertAgent(db, fleet.Agent{
 		Name: "coder", Backend: "claude", Prompt: "p", Skills: []string{}, CanDispatch: []string{},
 	}); err != nil {
 		t.Fatalf("UpsertAgent: %v", err)
 	}
 
-	r := config.RepoDef{
+	r := fleet.Repo{
 		Name:    "owner/repo",
 		Enabled: true,
-		Use: []config.Binding{
+		Use: []fleet.Binding{
 			{Agent: "coder", Labels: []string{"ai:fix"}},
 			{Agent: "coder", Cron: "0 9 * * *"},
 		},
@@ -355,7 +355,7 @@ func TestUpsertRepoReplacesBindings(t *testing.T) {
 	}
 
 	// Re-upsert with only one binding.
-	r.Use = []config.Binding{{Agent: "coder", Labels: []string{"ai:fix"}}}
+	r.Use = []fleet.Binding{{Agent: "coder", Labels: []string{"ai:fix"}}}
 	if err := store.UpsertRepo(db, r); err != nil {
 		t.Fatalf("second upsert: %v", err)
 	}
@@ -375,7 +375,7 @@ func TestDeleteRepo(t *testing.T) {
 
 	seedBackend(t, db, "claude")
 
-	if err := store.UpsertAgent(db, config.AgentDef{
+	if err := store.UpsertAgent(db, fleet.Agent{
 		Name: "coder", Backend: "claude", Prompt: "p", Skills: []string{}, CanDispatch: []string{},
 	}); err != nil {
 		t.Fatalf("UpsertAgent: %v", err)
@@ -383,10 +383,10 @@ func TestDeleteRepo(t *testing.T) {
 
 	// Seed two repos so that deleting one still leaves at least one enabled.
 	for _, name := range []string{"owner/repo", "owner/other"} {
-		if err := store.UpsertRepo(db, config.RepoDef{
+		if err := store.UpsertRepo(db, fleet.Repo{
 			Name:    name,
 			Enabled: true,
-			Use:     []config.Binding{{Agent: "coder", Labels: []string{"ai:fix"}}},
+			Use:     []fleet.Binding{{Agent: "coder", Labels: []string{"ai:fix"}}},
 		}); err != nil {
 			t.Fatalf("UpsertRepo %s: %v", name, err)
 		}
@@ -425,7 +425,7 @@ func TestReadSnapshot(t *testing.T) {
 	seedBackend(t, db, "claude")
 
 	// Seed one agent and one repo.
-	a := config.AgentDef{
+	a := fleet.Agent{
 		Name:    "coder",
 		Backend: "claude",
 		Skills:  []string{},
@@ -435,10 +435,10 @@ func TestReadSnapshot(t *testing.T) {
 		t.Fatalf("UpsertAgent: %v", err)
 	}
 	enabled := true
-	r := config.RepoDef{
+	r := fleet.Repo{
 		Name:    "owner/repo",
 		Enabled: true,
-		Use:     []config.Binding{{Agent: "coder", Events: []string{"issues.labeled"}, Enabled: &enabled}},
+		Use:     []fleet.Binding{{Agent: "coder", Events: []string{"issues.labeled"}, Enabled: &enabled}},
 	}
 	if err := store.UpsertRepo(db, r); err != nil {
 		t.Fatalf("UpsertRepo: %v", err)
@@ -472,19 +472,19 @@ func TestUpsertAgentCrossRefErrors(t *testing.T) {
 	tests := []struct {
 		name    string
 		setup   func(t *testing.T, db *sql.DB)
-		agent   config.AgentDef
+		agent   fleet.Agent
 		wantErr string
 	}{
 		{
 			name:    "unknown backend",
 			setup:   func(t *testing.T, db *sql.DB) { t.Helper() }, // no backend seeded
-			agent:   config.AgentDef{Name: "coder", Backend: "claude", Prompt: "p", Skills: []string{}},
+			agent:   fleet.Agent{Name: "coder", Backend: "claude", Prompt: "p", Skills: []string{}},
 			wantErr: "unknown backend",
 		},
 		{
 			name:    "unknown skill",
 			setup:   func(t *testing.T, db *sql.DB) { seedBackend(t, db, "claude") },
-			agent:   config.AgentDef{Name: "coder", Backend: "claude", Prompt: "p", Skills: []string{"architect"}},
+			agent:   fleet.Agent{Name: "coder", Backend: "claude", Prompt: "p", Skills: []string{"architect"}},
 			wantErr: "unknown skill",
 		},
 	}
@@ -511,10 +511,10 @@ func TestUpsertRepoRejectedWithUnknownAgent(t *testing.T) {
 	// No agent seeded — binding references "ghost". The FK constraint on
 	// bindings.agent may fire first, or validateCrossRefs catches it; either
 	// way an error must be returned and nothing must be committed.
-	err := store.UpsertRepo(db, config.RepoDef{
+	err := store.UpsertRepo(db, fleet.Repo{
 		Name:    "owner/repo",
 		Enabled: true,
-		Use:     []config.Binding{{Agent: "ghost", Labels: []string{"ai:fix"}}},
+		Use:     []fleet.Binding{{Agent: "ghost", Labels: []string{"ai:fix"}}},
 	})
 	if err == nil {
 		t.Fatal("UpsertRepo with unknown agent binding: want error, got nil")
@@ -538,7 +538,7 @@ func TestDeleteBackendRejectedWhenAgentReferences(t *testing.T) {
 	// reason the delete fails — only the agent reference should block it.
 	seedBackend(t, db, "claude")
 	seedBackend(t, db, "codex")
-	if err := store.UpsertAgent(db, config.AgentDef{
+	if err := store.UpsertAgent(db, fleet.Agent{
 		Name:    "coder",
 		Backend: "claude",
 		Prompt:  "p",
@@ -572,7 +572,7 @@ func TestDeleteSkillRejectedWhenAgentReferences(t *testing.T) {
 
 	seedBackend(t, db, "claude")
 	seedSkill(t, db, "architect")
-	if err := store.UpsertAgent(db, config.AgentDef{
+	if err := store.UpsertAgent(db, fleet.Agent{
 		Name:    "coder",
 		Backend: "claude",
 		Prompt:  "p",
@@ -606,17 +606,17 @@ func TestDeleteAgentRejectedWhenBindingReferences(t *testing.T) {
 
 	seedBackend(t, db, "claude")
 	for _, name := range []string{"coder", "reviewer"} {
-		if err := store.UpsertAgent(db, config.AgentDef{
+		if err := store.UpsertAgent(db, fleet.Agent{
 			Name: name, Backend: "claude", Prompt: "p", Skills: []string{}, CanDispatch: []string{},
 		}); err != nil {
 			t.Fatalf("UpsertAgent %s: %v", name, err)
 		}
 	}
 	enabled := true
-	if err := store.UpsertRepo(db, config.RepoDef{
+	if err := store.UpsertRepo(db, fleet.Repo{
 		Name:    "owner/repo",
 		Enabled: true,
-		Use:     []config.Binding{{Agent: "coder", Labels: []string{"ai:fix"}, Enabled: &enabled}},
+		Use:     []fleet.Binding{{Agent: "coder", Labels: []string{"ai:fix"}, Enabled: &enabled}},
 	}); err != nil {
 		t.Fatalf("UpsertRepo: %v", err)
 	}
@@ -652,7 +652,7 @@ func TestDeleteAgentCascadeRemovesBindings(t *testing.T) {
 
 	seedBackend(t, db, "claude")
 	for _, name := range []string{"coder", "reviewer"} {
-		if err := store.UpsertAgent(db, config.AgentDef{
+		if err := store.UpsertAgent(db, fleet.Agent{
 			Name: name, Backend: "claude", Prompt: "p", Skills: []string{}, CanDispatch: []string{},
 		}); err != nil {
 			t.Fatalf("UpsertAgent %s: %v", name, err)
@@ -661,10 +661,10 @@ func TestDeleteAgentCascadeRemovesBindings(t *testing.T) {
 	enabled := true
 	// Repo keeps a binding for "reviewer" so the cascade path does not wipe
 	// the repo entirely; only bindings referencing "coder" should disappear.
-	if err := store.UpsertRepo(db, config.RepoDef{
+	if err := store.UpsertRepo(db, fleet.Repo{
 		Name:    "owner/repo",
 		Enabled: true,
-		Use: []config.Binding{
+		Use: []fleet.Binding{
 			{Agent: "coder", Labels: []string{"ai:fix"}, Enabled: &enabled},
 			{Agent: "coder", Events: []string{"issues.opened"}, Enabled: &enabled},
 			{Agent: "reviewer", Labels: []string{"ai:review"}, Enabled: &enabled},
@@ -705,7 +705,7 @@ func TestDeleteAgentCascadeStillRejectsLastAgent(t *testing.T) {
 	db := openTestDB(t)
 
 	seedBackend(t, db, "claude")
-	if err := store.UpsertAgent(db, config.AgentDef{
+	if err := store.UpsertAgent(db, fleet.Agent{
 		Name: "coder", Backend: "claude", Prompt: "p", Skills: []string{}, CanDispatch: []string{},
 	}); err != nil {
 		t.Fatalf("UpsertAgent: %v", err)
@@ -725,13 +725,13 @@ func TestDeleteAgentCascadeStillRejectsWhenInCanDispatch(t *testing.T) {
 	db := openTestDB(t)
 
 	seedBackend(t, db, "claude")
-	if err := store.UpsertAgent(db, config.AgentDef{
+	if err := store.UpsertAgent(db, fleet.Agent{
 		Name: "target", Backend: "claude", Prompt: "p", Description: "a dispatchable target",
 		Skills: []string{}, CanDispatch: []string{},
 	}); err != nil {
 		t.Fatalf("UpsertAgent target: %v", err)
 	}
-	if err := store.UpsertAgent(db, config.AgentDef{
+	if err := store.UpsertAgent(db, fleet.Agent{
 		Name: "dispatcher", Backend: "claude", Prompt: "p",
 		Skills: []string{}, CanDispatch: []string{"target"},
 	}); err != nil {
@@ -753,7 +753,7 @@ func TestDeleteAgentRejectedWhenDispatchListReferences(t *testing.T) {
 	seedBackend(t, db, "claude")
 
 	// Seed two agents: "dispatcher" can_dispatch to "target".
-	if err := store.UpsertAgent(db, config.AgentDef{
+	if err := store.UpsertAgent(db, fleet.Agent{
 		Name:        "target",
 		Backend:     "claude",
 		Prompt:      "p",
@@ -763,7 +763,7 @@ func TestDeleteAgentRejectedWhenDispatchListReferences(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("UpsertAgent target: %v", err)
 	}
-	if err := store.UpsertAgent(db, config.AgentDef{
+	if err := store.UpsertAgent(db, fleet.Agent{
 		Name:        "dispatcher",
 		Backend:     "claude",
 		Prompt:      "p",
@@ -790,19 +790,19 @@ func TestUpsertBackendValidationErrors(t *testing.T) {
 	tests := []struct {
 		name    string
 		bName   string
-		cfg     config.AIBackendConfig
+		cfg     fleet.Backend
 		wantErr string
 	}{
 		{
 			name:    "empty command",
 			bName:   "claude",
-			cfg:     config.AIBackendConfig{Command: "", },
+			cfg:     fleet.Backend{Command: "", },
 			wantErr: "command is required",
 		},
 		{
 			name:    "invalid name",
 			bName:   "unknown-ai",
-			cfg:     config.AIBackendConfig{Command: "ai", },
+			cfg:     fleet.Backend{Command: "ai", },
 			wantErr: "unsupported ai backend",
 		},
 	}
@@ -825,7 +825,7 @@ func TestUpsertSkillRejectedWithEmptyPrompt(t *testing.T) {
 	t.Parallel()
 	db := openTestDB(t)
 
-	err := store.UpsertSkill(db, "testing", config.SkillDef{Prompt: ""})
+	err := store.UpsertSkill(db, "testing", fleet.Skill{Prompt: ""})
 	if err == nil {
 		t.Fatal("UpsertSkill with empty prompt: want error, got nil")
 	}
@@ -839,7 +839,7 @@ func TestUpsertAgentRejectedWithEmptyPrompt(t *testing.T) {
 	db := openTestDB(t)
 
 	seedBackend(t, db, "claude")
-	err := store.UpsertAgent(db, config.AgentDef{
+	err := store.UpsertAgent(db, fleet.Agent{
 		Name:    "coder",
 		Backend: "claude",
 		Prompt:  "",
@@ -858,16 +858,16 @@ func TestUpsertRepoRejectedWithNoTrigger(t *testing.T) {
 	db := openTestDB(t)
 
 	seedBackend(t, db, "claude")
-	if err := store.UpsertAgent(db, config.AgentDef{
+	if err := store.UpsertAgent(db, fleet.Agent{
 		Name: "coder", Backend: "claude", Prompt: "p", Skills: []string{}, CanDispatch: []string{},
 	}); err != nil {
 		t.Fatalf("UpsertAgent: %v", err)
 	}
 	// Binding has no labels, events, or cron — invalid.
-	err := store.UpsertRepo(db, config.RepoDef{
+	err := store.UpsertRepo(db, fleet.Repo{
 		Name:    "owner/repo",
 		Enabled: true,
-		Use:     []config.Binding{{Agent: "coder"}},
+		Use:     []fleet.Binding{{Agent: "coder"}},
 	})
 	if err == nil {
 		t.Fatal("UpsertRepo with no-trigger binding: want error, got nil")
@@ -882,16 +882,16 @@ func TestUpsertRepoRejectedWithMixedTriggers(t *testing.T) {
 	db := openTestDB(t)
 
 	seedBackend(t, db, "claude")
-	if err := store.UpsertAgent(db, config.AgentDef{
+	if err := store.UpsertAgent(db, fleet.Agent{
 		Name: "coder", Backend: "claude", Prompt: "p", Skills: []string{}, CanDispatch: []string{},
 	}); err != nil {
 		t.Fatalf("UpsertAgent: %v", err)
 	}
 	// Binding mixes labels and events — invalid.
-	err := store.UpsertRepo(db, config.RepoDef{
+	err := store.UpsertRepo(db, fleet.Repo{
 		Name:    "owner/repo",
 		Enabled: true,
-		Use: []config.Binding{{
+		Use: []fleet.Binding{{
 			Agent:  "coder",
 			Labels: []string{"ai:fix"},
 			Events: []string{"push"},
@@ -910,7 +910,7 @@ func TestDeleteAgentRejectedAsLast(t *testing.T) {
 	db := openTestDB(t)
 
 	seedBackend(t, db, "claude")
-	if err := store.UpsertAgent(db, config.AgentDef{
+	if err := store.UpsertAgent(db, fleet.Agent{
 		Name: "coder", Backend: "claude", Prompt: "p", Skills: []string{}, CanDispatch: []string{},
 	}); err != nil {
 		t.Fatalf("UpsertAgent: %v", err)
@@ -938,7 +938,7 @@ func TestDeleteBackendRejectedAsLast(t *testing.T) {
 	t.Parallel()
 	db := openTestDB(t)
 
-	if err := store.UpsertBackend(db, "claude", config.AIBackendConfig{
+	if err := store.UpsertBackend(db, "claude", fleet.Backend{
 		Command: "claude",
 	}); err != nil {
 		t.Fatalf("UpsertBackend: %v", err)
@@ -971,15 +971,15 @@ func TestDeleteRepoAllowsLastEnabled(t *testing.T) {
 	db := openTestDB(t)
 
 	seedBackend(t, db, "claude")
-	if err := store.UpsertAgent(db, config.AgentDef{
+	if err := store.UpsertAgent(db, fleet.Agent{
 		Name: "coder", Backend: "claude", Prompt: "p", Skills: []string{}, CanDispatch: []string{},
 	}); err != nil {
 		t.Fatalf("UpsertAgent: %v", err)
 	}
-	if err := store.UpsertRepo(db, config.RepoDef{
+	if err := store.UpsertRepo(db, fleet.Repo{
 		Name:    "owner/repo",
 		Enabled: true,
-		Use:     []config.Binding{{Agent: "coder", Labels: []string{"ai:fix"}}},
+		Use:     []fleet.Binding{{Agent: "coder", Labels: []string{"ai:fix"}}},
 	}); err != nil {
 		t.Fatalf("UpsertRepo: %v", err)
 	}
@@ -1018,7 +1018,7 @@ func TestUpsertNormalizesNames(t *testing.T) {
 	db := openTestDB(t)
 
 	// Backend — mixed-case name should be stored lowercase.
-	if err := store.UpsertBackend(db, "Claude", config.AIBackendConfig{
+	if err := store.UpsertBackend(db, "Claude", fleet.Backend{
 		Command: "claude",
 	}); err != nil {
 		t.Fatalf("UpsertBackend: %v", err)
@@ -1035,7 +1035,7 @@ func TestUpsertNormalizesNames(t *testing.T) {
 	}
 
 	// Skill — mixed-case key should be stored lowercase.
-	if err := store.UpsertSkill(db, "Architect", config.SkillDef{Prompt: "p"}); err != nil {
+	if err := store.UpsertSkill(db, "Architect", fleet.Skill{Prompt: "p"}); err != nil {
 		t.Fatalf("UpsertSkill: %v", err)
 	}
 	skills, err := store.ReadSkills(db)
@@ -1047,7 +1047,7 @@ func TestUpsertNormalizesNames(t *testing.T) {
 	}
 
 	// Agent — mixed-case name, backend, and skill reference should be stored lowercase.
-	if err := store.UpsertAgent(db, config.AgentDef{
+	if err := store.UpsertAgent(db, fleet.Agent{
 		Name:        "Coder",
 		Backend:     "Claude",
 		Prompt:      "p",
@@ -1075,10 +1075,10 @@ func TestUpsertNormalizesNames(t *testing.T) {
 	}
 
 	// Repo — binding agent name should be stored lowercase.
-	if err := store.UpsertRepo(db, config.RepoDef{
+	if err := store.UpsertRepo(db, fleet.Repo{
 		Name:    "owner/repo",
 		Enabled: true,
-		Use:     []config.Binding{{Agent: "Coder", Labels: []string{"ai:fix"}}},
+		Use:     []fleet.Binding{{Agent: "Coder", Labels: []string{"ai:fix"}}},
 	}); err != nil {
 		t.Fatalf("UpsertRepo: %v", err)
 	}
@@ -1104,7 +1104,7 @@ func TestUpsertSkillNormalizesPrompt(t *testing.T) {
 	db := openTestDB(t)
 
 	// Whitespace-only prompt should be trimmed to "" and rejected.
-	err := store.UpsertSkill(db, "testing", config.SkillDef{Prompt: "   "})
+	err := store.UpsertSkill(db, "testing", fleet.Skill{Prompt: "   "})
 	if err == nil {
 		t.Fatal("UpsertSkill with whitespace-only prompt: want error, got nil")
 	}
@@ -1113,7 +1113,7 @@ func TestUpsertSkillNormalizesPrompt(t *testing.T) {
 	}
 
 	// A prompt with surrounding whitespace should be trimmed and stored cleanly.
-	if err := store.UpsertSkill(db, "testing", config.SkillDef{Prompt: "  skill guidance  "}); err != nil {
+	if err := store.UpsertSkill(db, "testing", fleet.Skill{Prompt: "  skill guidance  "}); err != nil {
 		t.Fatalf("UpsertSkill with padded prompt: %v", err)
 	}
 	skills, err := store.ReadSkills(db)
@@ -1135,7 +1135,7 @@ func TestUpsertBackendNormalizesCommand(t *testing.T) {
 	db := openTestDB(t)
 
 	// Whitespace-only command must be trimmed to "" and rejected.
-	err := store.UpsertBackend(db, "claude", config.AIBackendConfig{
+	err := store.UpsertBackend(db, "claude", fleet.Backend{
 		Command: "   ",
 	})
 	if err == nil {
@@ -1146,7 +1146,7 @@ func TestUpsertBackendNormalizesCommand(t *testing.T) {
 	}
 
 	// Padded command should be stored trimmed.
-	if err := store.UpsertBackend(db, "claude", config.AIBackendConfig{
+	if err := store.UpsertBackend(db, "claude", fleet.Backend{
 		Command: "  claude  ",
 	}); err != nil {
 		t.Fatalf("UpsertBackend with padded command: %v", err)
@@ -1168,15 +1168,15 @@ func TestUpsertBackendNormalizesCommand(t *testing.T) {
 func seedRepoWithAgent(t *testing.T, db *sql.DB) {
 	t.Helper()
 	seedBackend(t, db, "claude")
-	if err := store.UpsertAgent(db, config.AgentDef{
+	if err := store.UpsertAgent(db, fleet.Agent{
 		Name: "coder", Backend: "claude", Prompt: "p", Skills: []string{}, CanDispatch: []string{},
 	}); err != nil {
 		t.Fatalf("UpsertAgent coder: %v", err)
 	}
-	if err := store.UpsertRepo(db, config.RepoDef{
+	if err := store.UpsertRepo(db, fleet.Repo{
 		Name:    "owner/repo",
 		Enabled: true,
-		Use:     []config.Binding{{Agent: "coder", Labels: []string{"ai:seed"}}},
+		Use:     []fleet.Binding{{Agent: "coder", Labels: []string{"ai:seed"}}},
 	}); err != nil {
 		t.Fatalf("UpsertRepo owner/repo: %v", err)
 	}
@@ -1187,7 +1187,7 @@ func TestCreateBinding(t *testing.T) {
 	db := openTestDB(t)
 	seedRepoWithAgent(t, db)
 
-	id, persisted, err := store.CreateBinding(db, "owner/repo", config.Binding{
+	id, persisted, err := store.CreateBinding(db, "owner/repo", fleet.Binding{
 		Agent:  "coder",
 		Labels: []string{"ai:fix"},
 	})
@@ -1219,14 +1219,14 @@ func TestCreateBindingInvalidTrigger(t *testing.T) {
 	seedRepoWithAgent(t, db)
 
 	// No trigger at all.
-	_, _, err := store.CreateBinding(db, "owner/repo", config.Binding{Agent: "coder"})
+	_, _, err := store.CreateBinding(db, "owner/repo", fleet.Binding{Agent: "coder"})
 	var valErr *store.ErrValidation
 	if !errors.As(err, &valErr) {
 		t.Fatalf("expected ErrValidation for missing trigger, got %v", err)
 	}
 
 	// Mixed triggers.
-	_, _, err = store.CreateBinding(db, "owner/repo", config.Binding{
+	_, _, err = store.CreateBinding(db, "owner/repo", fleet.Binding{
 		Agent: "coder", Labels: []string{"a"}, Cron: "* * * * *",
 	})
 	if !errors.As(err, &valErr) {
@@ -1234,7 +1234,7 @@ func TestCreateBindingInvalidTrigger(t *testing.T) {
 	}
 
 	// Bad cron.
-	_, _, err = store.CreateBinding(db, "owner/repo", config.Binding{
+	_, _, err = store.CreateBinding(db, "owner/repo", fleet.Binding{
 		Agent: "coder", Cron: "bogus",
 	})
 	if !errors.As(err, &valErr) {
@@ -1247,7 +1247,7 @@ func TestCreateBindingUnknownRepo(t *testing.T) {
 	db := openTestDB(t)
 	seedRepoWithAgent(t, db)
 
-	_, _, err := store.CreateBinding(db, "owner/missing", config.Binding{
+	_, _, err := store.CreateBinding(db, "owner/missing", fleet.Binding{
 		Agent: "coder", Labels: []string{"a"},
 	})
 	var nf *store.ErrNotFound
@@ -1261,7 +1261,7 @@ func TestCreateBindingUnknownAgent(t *testing.T) {
 	db := openTestDB(t)
 	seedRepoWithAgent(t, db)
 
-	_, _, err := store.CreateBinding(db, "owner/repo", config.Binding{
+	_, _, err := store.CreateBinding(db, "owner/repo", fleet.Binding{
 		Agent: "ghost", Labels: []string{"a"},
 	})
 	var valErr *store.ErrValidation
@@ -1275,7 +1275,7 @@ func TestUpdateBinding(t *testing.T) {
 	db := openTestDB(t)
 	seedRepoWithAgent(t, db)
 
-	id, _, err := store.CreateBinding(db, "owner/repo", config.Binding{
+	id, _, err := store.CreateBinding(db, "owner/repo", fleet.Binding{
 		Agent: "coder", Labels: []string{"ai:old"},
 	})
 	if err != nil {
@@ -1283,7 +1283,7 @@ func TestUpdateBinding(t *testing.T) {
 	}
 
 	disabled := false
-	updated, err := store.UpdateBinding(db, id, config.Binding{
+	updated, err := store.UpdateBinding(db, id, fleet.Binding{
 		Agent:   "coder",
 		Cron:    "0 9 * * *",
 		Enabled: &disabled,
@@ -1312,7 +1312,7 @@ func TestUpdateBindingNotFound(t *testing.T) {
 	db := openTestDB(t)
 	seedRepoWithAgent(t, db)
 
-	_, err := store.UpdateBinding(db, 99999, config.Binding{
+	_, err := store.UpdateBinding(db, 99999, fleet.Binding{
 		Agent: "coder", Labels: []string{"x"},
 	})
 	var nf *store.ErrNotFound
@@ -1326,7 +1326,7 @@ func TestDeleteBinding(t *testing.T) {
 	db := openTestDB(t)
 	seedRepoWithAgent(t, db)
 
-	id, _, err := store.CreateBinding(db, "owner/repo", config.Binding{
+	id, _, err := store.CreateBinding(db, "owner/repo", fleet.Binding{
 		Agent: "coder", Labels: []string{"ai:gone"},
 	})
 	if err != nil {
@@ -1361,13 +1361,13 @@ func TestReadBindingExposesIDViaLoadRepos(t *testing.T) {
 	db := openTestDB(t)
 	seedRepoWithAgent(t, db)
 
-	id1, _, err := store.CreateBinding(db, "owner/repo", config.Binding{
+	id1, _, err := store.CreateBinding(db, "owner/repo", fleet.Binding{
 		Agent: "coder", Labels: []string{"ai:a"},
 	})
 	if err != nil {
 		t.Fatalf("CreateBinding 1: %v", err)
 	}
-	id2, _, err := store.CreateBinding(db, "owner/repo", config.Binding{
+	id2, _, err := store.CreateBinding(db, "owner/repo", fleet.Binding{
 		Agent: "coder", Cron: "0 * * * *",
 	})
 	if err != nil {
@@ -1378,7 +1378,7 @@ func TestReadBindingExposesIDViaLoadRepos(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadRepos: %v", err)
 	}
-	var r *config.RepoDef
+	var r *fleet.Repo
 	for i := range repos {
 		if repos[i].Name == "owner/repo" {
 			r = &repos[i]

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -30,6 +30,7 @@ import (
 	_ "modernc.org/sqlite" // register the sqlite3 driver
 
 	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/fleet"
 )
 
 // querier is a minimal interface satisfied by both *sql.DB and *sql.Tx,
@@ -250,7 +251,7 @@ func importDaemon(tx *sql.Tx, d config.DaemonConfig) error {
 	return nil
 }
 
-func importBackends(tx *sql.Tx, backends map[string]config.AIBackendConfig) error {
+func importBackends(tx *sql.Tx, backends map[string]fleet.Backend) error {
 	for name, b := range backends {
 		models, err := json.Marshal(b.Models)
 		if err != nil {
@@ -271,7 +272,7 @@ func importBackends(tx *sql.Tx, backends map[string]config.AIBackendConfig) erro
 	return nil
 }
 
-func importSkills(tx *sql.Tx, skills map[string]config.SkillDef) error {
+func importSkills(tx *sql.Tx, skills map[string]fleet.Skill) error {
 	for name, s := range skills {
 		if _, err := tx.Exec(
 			"INSERT OR REPLACE INTO skills(name,prompt) VALUES(?,?)",
@@ -283,7 +284,7 @@ func importSkills(tx *sql.Tx, skills map[string]config.SkillDef) error {
 	return nil
 }
 
-func importAgents(tx *sql.Tx, agents []config.AgentDef) error {
+func importAgents(tx *sql.Tx, agents []fleet.Agent) error {
 	for _, a := range agents {
 		skills, err := json.Marshal(a.Skills)
 		if err != nil {
@@ -309,7 +310,7 @@ func importAgents(tx *sql.Tx, agents []config.AgentDef) error {
 	return nil
 }
 
-func importRepos(tx *sql.Tx, repos []config.RepoDef) error {
+func importRepos(tx *sql.Tx, repos []fleet.Repo) error {
 	for _, r := range repos {
 		enabled := boolToInt(r.Enabled)
 		if _, err := tx.Exec(
@@ -422,7 +423,7 @@ func loadBackends(db querier, cfg *config.Config) error {
 	}
 	defer rows.Close()
 
-	backends := make(map[string]config.AIBackendConfig)
+	backends := make(map[string]fleet.Backend)
 	for rows.Next() {
 		var name, command, version, modelsJSON, healthDetail, localModelURL, saltEnv string
 		var timeout, maxChars, healthy int
@@ -433,7 +434,7 @@ func loadBackends(db querier, cfg *config.Config) error {
 		if err := json.Unmarshal([]byte(modelsJSON), &models); err != nil {
 			return fmt.Errorf("store load: parse backend %s models: %w", name, err)
 		}
-		backends[name] = config.AIBackendConfig{
+		backends[name] = fleet.Backend{
 			Command:          command,
 			Version:          version,
 			Models:           models,
@@ -459,13 +460,13 @@ func loadSkills(db querier, cfg *config.Config) error {
 	}
 	defer rows.Close()
 
-	skills := make(map[string]config.SkillDef)
+	skills := make(map[string]fleet.Skill)
 	for rows.Next() {
 		var name, prompt string
 		if err := rows.Scan(&name, &prompt); err != nil {
 			return fmt.Errorf("store load: scan skill: %w", err)
 		}
-		skills[name] = config.SkillDef{Prompt: prompt}
+		skills[name] = fleet.Skill{Prompt: prompt}
 	}
 	if err := rows.Err(); err != nil {
 		return fmt.Errorf("store load: iterate skills: %w", err)
@@ -483,7 +484,7 @@ func loadAgents(db querier, cfg *config.Config) error {
 	}
 	defer rows.Close()
 
-	var agents []config.AgentDef
+	var agents []fleet.Agent
 	for rows.Next() {
 		var name, backend, model, skillsJSON, prompt, canDispatchJSON, description string
 		var allowPRs, allowDispatch, allowMemory int
@@ -505,7 +506,7 @@ func loadAgents(db querier, cfg *config.Config) error {
 		// readers see a concrete bool reflecting the stored row, not the
 		// "absent" sentinel that nil represents on inbound YAML/JSON paths.
 		allowMem := intToBool(allowMemory)
-		agents = append(agents, config.AgentDef{
+		agents = append(agents, fleet.Agent{
 			Name:          name,
 			Backend:       backend,
 			Model:         model,
@@ -532,14 +533,14 @@ func loadRepos(db querier, cfg *config.Config) error {
 	}
 	defer rows.Close()
 
-	var repos []config.RepoDef
+	var repos []fleet.Repo
 	for rows.Next() {
 		var name string
 		var enabled int
 		if err := rows.Scan(&name, &enabled); err != nil {
 			return fmt.Errorf("store load: scan repo: %w", err)
 		}
-		repos = append(repos, config.RepoDef{Name: name, Enabled: intToBool(enabled)})
+		repos = append(repos, fleet.Repo{Name: name, Enabled: intToBool(enabled)})
 	}
 	if err := rows.Err(); err != nil {
 		return fmt.Errorf("store load: iterate repos: %w", err)
@@ -557,7 +558,7 @@ func loadRepos(db querier, cfg *config.Config) error {
 	return nil
 }
 
-func loadBindingsForRepo(db querier, repo string) ([]config.Binding, error) {
+func loadBindingsForRepo(db querier, repo string) ([]fleet.Binding, error) {
 	rows, err := db.Query(
 		"SELECT id,agent,labels,events,cron,enabled FROM bindings WHERE repo=? ORDER BY id", repo,
 	)
@@ -566,7 +567,7 @@ func loadBindingsForRepo(db querier, repo string) ([]config.Binding, error) {
 	}
 	defer rows.Close()
 
-	var bindings []config.Binding
+	var bindings []fleet.Binding
 	for rows.Next() {
 		var id int64
 		var agent, labelsJSON, eventsJSON, cron string
@@ -582,7 +583,7 @@ func loadBindingsForRepo(db querier, repo string) ([]config.Binding, error) {
 		if err := json.Unmarshal([]byte(eventsJSON), &events); err != nil {
 			return nil, fmt.Errorf("store load: parse binding events for %s: %w", repo, err)
 		}
-		b := config.Binding{
+		b := fleet.Binding{
 			ID:     id,
 			Agent:  agent,
 			Labels: labels,

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/fleet"
 	"github.com/eloylp/agents/internal/store"
 )
 
@@ -42,7 +43,7 @@ func minimalCfg() *config.Config {
 					DedupWindowSeconds: 300,
 				},
 			},
-			AIBackends: map[string]config.AIBackendConfig{
+			AIBackends: map[string]fleet.Backend{
 				"claude": {
 					Command:          "claude",
 					TimeoutSeconds:   600,
@@ -58,11 +59,11 @@ func minimalCfg() *config.Config {
 				},
 			},
 		},
-		Skills: map[string]config.SkillDef{
+		Skills: map[string]fleet.Skill{
 			"architect": {Prompt: "Focus on architecture."},
 			"testing":   {Prompt: "Focus on testing."},
 		},
-		Agents: []config.AgentDef{
+		Agents: []fleet.Agent{
 			{
 				Name:          "coder",
 				Backend:       "claude",
@@ -83,11 +84,11 @@ func minimalCfg() *config.Config {
 				Description:   "Reviews pull requests",
 			},
 		},
-		Repos: []config.RepoDef{
+		Repos: []fleet.Repo{
 			{
 				Name:    "owner/repo",
 				Enabled: true,
-				Use: []config.Binding{
+				Use: []fleet.Binding{
 					{Agent: "coder", Events: []string{"issues.labeled"}, Enabled: &enabled},
 					{Agent: "pr-reviewer", Cron: "0 9 * * *", Enabled: &disabled},
 					{Agent: "coder", Labels: []string{"ai:review"}},
@@ -186,7 +187,7 @@ func TestImportLoad(t *testing.T) {
 	if len(out.Agents) != 2 {
 		t.Fatalf("agents: got %d, want 2", len(out.Agents))
 	}
-	var coder config.AgentDef
+	var coder fleet.Agent
 	for _, a := range out.Agents {
 		if a.Name == "coder" {
 			coder = a
@@ -323,12 +324,12 @@ func TestLoadEmptyDatabase(t *testing.T) {
 
 func seedAgent(t *testing.T, db *sql.DB, name string) {
 	t.Helper()
-	if err := store.UpsertBackend(db, "claude", config.AIBackendConfig{
+	if err := store.UpsertBackend(db, "claude", fleet.Backend{
 		Command: "claude",
 	}); err != nil {
 		t.Fatalf("seedAgent backend: %v", err)
 	}
-	if err := store.UpsertAgent(db, config.AgentDef{
+	if err := store.UpsertAgent(db, fleet.Agent{
 		Name: name, Backend: "claude", Prompt: "p", Skills: []string{}, CanDispatch: []string{},
 	}); err != nil {
 		t.Fatalf("seedAgent %s: %v", name, err)

--- a/internal/webhook/api_test.go
+++ b/internal/webhook/api_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/fleet"
 	"github.com/eloylp/agents/internal/observe"
 	"github.com/eloylp/agents/internal/server"
 	"github.com/eloylp/agents/internal/store"
@@ -24,7 +25,7 @@ import (
 func TestHandleAPIAgentsReturnsConfiguredAgents(t *testing.T) {
 	t.Parallel()
 	cfg := testCfg(func(c *config.Config) {
-		c.Agents = []config.AgentDef{
+		c.Agents = []fleet.Agent{
 			{
 				Name:          "reviewer",
 				Backend:       "claude",
@@ -34,11 +35,11 @@ func TestHandleAPIAgentsReturnsConfiguredAgents(t *testing.T) {
 				CanDispatch:   []string{"sec-reviewer"},
 			},
 		}
-		c.Repos = []config.RepoDef{
+		c.Repos = []fleet.Repo{
 			{
 				Name:    "owner/repo",
 				Enabled: true,
-				Use: []config.Binding{
+				Use: []fleet.Binding{
 					{Agent: "reviewer", Labels: []string{"review-me"}},
 				},
 			},
@@ -86,12 +87,12 @@ func TestHandleAPIAgentsAttachesScheduleForCronBindings(t *testing.T) {
 	next := now.Add(time.Hour)
 
 	cfg := testCfg(func(c *config.Config) {
-		c.Agents = []config.AgentDef{{Name: "worker", Backend: "codex"}}
-		c.Repos = []config.RepoDef{
+		c.Agents = []fleet.Agent{{Name: "worker", Backend: "codex"}}
+		c.Repos = []fleet.Repo{
 			{
 				Name:    "owner/repo",
 				Enabled: true,
-				Use:     []config.Binding{{Agent: "worker", Cron: "0 * * * *"}},
+				Use:     []fleet.Binding{{Agent: "worker", Cron: "0 * * * *"}},
 			},
 		}
 	})
@@ -137,17 +138,17 @@ func TestHandleAPIAgentsMultiRepoSchedulePreserved(t *testing.T) {
 	next2 := now.Add(2 * time.Hour)
 
 	cfg := testCfg(func(c *config.Config) {
-		c.Agents = []config.AgentDef{{Name: "worker", Backend: "codex"}}
-		c.Repos = []config.RepoDef{
+		c.Agents = []fleet.Agent{{Name: "worker", Backend: "codex"}}
+		c.Repos = []fleet.Repo{
 			{
 				Name:    "owner/repo-a",
 				Enabled: true,
-				Use:     []config.Binding{{Agent: "worker", Cron: "0 * * * *"}},
+				Use:     []fleet.Binding{{Agent: "worker", Cron: "0 * * * *"}},
 			},
 			{
 				Name:    "owner/repo-b",
 				Enabled: true,
-				Use:     []config.Binding{{Agent: "worker", Cron: "30 * * * *"}},
+				Use:     []fleet.Binding{{Agent: "worker", Cron: "30 * * * *"}},
 			},
 		}
 	})
@@ -213,17 +214,17 @@ func TestHandleAPIAgentsMultiRepoSchedulePreserved(t *testing.T) {
 func TestHandleAPIAgentsSkipsDisabledRepos(t *testing.T) {
 	t.Parallel()
 	cfg := testCfg(func(c *config.Config) {
-		c.Agents = []config.AgentDef{{Name: "worker", Backend: "claude"}}
-		c.Repos = []config.RepoDef{
+		c.Agents = []fleet.Agent{{Name: "worker", Backend: "claude"}}
+		c.Repos = []fleet.Repo{
 			{
 				Name:    "owner/active-repo",
 				Enabled: true,
-				Use:     []config.Binding{{Agent: "worker", Events: []string{"push"}}},
+				Use:     []fleet.Binding{{Agent: "worker", Events: []string{"push"}}},
 			},
 			{
 				Name:    "owner/disabled-repo",
 				Enabled: false,
-				Use:     []config.Binding{{Agent: "worker", Events: []string{"push"}}},
+				Use:     []fleet.Binding{{Agent: "worker", Events: []string{"push"}}},
 			},
 		}
 	})
@@ -305,7 +306,7 @@ func (s *stubRuntimeState) IsRunning(name string) bool { return s.running[name] 
 func TestHandleAPIAgentsCurrentStatusRunningWhenActive(t *testing.T) {
 	t.Parallel()
 	cfg := testCfg(func(c *config.Config) {
-		c.Agents = []config.AgentDef{{Name: "coder", Backend: "claude"}}
+		c.Agents = []fleet.Agent{{Name: "coder", Backend: "claude"}}
 	})
 	srv, _ := newTestServer(cfg)
 	srv.WithRuntimeState(&stubRuntimeState{running: map[string]bool{"coder": true}})
@@ -351,7 +352,7 @@ func TestHandleAPIConfigRedactsSecrets(t *testing.T) {
 				APIKeyEnv: "PROXY_API_KEY",
 			},
 		}
-		c.Daemon.AIBackends = map[string]config.AIBackendConfig{
+		c.Daemon.AIBackends = map[string]fleet.Backend{
 			"claude": {
 				Command: "claude",
 			},
@@ -460,11 +461,11 @@ func TestHandleAPIConfigContentType(t *testing.T) {
 func TestHandleAPIConfigRepoBindingDefaultEnabled(t *testing.T) {
 	t.Parallel()
 	cfg := testCfg(func(c *config.Config) {
-		c.Repos = []config.RepoDef{
+		c.Repos = []fleet.Repo{
 			{
 				Name:    "owner/repo",
 				Enabled: true,
-				Use: []config.Binding{
+				Use: []fleet.Binding{
 					{Agent: "worker", Labels: []string{"triage"}},
 				},
 			},

--- a/internal/webhook/crud.go
+++ b/internal/webhook/crud.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/eloylp/agents/internal/backends"
 	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/fleet"
 	"github.com/eloylp/agents/internal/store"
 )
 
@@ -37,7 +38,7 @@ type storeAgentJSON struct {
 	AllowMemory *bool `json:"allow_memory,omitempty"`
 }
 
-func agentToStoreJSON(a config.AgentDef) storeAgentJSON {
+func agentToStoreJSON(a fleet.Agent) storeAgentJSON {
 	allowMem := a.IsAllowMemory()
 	return storeAgentJSON{
 		Name:          a.Name,
@@ -53,8 +54,8 @@ func agentToStoreJSON(a config.AgentDef) storeAgentJSON {
 	}
 }
 
-func (j storeAgentJSON) toConfig() config.AgentDef {
-	return config.AgentDef{
+func (j storeAgentJSON) toConfig() fleet.Agent {
+	return fleet.Agent{
 		Name:          j.Name,
 		Backend:       j.Backend,
 		Model:         j.Model,
@@ -95,7 +96,7 @@ func (p storeAgentPatchJSON) anyFieldSet() bool {
 
 // apply mutates a in place with any non-nil field on p. Name is preserved
 // because it is addressed via the URL path and is not patchable.
-func (p storeAgentPatchJSON) apply(a *config.AgentDef) {
+func (p storeAgentPatchJSON) apply(a *fleet.Agent) {
 	if p.Backend != nil {
 		a.Backend = *p.Backend
 	}
@@ -140,7 +141,7 @@ type storeSkillPatchJSON struct {
 
 func (p storeSkillPatchJSON) anyFieldSet() bool { return p.Prompt != nil }
 
-func (p storeSkillPatchJSON) apply(s *config.SkillDef) {
+func (p storeSkillPatchJSON) apply(s *fleet.Skill) {
 	if p.Prompt != nil {
 		s.Prompt = *p.Prompt
 	}
@@ -187,7 +188,7 @@ func (p storeBackendPatchJSON) anyFieldSet() bool {
 		p.MaxPromptChars != nil || p.RedactionSaltEnv != nil
 }
 
-func (p storeBackendPatchJSON) apply(b *config.AIBackendConfig) {
+func (p storeBackendPatchJSON) apply(b *fleet.Backend) {
 	if p.Command != nil {
 		b.Command = *p.Command
 	}
@@ -226,7 +227,7 @@ type backendRuntimeSettingsJSON struct {
 	MaxPromptChars *int `json:"max_prompt_chars,omitempty"`
 }
 
-func backendToStoreJSON(name string, b config.AIBackendConfig) storeBackendJSON {
+func backendToStoreJSON(name string, b fleet.Backend) storeBackendJSON {
 	return storeBackendJSON{
 		Name:             name,
 		Command:          b.Command,
@@ -241,8 +242,8 @@ func backendToStoreJSON(name string, b config.AIBackendConfig) storeBackendJSON 
 	}
 }
 
-func (j storeBackendJSON) toConfig() config.AIBackendConfig {
-	return config.AIBackendConfig{
+func (j storeBackendJSON) toConfig() fleet.Backend {
+	return fleet.Backend{
 		Command:          j.Command,
 		Version:          j.Version,
 		Models:           nilSafeStrings(j.Models),
@@ -264,7 +265,7 @@ type storeBindingJSON struct {
 	Enabled *bool    `json:"enabled,omitempty"`
 }
 
-func bindingToStoreJSON(b config.Binding) storeBindingJSON {
+func bindingToStoreJSON(b fleet.Binding) storeBindingJSON {
 	enabled := b.IsEnabled()
 	return storeBindingJSON{
 		ID:      b.ID,
@@ -276,8 +277,8 @@ func bindingToStoreJSON(b config.Binding) storeBindingJSON {
 	}
 }
 
-func (j storeBindingJSON) toConfig() config.Binding {
-	return config.Binding{
+func (j storeBindingJSON) toConfig() fleet.Binding {
+	return fleet.Binding{
 		ID:      j.ID,
 		Agent:   j.Agent,
 		Labels:  j.Labels,
@@ -293,7 +294,7 @@ type storeRepoJSON struct {
 	Bindings []storeBindingJSON `json:"bindings"`
 }
 
-func repoToStoreJSON(r config.RepoDef) storeRepoJSON {
+func repoToStoreJSON(r fleet.Repo) storeRepoJSON {
 	bindings := make([]storeBindingJSON, len(r.Use))
 	for i, b := range r.Use {
 		bindings[i] = bindingToStoreJSON(b)
@@ -301,12 +302,12 @@ func repoToStoreJSON(r config.RepoDef) storeRepoJSON {
 	return storeRepoJSON{Name: r.Name, Enabled: r.Enabled, Bindings: bindings}
 }
 
-func (j storeRepoJSON) toConfig() config.RepoDef {
-	use := make([]config.Binding, len(j.Bindings))
+func (j storeRepoJSON) toConfig() fleet.Repo {
+	use := make([]fleet.Binding, len(j.Bindings))
 	for i, b := range j.Bindings {
 		use[i] = b.toConfig()
 	}
-	return config.RepoDef{Name: j.Name, Enabled: j.Enabled, Use: use}
+	return fleet.Repo{Name: j.Name, Enabled: j.Enabled, Use: use}
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -464,9 +465,9 @@ func (s *Server) handleStoreAgents(w http.ResponseWriter, r *http.Request) {
 //
 // Exposed so non-HTTP surfaces (e.g. the MCP create_agent tool) can run the
 // same upsert path as POST /agents without going through the router.
-func (s *Server) UpsertAgent(a config.AgentDef) (config.AgentDef, error) {
+func (s *Server) UpsertAgent(a fleet.Agent) (fleet.Agent, error) {
 	if strings.TrimSpace(a.Name) == "" {
-		return config.AgentDef{}, &store.ErrValidation{Msg: "name is required"}
+		return fleet.Agent{}, &store.ErrValidation{Msg: "name is required"}
 	}
 	s.storeMu.Lock()
 	err := store.UpsertAgent(s.db, a)
@@ -475,7 +476,7 @@ func (s *Server) UpsertAgent(a config.AgentDef) (config.AgentDef, error) {
 	}
 	s.storeMu.Unlock()
 	if err != nil {
-		return config.AgentDef{}, err
+		return fleet.Agent{}, err
 	}
 	config.NormalizeAgentDef(&a)
 	return a, nil
@@ -541,15 +542,15 @@ func (s *Server) handleUpdateAgent(w http.ResponseWriter, r *http.Request, name 
 //
 // Exposed so non-HTTP surfaces (e.g. the MCP update_agent tool) can drive the
 // same path as PATCH /agents/{name} without going through the router.
-func (s *Server) UpdateAgent(name string, patch storeAgentPatchJSON) (config.AgentDef, error) {
+func (s *Server) UpdateAgent(name string, patch storeAgentPatchJSON) (fleet.Agent, error) {
 	normalized := config.NormalizeAgentName(name)
 	s.storeMu.Lock()
 	defer s.storeMu.Unlock()
 	agents, err := store.ReadAgents(s.db)
 	if err != nil {
-		return config.AgentDef{}, err
+		return fleet.Agent{}, err
 	}
-	var existing *config.AgentDef
+	var existing *fleet.Agent
 	for i := range agents {
 		if agents[i].Name == normalized {
 			existing = &agents[i]
@@ -557,15 +558,15 @@ func (s *Server) UpdateAgent(name string, patch storeAgentPatchJSON) (config.Age
 		}
 	}
 	if existing == nil {
-		return config.AgentDef{}, &store.ErrNotFound{Msg: fmt.Sprintf("agent %q not found", normalized)}
+		return fleet.Agent{}, &store.ErrNotFound{Msg: fmt.Sprintf("agent %q not found", normalized)}
 	}
 	merged := *existing
 	patch.apply(&merged)
 	if err := store.UpsertAgent(s.db, merged); err != nil {
-		return config.AgentDef{}, err
+		return fleet.Agent{}, err
 	}
 	if err := s.reloadCron(); err != nil {
-		return config.AgentDef{}, err
+		return fleet.Agent{}, err
 	}
 	config.NormalizeAgentDef(&merged)
 	return merged, nil
@@ -615,7 +616,7 @@ func (s *Server) handleStoreSkills(w http.ResponseWriter, r *http.Request) {
 		if !decodeBody(w, r, s.loadCfg().Daemon.HTTP.MaxBodyBytes, &req) {
 			return
 		}
-		name, sk, err := s.UpsertSkill(req.Name, config.SkillDef{Prompt: req.Prompt})
+		name, sk, err := s.UpsertSkill(req.Name, fleet.Skill{Prompt: req.Prompt})
 		if err != nil {
 			s.storeWriteErr(w, err, "skill upsert or cron reload")
 			return
@@ -635,9 +636,9 @@ func (s *Server) handleStoreSkills(w http.ResponseWriter, r *http.Request) {
 //
 // Exposed so non-HTTP surfaces (e.g. the MCP create_skill tool) can run the
 // same upsert path as POST /skills without going through the router.
-func (s *Server) UpsertSkill(name string, sk config.SkillDef) (string, config.SkillDef, error) {
+func (s *Server) UpsertSkill(name string, sk fleet.Skill) (string, fleet.Skill, error) {
 	if strings.TrimSpace(name) == "" {
-		return "", config.SkillDef{}, &store.ErrValidation{Msg: "name is required"}
+		return "", fleet.Skill{}, &store.ErrValidation{Msg: "name is required"}
 	}
 	s.storeMu.Lock()
 	err := store.UpsertSkill(s.db, name, sk)
@@ -646,7 +647,7 @@ func (s *Server) UpsertSkill(name string, sk config.SkillDef) (string, config.Sk
 	}
 	s.storeMu.Unlock()
 	if err != nil {
-		return "", config.SkillDef{}, err
+		return "", fleet.Skill{}, err
 	}
 	config.NormalizeSkillDef(&sk)
 	return config.NormalizeSkillName(name), sk, nil
@@ -709,24 +710,24 @@ func (s *Server) handleUpdateSkill(w http.ResponseWriter, r *http.Request, name 
 //
 // Exposed so non-HTTP surfaces (e.g. the MCP update_skill tool) can drive the
 // same path as PATCH /skills/{name} without going through the router.
-func (s *Server) UpdateSkill(name string, patch storeSkillPatchJSON) (string, config.SkillDef, error) {
+func (s *Server) UpdateSkill(name string, patch storeSkillPatchJSON) (string, fleet.Skill, error) {
 	normalized := config.NormalizeSkillName(name)
 	s.storeMu.Lock()
 	defer s.storeMu.Unlock()
 	skills, err := store.ReadSkills(s.db)
 	if err != nil {
-		return "", config.SkillDef{}, err
+		return "", fleet.Skill{}, err
 	}
 	existing, ok := skills[normalized]
 	if !ok {
-		return "", config.SkillDef{}, &store.ErrNotFound{Msg: fmt.Sprintf("skill %q not found", normalized)}
+		return "", fleet.Skill{}, &store.ErrNotFound{Msg: fmt.Sprintf("skill %q not found", normalized)}
 	}
 	patch.apply(&existing)
 	if err := store.UpsertSkill(s.db, normalized, existing); err != nil {
-		return "", config.SkillDef{}, err
+		return "", fleet.Skill{}, err
 	}
 	if err := s.reloadCron(); err != nil {
-		return "", config.SkillDef{}, err
+		return "", fleet.Skill{}, err
 	}
 	config.NormalizeSkillDef(&existing)
 	return normalized, existing, nil
@@ -789,9 +790,9 @@ func (s *Server) handleStoreBackends(w http.ResponseWriter, r *http.Request) {
 //
 // Exposed so non-HTTP surfaces (e.g. the MCP create_backend tool) can run the
 // same upsert path as POST /backends without going through the router.
-func (s *Server) UpsertBackend(name string, b config.AIBackendConfig) (string, config.AIBackendConfig, error) {
+func (s *Server) UpsertBackend(name string, b fleet.Backend) (string, fleet.Backend, error) {
 	if strings.TrimSpace(name) == "" {
-		return "", config.AIBackendConfig{}, &store.ErrValidation{Msg: "name is required"}
+		return "", fleet.Backend{}, &store.ErrValidation{Msg: "name is required"}
 	}
 	s.storeMu.Lock()
 	err := store.UpsertBackend(s.db, name, b)
@@ -800,7 +801,7 @@ func (s *Server) UpsertBackend(name string, b config.AIBackendConfig) (string, c
 	}
 	s.storeMu.Unlock()
 	if err != nil {
-		return "", config.AIBackendConfig{}, err
+		return "", fleet.Backend{}, err
 	}
 	config.NormalizeBackendConfig(&b)
 	config.ApplyBackendDefaults(&b)
@@ -886,7 +887,7 @@ func (s *Server) handleBackendsLocal(w http.ResponseWriter, r *http.Request) {
 	local.Command = base.Command
 	local.LocalModelURL = req.URL
 
-	diagMap := map[string]config.AIBackendConfig{
+	diagMap := map[string]fleet.Backend{
 		backends.ClaudeName: base,
 		name:                local,
 	}
@@ -975,24 +976,24 @@ func (s *Server) handleStoreBackendPatch(w http.ResponseWriter, r *http.Request)
 //
 // Exposed so non-HTTP surfaces (e.g. the MCP update_backend tool) can drive
 // the same path as PATCH /backends/{name} without going through the router.
-func (s *Server) UpdateBackend(name string, patch storeBackendPatchJSON) (string, config.AIBackendConfig, error) {
+func (s *Server) UpdateBackend(name string, patch storeBackendPatchJSON) (string, fleet.Backend, error) {
 	normalized := config.NormalizeBackendName(name)
 	s.storeMu.Lock()
 	defer s.storeMu.Unlock()
 	backendsByName, err := store.ReadBackends(s.db)
 	if err != nil {
-		return "", config.AIBackendConfig{}, err
+		return "", fleet.Backend{}, err
 	}
 	existing, ok := backendsByName[normalized]
 	if !ok {
-		return "", config.AIBackendConfig{}, &store.ErrNotFound{Msg: fmt.Sprintf("backend %q not found", normalized)}
+		return "", fleet.Backend{}, &store.ErrNotFound{Msg: fmt.Sprintf("backend %q not found", normalized)}
 	}
 	patch.apply(&existing)
 	if err := store.UpsertBackend(s.db, normalized, existing); err != nil {
-		return "", config.AIBackendConfig{}, err
+		return "", fleet.Backend{}, err
 	}
 	if err := s.reloadCron(); err != nil {
-		return "", config.AIBackendConfig{}, err
+		return "", fleet.Backend{}, err
 	}
 	config.NormalizeBackendConfig(&existing)
 	config.ApplyBackendDefaults(&existing)
@@ -1067,9 +1068,9 @@ func (s *Server) handleStoreRepos(w http.ResponseWriter, r *http.Request) {
 //
 // Exposed so non-HTTP surfaces (e.g. the MCP create_repo tool) can run the
 // same upsert path as POST /repos without going through the router.
-func (s *Server) UpsertRepo(r config.RepoDef) (config.RepoDef, error) {
+func (s *Server) UpsertRepo(r fleet.Repo) (fleet.Repo, error) {
 	if strings.TrimSpace(r.Name) == "" {
-		return config.RepoDef{}, &store.ErrValidation{Msg: "name is required"}
+		return fleet.Repo{}, &store.ErrValidation{Msg: "name is required"}
 	}
 	s.storeMu.Lock()
 	err := store.UpsertRepo(s.db, r)
@@ -1078,7 +1079,7 @@ func (s *Server) UpsertRepo(r config.RepoDef) (config.RepoDef, error) {
 	}
 	s.storeMu.Unlock()
 	if err != nil {
-		return config.RepoDef{}, err
+		return fleet.Repo{}, err
 	}
 	config.NormalizeRepoDef(&r)
 	return r, nil
@@ -1138,16 +1139,16 @@ func (s *Server) handleStoreRepo(w http.ResponseWriter, r *http.Request) {
 // PatchRepo updates the enabled flag on an existing repo without touching its
 // bindings. Returns the canonical RepoDef (with current bindings) so callers
 // can refresh their view. *ErrNotFound when the repo does not exist.
-func (s *Server) PatchRepo(repoName string, enabled bool) (config.RepoDef, error) {
+func (s *Server) PatchRepo(repoName string, enabled bool) (fleet.Repo, error) {
 	s.storeMu.Lock()
 	defer s.storeMu.Unlock()
 	// Load the repo (and its bindings) so we can rewrite it intact without
 	// having to pipe every field through the wire struct.
 	repos, err := store.ReadRepos(s.db)
 	if err != nil {
-		return config.RepoDef{}, err
+		return fleet.Repo{}, err
 	}
-	var existing *config.RepoDef
+	var existing *fleet.Repo
 	for i := range repos {
 		if repos[i].Name == repoName {
 			existing = &repos[i]
@@ -1155,7 +1156,7 @@ func (s *Server) PatchRepo(repoName string, enabled bool) (config.RepoDef, error
 		}
 	}
 	if existing == nil {
-		return config.RepoDef{}, &store.ErrNotFound{Msg: fmt.Sprintf("repo %q not found", repoName)}
+		return fleet.Repo{}, &store.ErrNotFound{Msg: fmt.Sprintf("repo %q not found", repoName)}
 	}
 	if existing.Enabled == enabled {
 		return *existing, nil
@@ -1163,10 +1164,10 @@ func (s *Server) PatchRepo(repoName string, enabled bool) (config.RepoDef, error
 	// Flip the enabled flag via a direct UPDATE so we don't re-run the
 	// delete+insert cycle that UpsertRepo performs on bindings.
 	if _, err := s.db.Exec("UPDATE repos SET enabled=? WHERE name=?", boolToInt(enabled), repoName); err != nil {
-		return config.RepoDef{}, fmt.Errorf("patch repo %s: %w", repoName, err)
+		return fleet.Repo{}, fmt.Errorf("patch repo %s: %w", repoName, err)
 	}
 	if err := s.reloadCron(); err != nil {
-		return config.RepoDef{}, err
+		return fleet.Repo{}, err
 	}
 	existing.Enabled = enabled
 	return *existing, nil
@@ -1243,15 +1244,15 @@ func (s *Server) handleCreateBinding(w http.ResponseWriter, r *http.Request) {
 
 // CreateBinding persists a new binding on repoName and reloads cron. Exposed
 // for non-HTTP callers (MCP create_binding tool).
-func (s *Server) CreateBinding(repoName string, b config.Binding) (config.Binding, error) {
+func (s *Server) CreateBinding(repoName string, b fleet.Binding) (fleet.Binding, error) {
 	s.storeMu.Lock()
 	defer s.storeMu.Unlock()
 	_, persisted, err := store.CreateBinding(s.db, repoName, b)
 	if err != nil {
-		return config.Binding{}, err
+		return fleet.Binding{}, err
 	}
 	if err := s.reloadCron(); err != nil {
-		return config.Binding{}, err
+		return fleet.Binding{}, err
 	}
 	return persisted, nil
 }
@@ -1299,22 +1300,22 @@ func (s *Server) handleUpdateBinding(w http.ResponseWriter, r *http.Request) {
 
 // UpdateBinding verifies the id belongs to repoName, replaces the row, and
 // reloads cron. Exposed for non-HTTP callers (MCP update_binding tool).
-func (s *Server) UpdateBinding(repoName string, id int64, b config.Binding) (config.Binding, error) {
+func (s *Server) UpdateBinding(repoName string, id int64, b fleet.Binding) (fleet.Binding, error) {
 	s.storeMu.Lock()
 	defer s.storeMu.Unlock()
 	existingRepo, _, found, err := store.ReadBinding(s.db, id)
 	if err != nil {
-		return config.Binding{}, err
+		return fleet.Binding{}, err
 	}
 	if !found || existingRepo != repoName {
-		return config.Binding{}, &store.ErrNotFound{Msg: fmt.Sprintf("binding id=%d not found for repo %q", id, repoName)}
+		return fleet.Binding{}, &store.ErrNotFound{Msg: fmt.Sprintf("binding id=%d not found for repo %q", id, repoName)}
 	}
 	updated, err := store.UpdateBinding(s.db, id, b)
 	if err != nil {
-		return config.Binding{}, err
+		return fleet.Binding{}, err
 	}
 	if err := s.reloadCron(); err != nil {
-		return config.Binding{}, err
+		return fleet.Binding{}, err
 	}
 	return updated, nil
 }
@@ -1336,13 +1337,13 @@ func (s *Server) handleDeleteBinding(w http.ResponseWriter, r *http.Request) {
 
 // ReadBinding fetches one binding by ID, verifying it belongs to repoName.
 // Exposed for non-HTTP callers (MCP get_binding tool).
-func (s *Server) ReadBinding(repoName string, id int64) (config.Binding, error) {
+func (s *Server) ReadBinding(repoName string, id int64) (fleet.Binding, error) {
 	existingRepo, b, found, err := store.ReadBinding(s.db, id)
 	if err != nil {
-		return config.Binding{}, err
+		return fleet.Binding{}, err
 	}
 	if !found || existingRepo != repoName {
-		return config.Binding{}, &store.ErrNotFound{Msg: fmt.Sprintf("binding id=%d not found for repo %q", id, repoName)}
+		return fleet.Binding{}, &store.ErrNotFound{Msg: fmt.Sprintf("binding id=%d not found for repo %q", id, repoName)}
 	}
 	return b, nil
 }
@@ -1371,14 +1372,14 @@ func (s *Server) DeleteBinding(repoName string, id int64) error {
 // four CRUD-mutable sections; daemon-level config (HTTP, log, proxy) is
 // intentionally excluded — it is not managed by the write API.
 type exportYAML struct {
-	Skills map[string]config.SkillDef `yaml:"skills,omitempty"`
-	Agents []config.AgentDef          `yaml:"agents,omitempty"`
-	Repos  []config.RepoDef           `yaml:"repos,omitempty"`
+	Skills map[string]fleet.Skill `yaml:"skills,omitempty"`
+	Agents []fleet.Agent          `yaml:"agents,omitempty"`
+	Repos  []fleet.Repo           `yaml:"repos,omitempty"`
 	Daemon *exportDaemonYAML          `yaml:"daemon,omitempty"`
 }
 
 type exportDaemonYAML struct {
-	AIBackends map[string]config.AIBackendConfig `yaml:"ai_backends,omitempty"`
+	AIBackends map[string]fleet.Backend `yaml:"ai_backends,omitempty"`
 }
 
 // handleStoreExport serves GET /api/store/export — returns a config.yaml
@@ -1464,7 +1465,7 @@ func (s *Server) ImportYAML(body []byte, mode string) (map[string]int, error) {
 		return nil, &store.ErrValidation{Msg: fmt.Sprintf("parse yaml: %v", err)}
 	}
 
-	backends := map[string]config.AIBackendConfig{}
+	backends := map[string]fleet.Backend{}
 	if payload.Daemon != nil {
 		backends = payload.Daemon.AIBackends
 	}

--- a/internal/webhook/crud_test.go
+++ b/internal/webhook/crud_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/fleet"
 	"github.com/eloylp/agents/internal/server"
 	"github.com/eloylp/agents/internal/store"
 	"github.com/eloylp/agents/internal/workflow"
@@ -43,7 +44,7 @@ func openCRUDTestServer(t *testing.T) *Server {
 // so that subsequent agent upserts that reference it pass cross-ref validation.
 func seedStoreBackend(t *testing.T, s *Server, name string) {
 	t.Helper()
-	b := config.AIBackendConfig{Command: name}
+	b := fleet.Backend{Command: name}
 	if err := store.UpsertBackend(s.db, name, b); err != nil {
 		t.Fatalf("seedStoreBackend %s: %v", name, err)
 	}
@@ -52,7 +53,7 @@ func seedStoreBackend(t *testing.T, s *Server, name string) {
 // seedStoreSkill inserts a minimal skill into the server's store directly.
 func seedStoreSkill(t *testing.T, s *Server, name string) {
 	t.Helper()
-	if err := store.UpsertSkill(s.db, name, config.SkillDef{Prompt: "skill prompt"}); err != nil {
+	if err := store.UpsertSkill(s.db, name, fleet.Skill{Prompt: "skill prompt"}); err != nil {
 		t.Fatalf("seedStoreSkill %s: %v", name, err)
 	}
 }
@@ -484,7 +485,7 @@ func TestBackendsLocalCreateNamedAndDelete(t *testing.T) {
 	s := openCRUDTestServer(t)
 
 	// Local backend creation requires a discovered claude backend.
-	if err := store.UpsertBackend(s.db, "claude", config.AIBackendConfig{
+	if err := store.UpsertBackend(s.db, "claude", fleet.Backend{
 		Command: "/bin/sh",
 	}); err != nil {
 		t.Fatalf("seed claude backend: %v", err)
@@ -523,7 +524,7 @@ func TestBackendsLocalRejectReservedName(t *testing.T) {
 	t.Parallel()
 	s := openCRUDTestServer(t)
 
-	if err := store.UpsertBackend(s.db, "claude", config.AIBackendConfig{
+	if err := store.UpsertBackend(s.db, "claude", fleet.Backend{
 		Command: "/bin/sh",
 	}); err != nil {
 		t.Fatalf("seed claude backend: %v", err)
@@ -851,7 +852,7 @@ func itoa(i int) string { return strconv.Itoa(i) }
 // errCronReloader satisfies server.CronReloader and always returns an error from Reload.
 type errCronReloader struct{ err error }
 
-func (r *errCronReloader) Reload([]config.RepoDef, []config.AgentDef, map[string]config.SkillDef, map[string]config.AIBackendConfig) error {
+func (r *errCronReloader) Reload([]fleet.Repo, []fleet.Agent, map[string]fleet.Skill, map[string]fleet.Backend) error {
 	return r.err
 }
 
@@ -1241,10 +1242,10 @@ func TestStoreCRUDConflictErrorReturns409(t *testing.T) {
 type countingCronReloader struct {
 	mu    sync.Mutex
 	calls int32
-	last  []config.AgentDef
+	last  []fleet.Agent
 }
 
-func (r *countingCronReloader) Reload(_ []config.RepoDef, agents []config.AgentDef, _ map[string]config.SkillDef, _ map[string]config.AIBackendConfig) error {
+func (r *countingCronReloader) Reload(_ []fleet.Repo, agents []fleet.Agent, _ map[string]fleet.Skill, _ map[string]fleet.Backend) error {
 	atomic.AddInt32(&r.calls, 1)
 	r.mu.Lock()
 	r.last = agents

--- a/internal/webhook/mcp_adapters.go
+++ b/internal/webhook/mcp_adapters.go
@@ -1,7 +1,7 @@
 package webhook
 
 import (
-	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/fleet"
 	"github.com/eloylp/agents/internal/mcp"
 )
 
@@ -9,7 +9,7 @@ import (
 // storeAgentPatchJSON and delegates to UpdateAgent. Implements the
 // mcp.AgentWriter contract so the MCP server and REST PATCH /agents/{name}
 // share the same store-mutation path.
-func (s *Server) UpdateAgentPatch(name string, patch mcp.AgentPatch) (config.AgentDef, error) {
+func (s *Server) UpdateAgentPatch(name string, patch mcp.AgentPatch) (fleet.Agent, error) {
 	return s.UpdateAgent(name, storeAgentPatchJSON{
 		Backend:       patch.Backend,
 		Model:         patch.Model,
@@ -25,13 +25,13 @@ func (s *Server) UpdateAgentPatch(name string, patch mcp.AgentPatch) (config.Age
 
 // UpdateSkillPatch adapts an mcp.SkillPatch to storeSkillPatchJSON and
 // delegates to UpdateSkill. Implements mcp.SkillWriter.
-func (s *Server) UpdateSkillPatch(name string, patch mcp.SkillPatch) (string, config.SkillDef, error) {
+func (s *Server) UpdateSkillPatch(name string, patch mcp.SkillPatch) (string, fleet.Skill, error) {
 	return s.UpdateSkill(name, storeSkillPatchJSON{Prompt: patch.Prompt})
 }
 
 // UpdateBackendPatch adapts an mcp.BackendPatch to storeBackendPatchJSON and
 // delegates to UpdateBackend. Implements mcp.BackendWriter.
-func (s *Server) UpdateBackendPatch(name string, patch mcp.BackendPatch) (string, config.AIBackendConfig, error) {
+func (s *Server) UpdateBackendPatch(name string, patch mcp.BackendPatch) (string, fleet.Backend, error) {
 	return s.UpdateBackend(name, storeBackendPatchJSON{
 		Command:          patch.Command,
 		Version:          patch.Version,

--- a/internal/webhook/orphans_test.go
+++ b/internal/webhook/orphans_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/fleet"
 )
 
 func TestCanonicalModels(t *testing.T) {
@@ -39,23 +40,23 @@ func TestComputeOrphanedAgents(t *testing.T) {
 	t.Parallel()
 
 	cfg := testCfg(func(c *config.Config) {
-		c.Daemon.AIBackends = map[string]config.AIBackendConfig{
+		c.Daemon.AIBackends = map[string]fleet.Backend{
 			"claude": {
 				Command: "claude",
 				Models:  []string{"claude-3.7", "claude-4"},
 			},
 		}
-		c.Agents = []config.AgentDef{
+		c.Agents = []fleet.Agent{
 			{Name: "coder", Backend: "claude", Model: "claude-3.5", Prompt: "x"},
 			{Name: "reviewer", Backend: "claude", Model: "claude-4", Prompt: "x"},
 			{Name: "defaulted", Backend: "claude", Prompt: "x"},
 		}
 		enabled := true
-		c.Repos = []config.RepoDef{
+		c.Repos = []fleet.Repo{
 			{
 				Name:    "owner/repo",
 				Enabled: true,
-				Use: []config.Binding{
+				Use: []fleet.Binding{
 					{Agent: "coder", Labels: []string{"ai:fix"}, Enabled: &enabled},
 				},
 			},
@@ -84,13 +85,13 @@ func TestAgentsOrphansEndpointAndStatusSummary(t *testing.T) {
 	t.Parallel()
 
 	cfg := testCfg(func(c *config.Config) {
-		c.Daemon.AIBackends = map[string]config.AIBackendConfig{
+		c.Daemon.AIBackends = map[string]fleet.Backend{
 			"claude": {
 				Command: "claude",
 				Models:  []string{"claude-4"},
 			},
 		}
-		c.Agents = []config.AgentDef{
+		c.Agents = []fleet.Agent{
 			{Name: "coder", Backend: "claude", Model: "claude-3.5", Prompt: "x"},
 		}
 	})

--- a/internal/webhook/server_test.go
+++ b/internal/webhook/server_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/fleet"
 	"github.com/eloylp/agents/internal/server"
 	"github.com/eloylp/agents/internal/workflow"
 )
@@ -34,7 +35,7 @@ func testCfg(mutator func(*config.Config)) *config.Config {
 				DeliveryTTLSeconds: 3600,
 			},
 		},
-		Repos: []config.RepoDef{{Name: "owner/repo", Enabled: true}},
+		Repos: []fleet.Repo{{Name: "owner/repo", Enabled: true}},
 	}
 	if mutator != nil {
 		mutator(cfg)

--- a/internal/workflow/allow_memory_test.go
+++ b/internal/workflow/allow_memory_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/eloylp/agents/internal/ai"
 	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/fleet"
 )
 
 // stubMemory is a minimal MemoryBackend implementation for tests. It records
@@ -209,13 +210,13 @@ func newMemoryTestCfg(allowMemory *bool) *config.Config {
 	return &config.Config{
 		Daemon: config.DaemonConfig{
 			Processor:  config.ProcessorConfig{MaxConcurrentAgents: 4},
-			AIBackends: map[string]config.AIBackendConfig{"claude": {Command: "claude"}},
+			AIBackends: map[string]fleet.Backend{"claude": {Command: "claude"}},
 		},
-		Agents: []config.AgentDef{
+		Agents: []fleet.Agent{
 			{Name: "arch-reviewer", Backend: "claude", Prompt: "Review.", AllowMemory: allowMemory},
 		},
-		Repos: []config.RepoDef{
-			{Name: "owner/repo", Enabled: true, Use: []config.Binding{
+		Repos: []fleet.Repo{
+			{Name: "owner/repo", Enabled: true, Use: []fleet.Binding{
 				{Agent: "arch-reviewer", Labels: []string{"ai:review:arch-reviewer"}},
 			}},
 		},

--- a/internal/workflow/dispatch.go
+++ b/internal/workflow/dispatch.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/eloylp/agents/internal/ai"
 	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/fleet"
 )
 
 // EventEnqueuer can accept events for async processing.
@@ -410,7 +411,7 @@ func (s *DispatchDedupStore) TryClaimForDispatch(agent, repo string, number int,
 // dedup safety limits.
 type Dispatcher struct {
 	cfg      config.DispatchConfig
-	agents   map[string]config.AgentDef // all agents by name (lower-cased)
+	agents   map[string]fleet.Agent // all agents by name (lower-cased)
 	agentsMu sync.RWMutex               // protects agents map
 	dedup    *DispatchDedupStore
 	counters dispatchCounters
@@ -421,7 +422,7 @@ type Dispatcher struct {
 
 // NewDispatcher builds a Dispatcher. agents must be the full agent map (by
 // lower-cased name) from the loaded config.
-func NewDispatcher(cfg config.DispatchConfig, agents map[string]config.AgentDef, dedup *DispatchDedupStore, queue EventEnqueuer, logger zerolog.Logger) *Dispatcher {
+func NewDispatcher(cfg config.DispatchConfig, agents map[string]fleet.Agent, dedup *DispatchDedupStore, queue EventEnqueuer, logger zerolog.Logger) *Dispatcher {
 	return &Dispatcher{
 		cfg:    cfg,
 		agents: agents,
@@ -440,8 +441,8 @@ func (d *Dispatcher) WithGraphRecorder(r GraphRecorder) {
 // UpdateAgents replaces the agent map used for dispatch allowlist and opt-in
 // checks. It is safe to call concurrently with ProcessDispatches and is
 // intended for hot-reload paths (e.g. CRUD API followed by cron reload).
-func (d *Dispatcher) UpdateAgents(agents []config.AgentDef) {
-	m := make(map[string]config.AgentDef, len(agents))
+func (d *Dispatcher) UpdateAgents(agents []fleet.Agent) {
+	m := make(map[string]fleet.Agent, len(agents))
 	for _, a := range agents {
 		m[a.Name] = a
 	}
@@ -458,7 +459,7 @@ func (d *Dispatcher) UpdateAgents(agents []config.AgentDef) {
 // All requests are attempted; an error is returned if any enqueue fails.
 func (d *Dispatcher) ProcessDispatches(
 	ctx context.Context,
-	originator config.AgentDef,
+	originator fleet.Agent,
 	ev Event,
 	rootEventID string,
 	currentDepth int,

--- a/internal/workflow/dispatch_test.go
+++ b/internal/workflow/dispatch_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/eloylp/agents/internal/ai"
 	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/fleet"
 )
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
@@ -48,8 +49,8 @@ func testDispatchCfg() config.DispatchConfig {
 	}
 }
 
-func testAgentMap() map[string]config.AgentDef {
-	return map[string]config.AgentDef{
+func testAgentMap() map[string]fleet.Agent {
+	return map[string]fleet.Agent{
 		"coder": {
 			Name:          "coder",
 			Description:   "Writes code",
@@ -74,7 +75,7 @@ func testDispatcher(q *fakeQueue) *Dispatcher {
 	return NewDispatcher(testDispatchCfg(), testAgentMap(), NewDispatchDedupStore(300), q, zerolog.Nop())
 }
 
-func originatorAgent(name string) config.AgentDef {
+func originatorAgent(name string) fleet.Agent {
 	return testAgentMap()[name]
 }
 
@@ -168,7 +169,7 @@ func TestDispatcherDropsRequest(t *testing.T) {
 		targetAgent  string
 		currentDepth int
 		modifyCfg    func(*config.DispatchConfig)
-		modifyAgents func(map[string]config.AgentDef)
+		modifyAgents func(map[string]fleet.Agent)
 		wantStat     func(DispatchStats) int64
 		wantStatName string
 	}{
@@ -187,7 +188,7 @@ func TestDispatcherDropsRequest(t *testing.T) {
 		{
 			name:        "target has allow_dispatch false",
 			targetAgent: "pr-reviewer",
-			modifyAgents: func(agents map[string]config.AgentDef) {
+			modifyAgents: func(agents map[string]fleet.Agent) {
 				a := agents["pr-reviewer"]
 				a.AllowDispatch = false
 				agents["pr-reviewer"] = a
@@ -233,7 +234,7 @@ func TestDispatcherDropsExceedsMaxFanout(t *testing.T) {
 	t.Parallel()
 
 	// Build an agent map with many valid targets.
-	agents := map[string]config.AgentDef{
+	agents := map[string]fleet.Agent{
 		"coder": {Name: "coder", Description: "Codes", CanDispatch: []string{"a", "b", "c", "d", "e"}},
 		"a":     {Name: "a", Description: "Agent A", AllowDispatch: true},
 		"b":     {Name: "b", Description: "Agent B", AllowDispatch: true},
@@ -253,7 +254,7 @@ func TestDispatcherDropsExceedsMaxFanout(t *testing.T) {
 		{Agent: "d", Number: 4, Reason: "r"}, // exceeds fanout
 		{Agent: "e", Number: 5, Reason: "r"}, // exceeds fanout
 	}
-	originator := config.AgentDef{Name: "coder", CanDispatch: []string{"a", "b", "c", "d", "e"}}
+	originator := fleet.Agent{Name: "coder", CanDispatch: []string{"a", "b", "c", "d", "e"}}
 	d.ProcessDispatches(context.Background(), originator, testEvent("owner/repo", 0), "root-1", 0, "", reqs)
 
 	if got := len(q.popped()); got != 3 {
@@ -352,20 +353,20 @@ func TestEngineHandlesAgentDispatchEvent(t *testing.T) {
 				MaxConcurrentAgents: 4,
 				Dispatch:            config.DispatchConfig{MaxDepth: 3, MaxFanout: 4, DedupWindowSeconds: 300},
 			},
-			AIBackends: map[string]config.AIBackendConfig{
+			AIBackends: map[string]fleet.Backend{
 				"claude": {Command: "claude"},
 			},
 		},
-		Skills: map[string]config.SkillDef{},
-		Agents: []config.AgentDef{
+		Skills: map[string]fleet.Skill{},
+		Agents: []fleet.Agent{
 			{Name: "coder", Backend: "claude", Prompt: "Write code.", AllowDispatch: true},
 			{Name: "pr-reviewer", Backend: "claude", Prompt: "Review code.", AllowDispatch: true},
 		},
-		Repos: []config.RepoDef{
+		Repos: []fleet.Repo{
 			{
 				Name:    "owner/repo",
 				Enabled: true,
-				Use: []config.Binding{
+				Use: []fleet.Binding{
 					{Agent: "coder", Labels: []string{"ai:code"}},
 					{Agent: "pr-reviewer", Labels: []string{"ai:review"}},
 				},
@@ -408,18 +409,18 @@ func TestEngineDispatchEventUnboundTargetReturnsError(t *testing.T) {
 				MaxConcurrentAgents: 4,
 				Dispatch:            config.DispatchConfig{MaxDepth: 3, MaxFanout: 4, DedupWindowSeconds: 300},
 			},
-			AIBackends: map[string]config.AIBackendConfig{"claude": {Command: "claude"}},
+			AIBackends: map[string]fleet.Backend{"claude": {Command: "claude"}},
 		},
-		Skills: map[string]config.SkillDef{},
-		Agents: []config.AgentDef{
+		Skills: map[string]fleet.Skill{},
+		Agents: []fleet.Agent{
 			{Name: "coder", Backend: "claude", Prompt: "Code."},
 			{Name: "pr-reviewer", Backend: "claude", Prompt: "Review."},
 		},
-		Repos: []config.RepoDef{
+		Repos: []fleet.Repo{
 			{
 				Name:    "owner/repo",
 				Enabled: true,
-				Use:     []config.Binding{{Agent: "coder", Labels: []string{"ai:code"}}},
+				Use:     []fleet.Binding{{Agent: "coder", Labels: []string{"ai:code"}}},
 				// pr-reviewer NOT bound to this repo
 			},
 		},
@@ -654,7 +655,7 @@ func TestPostRunDispatchSuppressedWithinDedupWindow(t *testing.T) {
 
 	// Use a short TTL (2 seconds) so we can verify expiry without long sleeps.
 	dedup := NewDispatchDedupStore(2)
-	agents := map[string]config.AgentDef{
+	agents := map[string]fleet.Agent{
 		"pr-reviewer": {Name: "pr-reviewer", AllowDispatch: true, CanDispatch: []string{"coder"}},
 		"coder":        {Name: "coder", AllowDispatch: true},
 	}
@@ -791,7 +792,7 @@ func TestLongRunningCronMarkBlocksDispatchPastTTL(t *testing.T) {
 	// 1-second TTL so we can simulate expiry without real sleeps.
 	const ttlSeconds = 1
 	dedup := NewDispatchDedupStore(ttlSeconds)
-	agents := map[string]config.AgentDef{
+	agents := map[string]fleet.Agent{
 		"pr-reviewer": {Name: "pr-reviewer", AllowDispatch: true, CanDispatch: []string{"coder"}},
 		"coder":        {Name: "coder", AllowDispatch: true},
 	}
@@ -845,7 +846,7 @@ func TestFinalizeAutonomousRunKeepsTTLBlocksDispatchWithinWindow(t *testing.T) {
 
 	const ttlSeconds = 60
 	dedup := NewDispatchDedupStore(ttlSeconds)
-	agents := map[string]config.AgentDef{
+	agents := map[string]fleet.Agent{
 		"pr-reviewer": {Name: "pr-reviewer", AllowDispatch: true, CanDispatch: []string{"coder"}},
 		"coder":       {Name: "coder", AllowDispatch: true},
 	}
@@ -971,7 +972,7 @@ func TestDispatcherUpdateAgentsReflectsNewAllowlists(t *testing.T) {
 	}
 
 	// Hot-reload: update sec-reviewer to allow dispatch.
-	updated := []config.AgentDef{
+	updated := []fleet.Agent{
 		{Name: "coder", AllowDispatch: true, CanDispatch: []string{"pr-reviewer", "sec-reviewer"}},
 		{Name: "pr-reviewer", AllowDispatch: true, CanDispatch: []string{"coder"}},
 		{Name: "sec-reviewer", AllowDispatch: true},

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/eloylp/agents/internal/ai"
 	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/fleet"
 )
 
 // labeledKinds are the event kinds that trigger label-based bindings.
@@ -100,7 +101,7 @@ func NewEngine(cfg *config.Config, runners map[string]ai.Runner, queue EventEnqu
 		logger:        logger.With().Str("component", "workflow_engine").Logger(),
 	}
 	if queue != nil {
-		agentMap := make(map[string]config.AgentDef, len(cfg.Agents))
+		agentMap := make(map[string]fleet.Agent, len(cfg.Agents))
 		for _, a := range cfg.Agents {
 			agentMap[a.Name] = a
 		}
@@ -249,7 +250,7 @@ func (e *Engine) handleDispatchEvent(ctx context.Context, ev Event) error {
 
 	// agent.dispatch requires an enabled binding; agents.run (manual trigger)
 	// skips the check — explicit operator intent always runs.
-	if ev.Kind != "agents.run" && !slices.ContainsFunc(repo.Use, func(b config.Binding) bool {
+	if ev.Kind != "agents.run" && !slices.ContainsFunc(repo.Use, func(b fleet.Binding) bool {
 		return b.Agent == targetName && b.IsEnabled()
 	}) {
 		return fmt.Errorf("dispatch: target agent %q is not bound to repo %q", targetName, ev.Repo.FullName)
@@ -337,7 +338,7 @@ func (e *Engine) fanOut(ctx context.Context, ev Event) error {
 			break
 		}
 		wg.Add(1)
-		go func(a config.AgentDef) {
+		go func(a fleet.Agent) {
 			defer wg.Done()
 			defer sem.Release(1)
 
@@ -413,7 +414,7 @@ func (e *Engine) fanOut(ctx context.Context, ev Event) error {
 // when ev.Kind appears in the binding's Events slice.
 // cfg must be a snapshot already held by the caller to ensure a single
 // consistent epoch across the lookup and the subsequent runAgent calls.
-func (e *Engine) agentsForEvent(cfg *config.Config, ev Event) []config.AgentDef {
+func (e *Engine) agentsForEvent(cfg *config.Config, ev Event) []fleet.Agent {
 	repo, ok := cfg.RepoByName(ev.Repo.FullName)
 	if !ok || !repo.Enabled {
 		return nil
@@ -428,7 +429,7 @@ func (e *Engine) agentsForEvent(cfg *config.Config, ev Event) []config.AgentDef 
 	}
 
 	seen := make(map[string]struct{})
-	var matched []config.AgentDef
+	var matched []fleet.Agent
 	for _, b := range repo.Use {
 		if !b.IsEnabled() {
 			continue
@@ -510,7 +511,7 @@ func extractDispatchContext(ev Event) (rootEventID string, depth int) {
 // caller. Both must come from the same atomic snapshot so that agent lookup
 // and backend resolution operate on a single consistent epoch. The caller is
 // responsible for snapshotting under cfgMu+runnersMu before calling here.
-func (e *Engine) runAgent(ctx context.Context, ev Event, agent config.AgentDef, cfg *config.Config, runners map[string]ai.Runner) error {
+func (e *Engine) runAgent(ctx context.Context, ev Event, agent fleet.Agent, cfg *config.Config, runners map[string]ai.Runner) error {
 	backend := cfg.ResolveBackend(agent.Backend)
 	if backend == "" {
 		return fmt.Errorf("agent %q: no runner available for backend %q", agent.Name, agent.Backend)

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/eloylp/agents/internal/ai"
 	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/fleet"
 )
 
 type stubRunner struct {
@@ -60,23 +61,23 @@ func newTestEngine(cfgMutator func(*config.Config)) (*Engine, *stubRunner) {
 	cfg := &config.Config{
 		Daemon: config.DaemonConfig{
 			Processor: config.ProcessorConfig{MaxConcurrentAgents: 4},
-			AIBackends: map[string]config.AIBackendConfig{
+			AIBackends: map[string]fleet.Backend{
 				"claude": {Command: "claude"},
 			},
 		},
-		Skills: map[string]config.SkillDef{
+		Skills: map[string]fleet.Skill{
 			"architect": {Prompt: "Focus on architecture."},
 			"security":  {Prompt: "Focus on security."},
 		},
-		Agents: []config.AgentDef{
+		Agents: []fleet.Agent{
 			{Name: "arch-reviewer", Backend: "claude", Skills: []string{"architect"}, Prompt: "Review architecture."},
 			{Name: "sec-reviewer", Backend: "claude", Skills: []string{"security"}, Prompt: "Review security."},
 		},
-		Repos: []config.RepoDef{
+		Repos: []fleet.Repo{
 			{
 				Name:    "owner/repo",
 				Enabled: true,
-				Use: []config.Binding{
+				Use: []fleet.Binding{
 					{Agent: "arch-reviewer", Labels: []string{"ai:review:arch-reviewer"}},
 					{Agent: "sec-reviewer", Labels: []string{"ai:review:sec-reviewer"}},
 				},
@@ -102,8 +103,8 @@ func labelEvent(kind, repo, label string, number int) Event {
 func TestHandleEventIssueRunsMatchingLabelBinding(t *testing.T) {
 	t.Parallel()
 	e, runner := newTestEngine(func(c *config.Config) {
-		c.Agents = append(c.Agents, config.AgentDef{Name: "refiner", Backend: "claude", Prompt: "Refine the issue."})
-		c.Repos[0].Use = append(c.Repos[0].Use, config.Binding{Agent: "refiner", Labels: []string{"ai:refine"}})
+		c.Agents = append(c.Agents, fleet.Agent{Name: "refiner", Backend: "claude", Prompt: "Refine the issue."})
+		c.Repos[0].Use = append(c.Repos[0].Use, fleet.Binding{Agent: "refiner", Labels: []string{"ai:refine"}})
 	})
 	err := e.HandleEvent(context.Background(), labelEvent("issues.labeled", "owner/repo", "ai:refine", 7))
 	if err != nil {
@@ -129,7 +130,7 @@ func TestHandleEventPRRunsSingleLabelBinding(t *testing.T) {
 func TestHandleEventFansOutToMultipleLabelBindings(t *testing.T) {
 	t.Parallel()
 	e, runner := newTestEngine(func(c *config.Config) {
-		c.Repos[0].Use = []config.Binding{
+		c.Repos[0].Use = []fleet.Binding{
 			{Agent: "arch-reviewer", Labels: []string{"ai:review:all"}},
 			{Agent: "sec-reviewer", Labels: []string{"ai:review:all"}},
 		}
@@ -174,7 +175,7 @@ func TestEngineJoinsErrorsAcrossAgents(t *testing.T) {
 	t.Parallel()
 	boom := errors.New("boom")
 	e, runner := newTestEngine(func(c *config.Config) {
-		c.Repos[0].Use = []config.Binding{
+		c.Repos[0].Use = []fleet.Binding{
 			{Agent: "arch-reviewer", Labels: []string{"ai:review:all"}},
 			{Agent: "sec-reviewer", Labels: []string{"ai:review:all"}},
 		}
@@ -232,8 +233,8 @@ func TestHandleEventEventBindings(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			e, runner := newTestEngine(func(c *config.Config) {
-				c.Agents = append(c.Agents, config.AgentDef{Name: "watcher", Backend: "claude", Prompt: "React to events."})
-				c.Repos[0].Use = append(c.Repos[0].Use, config.Binding{Agent: "watcher", Events: []string{tc.bindEvent}})
+				c.Agents = append(c.Agents, fleet.Agent{Name: "watcher", Backend: "claude", Prompt: "React to events."})
+				c.Repos[0].Use = append(c.Repos[0].Use, fleet.Binding{Agent: "watcher", Events: []string{tc.bindEvent}})
 			})
 			ev := Event{
 				Repo:   RepoRef{FullName: "owner/repo", Enabled: true},
@@ -285,20 +286,20 @@ func TestEngineDispatchEventPayloadPropagatedToPrompt(t *testing.T) {
 				MaxConcurrentAgents: 4,
 				Dispatch:            config.DispatchConfig{MaxDepth: 3, MaxFanout: 4, DedupWindowSeconds: 300},
 			},
-			AIBackends: map[string]config.AIBackendConfig{
+			AIBackends: map[string]fleet.Backend{
 				"claude": {Command: "claude"},
 			},
 		},
-		Skills: map[string]config.SkillDef{},
-		Agents: []config.AgentDef{
+		Skills: map[string]fleet.Skill{},
+		Agents: []fleet.Agent{
 			{Name: "coder", Backend: "claude", Prompt: "Write code.", AllowDispatch: true},
 			{Name: "pr-reviewer", Backend: "claude", Prompt: "Review code.", AllowDispatch: true},
 		},
-		Repos: []config.RepoDef{
+		Repos: []fleet.Repo{
 			{
 				Name:    "owner/repo",
 				Enabled: true,
-				Use: []config.Binding{
+				Use: []fleet.Binding{
 					{Agent: "coder", Labels: []string{"ai:code"}},
 					{Agent: "pr-reviewer", Labels: []string{"ai:review"}},
 				},
@@ -392,19 +393,19 @@ func newTestEngineWithDedup(cfgMutator func(*config.Config)) (*Engine, *stubRunn
 					DedupWindowSeconds: 60,
 				},
 			},
-			AIBackends: map[string]config.AIBackendConfig{
+			AIBackends: map[string]fleet.Backend{
 				"claude": {Command: "claude"},
 			},
 		},
-		Skills: map[string]config.SkillDef{},
-		Agents: []config.AgentDef{
+		Skills: map[string]fleet.Skill{},
+		Agents: []fleet.Agent{
 			{Name: "pr-reviewer", Backend: "claude", Prompt: "Review PR."},
 		},
-		Repos: []config.RepoDef{
+		Repos: []fleet.Repo{
 			{
 				Name:    "owner/repo",
 				Enabled: true,
-				Use: []config.Binding{
+				Use: []fleet.Binding{
 					{Agent: "pr-reviewer", Events: []string{"pull_request.synchronize"}},
 				},
 			},
@@ -545,8 +546,8 @@ func TestFanOutClaimAbandonedOnRunFailure(t *testing.T) {
 func TestFanOutDoesNotDedupZeroNumberEvents(t *testing.T) {
 	t.Parallel()
 	e, runner, _ := newTestEngineWithDedup(func(c *config.Config) {
-		c.Agents = append(c.Agents, config.AgentDef{Name: "pusher", Backend: "claude", Prompt: "React to pushes."})
-		c.Repos[0].Use = append(c.Repos[0].Use, config.Binding{Agent: "pusher", Events: []string{"push"}})
+		c.Agents = append(c.Agents, fleet.Agent{Name: "pusher", Backend: "claude", Prompt: "React to pushes."})
+		c.Repos[0].Use = append(c.Repos[0].Use, fleet.Binding{Agent: "pusher", Events: []string{"push"}})
 	})
 
 	push1 := Event{
@@ -585,7 +586,7 @@ func TestDispatchEventRunsAfterEnqueue(t *testing.T) {
 	t.Parallel()
 	e, runner, q := newTestEngineWithDedup(func(c *config.Config) {
 		c.Agents[0].AllowDispatch = true
-		c.Agents = append(c.Agents, config.AgentDef{
+		c.Agents = append(c.Agents, fleet.Agent{
 			Name:          "coder",
 			Backend:       "claude",
 			Prompt:        "Write code.",
@@ -594,7 +595,7 @@ func TestDispatchEventRunsAfterEnqueue(t *testing.T) {
 		})
 	})
 
-	originator := config.AgentDef{
+	originator := fleet.Agent{
 		Name:        "coder",
 		CanDispatch: []string{"pr-reviewer"},
 	}
@@ -633,7 +634,7 @@ func TestDispatchDedupPreventsDoubleEnqueue(t *testing.T) {
 	t.Parallel()
 	e, _, q := newTestEngineWithDedup(func(c *config.Config) {
 		c.Agents[0].AllowDispatch = true
-		c.Agents = append(c.Agents, config.AgentDef{
+		c.Agents = append(c.Agents, fleet.Agent{
 			Name:          "coder",
 			Backend:       "claude",
 			Prompt:        "Write code.",
@@ -642,7 +643,7 @@ func TestDispatchDedupPreventsDoubleEnqueue(t *testing.T) {
 		})
 	})
 
-	originator := config.AgentDef{
+	originator := fleet.Agent{
 		Name:        "coder",
 		CanDispatch: []string{"pr-reviewer"},
 	}
@@ -785,7 +786,7 @@ func TestEngineUpdateConfigRunnersRaceWithHandleEvent(t *testing.T) {
 
 	e, runner := newTestEngine(func(c *config.Config) {
 		// Add an event binding so HandleEvent actually dispatches the agent.
-		c.Repos[0].Use = append(c.Repos[0].Use, config.Binding{
+		c.Repos[0].Use = append(c.Repos[0].Use, fleet.Binding{
 			Agent:  "arch-reviewer",
 			Events: []string{"push"},
 		})
@@ -806,19 +807,19 @@ func TestEngineUpdateConfigRunnersRaceWithHandleEvent(t *testing.T) {
 	altCfg := &config.Config{
 		Daemon: config.DaemonConfig{
 			Processor:  config.ProcessorConfig{MaxConcurrentAgents: 4},
-			AIBackends: map[string]config.AIBackendConfig{"claude": {Command: "claude"}},
+			AIBackends: map[string]fleet.Backend{"claude": {Command: "claude"}},
 		},
-		Skills: map[string]config.SkillDef{
+		Skills: map[string]fleet.Skill{
 			"architect": {Prompt: "Focus on architecture."},
 		},
-		Agents: []config.AgentDef{
+		Agents: []fleet.Agent{
 			{Name: "arch-reviewer", Backend: "claude", Skills: []string{"architect"}, Prompt: "Review architecture."},
 		},
-		Repos: []config.RepoDef{
+		Repos: []fleet.Repo{
 			{
 				Name:    "owner/repo",
 				Enabled: true,
-				Use:     []config.Binding{{Agent: "arch-reviewer", Events: []string{"push"}}},
+				Use:     []fleet.Binding{{Agent: "arch-reviewer", Events: []string{"push"}}},
 			},
 		},
 	}
@@ -869,16 +870,16 @@ func TestEngineUpdateConfigAndRunnersAtomic(t *testing.T) {
 		return &config.Config{
 			Daemon: config.DaemonConfig{
 				Processor:  config.ProcessorConfig{MaxConcurrentAgents: 8},
-				AIBackends: map[string]config.AIBackendConfig{backendName: {Command: backendName}},
+				AIBackends: map[string]fleet.Backend{backendName: {Command: backendName}},
 			},
-			Agents: []config.AgentDef{
+			Agents: []fleet.Agent{
 				{Name: "worker", Backend: backendName, Prompt: "do work"},
 			},
-			Repos: []config.RepoDef{
+			Repos: []fleet.Repo{
 				{
 					Name:    "owner/repo",
 					Enabled: true,
-					Use:     []config.Binding{{Agent: "worker", Events: []string{"push"}}},
+					Use:     []fleet.Binding{{Agent: "worker", Events: []string{"push"}}},
 				},
 			},
 		}


### PR DESCRIPTION
## Summary
- Move `Agent`, `Repo`, `Skill`, `Backend`, `Binding` from `internal/config` into a new zero-dependency `internal/fleet` package.
- Drop the `*Def` suffix at the same time (`AgentDef` → `Agent`, `RepoDef` → `Repo`, `SkillDef` → `Skill`, `AIBackendConfig` → `Backend`).
- `config` now imports `fleet`; cross-cutting validators and YAML helpers stay where they are.

## Why
The `config` package had been silently doubling as the domain-types package. That coupling blocks the server/fleet, server/repos, and server/config splits planned in #250 (phases 3-4) — a dispatch tool needing an `Agent` type shouldn't have to drag the YAML loader along with it.

`fleet` is intentionally tiny: just the structs and a handful of pure methods (`IsAllowMemory`, `IsCron`, `IsLabel`, `IsEvent`, `IsEnabled`). No transitive imports.

## Scope
- 5 new files under `internal/fleet/` (one per entity).
- ~35 files updated to import the new package and use the renamed types.
- `internal/config/config.go` shrinks by ~110 lines (type defs removed; validators stay).
- No behaviour changes. Same YAML parses to the same shape.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./... -race -count=1` green across all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)