### PR TITLE
refactor: move pure entity helpers from config to fleet

### DIFF
--- a/internal/autonomous/scheduler.go
+++ b/internal/autonomous/scheduler.go
@@ -397,7 +397,7 @@ func (s *Scheduler) executeAgentRun(ctx context.Context, repo string, agent flee
 		}
 		return fmt.Errorf("no configured backend for agent %q (configured: %q)", agent.Name, agent.Backend)
 	}
-	if backendCfg, ok := cfg.Daemon.AIBackends[backend]; ok && config.IsPinnedModelUnavailable(agent.Model, backendCfg) {
+	if backendCfg, ok := cfg.Daemon.AIBackends[backend]; ok && fleet.IsPinnedModelUnavailable(agent.Model, backendCfg) {
 		if s.dispatcher != nil {
 			s.dispatcher.RollbackAutonomousRun(agent.Name, repo)
 		}

--- a/internal/autonomous/scheduler_test.go
+++ b/internal/autonomous/scheduler_test.go
@@ -1608,13 +1608,13 @@ func TestSchedulerReloadReleasesMuBeforeSinkCall(t *testing.T) {
 	}
 }
 
-// TestSchedulerCronJobUsesPostReloadAgentDef verifies that a cron closure
+// TestSchedulerCronJobUsesPostReloadAgent verifies that a cron closure
 // resolves the agent definition from the config snapshot at execution time
 // rather than capturing it by value at registration time. A cron tick that
 // fires after a Reload (i.e., the closure was enqueued before the old entry
 // was removed but runs after bindMu is released) must use the post-reload
 // agent definition, not the stale pre-reload one.
-func TestSchedulerCronJobUsesPostReloadAgentDef(t *testing.T) {
+func TestSchedulerCronJobUsesPostReloadAgent(t *testing.T) {
 	t.Parallel()
 
 	runner := &promptCapturingRunner{}

--- a/internal/backends/discovery.go
+++ b/internal/backends/discovery.go
@@ -15,7 +15,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/eloylp/agents/internal/config"
 	"github.com/eloylp/agents/internal/fleet"
 	"github.com/eloylp/agents/internal/store"
 )
@@ -149,8 +148,8 @@ func persistDiagnostics(db *sql.DB, existing map[string]fleet.Backend, diag Diag
 		next.Healthy = b.Healthy
 		next.HealthDetail = b.HealthDetail
 		next.LocalModelURL = b.LocalModelURL
-		config.ApplyBackendDefaults(&next)
-		config.NormalizeBackendConfig(&next)
+		fleet.ApplyBackendDefaults(&next)
+		fleet.NormalizeBackend(&next)
 
 		if err := store.UpsertBackend(db, b.Name, next); err != nil {
 			return fmt.Errorf("persist backend %s: %w", b.Name, err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,9 +66,6 @@ const (
 	defaultEventQueueBufferSize = 256
 	defaultMaxConcurrentAgents  = 4
 
-	defaultAITimeoutSeconds = 600
-	defaultMaxPromptChars   = 12000
-
 	defaultProxyPath           = "/v1/messages"
 	defaultProxyTimeoutSeconds = 120
 )
@@ -444,12 +441,7 @@ func (c *Config) applyDefaults() {
 
 	// daemon.ai_backends defaults
 	for name, backend := range c.Daemon.AIBackends {
-		if backend.TimeoutSeconds == 0 {
-			backend.TimeoutSeconds = defaultAITimeoutSeconds
-		}
-		if backend.MaxPromptChars == 0 {
-			backend.MaxPromptChars = defaultMaxPromptChars
-		}
+		fleet.ApplyBackendDefaults(&backend)
 		c.Daemon.AIBackends[name] = backend
 	}
 
@@ -463,14 +455,8 @@ func (c *Config) normalize() {
 	if len(c.Daemon.AIBackends) > 0 {
 		lower := make(map[string]fleet.Backend, len(c.Daemon.AIBackends))
 		for name, backend := range c.Daemon.AIBackends {
-			key := strings.ToLower(strings.TrimSpace(name))
-			backend.Command = strings.TrimSpace(backend.Command)
-			backend.Version = strings.TrimSpace(backend.Version)
-			backend.HealthDetail = strings.TrimSpace(backend.HealthDetail)
-			backend.LocalModelURL = strings.TrimSpace(backend.LocalModelURL)
-			for i := range backend.Models {
-				backend.Models[i] = strings.TrimSpace(backend.Models[i])
-			}
+			key := fleet.NormalizeBackendName(name)
+			fleet.NormalizeBackend(&backend)
 			lower[key] = backend
 		}
 		c.Daemon.AIBackends = lower
@@ -480,9 +466,8 @@ func (c *Config) normalize() {
 	if len(c.Skills) > 0 {
 		lower := make(map[string]fleet.Skill, len(c.Skills))
 		for name, skill := range c.Skills {
-			key := strings.ToLower(strings.TrimSpace(name))
-			skill.Prompt = strings.TrimSpace(skill.Prompt)
-			skill.PromptFile = strings.TrimSpace(skill.PromptFile)
+			key := fleet.NormalizeSkillName(name)
+			fleet.NormalizeSkill(&skill)
 			lower[key] = skill
 		}
 		c.Skills = lower
@@ -490,30 +475,12 @@ func (c *Config) normalize() {
 
 	// Agents.
 	for i := range c.Agents {
-		c.Agents[i].Name = strings.ToLower(strings.TrimSpace(c.Agents[i].Name))
-		c.Agents[i].Backend = strings.ToLower(strings.TrimSpace(c.Agents[i].Backend))
-		c.Agents[i].Model = strings.TrimSpace(c.Agents[i].Model)
-		c.Agents[i].Prompt = strings.TrimSpace(c.Agents[i].Prompt)
-		c.Agents[i].PromptFile = strings.TrimSpace(c.Agents[i].PromptFile)
-		c.Agents[i].Description = strings.TrimSpace(c.Agents[i].Description)
-		for j := range c.Agents[i].Skills {
-			c.Agents[i].Skills[j] = strings.ToLower(strings.TrimSpace(c.Agents[i].Skills[j]))
-		}
-		for j := range c.Agents[i].CanDispatch {
-			c.Agents[i].CanDispatch[j] = strings.ToLower(strings.TrimSpace(c.Agents[i].CanDispatch[j]))
-		}
+		fleet.NormalizeAgent(&c.Agents[i])
 	}
 
 	// Repos.
 	for i := range c.Repos {
-		c.Repos[i].Name = strings.TrimSpace(c.Repos[i].Name)
-		for j := range c.Repos[i].Use {
-			c.Repos[i].Use[j].Agent = strings.ToLower(strings.TrimSpace(c.Repos[i].Use[j].Agent))
-			c.Repos[i].Use[j].Cron = strings.TrimSpace(c.Repos[i].Use[j].Cron)
-			for k := range c.Repos[i].Use[j].Events {
-				c.Repos[i].Use[j].Events[k] = strings.ToLower(strings.TrimSpace(c.Repos[i].Use[j].Events[k]))
-			}
-		}
+		fleet.NormalizeRepo(&c.Repos[i])
 	}
 
 	// Log.
@@ -808,124 +775,12 @@ func isSupportedBackend(name string, backend fleet.Backend) bool {
 	return strings.TrimSpace(backend.LocalModelURL) != ""
 }
 
-// IsPinnedModelUnavailable reports whether a non-empty model is explicitly
-// known to be unavailable for the given backend snapshot.
-//
-// If backend.Models is empty, availability is treated as unknown (returns
-// false) so callers can avoid blocking on missing catalog metadata.
-func IsPinnedModelUnavailable(model string, backend fleet.Backend) bool {
-	model = strings.TrimSpace(model)
-	if model == "" {
-		return false
-	}
-	if len(backend.Models) == 0 {
-		return false
-	}
-	return !slices.Contains(backend.Models, model)
-}
-
 func validateAgentModel(_ string, _ string, _ fleet.Backend) error {
 	// Model/backend mismatches are intentionally allowed at config validation
 	// time so discovery can persist backend model changes even if agents become
 	// temporarily orphaned. Runtime paths enforce this strictly before invoking
 	// a backend, and UI surfaces orphan remediation flows.
 	return nil
-}
-
-// ApplyBackendDefaults fills in zero-value fields of b with the same defaults
-// that Load / FinishLoad apply at startup. Callers that persist a backend via
-// the CRUD API should call this before writing so that the stored values match
-// what the daemon would derive from those zeros on the next restart.
-func ApplyBackendDefaults(b *fleet.Backend) {
-	setDefaultInt(&b.TimeoutSeconds, defaultAITimeoutSeconds)
-	setDefaultInt(&b.MaxPromptChars, defaultMaxPromptChars)
-}
-
-// NormalizeBackendConfig applies the same per-entry field normalization that
-// normalize() performs at startup: it trims Command and scrubs env keys that
-// are empty after trimming. CRUD callers must invoke this before persisting a
-// backend so that the stored values match the canonical form the daemon derives
-// at boot, preventing live behavior from diverging until a restart.
-func NormalizeBackendConfig(b *fleet.Backend) {
-	b.Command = strings.TrimSpace(b.Command)
-	b.Version = strings.TrimSpace(b.Version)
-	b.HealthDetail = strings.TrimSpace(b.HealthDetail)
-	b.LocalModelURL = strings.TrimSpace(b.LocalModelURL)
-	for i := range b.Models {
-		b.Models[i] = strings.TrimSpace(b.Models[i])
-	}
-}
-
-// NormalizeSkillDef applies the same field normalization that normalize()
-// performs on skill values at startup: it trims Prompt and PromptFile.
-// CRUD callers must invoke this before persisting a skill so that the stored
-// values match the canonical form the daemon derives at boot.
-func NormalizeSkillDef(s *fleet.Skill) {
-	s.Prompt = strings.TrimSpace(s.Prompt)
-	s.PromptFile = strings.TrimSpace(s.PromptFile)
-}
-
-// NormalizeAgentDef applies the same name/field normalization that FinishLoad
-// performs at startup (lowercase + trim on names, backend, skills, can_dispatch).
-// CRUD callers must invoke this before writing an agent to SQLite so the stored
-// values are already in the canonical form that AgentByName and registerJobs
-// expect, preventing live behavior from diverging until the next restart.
-func NormalizeAgentDef(a *fleet.Agent) {
-	a.Name = strings.ToLower(strings.TrimSpace(a.Name))
-	a.Backend = strings.ToLower(strings.TrimSpace(a.Backend))
-	a.Model = strings.TrimSpace(a.Model)
-	a.Prompt = strings.TrimSpace(a.Prompt)
-	a.PromptFile = strings.TrimSpace(a.PromptFile)
-	a.Description = strings.TrimSpace(a.Description)
-	for i := range a.Skills {
-		a.Skills[i] = strings.ToLower(strings.TrimSpace(a.Skills[i]))
-	}
-	for i := range a.CanDispatch {
-		a.CanDispatch[i] = strings.ToLower(strings.TrimSpace(a.CanDispatch[i]))
-	}
-}
-
-// NormalizeAgentName returns the canonical form of an agent name (lowercase,
-// trimmed). CRUD callers should normalise path-parameter names before lookups
-// or deletes so that GET/DELETE /api/store/agents/{name} follows the same
-// case-insensitive semantics as AgentByName.
-func NormalizeAgentName(name string) string {
-	return strings.ToLower(strings.TrimSpace(name))
-}
-
-// NormalizeSkillName returns the canonical form of a skill map key (lowercase,
-// trimmed). CRUD callers should normalise the key before writing to SQLite.
-func NormalizeSkillName(name string) string {
-	return strings.ToLower(strings.TrimSpace(name))
-}
-
-// NormalizeBackendName returns the canonical form of a backend map key
-// (lowercase, trimmed). CRUD callers should normalise the key before writing.
-func NormalizeBackendName(name string) string {
-	return strings.ToLower(strings.TrimSpace(name))
-}
-
-// NormalizeRepoName returns the canonical form of a repo full name
-// (lowercase, trimmed). CRUD callers should normalise path-parameter names
-// before lookups or deletes so that GET/DELETE /api/store/repos/{owner}/{repo}
-// follows the same case-insensitive semantics as RepoByName.
-func NormalizeRepoName(name string) string {
-	return strings.ToLower(strings.TrimSpace(name))
-}
-
-// NormalizeRepoDef applies the same normalization that FinishLoad performs on
-// repo entries: lowercase+trim the repo name, and lowercase+trim each binding
-// agent name, cron, and event strings. CRUD callers must invoke this before
-// writing a repo.
-func NormalizeRepoDef(r *fleet.Repo) {
-	r.Name = NormalizeRepoName(r.Name)
-	for i := range r.Use {
-		r.Use[i].Agent = strings.ToLower(strings.TrimSpace(r.Use[i].Agent))
-		r.Use[i].Cron = strings.TrimSpace(r.Use[i].Cron)
-		for k := range r.Use[i].Events {
-			r.Use[i].Events[k] = strings.ToLower(strings.TrimSpace(r.Use[i].Events[k]))
-		}
-	}
 }
 
 func setDefault(dst *string, def string) {

--- a/internal/fleet/normalize.go
+++ b/internal/fleet/normalize.go
@@ -1,0 +1,126 @@
+package fleet
+
+import (
+	"slices"
+	"strings"
+)
+
+// Default values applied to a Backend's optional integer fields when they are
+// zero. The same values are used by Config.applyDefaults at startup so that
+// CRUD-persisted backends and YAML-loaded backends end up identical.
+const (
+	DefaultAITimeoutSeconds = 600
+	DefaultMaxPromptChars   = 12000
+)
+
+// NormalizeAgentName returns the canonical form of an agent name (lowercase,
+// trimmed). CRUD callers should normalise path-parameter names before lookups
+// or deletes so HTTP routes follow the same case-insensitive semantics as the
+// in-memory lookups.
+func NormalizeAgentName(name string) string {
+	return strings.ToLower(strings.TrimSpace(name))
+}
+
+// NormalizeSkillName returns the canonical form of a skill map key
+// (lowercase, trimmed). CRUD callers should normalise the key before writing.
+func NormalizeSkillName(name string) string {
+	return strings.ToLower(strings.TrimSpace(name))
+}
+
+// NormalizeBackendName returns the canonical form of a backend map key
+// (lowercase, trimmed). CRUD callers should normalise the key before writing.
+func NormalizeBackendName(name string) string {
+	return strings.ToLower(strings.TrimSpace(name))
+}
+
+// NormalizeRepoName returns the canonical form of a repo full name
+// (lowercase, trimmed). CRUD callers should normalise path-parameter names
+// before lookups or deletes so HTTP routes follow the same case-insensitive
+// semantics as the in-memory lookups.
+func NormalizeRepoName(name string) string {
+	return strings.ToLower(strings.TrimSpace(name))
+}
+
+// NormalizeAgent applies the same name/field normalization that the YAML
+// loader performs at startup (lowercase + trim on names, backend, skills,
+// can_dispatch, plus trim on free-text fields). CRUD callers must invoke this
+// before writing an agent so the stored values are already in the canonical
+// form that lookups expect.
+func NormalizeAgent(a *Agent) {
+	a.Name = NormalizeAgentName(a.Name)
+	a.Backend = NormalizeBackendName(a.Backend)
+	a.Model = strings.TrimSpace(a.Model)
+	a.Prompt = strings.TrimSpace(a.Prompt)
+	a.PromptFile = strings.TrimSpace(a.PromptFile)
+	a.Description = strings.TrimSpace(a.Description)
+	for i := range a.Skills {
+		a.Skills[i] = NormalizeSkillName(a.Skills[i])
+	}
+	for i := range a.CanDispatch {
+		a.CanDispatch[i] = NormalizeAgentName(a.CanDispatch[i])
+	}
+}
+
+// NormalizeSkill applies the same field normalization that the YAML loader
+// performs on skill values: trims Prompt and PromptFile.
+func NormalizeSkill(s *Skill) {
+	s.Prompt = strings.TrimSpace(s.Prompt)
+	s.PromptFile = strings.TrimSpace(s.PromptFile)
+}
+
+// NormalizeBackend applies the same per-entry field normalization that the
+// YAML loader performs at startup: trims string fields and each entry of the
+// Models slice. CRUD callers must invoke this before persisting a backend so
+// the stored values match the canonical form the daemon derives at boot.
+func NormalizeBackend(b *Backend) {
+	b.Command = strings.TrimSpace(b.Command)
+	b.Version = strings.TrimSpace(b.Version)
+	b.HealthDetail = strings.TrimSpace(b.HealthDetail)
+	b.LocalModelURL = strings.TrimSpace(b.LocalModelURL)
+	for i := range b.Models {
+		b.Models[i] = strings.TrimSpace(b.Models[i])
+	}
+}
+
+// NormalizeRepo applies the same normalization that the YAML loader performs
+// on repo entries: lowercase+trim the repo name, and lowercase+trim each
+// binding agent name, cron, and event strings.
+func NormalizeRepo(r *Repo) {
+	r.Name = NormalizeRepoName(r.Name)
+	for i := range r.Use {
+		r.Use[i].Agent = NormalizeAgentName(r.Use[i].Agent)
+		r.Use[i].Cron = strings.TrimSpace(r.Use[i].Cron)
+		for k := range r.Use[i].Events {
+			r.Use[i].Events[k] = strings.ToLower(strings.TrimSpace(r.Use[i].Events[k]))
+		}
+	}
+}
+
+// ApplyBackendDefaults fills in zero-value fields of b with the same defaults
+// the YAML loader applies at startup. CRUD callers that persist a backend
+// should call this before writing so that the stored values match what the
+// daemon would derive from those zeros on the next restart.
+func ApplyBackendDefaults(b *Backend) {
+	if b.TimeoutSeconds == 0 {
+		b.TimeoutSeconds = DefaultAITimeoutSeconds
+	}
+	if b.MaxPromptChars == 0 {
+		b.MaxPromptChars = DefaultMaxPromptChars
+	}
+}
+
+// IsPinnedModelUnavailable reports whether a non-empty model is explicitly
+// known to be unavailable for the given backend snapshot.
+//
+// If backend.Models is empty, availability is treated as unknown (returns
+// false) so callers can avoid blocking on missing catalog metadata.
+func IsPinnedModelUnavailable(model string, backend Backend) bool {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return false
+	}
+	if len(backend.Models) == 0 {
+		return false
+	}
+	return !slices.Contains(backend.Models, model)
+}

--- a/internal/mcp/allow_memory_test.go
+++ b/internal/mcp/allow_memory_test.go
@@ -49,7 +49,7 @@ func TestToolCreateAgentForwardsAllowMemoryFalse(t *testing.T) {
 }
 
 // TestToolCreateAgentLeavesAllowMemoryNilWhenAbsent verifies that omitting
-// allow_memory leaves the AgentDef pointer nil, so AgentDef.IsAllowMemory()
+// allow_memory leaves the Agent pointer nil, so Agent.IsAllowMemory()
 // returns the documented default of true downstream.
 func TestToolCreateAgentLeavesAllowMemoryNilWhenAbsent(t *testing.T) {
 	t.Parallel()
@@ -82,7 +82,7 @@ func TestToolCreateAgentLeavesAllowMemoryNilWhenAbsent(t *testing.T) {
 
 // TestToolUpdateAgentForwardsAllowMemoryPatch verifies that update_agent
 // surfaces allow_memory in the partial-update payload as a *bool — exactly
-// what the webhook adapter expects to merge over an existing AgentDef.
+// what the webhook adapter expects to merge over an existing Agent.
 func TestToolUpdateAgentForwardsAllowMemoryPatch(t *testing.T) {
 	t.Parallel()
 	canonical := fleet.Agent{Name: "coder", Backend: "claude", Prompt: "p"}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -151,7 +151,7 @@ type SkillPatch struct {
 }
 
 // SkillWriter writes a single skill into the store and removes existing ones.
-// Upsert returns the canonical (normalized) name and SkillDef that were
+// Upsert returns the canonical (normalized) name and Skill that were
 // persisted so callers can surface the same shape REST clients see in the
 // POST /skills response — lowercase name, trimmed prompt. UpdateSkill applies
 // a partial patch and returns *store.ErrNotFound if the skill is missing.
@@ -182,7 +182,7 @@ type BackendPatch struct {
 
 // BackendWriter writes a single AI backend definition into the store and
 // removes existing ones. Upsert returns the canonical (normalized) name and
-// AIBackendConfig that were persisted so callers can surface the same shape
+// Backend that were persisted so callers can surface the same shape
 // REST clients see in the POST /backends response — lowercase name, trimmed
 // command, defaults applied. UpdateBackend applies a partial patch and
 // returns *store.ErrNotFound if the backend is missing.
@@ -197,7 +197,7 @@ type BackendWriter interface {
 
 // RepoWriter writes a single repo definition (name, enabled flag, bindings)
 // into the store and removes existing ones. Upsert returns the canonical
-// (normalized) RepoDef that was persisted so callers can surface the same
+// (normalized) Repo that was persisted so callers can surface the same
 // shape REST clients see in the POST /repos response — lowercase repo name,
 // lowercased binding agents, trimmed cron, lowercased events.
 //

--- a/internal/mcp/tools_crud.go
+++ b/internal/mcp/tools_crud.go
@@ -8,7 +8,6 @@ import (
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
-	"github.com/eloylp/agents/internal/config"
 	"github.com/eloylp/agents/internal/fleet"
 )
 
@@ -44,7 +43,7 @@ func toolCreateAgent(deps Deps) server.ToolHandlerFunc {
 			AllowDispatch: req.GetBool("allow_dispatch", false),
 		}
 		// allow_memory: keep AllowMemory nil when the caller omits the field so
-		// AgentDef.IsAllowMemory() returns the documented default of true.
+		// Agent.IsAllowMemory() returns the documented default of true.
 		// Only an explicit true/false in the payload materialises a non-nil
 		// pointer, mirroring the binding-enabled convention.
 		if v, ok, errMsg := boolPtrArg(args, "allow_memory"); ok {
@@ -138,12 +137,12 @@ func toolDeleteAgent(deps Deps) server.ToolHandlerFunc {
 			return mcpgo.NewToolResultError("name is required"), nil
 		}
 		cascade := req.GetBool("cascade", false)
-		if err := deps.AgentWrite.DeleteAgent(config.NormalizeAgentName(name), cascade); err != nil {
+		if err := deps.AgentWrite.DeleteAgent(fleet.NormalizeAgentName(name), cascade); err != nil {
 			return mcpgo.NewToolResultErrorFromErr("delete agent", err), nil
 		}
 		return jsonResult(map[string]any{
 			"status":  "deleted",
-			"name":    config.NormalizeAgentName(name),
+			"name":    fleet.NormalizeAgentName(name),
 			"cascade": cascade,
 		})
 	}
@@ -207,7 +206,7 @@ func toolDeleteSkill(deps Deps) server.ToolHandlerFunc {
 		if !ok {
 			return mcpgo.NewToolResultError("name is required"), nil
 		}
-		canonical := config.NormalizeSkillName(name)
+		canonical := fleet.NormalizeSkillName(name)
 		if err := deps.SkillWrite.DeleteSkill(canonical); err != nil {
 			return mcpgo.NewToolResultErrorFromErr("delete skill", err), nil
 		}
@@ -329,7 +328,7 @@ func toolDeleteBackend(deps Deps) server.ToolHandlerFunc {
 		if !ok {
 			return mcpgo.NewToolResultError("name is required"), nil
 		}
-		canonical := config.NormalizeBackendName(name)
+		canonical := fleet.NormalizeBackendName(name)
 		if err := deps.BackendWrite.DeleteBackend(canonical); err != nil {
 			return mcpgo.NewToolResultErrorFromErr("delete backend", err), nil
 		}
@@ -382,7 +381,7 @@ func toolDeleteRepo(deps Deps) server.ToolHandlerFunc {
 		if !ok {
 			return mcpgo.NewToolResultError("name is required"), nil
 		}
-		canonical := config.NormalizeRepoName(name)
+		canonical := fleet.NormalizeRepoName(name)
 		if err := deps.RepoWrite.DeleteRepo(canonical); err != nil {
 			return mcpgo.NewToolResultErrorFromErr("delete repo", err), nil
 		}
@@ -476,7 +475,7 @@ func toolDeleteBinding(deps Deps) server.ToolHandlerFunc {
 		return jsonResult(map[string]any{
 			"status": "deleted",
 			"id":     id,
-			"repo":   config.NormalizeRepoName(repo),
+			"repo":   fleet.NormalizeRepoName(repo),
 		})
 	}
 }
@@ -508,7 +507,7 @@ func bindingFromReq(req mcpgo.CallToolRequest, agent string) (fleet.Binding, str
 	return b, ""
 }
 
-// repoJSON renders a RepoDef in the same wire shape as an element of the
+// repoJSON renders a Repo in the same wire shape as an element of the
 // list_repos / get_repo responses, so create_repo/delete_repo callers consume
 // one schema regardless of whether they are reading or writing.
 func repoJSON(r fleet.Repo) map[string]any {

--- a/internal/mcp/tools_fleet.go
+++ b/internal/mcp/tools_fleet.go
@@ -9,7 +9,6 @@ import (
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
-	"github.com/eloylp/agents/internal/config"
 	"github.com/eloylp/agents/internal/fleet"
 	"github.com/eloylp/agents/internal/store"
 	"github.com/eloylp/agents/internal/workflow"
@@ -33,7 +32,7 @@ func toolListAgents(deps Deps) server.ToolHandlerFunc {
 }
 
 // toolGetAgent fetches a single agent by name. Matches case-insensitively
-// via config.NormalizeAgentName, so "Coder" and "coder" both resolve to the
+// via fleet.NormalizeAgentName, so "Coder" and "coder" both resolve to the
 // same entry.
 func toolGetAgent(deps Deps) server.ToolHandlerFunc {
 	return func(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -45,7 +44,7 @@ func toolGetAgent(deps Deps) server.ToolHandlerFunc {
 		if err != nil {
 			return mcpgo.NewToolResultErrorFromErr("get agent", err), nil
 		}
-		key := config.NormalizeAgentName(name)
+		key := fleet.NormalizeAgentName(name)
 		if idx := slices.IndexFunc(agents, func(a fleet.Agent) bool { return a.Name == key }); idx != -1 {
 			return jsonResult(agentJSON(agents[idx]))
 		}
@@ -73,7 +72,7 @@ func toolListSkills(deps Deps) server.ToolHandlerFunc {
 }
 
 // toolGetSkill fetches one skill by its map key. Map lookup is
-// case-insensitive via config.NormalizeSkillName so agents can reference
+// case-insensitive via fleet.NormalizeSkillName so agents can reference
 // skills without worrying about casing.
 func toolGetSkill(deps Deps) server.ToolHandlerFunc {
 	return func(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
@@ -85,7 +84,7 @@ func toolGetSkill(deps Deps) server.ToolHandlerFunc {
 		if err != nil {
 			return mcpgo.NewToolResultErrorFromErr("get skill", err), nil
 		}
-		key := config.NormalizeSkillName(name)
+		key := fleet.NormalizeSkillName(name)
 		s, found := skills[key]
 		if !found {
 			return mcpgo.NewToolResultErrorf("skill %q not found", name), nil
@@ -124,7 +123,7 @@ func toolGetBackend(deps Deps) server.ToolHandlerFunc {
 		if err != nil {
 			return mcpgo.NewToolResultErrorFromErr("get backend", err), nil
 		}
-		key := config.NormalizeBackendName(name)
+		key := fleet.NormalizeBackendName(name)
 		b, found := backends[key]
 		if !found {
 			return mcpgo.NewToolResultErrorf("backend %q not found", name), nil
@@ -159,7 +158,7 @@ func toolGetRepo(deps Deps) server.ToolHandlerFunc {
 		if err != nil {
 			return mcpgo.NewToolResultErrorFromErr("get repo", err), nil
 		}
-		key := config.NormalizeRepoName(name)
+		key := fleet.NormalizeRepoName(name)
 		if idx := slices.IndexFunc(repos, func(r fleet.Repo) bool { return r.Name == key }); idx != -1 {
 			return jsonResult(repoJSON(repos[idx]))
 		}

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -2038,7 +2038,7 @@ func TestToolDeleteBackendPropagatesConflict(t *testing.T) {
 	}
 }
 
-// stubRepoWriter records the RepoDef arguments it received and returns
+// stubRepoWriter records the Repo arguments it received and returns
 // canned values. Tests pin both the raw inputs the writer observed and the
 // canonical repo the tool surfaces back to the caller.
 type stubRepoWriter struct {

--- a/internal/store/crud.go
+++ b/internal/store/crud.go
@@ -136,7 +136,7 @@ func ReadAgents(db *sql.DB) ([]fleet.Agent, error) {
 // writing so the stored values match the canonical form that AgentByName and
 // registerJobs expect, keeping live behavior consistent with startup.
 func UpsertAgent(db *sql.DB, a fleet.Agent) error {
-	config.NormalizeAgentDef(&a)
+	fleet.NormalizeAgent(&a)
 	tx, err := db.Begin()
 	if err != nil {
 		return fmt.Errorf("store: upsert agent %s: begin: %w", a.Name, err)
@@ -243,13 +243,13 @@ func ReadSkills(db *sql.DB) (map[string]fleet.Skill, error) {
 }
 
 // UpsertSkill inserts or replaces a single skill.
-// The skill name is normalized (lowercase, trimmed) and SkillDef fields
+// The skill name is normalized (lowercase, trimmed) and Skill fields
 // (Prompt, PromptFile) are trimmed before writing, matching the normalization
 // startup applies in normalize() so that the stored values are already in
 // canonical form and validation sees the same shape as after a restart.
 func UpsertSkill(db *sql.DB, name string, s fleet.Skill) error {
-	name = config.NormalizeSkillName(name)
-	config.NormalizeSkillDef(&s)
+	name = fleet.NormalizeSkillName(name)
+	fleet.NormalizeSkill(&s)
 	tx, err := db.Begin()
 	if err != nil {
 		return fmt.Errorf("store: upsert skill %s: begin: %w", name, err)
@@ -303,9 +303,9 @@ func ReadBackends(db *sql.DB) (map[string]fleet.Backend, error) {
 // ensures the stored values are already in canonical form so that live
 // behavior never diverges from a post-restart load.
 func UpsertBackend(db *sql.DB, name string, b fleet.Backend) error {
-	name = config.NormalizeBackendName(name)
-	config.NormalizeBackendConfig(&b)
-	config.ApplyBackendDefaults(&b)
+	name = fleet.NormalizeBackendName(name)
+	fleet.NormalizeBackend(&b)
+	fleet.ApplyBackendDefaults(&b)
 	tx, err := db.Begin()
 	if err != nil {
 		return fmt.Errorf("store: upsert backend %s: begin: %w", name, err)
@@ -393,7 +393,7 @@ func ReadRepos(db *sql.DB) ([]fleet.Repo, error) {
 // the new list is written. The repo name and binding agents/events are
 // normalized (trimmed / lowercased) before writing.
 func UpsertRepo(db *sql.DB, r fleet.Repo) error {
-	config.NormalizeRepoDef(&r)
+	fleet.NormalizeRepo(&r)
 	tx, err := db.Begin()
 	if err != nil {
 		return fmt.Errorf("store: upsert repo %s: begin: %w", r.Name, err)
@@ -417,22 +417,22 @@ func normalizeFleet(
 	backends map[string]fleet.Backend,
 ) (map[string]fleet.Skill, map[string]fleet.Backend) {
 	for i := range agents {
-		config.NormalizeAgentDef(&agents[i])
+		fleet.NormalizeAgent(&agents[i])
 	}
 	for i := range repos {
-		config.NormalizeRepoDef(&repos[i])
+		fleet.NormalizeRepo(&repos[i])
 	}
 	normalizedSkills := make(map[string]fleet.Skill, len(skills))
 	for name, s := range skills {
-		name = config.NormalizeSkillName(name)
-		config.NormalizeSkillDef(&s)
+		name = fleet.NormalizeSkillName(name)
+		fleet.NormalizeSkill(&s)
 		normalizedSkills[name] = s
 	}
 	normalizedBackends := make(map[string]fleet.Backend, len(backends))
 	for name, b := range backends {
-		name = config.NormalizeBackendName(name)
-		config.NormalizeBackendConfig(&b)
-		config.ApplyBackendDefaults(&b)
+		name = fleet.NormalizeBackendName(name)
+		fleet.NormalizeBackend(&b)
+		fleet.ApplyBackendDefaults(&b)
 		normalizedBackends[name] = b
 	}
 	return normalizedSkills, normalizedBackends
@@ -571,7 +571,7 @@ func normalizeBinding(b *fleet.Binding) {
 // references surface as *ErrNotFound (HTTP 404). The caller is responsible for
 // holding the store mutex and reloading cron schedules after success.
 func CreateBinding(db *sql.DB, repoName string, b fleet.Binding) (int64, fleet.Binding, error) {
-	repoName = config.NormalizeRepoName(repoName)
+	repoName = fleet.NormalizeRepoName(repoName)
 	normalizeBinding(&b)
 	if err := validateBindingShape(b); err != nil {
 		return 0, fleet.Binding{}, err

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -662,7 +662,7 @@ func bindingEnabledInt(enabled *bool) int {
 
 // allowMemoryInt converts an agent's nullable allow_memory flag to 0/1 for
 // SQLite storage. Nil means the default (enabled), matching
-// AgentDef.IsAllowMemory(); only an explicit non-nil false maps to 0.
+// Agent.IsAllowMemory(); only an explicit non-nil false maps to 0.
 func allowMemoryInt(allow *bool) int {
 	if allow != nil && !*allow {
 		return 0

--- a/internal/webhook/crud.go
+++ b/internal/webhook/crud.go
@@ -14,7 +14,6 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/eloylp/agents/internal/backends"
-	"github.com/eloylp/agents/internal/config"
 	"github.com/eloylp/agents/internal/fleet"
 	"github.com/eloylp/agents/internal/store"
 )
@@ -32,7 +31,7 @@ type storeAgentJSON struct {
 	CanDispatch   []string `json:"can_dispatch"`
 	Description   string   `json:"description"`
 	// AllowMemory is a *bool so POST clients that omit the field get the
-	// default-true semantics (`AgentDef.AllowMemory == nil` → IsAllowMemory()
+	// default-true semantics (`Agent.AllowMemory == nil` → IsAllowMemory()
 	// returns true). Responses always populate it (see agentToStoreJSON) so
 	// every read sees a concrete value.
 	AllowMemory *bool `json:"allow_memory,omitempty"`
@@ -478,13 +477,13 @@ func (s *Server) UpsertAgent(a fleet.Agent) (fleet.Agent, error) {
 	if err != nil {
 		return fleet.Agent{}, err
 	}
-	config.NormalizeAgentDef(&a)
+	fleet.NormalizeAgent(&a)
 	return a, nil
 }
 
 // handleStoreAgent serves GET, PATCH, and DELETE /api/store/agents/{name}.
 func (s *Server) handleStoreAgent(w http.ResponseWriter, r *http.Request) {
-	name := config.NormalizeAgentName(mux.Vars(r)["name"])
+	name := fleet.NormalizeAgentName(mux.Vars(r)["name"])
 	switch r.Method {
 	case http.MethodGet:
 		agents, err := store.ReadAgents(s.db)
@@ -543,7 +542,7 @@ func (s *Server) handleUpdateAgent(w http.ResponseWriter, r *http.Request, name 
 // Exposed so non-HTTP surfaces (e.g. the MCP update_agent tool) can drive the
 // same path as PATCH /agents/{name} without going through the router.
 func (s *Server) UpdateAgent(name string, patch storeAgentPatchJSON) (fleet.Agent, error) {
-	normalized := config.NormalizeAgentName(name)
+	normalized := fleet.NormalizeAgentName(name)
 	s.storeMu.Lock()
 	defer s.storeMu.Unlock()
 	agents, err := store.ReadAgents(s.db)
@@ -568,7 +567,7 @@ func (s *Server) UpdateAgent(name string, patch storeAgentPatchJSON) (fleet.Agen
 	if err := s.reloadCron(); err != nil {
 		return fleet.Agent{}, err
 	}
-	config.NormalizeAgentDef(&merged)
+	fleet.NormalizeAgent(&merged)
 	return merged, nil
 }
 
@@ -626,7 +625,7 @@ func (s *Server) handleStoreSkills(w http.ResponseWriter, r *http.Request) {
 }
 
 // UpsertSkill writes a single skill into the store and reloads the cron
-// scheduler. Returns the canonical (normalized) name and SkillDef that were
+// scheduler. Returns the canonical (normalized) name and Skill that were
 // persisted so callers can surface the same shape REST clients see in the
 // POST response — lowercase/trimmed name, trimmed prompt.
 //
@@ -649,13 +648,13 @@ func (s *Server) UpsertSkill(name string, sk fleet.Skill) (string, fleet.Skill, 
 	if err != nil {
 		return "", fleet.Skill{}, err
 	}
-	config.NormalizeSkillDef(&sk)
-	return config.NormalizeSkillName(name), sk, nil
+	fleet.NormalizeSkill(&sk)
+	return fleet.NormalizeSkillName(name), sk, nil
 }
 
 // handleStoreSkill serves GET, PATCH, and DELETE /api/store/skills/{name}.
 func (s *Server) handleStoreSkill(w http.ResponseWriter, r *http.Request) {
-	name := config.NormalizeSkillName(mux.Vars(r)["name"])
+	name := fleet.NormalizeSkillName(mux.Vars(r)["name"])
 	switch r.Method {
 	case http.MethodGet:
 		skills, err := store.ReadSkills(s.db)
@@ -711,7 +710,7 @@ func (s *Server) handleUpdateSkill(w http.ResponseWriter, r *http.Request, name 
 // Exposed so non-HTTP surfaces (e.g. the MCP update_skill tool) can drive the
 // same path as PATCH /skills/{name} without going through the router.
 func (s *Server) UpdateSkill(name string, patch storeSkillPatchJSON) (string, fleet.Skill, error) {
-	normalized := config.NormalizeSkillName(name)
+	normalized := fleet.NormalizeSkillName(name)
 	s.storeMu.Lock()
 	defer s.storeMu.Unlock()
 	skills, err := store.ReadSkills(s.db)
@@ -729,7 +728,7 @@ func (s *Server) UpdateSkill(name string, patch storeSkillPatchJSON) (string, fl
 	if err := s.reloadCron(); err != nil {
 		return "", fleet.Skill{}, err
 	}
-	config.NormalizeSkillDef(&existing)
+	fleet.NormalizeSkill(&existing)
 	return normalized, existing, nil
 }
 
@@ -803,9 +802,9 @@ func (s *Server) UpsertBackend(name string, b fleet.Backend) (string, fleet.Back
 	if err != nil {
 		return "", fleet.Backend{}, err
 	}
-	config.NormalizeBackendConfig(&b)
-	config.ApplyBackendDefaults(&b)
-	return config.NormalizeBackendName(name), b, nil
+	fleet.NormalizeBackend(&b)
+	fleet.ApplyBackendDefaults(&b)
+	return fleet.NormalizeBackendName(name), b, nil
 }
 
 // handleBackendsStatus serves GET /backends/status with live diagnostics.
@@ -845,7 +844,7 @@ func (s *Server) handleBackendsLocal(w http.ResponseWriter, r *http.Request) {
 	if !decodeBody(w, r, s.loadCfg().Daemon.HTTP.MaxBodyBytes, &req) {
 		return
 	}
-	name := config.NormalizeBackendName(req.Name)
+	name := fleet.NormalizeBackendName(req.Name)
 	if name == "" {
 		name = backends.ClaudeLocalName
 	}
@@ -920,7 +919,7 @@ func (s *Server) handleBackendsLocal(w http.ResponseWriter, r *http.Request) {
 }
 
 func backendPathName(r *http.Request) string {
-	name := config.NormalizeBackendName(mux.Vars(r)["name"])
+	name := fleet.NormalizeBackendName(mux.Vars(r)["name"])
 	return name
 }
 
@@ -977,7 +976,7 @@ func (s *Server) handleStoreBackendPatch(w http.ResponseWriter, r *http.Request)
 // Exposed so non-HTTP surfaces (e.g. the MCP update_backend tool) can drive
 // the same path as PATCH /backends/{name} without going through the router.
 func (s *Server) UpdateBackend(name string, patch storeBackendPatchJSON) (string, fleet.Backend, error) {
-	normalized := config.NormalizeBackendName(name)
+	normalized := fleet.NormalizeBackendName(name)
 	s.storeMu.Lock()
 	defer s.storeMu.Unlock()
 	backendsByName, err := store.ReadBackends(s.db)
@@ -995,8 +994,8 @@ func (s *Server) UpdateBackend(name string, patch storeBackendPatchJSON) (string
 	if err := s.reloadCron(); err != nil {
 		return "", fleet.Backend{}, err
 	}
-	config.NormalizeBackendConfig(&existing)
-	config.ApplyBackendDefaults(&existing)
+	fleet.NormalizeBackend(&existing)
+	fleet.ApplyBackendDefaults(&existing)
 	return normalized, existing, nil
 }
 
@@ -1081,7 +1080,7 @@ func (s *Server) UpsertRepo(r fleet.Repo) (fleet.Repo, error) {
 	if err != nil {
 		return fleet.Repo{}, err
 	}
-	config.NormalizeRepoDef(&r)
+	fleet.NormalizeRepo(&r)
 	return r, nil
 }
 
@@ -1095,7 +1094,7 @@ type repoRuntimeSettingsJSON struct {
 // handleStoreRepo serves GET, PATCH, and DELETE /api/store/repos/{owner}/{repo}.
 func (s *Server) handleStoreRepo(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
-	repoName := config.NormalizeRepoName(vars["owner"]) + "/" + config.NormalizeRepoName(vars["repo"])
+	repoName := fleet.NormalizeRepoName(vars["owner"]) + "/" + fleet.NormalizeRepoName(vars["repo"])
 	switch r.Method {
 	case http.MethodGet:
 		repos, err := store.ReadRepos(s.db)
@@ -1137,7 +1136,7 @@ func (s *Server) handleStoreRepo(w http.ResponseWriter, r *http.Request) {
 }
 
 // PatchRepo updates the enabled flag on an existing repo without touching its
-// bindings. Returns the canonical RepoDef (with current bindings) so callers
+// bindings. Returns the canonical Repo (with current bindings) so callers
 // can refresh their view. *ErrNotFound when the repo does not exist.
 func (s *Server) PatchRepo(repoName string, enabled bool) (fleet.Repo, error) {
 	s.storeMu.Lock()
@@ -1204,7 +1203,7 @@ func (s *Server) DeleteRepo(name string) error {
 // repoNameFromVars reconstructs the normalized owner/repo path parameter.
 func repoNameFromVars(r *http.Request) string {
 	vars := mux.Vars(r)
-	return config.NormalizeRepoName(vars["owner"]) + "/" + config.NormalizeRepoName(vars["repo"])
+	return fleet.NormalizeRepoName(vars["owner"]) + "/" + fleet.NormalizeRepoName(vars["repo"])
 }
 
 // bindingIDFromVars parses the {id} path parameter. On error it writes a 400

--- a/internal/webhook/orphans.go
+++ b/internal/webhook/orphans.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/fleet"
 	"github.com/eloylp/agents/internal/store"
 )
 
@@ -114,7 +115,7 @@ func computeOrphanedAgents(cfg *config.Config) []OrphanedAgent {
 			continue
 		}
 		backend, ok := cfg.Daemon.AIBackends[backendName]
-		if !ok || !config.IsPinnedModelUnavailable(agent.Model, backend) {
+		if !ok || !fleet.IsPinnedModelUnavailable(agent.Model, backend) {
 			continue
 		}
 		orphan = append(orphan, OrphanedAgent{

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -516,7 +516,7 @@ func (e *Engine) runAgent(ctx context.Context, ev Event, agent fleet.Agent, cfg 
 	if backend == "" {
 		return fmt.Errorf("agent %q: no runner available for backend %q", agent.Name, agent.Backend)
 	}
-	if backendCfg, ok := cfg.Daemon.AIBackends[backend]; ok && config.IsPinnedModelUnavailable(agent.Model, backendCfg) {
+	if backendCfg, ok := cfg.Daemon.AIBackends[backend]; ok && fleet.IsPinnedModelUnavailable(agent.Model, backendCfg) {
 		return fmt.Errorf(
 			"agent %q: configured model %q is not available for backend %q; run backend discovery and update the agent model",
 			agent.Name,


### PR DESCRIPTION
## Summary
- Move the entity-level helpers (Normalize*, ApplyBackendDefaults, IsPinnedModelUnavailable) from \`internal/config\` into \`internal/fleet\`.
- Drop the legacy \`*Def\` / \`*Config\` suffix on the helper names while moving them.
- \`config.normalize()\` and \`config.applyDefaults()\` now delegate to the fleet helpers so YAML and CRUD paths share one canonical normalisation.

## Why
After #313 moved the entities to \`internal/fleet\`, six packages still imported \`internal/config\` only to reach these helpers. The helpers don't depend on YAML loader state — they're pure functions on fleet types. Keeping them in \`config\` made the config package a hidden domain layer that everything else had to import. This finishes the split:

- \`autonomous\`, \`backends\`, \`mcp\`, \`store\`, \`webhook\`, \`workflow\` no longer import \`internal/config\` for these helpers.
- \`config.go\` shrinks ~150 lines.
- Single source of truth for backend defaults (\`fleet.DefaultAITimeoutSeconds\`, \`fleet.DefaultMaxPromptChars\`).

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./... -race -count=1\` green across all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)