### PR TITLE
refactor: lift observe handler construction out of webhook.Server

### DIFF
--- a/cmd/agents/main.go
+++ b/cmd/agents/main.go
@@ -6,11 +6,13 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
 
+	"github.com/gorilla/mux"
 	"github.com/joho/godotenv"
 	"github.com/rs/zerolog"
 	"golang.org/x/sync/errgroup"
@@ -24,6 +26,7 @@ import (
 	mcpserver "github.com/eloylp/agents/internal/mcp"
 	"github.com/eloylp/agents/internal/observe"
 	"github.com/eloylp/agents/internal/server"
+	serverobserve "github.com/eloylp/agents/internal/server/observe"
 	"github.com/eloylp/agents/internal/setup"
 	"github.com/eloylp/agents/internal/store"
 	"github.com/eloylp/agents/internal/ui"
@@ -153,7 +156,15 @@ func run() error {
 	// attach an SSE notifier so the UI stream stays live.
 	mem := memBackend.(*sqliteMemory)
 	mem.notifyFn = obs.PublishMemoryChange
-	srv.WithMemoryReader(&sqliteWebhookReader{db: db})
+	memReader := &sqliteWebhookReader{db: db}
+	srv.WithMemoryReader(memReader)
+
+	// Mount the observability routes via a closure so the webhook package
+	// stays free of any internal/server/observe import.
+	srv.WithObserveRegister(func(r *mux.Router, withTimeout func(http.Handler) http.Handler) {
+		obh := serverobserve.New(obs, srv, schedulerStatusAdapter{scheduler}, obs, engine, memReader)
+		obh.RegisterRoutes(r, withTimeout)
+	})
 
 	// Mount the MCP server on /mcp so MCP-capable clients (Claude Code,
 	// Cursor, Cline) can drive the fleet through the tool surface defined

--- a/internal/webhook/api_test.go
+++ b/internal/webhook/api_test.go
@@ -10,12 +10,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gorilla/mux"
 	"github.com/rs/zerolog"
 
 	"github.com/eloylp/agents/internal/config"
 	"github.com/eloylp/agents/internal/fleet"
 	"github.com/eloylp/agents/internal/observe"
 	"github.com/eloylp/agents/internal/server"
+	serverobserve "github.com/eloylp/agents/internal/server/observe"
 	"github.com/eloylp/agents/internal/store"
 	"github.com/eloylp/agents/internal/workflow"
 )
@@ -541,7 +543,7 @@ func TestBuildHandlerSSETimeoutSplit(t *testing.T) {
 	})
 	obs := newTestObserve(t)
 	srv, _ := newTestServer(cfg)
-	srv.WithObserve(obs)
+	wireObserveForTest(srv, obs)
 
 	ts := httptest.NewServer(srv.buildHandler())
 	t.Cleanup(ts.Close)
@@ -618,7 +620,7 @@ func TestServeSSEClearsServerWriteDeadline(t *testing.T) {
 
 	obs := newTestObserve(t)
 	srv, _ := newTestServer(testCfg(nil))
-	srv.WithObserve(obs)
+	wireObserveForTest(srv, obs)
 
 	ts := httptest.NewUnstartedServer(srv.buildHandler())
 	ts.Config.WriteTimeout = 200 * time.Millisecond
@@ -694,4 +696,16 @@ func newTestObserve(t *testing.T) *observe.Store {
 	}
 	t.Cleanup(func() { db.Close() })
 	return observe.NewStore(db)
+}
+
+// wireObserveForTest mounts the observability routes on srv. The observe
+// handler construction lives outside this package now (cmd/agents wires it
+// via WithObserveRegister); tests do the same so the routes are reachable
+// when integration tests exercise the full router.
+func wireObserveForTest(srv *Server, obs *observe.Store) {
+	srv.WithObserve(obs)
+	srv.WithObserveRegister(func(r *mux.Router, withTimeout func(http.Handler) http.Handler) {
+		obh := serverobserve.New(obs, srv, nil, nil, nil, nil)
+		obh.RegisterRoutes(r, withTimeout)
+	})
 }

--- a/internal/webhook/server.go
+++ b/internal/webhook/server.go
@@ -20,7 +20,6 @@ import (
 	"github.com/eloylp/agents/internal/server"
 	serverconfig "github.com/eloylp/agents/internal/server/config"
 	serverfleet "github.com/eloylp/agents/internal/server/fleet"
-	serverobserve "github.com/eloylp/agents/internal/server/observe"
 	serverrepos "github.com/eloylp/agents/internal/server/repos"
 	"github.com/eloylp/agents/internal/workflow"
 )
