### PR TITLE
refactor: extract webhook.Handler from webhook.Server

### DIFF
--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -1,0 +1,471 @@
+package webhook
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/rs/zerolog"
+
+	"github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/server"
+	"github.com/eloylp/agents/internal/workflow"
+)
+
+// ConfigGetter returns the current effective config. The handler reads it
+// per request so hot-reloaded webhook secrets and routing tables apply
+// without a daemon restart.
+type ConfigGetter interface {
+	Config() *config.Config
+}
+
+// Handler implements the GitHub webhook receiver: HMAC verification,
+// delivery dedupe, and per-event-type parsing into workflow events. It is
+// the single piece of webhook-domain logic in this package after the
+// server lifecycle and routing surface move out.
+//
+// Construct via NewHandler; mount with RegisterRoutes (the path comes from
+// cfg.Daemon.HTTP.WebhookPath). The current Server keeps its own
+// handleGitHubWebhook method as a thin delegate to this type so existing
+// tests that call it directly continue to work.
+type Handler struct {
+	delivery *DeliveryStore
+	channels server.EventQueue
+	cfg      ConfigGetter
+	logger   zerolog.Logger
+}
+
+// NewHandler constructs a Handler. delivery, channels, and cfg are required;
+// logger may be the daemon's root logger (the handler scopes a sub-logger
+// via the standard component label).
+func NewHandler(delivery *DeliveryStore, channels server.EventQueue, cfg ConfigGetter, logger zerolog.Logger) *Handler {
+	return &Handler{
+		delivery: delivery,
+		channels: channels,
+		cfg:      cfg,
+		logger:   logger.With().Str("component", "webhook").Logger(),
+	}
+}
+
+// RegisterRoutes mounts POST {cfg.Daemon.HTTP.WebhookPath} on r. The path
+// is read from cfg at registration time so operators can change it via
+// config without code edits.
+func (h *Handler) RegisterRoutes(r *mux.Router, withTimeout func(http.Handler) http.Handler) {
+	path := h.cfg.Config().Daemon.HTTP.WebhookPath
+	r.Handle(path, withTimeout(http.HandlerFunc(h.handleGitHubWebhook))).Methods(http.MethodPost)
+}
+
+func (h *Handler) handleGitHubWebhook(w http.ResponseWriter, r *http.Request) {
+	cfg := h.cfg.Config()
+	deliveryID := strings.TrimSpace(r.Header.Get("X-GitHub-Delivery"))
+	if deliveryID == "" {
+		http.Error(w, "missing delivery id", http.StatusBadRequest)
+		return
+	}
+
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, cfg.Daemon.HTTP.MaxBodyBytes))
+	if err != nil {
+		http.Error(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+	if !verifySignature(body, cfg.Daemon.HTTP.WebhookSecret, r.Header.Get("X-Hub-Signature-256")) {
+		http.Error(w, "invalid signature", http.StatusUnauthorized)
+		return
+	}
+	// Delivery dedup is checked only after signature verification so
+	// unauthenticated requests cannot poison the dedupe cache.
+	if h.delivery.SeenOrAdd(deliveryID, time.Now()) {
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+
+	event := strings.TrimSpace(r.Header.Get("X-GitHub-Event"))
+	switch event {
+	case "issues":
+		h.handleIssuesEvent(r.Context(), w, body, deliveryID)
+	case "pull_request":
+		h.handlePullRequestEvent(r.Context(), w, body, deliveryID)
+	case "issue_comment":
+		h.handleIssueCommentEvent(r.Context(), w, body, deliveryID)
+	case "pull_request_review":
+		h.handlePullRequestReviewEvent(r.Context(), w, body, deliveryID)
+	case "pull_request_review_comment":
+		h.handlePullRequestReviewCommentEvent(r.Context(), w, body, deliveryID)
+	case "push":
+		h.handlePushEvent(r.Context(), w, body, deliveryID)
+	default:
+		h.logger.Warn().Str("event", event).Str("delivery_id", deliveryID).Msg("unhandled webhook event type")
+		w.WriteHeader(http.StatusAccepted)
+	}
+}
+
+// ─── webhook payload shapes ───────────────────────────────────────────────────
+
+type webhookRepository struct {
+	FullName string `json:"full_name"`
+}
+
+type webhookSender struct {
+	Login string `json:"login"`
+}
+
+type webhookLabel struct {
+	Name string `json:"name"`
+}
+
+type webhookIssue struct {
+	Number      int       `json:"number"`
+	Title       string    `json:"title"`
+	Body        string    `json:"body"`
+	PullRequest *struct{} `json:"pull_request,omitempty"`
+}
+
+type webhookPullRequest struct {
+	Number int    `json:"number"`
+	Title  string `json:"title"`
+	Draft  bool   `json:"draft"`
+	Merged bool   `json:"merged"`
+}
+
+type webhookComment struct {
+	Body string `json:"body"`
+}
+
+type webhookReview struct {
+	Body  string `json:"body"`
+	State string `json:"state"`
+}
+
+// ─── event-type handlers ──────────────────────────────────────────────────────
+
+// handleIssuesEvent handles X-GitHub-Event: issues.
+// For "labeled" actions it filters to AI labels and emits "issues.labeled".
+// For lifecycle actions (opened, edited, reopened, closed) it emits the
+// corresponding "issues.{action}" event.
+// Events from issues that are pull requests (GitHub sends both) are dropped
+// for the "labeled" action; the pull_request event handles those.
+func (h *Handler) handleIssuesEvent(ctx context.Context, w http.ResponseWriter, body []byte, deliveryID string) {
+	cfg := h.cfg.Config()
+	var payload struct {
+		Action     string            `json:"action"`
+		Label      webhookLabel      `json:"label"`
+		Issue      webhookIssue      `json:"issue"`
+		Repository webhookRepository `json:"repository"`
+		Sender     webhookSender     `json:"sender"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+
+	repo, ok := cfg.RepoByName(payload.Repository.FullName)
+	if !ok || !repo.Enabled {
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+
+	repoRef := workflow.RepoRef{FullName: repo.Name, Enabled: repo.Enabled}
+
+	if payload.Issue.PullRequest != nil {
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+
+	switch payload.Action {
+	case "labeled":
+		ev := workflow.Event{
+			ID:     deliveryID,
+			Repo:   repoRef,
+			Kind:   "issues.labeled",
+			Number: payload.Issue.Number,
+			Actor:  payload.Sender.Login,
+			Payload: map[string]any{
+				"label": payload.Label.Name,
+			},
+		}
+		h.enqueue(ctx, w, ev, deliveryID)
+	case "opened", "edited", "reopened", "closed":
+		ev := workflow.Event{
+			ID:     deliveryID,
+			Repo:   repoRef,
+			Kind:   "issues." + payload.Action,
+			Number: payload.Issue.Number,
+			Actor:  payload.Sender.Login,
+			Payload: map[string]any{
+				"title": payload.Issue.Title,
+				"body":  payload.Issue.Body,
+			},
+		}
+		h.enqueue(ctx, w, ev, deliveryID)
+	default:
+		w.WriteHeader(http.StatusAccepted)
+	}
+}
+
+// handlePullRequestEvent handles X-GitHub-Event: pull_request.
+// For "labeled" actions it filters to AI labels (and skips drafts) and emits
+// "pull_request.labeled". For lifecycle actions it emits "pull_request.{action}".
+func (h *Handler) handlePullRequestEvent(ctx context.Context, w http.ResponseWriter, body []byte, deliveryID string) {
+	cfg := h.cfg.Config()
+	var payload struct {
+		Action      string             `json:"action"`
+		Label       webhookLabel       `json:"label"`
+		PullRequest webhookPullRequest `json:"pull_request"`
+		Repository  webhookRepository  `json:"repository"`
+		Sender      webhookSender      `json:"sender"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+
+	repo, ok := cfg.RepoByName(payload.Repository.FullName)
+	if !ok || !repo.Enabled {
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+
+	repoRef := workflow.RepoRef{FullName: repo.Name, Enabled: repo.Enabled}
+
+	switch payload.Action {
+	case "labeled":
+		if payload.PullRequest.Draft {
+			h.logger.Info().Str("repo", repo.Name).Int("number", payload.PullRequest.Number).Msg("pull request skipped, draft")
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		ev := workflow.Event{
+			ID:     deliveryID,
+			Repo:   repoRef,
+			Kind:   "pull_request.labeled",
+			Number: payload.PullRequest.Number,
+			Actor:  payload.Sender.Login,
+			Payload: map[string]any{
+				"label": payload.Label.Name,
+			},
+		}
+		h.enqueue(ctx, w, ev, deliveryID)
+	case "opened", "synchronize", "ready_for_review", "closed":
+		eventPayload := map[string]any{
+			"title": payload.PullRequest.Title,
+			"draft": payload.PullRequest.Draft,
+		}
+		if payload.Action == "closed" {
+			eventPayload["merged"] = payload.PullRequest.Merged
+		}
+		ev := workflow.Event{
+			ID:      deliveryID,
+			Repo:    repoRef,
+			Kind:    "pull_request." + payload.Action,
+			Number:  payload.PullRequest.Number,
+			Actor:   payload.Sender.Login,
+			Payload: eventPayload,
+		}
+		h.enqueue(ctx, w, ev, deliveryID)
+	default:
+		w.WriteHeader(http.StatusAccepted)
+	}
+}
+
+// handleIssueCommentEvent handles X-GitHub-Event: issue_comment.
+// Only "created" actions are forwarded as "issue_comment.created".
+func (h *Handler) handleIssueCommentEvent(ctx context.Context, w http.ResponseWriter, body []byte, deliveryID string) {
+	cfg := h.cfg.Config()
+	var payload struct {
+		Action     string            `json:"action"`
+		Comment    webhookComment    `json:"comment"`
+		Issue      webhookIssue      `json:"issue"`
+		Repository webhookRepository `json:"repository"`
+		Sender     webhookSender     `json:"sender"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+	if payload.Action != "created" {
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+
+	repo, ok := cfg.RepoByName(payload.Repository.FullName)
+	if !ok || !repo.Enabled {
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+
+	ev := workflow.Event{
+		ID:     deliveryID,
+		Repo:   workflow.RepoRef{FullName: repo.Name, Enabled: repo.Enabled},
+		Kind:   "issue_comment.created",
+		Number: payload.Issue.Number,
+		Actor:  payload.Sender.Login,
+		Payload: map[string]any{
+			"body": payload.Comment.Body,
+		},
+	}
+	h.enqueue(ctx, w, ev, deliveryID)
+}
+
+// handlePullRequestReviewEvent handles X-GitHub-Event: pull_request_review.
+// Only "submitted" actions are forwarded as "pull_request_review.submitted".
+func (h *Handler) handlePullRequestReviewEvent(ctx context.Context, w http.ResponseWriter, body []byte, deliveryID string) {
+	cfg := h.cfg.Config()
+	var payload struct {
+		Action      string             `json:"action"`
+		Review      webhookReview      `json:"review"`
+		PullRequest webhookPullRequest `json:"pull_request"`
+		Repository  webhookRepository  `json:"repository"`
+		Sender      webhookSender      `json:"sender"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+	if payload.Action != "submitted" {
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+
+	repo, ok := cfg.RepoByName(payload.Repository.FullName)
+	if !ok || !repo.Enabled {
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+
+	ev := workflow.Event{
+		ID:     deliveryID,
+		Repo:   workflow.RepoRef{FullName: repo.Name, Enabled: repo.Enabled},
+		Kind:   "pull_request_review.submitted",
+		Number: payload.PullRequest.Number,
+		Actor:  payload.Sender.Login,
+		Payload: map[string]any{
+			"state": payload.Review.State,
+			"body":  payload.Review.Body,
+		},
+	}
+	h.enqueue(ctx, w, ev, deliveryID)
+}
+
+// handlePullRequestReviewCommentEvent handles X-GitHub-Event:
+// pull_request_review_comment. Only "created" actions are forwarded as
+// "pull_request_review_comment.created".
+func (h *Handler) handlePullRequestReviewCommentEvent(ctx context.Context, w http.ResponseWriter, body []byte, deliveryID string) {
+	cfg := h.cfg.Config()
+	var payload struct {
+		Action      string             `json:"action"`
+		Comment     webhookComment     `json:"comment"`
+		PullRequest webhookPullRequest `json:"pull_request"`
+		Repository  webhookRepository  `json:"repository"`
+		Sender      webhookSender      `json:"sender"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+	if payload.Action != "created" {
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+
+	repo, ok := cfg.RepoByName(payload.Repository.FullName)
+	if !ok || !repo.Enabled {
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+
+	ev := workflow.Event{
+		ID:     deliveryID,
+		Repo:   workflow.RepoRef{FullName: repo.Name, Enabled: repo.Enabled},
+		Kind:   "pull_request_review_comment.created",
+		Number: payload.PullRequest.Number,
+		Actor:  payload.Sender.Login,
+		Payload: map[string]any{
+			"body": payload.Comment.Body,
+		},
+	}
+	h.enqueue(ctx, w, ev, deliveryID)
+}
+
+// handlePushEvent handles X-GitHub-Event: push.
+func (h *Handler) handlePushEvent(ctx context.Context, w http.ResponseWriter, body []byte, deliveryID string) {
+	cfg := h.cfg.Config()
+	var payload struct {
+		Ref        string            `json:"ref"`
+		After      string            `json:"after"`
+		Repository webhookRepository `json:"repository"`
+		Sender     webhookSender     `json:"sender"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+
+	repo, ok := cfg.RepoByName(payload.Repository.FullName)
+	if !ok || !repo.Enabled {
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+
+	// Ignore branch deletions (After is all-zero SHA) and non-branch refs
+	// (tags, notes). Only "new commit pushed to a branch" maps to push events.
+	const deletedSHA = "0000000000000000000000000000000000000000"
+	if payload.After == deletedSHA || !strings.HasPrefix(payload.Ref, "refs/heads/") {
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+
+	ev := workflow.Event{
+		ID:    deliveryID,
+		Repo:  workflow.RepoRef{FullName: repo.Name, Enabled: repo.Enabled},
+		Kind:  "push",
+		Actor: payload.Sender.Login,
+		Payload: map[string]any{
+			"ref":      payload.Ref,
+			"head_sha": payload.After,
+		},
+	}
+	h.enqueue(ctx, w, ev, deliveryID)
+}
+
+// enqueue pushes ev onto the event queue, handling all error cases.
+func (h *Handler) enqueue(ctx context.Context, w http.ResponseWriter, ev workflow.Event, deliveryID string) {
+	if err := h.channels.PushEvent(ctx, ev); err != nil {
+		if errors.Is(err, workflow.ErrEventQueueFull) {
+			h.delivery.Delete(deliveryID)
+			h.logger.Warn().Str("repo", ev.Repo.FullName).Str("kind", ev.Kind).Msg("event queue full, dropping webhook")
+			http.Error(w, "event queue full, retry later", http.StatusServiceUnavailable)
+			return
+		}
+		if errors.Is(err, workflow.ErrQueueClosed) {
+			h.logger.Warn().Str("repo", ev.Repo.FullName).Msg("queue closed during shutdown, dropping webhook")
+			http.Error(w, "shutting down, retry later", http.StatusServiceUnavailable)
+			return
+		}
+		h.delivery.Delete(deliveryID)
+		http.Error(w, "request cancelled", http.StatusRequestTimeout)
+		return
+	}
+	w.WriteHeader(http.StatusAccepted)
+}
+
+// verifySignature checks the HMAC-SHA256 signature from X-Hub-Signature-256.
+// hmac.Equal is used for the final comparison to avoid timing attacks that
+// could leak information about the expected value through execution time.
+func verifySignature(payload []byte, secret, signature string) bool {
+	signature = strings.TrimPrefix(strings.TrimSpace(signature), "sha256=")
+	if signature == "" || secret == "" {
+		return false
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write(payload)
+	expected := hex.EncodeToString(mac.Sum(nil))
+	return hmac.Equal([]byte(expected), []byte(signature))
+}

--- a/internal/webhook/server.go
+++ b/internal/webhook/server.go
@@ -2,16 +2,12 @@ package webhook
 
 import (
 	"context"
-	"crypto/hmac"
-	"crypto/sha256"
 	"database/sql"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"io"
 	"io/fs"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
 
@@ -34,6 +30,7 @@ type Server struct {
 	delivery      *DeliveryStore
 	logger        zerolog.Logger
 	channels      server.EventQueue
+	h             *Handler // GitHub webhook receiver — owns event parsing, HMAC, dedupe
 	provider      server.StatusProvider
 	runtimeState  server.RuntimeStateProvider // optional; used by /api/agents for live run status
 	dispatchStats server.DispatchStatsProvider
@@ -175,6 +172,11 @@ func NewServer(cfg *config.Config, delivery *DeliveryStore, channels server.Even
 	// effective YAML-loaded snapshot before WithStore wires /export +
 	// /import.
 	s.config = serverconfig.New(s, s, s.logger)
+	// GitHub webhook receiver — pure event-parsing + HMAC + delivery dedupe.
+	// The server delegates handleGitHubWebhook to it so existing tests that
+	// call s.handleGitHubWebhook keep working unchanged; future PRs will
+	// drop that delegate and mount h.RegisterRoutes directly.
+	s.h = NewHandler(delivery, channels, s, logger)
 	if cfg.Daemon.Proxy.Enabled {
 		up := cfg.Daemon.Proxy.Upstream
 		s.proxy = anthropicproxy.NewHandler(anthropicproxy.UpstreamConfig{
@@ -459,410 +461,13 @@ func (s *Server) handleAgentsRun(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// handleGitHubWebhook delegates to the package-internal Handler, which
+// owns HMAC verification, delivery dedupe, and per-event-type parsing.
+// Kept on the Server type so existing tests that call s.handleGitHubWebhook
+// directly continue to work; the route in buildHandler still goes through
+// here for the same reason. A follow-up PR will mount h.RegisterRoutes
+// directly and drop this method.
 func (s *Server) handleGitHubWebhook(w http.ResponseWriter, r *http.Request) {
-	cfg := s.loadCfg()
-	deliveryID := strings.TrimSpace(r.Header.Get("X-GitHub-Delivery"))
-	if deliveryID == "" {
-		http.Error(w, "missing delivery id", http.StatusBadRequest)
-		return
-	}
-
-	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, cfg.Daemon.HTTP.MaxBodyBytes))
-	if err != nil {
-		http.Error(w, "invalid body", http.StatusBadRequest)
-		return
-	}
-	if !verifySignature(body, cfg.Daemon.HTTP.WebhookSecret, r.Header.Get("X-Hub-Signature-256")) {
-		http.Error(w, "invalid signature", http.StatusUnauthorized)
-		return
-	}
-	// Delivery dedup is checked only after signature verification so
-	// unauthenticated requests cannot poison the dedupe cache.
-	if s.delivery.SeenOrAdd(deliveryID, time.Now()) {
-		w.WriteHeader(http.StatusAccepted)
-		return
-	}
-
-	event := strings.TrimSpace(r.Header.Get("X-GitHub-Event"))
-	switch event {
-	case "issues":
-		s.handleIssuesEvent(r.Context(), w, body, deliveryID)
-	case "pull_request":
-		s.handlePullRequestEvent(r.Context(), w, body, deliveryID)
-	case "issue_comment":
-		s.handleIssueCommentEvent(r.Context(), w, body, deliveryID)
-	case "pull_request_review":
-		s.handlePullRequestReviewEvent(r.Context(), w, body, deliveryID)
-	case "pull_request_review_comment":
-		s.handlePullRequestReviewCommentEvent(r.Context(), w, body, deliveryID)
-	case "push":
-		s.handlePushEvent(r.Context(), w, body, deliveryID)
-	default:
-		s.logger.Warn().Str("event", event).Str("delivery_id", deliveryID).Msg("unhandled webhook event type")
-		w.WriteHeader(http.StatusAccepted)
-	}
+	s.h.handleGitHubWebhook(w, r)
 }
 
-// ─── webhook payload shapes ───────────────────────────────────────────────────
-
-type webhookRepository struct {
-	FullName string `json:"full_name"`
-}
-
-type webhookSender struct {
-	Login string `json:"login"`
-}
-
-type webhookLabel struct {
-	Name string `json:"name"`
-}
-
-type webhookIssue struct {
-	Number      int       `json:"number"`
-	Title       string    `json:"title"`
-	Body        string    `json:"body"`
-	PullRequest *struct{} `json:"pull_request,omitempty"`
-}
-
-type webhookPullRequest struct {
-	Number int    `json:"number"`
-	Title  string `json:"title"`
-	Draft  bool   `json:"draft"`
-	Merged bool   `json:"merged"`
-}
-
-type webhookComment struct {
-	Body string `json:"body"`
-}
-
-type webhookReview struct {
-	Body  string `json:"body"`
-	State string `json:"state"`
-}
-
-// ─── event-type handlers ──────────────────────────────────────────────────────
-
-// handleIssuesEvent handles X-GitHub-Event: issues.
-// For "labeled" actions it filters to AI labels and emits "issues.labeled".
-// For lifecycle actions (opened, edited, reopened, closed) it emits the
-// corresponding "issues.{action}" event.
-// Events from issues that are pull requests (GitHub sends both) are dropped
-// for the "labeled" action; the pull_request event handles those.
-func (s *Server) handleIssuesEvent(ctx context.Context, w http.ResponseWriter, body []byte, deliveryID string) {
-	cfg := s.loadCfg()
-	var payload struct {
-		Action     string            `json:"action"`
-		Label      webhookLabel      `json:"label"`
-		Issue      webhookIssue      `json:"issue"`
-		Repository webhookRepository `json:"repository"`
-		Sender     webhookSender     `json:"sender"`
-	}
-	if err := json.Unmarshal(body, &payload); err != nil {
-		http.Error(w, "invalid payload", http.StatusBadRequest)
-		return
-	}
-
-	repo, ok := cfg.RepoByName(payload.Repository.FullName)
-	if !ok || !repo.Enabled {
-		w.WriteHeader(http.StatusAccepted)
-		return
-	}
-
-	repoRef := workflow.RepoRef{FullName: repo.Name, Enabled: repo.Enabled}
-
-	// GitHub sends issues events for PR-backed issues too; the pull_request event
-	// handles those, so drop all issue events that belong to a pull request.
-	if payload.Issue.PullRequest != nil {
-		w.WriteHeader(http.StatusAccepted)
-		return
-	}
-
-	switch payload.Action {
-	case "labeled":
-		ev := workflow.Event{
-			ID:     deliveryID,
-			Repo:   repoRef,
-			Kind:   "issues.labeled",
-			Number: payload.Issue.Number,
-			Actor:  payload.Sender.Login,
-			Payload: map[string]any{
-				"label": payload.Label.Name,
-			},
-		}
-		s.enqueue(ctx, w, ev, deliveryID)
-	case "opened", "edited", "reopened", "closed":
-		ev := workflow.Event{
-			ID:     deliveryID,
-			Repo:   repoRef,
-			Kind:   "issues." + payload.Action,
-			Number: payload.Issue.Number,
-			Actor:  payload.Sender.Login,
-			Payload: map[string]any{
-				"title": payload.Issue.Title,
-				"body":  payload.Issue.Body,
-			},
-		}
-		s.enqueue(ctx, w, ev, deliveryID)
-	default:
-		w.WriteHeader(http.StatusAccepted)
-	}
-}
-
-// handlePullRequestEvent handles X-GitHub-Event: pull_request.
-// For "labeled" actions it filters to AI labels (and skips drafts) and emits
-// "pull_request.labeled". For lifecycle actions it emits "pull_request.{action}".
-func (s *Server) handlePullRequestEvent(ctx context.Context, w http.ResponseWriter, body []byte, deliveryID string) {
-	cfg := s.loadCfg()
-	var payload struct {
-		Action      string             `json:"action"`
-		Label       webhookLabel       `json:"label"`
-		PullRequest webhookPullRequest `json:"pull_request"`
-		Repository  webhookRepository  `json:"repository"`
-		Sender      webhookSender      `json:"sender"`
-	}
-	if err := json.Unmarshal(body, &payload); err != nil {
-		http.Error(w, "invalid payload", http.StatusBadRequest)
-		return
-	}
-
-	repo, ok := cfg.RepoByName(payload.Repository.FullName)
-	if !ok || !repo.Enabled {
-		w.WriteHeader(http.StatusAccepted)
-		return
-	}
-
-	repoRef := workflow.RepoRef{FullName: repo.Name, Enabled: repo.Enabled}
-
-	switch payload.Action {
-	case "labeled":
-		if payload.PullRequest.Draft {
-			s.logger.Info().Str("repo", repo.Name).Int("number", payload.PullRequest.Number).Msg("pull request skipped, draft")
-			w.WriteHeader(http.StatusAccepted)
-			return
-		}
-		ev := workflow.Event{
-			ID:     deliveryID,
-			Repo:   repoRef,
-			Kind:   "pull_request.labeled",
-			Number: payload.PullRequest.Number,
-			Actor:  payload.Sender.Login,
-			Payload: map[string]any{
-				"label": payload.Label.Name,
-			},
-		}
-		s.enqueue(ctx, w, ev, deliveryID)
-	case "opened", "synchronize", "ready_for_review", "closed":
-		eventPayload := map[string]any{
-			"title": payload.PullRequest.Title,
-			"draft": payload.PullRequest.Draft,
-		}
-		if payload.Action == "closed" {
-			eventPayload["merged"] = payload.PullRequest.Merged
-		}
-		ev := workflow.Event{
-			ID:      deliveryID,
-			Repo:    repoRef,
-			Kind:    "pull_request." + payload.Action,
-			Number:  payload.PullRequest.Number,
-			Actor:   payload.Sender.Login,
-			Payload: eventPayload,
-		}
-		s.enqueue(ctx, w, ev, deliveryID)
-	default:
-		w.WriteHeader(http.StatusAccepted)
-	}
-}
-
-// handleIssueCommentEvent handles X-GitHub-Event: issue_comment.
-// Only "created" actions are forwarded as "issue_comment.created".
-func (s *Server) handleIssueCommentEvent(ctx context.Context, w http.ResponseWriter, body []byte, deliveryID string) {
-	cfg := s.loadCfg()
-	var payload struct {
-		Action     string            `json:"action"`
-		Comment    webhookComment    `json:"comment"`
-		Issue      webhookIssue      `json:"issue"`
-		Repository webhookRepository `json:"repository"`
-		Sender     webhookSender     `json:"sender"`
-	}
-	if err := json.Unmarshal(body, &payload); err != nil {
-		http.Error(w, "invalid payload", http.StatusBadRequest)
-		return
-	}
-	if payload.Action != "created" {
-		w.WriteHeader(http.StatusAccepted)
-		return
-	}
-
-	repo, ok := cfg.RepoByName(payload.Repository.FullName)
-	if !ok || !repo.Enabled {
-		w.WriteHeader(http.StatusAccepted)
-		return
-	}
-
-	ev := workflow.Event{
-		ID:     deliveryID,
-		Repo:   workflow.RepoRef{FullName: repo.Name, Enabled: repo.Enabled},
-		Kind:   "issue_comment.created",
-		Number: payload.Issue.Number,
-		Actor:  payload.Sender.Login,
-		Payload: map[string]any{
-			"body": payload.Comment.Body,
-		},
-	}
-	s.enqueue(ctx, w, ev, deliveryID)
-}
-
-// handlePullRequestReviewEvent handles X-GitHub-Event: pull_request_review.
-// Only "submitted" actions are forwarded as "pull_request_review.submitted".
-func (s *Server) handlePullRequestReviewEvent(ctx context.Context, w http.ResponseWriter, body []byte, deliveryID string) {
-	cfg := s.loadCfg()
-	var payload struct {
-		Action      string             `json:"action"`
-		Review      webhookReview      `json:"review"`
-		PullRequest webhookPullRequest `json:"pull_request"`
-		Repository  webhookRepository  `json:"repository"`
-		Sender      webhookSender      `json:"sender"`
-	}
-	if err := json.Unmarshal(body, &payload); err != nil {
-		http.Error(w, "invalid payload", http.StatusBadRequest)
-		return
-	}
-	if payload.Action != "submitted" {
-		w.WriteHeader(http.StatusAccepted)
-		return
-	}
-
-	repo, ok := cfg.RepoByName(payload.Repository.FullName)
-	if !ok || !repo.Enabled {
-		w.WriteHeader(http.StatusAccepted)
-		return
-	}
-
-	ev := workflow.Event{
-		ID:     deliveryID,
-		Repo:   workflow.RepoRef{FullName: repo.Name, Enabled: repo.Enabled},
-		Kind:   "pull_request_review.submitted",
-		Number: payload.PullRequest.Number,
-		Actor:  payload.Sender.Login,
-		Payload: map[string]any{
-			"state": payload.Review.State,
-			"body":  payload.Review.Body,
-		},
-	}
-	s.enqueue(ctx, w, ev, deliveryID)
-}
-
-// handlePullRequestReviewCommentEvent handles X-GitHub-Event: pull_request_review_comment.
-// Only "created" actions are forwarded as "pull_request_review_comment.created".
-func (s *Server) handlePullRequestReviewCommentEvent(ctx context.Context, w http.ResponseWriter, body []byte, deliveryID string) {
-	cfg := s.loadCfg()
-	var payload struct {
-		Action      string             `json:"action"`
-		Comment     webhookComment     `json:"comment"`
-		PullRequest webhookPullRequest `json:"pull_request"`
-		Repository  webhookRepository  `json:"repository"`
-		Sender      webhookSender      `json:"sender"`
-	}
-	if err := json.Unmarshal(body, &payload); err != nil {
-		http.Error(w, "invalid payload", http.StatusBadRequest)
-		return
-	}
-	if payload.Action != "created" {
-		w.WriteHeader(http.StatusAccepted)
-		return
-	}
-
-	repo, ok := cfg.RepoByName(payload.Repository.FullName)
-	if !ok || !repo.Enabled {
-		w.WriteHeader(http.StatusAccepted)
-		return
-	}
-
-	ev := workflow.Event{
-		ID:     deliveryID,
-		Repo:   workflow.RepoRef{FullName: repo.Name, Enabled: repo.Enabled},
-		Kind:   "pull_request_review_comment.created",
-		Number: payload.PullRequest.Number,
-		Actor:  payload.Sender.Login,
-		Payload: map[string]any{
-			"body": payload.Comment.Body,
-		},
-	}
-	s.enqueue(ctx, w, ev, deliveryID)
-}
-
-// handlePushEvent handles X-GitHub-Event: push.
-func (s *Server) handlePushEvent(ctx context.Context, w http.ResponseWriter, body []byte, deliveryID string) {
-	cfg := s.loadCfg()
-	var payload struct {
-		Ref        string            `json:"ref"`
-		After      string            `json:"after"`
-		Repository webhookRepository `json:"repository"`
-		Sender     webhookSender     `json:"sender"`
-	}
-	if err := json.Unmarshal(body, &payload); err != nil {
-		http.Error(w, "invalid payload", http.StatusBadRequest)
-		return
-	}
-
-	repo, ok := cfg.RepoByName(payload.Repository.FullName)
-	if !ok || !repo.Enabled {
-		w.WriteHeader(http.StatusAccepted)
-		return
-	}
-
-	// Ignore branch deletions (After is all-zero SHA) and non-branch refs
-	// (tags, notes). Only "new commit pushed to a branch" maps to push events.
-	const deletedSHA = "0000000000000000000000000000000000000000"
-	if payload.After == deletedSHA || !strings.HasPrefix(payload.Ref, "refs/heads/") {
-		w.WriteHeader(http.StatusAccepted)
-		return
-	}
-
-	ev := workflow.Event{
-		ID:    deliveryID,
-		Repo:  workflow.RepoRef{FullName: repo.Name, Enabled: repo.Enabled},
-		Kind:  "push",
-		Actor: payload.Sender.Login,
-		Payload: map[string]any{
-			"ref":      payload.Ref,
-			"head_sha": payload.After,
-		},
-	}
-	s.enqueue(ctx, w, ev, deliveryID)
-}
-
-// enqueue pushes ev onto the event queue, handling all error cases.
-func (s *Server) enqueue(ctx context.Context, w http.ResponseWriter, ev workflow.Event, deliveryID string) {
-	if err := s.channels.PushEvent(ctx, ev); err != nil {
-		if errors.Is(err, workflow.ErrEventQueueFull) {
-			s.delivery.Delete(deliveryID)
-			s.logger.Warn().Str("repo", ev.Repo.FullName).Str("kind", ev.Kind).Msg("event queue full, dropping webhook")
-			http.Error(w, "event queue full, retry later", http.StatusServiceUnavailable)
-			return
-		}
-		if errors.Is(err, workflow.ErrQueueClosed) {
-			s.logger.Warn().Str("repo", ev.Repo.FullName).Msg("queue closed during shutdown, dropping webhook")
-			http.Error(w, "shutting down, retry later", http.StatusServiceUnavailable)
-			return
-		}
-		s.delivery.Delete(deliveryID)
-		http.Error(w, "request cancelled", http.StatusRequestTimeout)
-		return
-	}
-	w.WriteHeader(http.StatusAccepted)
-}
-
-// verifySignature checks the HMAC-SHA256 signature from X-Hub-Signature-256.
-// hmac.Equal is used for the final comparison to avoid timing attacks that
-// could leak information about the expected value through execution time.
-func verifySignature(payload []byte, secret, signature string) bool {
-	signature = strings.TrimPrefix(strings.TrimSpace(signature), "sha256=")
-	if signature == "" || secret == "" {
-		return false
-	}
-	mac := hmac.New(sha256.New, []byte(secret))
-	_, _ = mac.Write(payload)
-	expected := hex.EncodeToString(mac.Sum(nil))
-	return hmac.Equal([]byte(expected), []byte(signature))
-}


### PR DESCRIPTION
## Summary
- New \`webhook.Handler\` type owns the GitHub-webhook receiver: HMAC verification, delivery dedupe, the 6 event-type parsers, and the \`/webhooks/github\` entry point.
- \`webhook.Server\` keeps a \`*Handler\` field; \`Server.handleGitHubWebhook\` becomes a one-line delegate. No test changes needed.
- \`Handler.RegisterRoutes\` exists but isn't yet wired into \`buildHandler\` — that's deferred to 4b-2 (the lifecycle move).

## Why
Step 4b-1 of the webhook split (#250). The previous attempt tried to move everything in one PR and broke ~hundreds of test call sites. This split lands the **design** first (handler type, ConfigGetter interface, RegisterRoutes shape) without touching any test. Once this lands, 4b-2 can move the HTTP \`Server\` itself to \`internal/server\` and the only churn left is mechanical package renames in test files.

After 4b-1: \`internal/webhook/\` clearly has two halves — \`handler.go\` (the webhook domain) and \`server.go\` (the HTTP lifecycle wrapper that's about to leave).

## Scope
- \`internal/webhook/handler.go\` (new, +469 lines): Handler struct, NewHandler, RegisterRoutes, all event-type methods, payload types, verifySignature, enqueue.
- \`internal/webhook/server.go\` (-395 lines net): keeps the 1-line delegate, drops everything that moved.
- Zero changes outside \`internal/webhook/\`.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./... -race -count=1\` green across every package
- [x] No test files modified — all webhook tests still hit \`s.handleGitHubWebhook\` via the delegate.
- [x] \`verifySignature\` is still a package-level function so the 3 unit tests that call it directly compile unchanged.

## What's next
4b-2: move the HTTP server lifecycle (router, \`With*\` setters, \`Run()\`, \`/status\`, \`/run\`, proxy/UI/MCP mounts) from \`internal/webhook\` into \`internal/server\`. Webhook ends up as a small package containing only \`Handler\`, \`DeliveryStore\`, and their tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)