@@ -42,6 +41,10 @@ type Server struct {
 	cronReloader  server.CronReloader // optional; called after repo/agent writes to reload cron
 	memReader     server.MemoryReader // optional; when set, /api/memory reads from this (SQLite mode)
 	mcp           http.Handler        // optional; when set, /mcp serves this MCP handler
+	// observeRegister mounts the observability routes when set via
+	// WithObserveRegister. cmd/agents constructs the observe handler
+	// externally so this server doesn't import internal/server/observe.
+	observeRegister func(*mux.Router, func(http.Handler) http.Handler)
 	repos         *serverrepos.Handler  // constructed in WithStore; nil until then
 	fleet         *serverfleet.Handler  // constructed in NewServer (cfg-only mode); db wired by WithStore
 	config        *serverconfig.Handler // constructed in NewServer (cfg-only mode); db wired by WithStore
@@ -64,13 +67,22 @@ func (s *Server) WithUI(uiFS fs.FS) {
 	s.uiFS = uiFS
 }
 
-// WithObserve attaches the observability store. When set, the server registers
-// the full suite of /api/events, /api/traces, /api/graph, and /api/memory
-// endpoints. The handlers themselves live in internal/server/observe; this
-// server constructs the package's Handler at buildHandler time and delegates
-// route registration to it.
+// WithObserve stores the observability store reference. Kept for backward
+// compatibility — the observability routes themselves are now mounted via
+// WithObserveRegister, which cmd/agents calls with a closure that
+// constructs the internal/server/observe.Handler. This setter remains a
+// useful place to record the store for surfaces beyond HTTP that need
+// access to it.
 func (s *Server) WithObserve(store *observe.Store) {
 	s.observeStore = store
+}
+
+// WithObserveRegister installs a closure that mounts the observability
+// surface on the router. The composing caller (cmd/agents) constructs the
+// internal/server/observe.Handler externally so this package stays free of
+// any dependency on it.
+func (s *Server) WithObserveRegister(register func(*mux.Router, func(http.Handler) http.Handler)) {
+	s.observeRegister = register
 }
 
 // WithRuntimeState attaches an optional runtime-state provider used by
@@ -244,11 +256,11 @@ func (s *Server) buildHandler() http.Handler {
 		s.repos.RegisterRoutes(router, withTimeout)
 	}
 
-	// Observability surface lives in its own package; routes are registered
-	// only when the observability store has been attached.
-	if s.observeStore != nil {
-		obh := serverobserve.New(s.observeStore, s, s.provider, s.runtimeState, s.dispatchStats, s.memReader)
-		obh.RegisterRoutes(router, withTimeout)
+	// Observability surface lives in its own package; the composing caller
+	// (cmd/agents, or a test helper) constructs the handler and supplies a
+	// closure via WithObserveRegister.
+	if s.observeRegister != nil {
+		s.observeRegister(router, withTimeout)
 	}
 
 	s.config.RegisterRoutes(router, withTimeout)

--- a/internal/webhook/server_test.go
+++ b/internal/webhook/server_test.go
@@ -743,7 +743,7 @@ func TestBuildHandlerObservabilityRoutesAreOpen(t *testing.T) {
 
 	srv, _ := newTestServer(testCfg(nil))
 	srv.WithUI(uiFS)
-	srv.WithObserve(newTestObserve(t))
+	wireObserveForTest(srv, newTestObserve(t))
 
 	ts := httptest.NewServer(srv.buildHandler())
 	t.Cleanup(ts.Close)


### PR DESCRIPTION
## Summary
- \`webhook.Server\` stops constructing the \`internal/server/observe.Handler\` internally.
- New \`Server.WithObserveRegister(register func(...))\` setter; \`buildHandler\` invokes the registered closure when set.
- \`cmd/agents\` builds the observe handler externally and wires it via the closure.
- Three webhook tests that exercise observability routes use a new \`wireObserveForTest(srv, obs)\` helper that mirrors what cmd/agents does.

## Why
Step 4b-2a-1 of the webhook split (#250). \`webhook.Server\` currently imports four sub-packages (\`server/fleet\`, \`server/repos\`, \`server/config\`, \`server/observe\`) to construct their handlers. Those imports block moving the Server type into \`internal/server\` because it would create a cycle (server → server/X → server). This PR lifts the **simplest one** (observe — narrow API, no cross-domain hooks) out, validating the pattern before doing the harder ones.

After this PR, three sub-package imports remain in webhook. Follow-up PRs will lift each one with the same closure-injection shape.

## Scope
- \`internal/webhook/server.go\`: -1 import, +1 field (\`observeRegister\` closure), +1 setter, replaced inline construction with closure invocation.
- \`cmd/agents/main.go\`: imports \`serverobserve\`, \`mux\`, \`net/http\`; one new \`WithObserveRegister\` call.
- \`internal/webhook/api_test.go\`: new \`wireObserveForTest\` helper; two existing tests updated to call it.
- \`internal/webhook/server_test.go\`: one existing test updated to call \`wireObserveForTest\`.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./... -race -count=1\` green
- [x] All three observe-route tests in webhook still pass after the wiring change.

## What's next
4b-2a-2: lift fleet handler construction (the trickiest — has cross-domain hooks for \`/agents\` dispatch and \`/status\` orphan summary).
4b-2a-3: lift repos handler.
4b-2a-4: lift config handler.
4b-2b: \`git mv\` \`internal/webhook/server.go\` → \`internal/server/server.go\`. Mechanical at that point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)