### PR TITLE
refactor: lift fleet handler construction out of webhook.Server

### DIFF
--- a/cmd/agents/main.go
+++ b/cmd/agents/main.go
@@ -26,6 +26,7 @@ import (
 	mcpserver "github.com/eloylp/agents/internal/mcp"
 	"github.com/eloylp/agents/internal/observe"
 	"github.com/eloylp/agents/internal/server"
+	serverfleet "github.com/eloylp/agents/internal/server/fleet"
 	serverobserve "github.com/eloylp/agents/internal/server/observe"
 	"github.com/eloylp/agents/internal/setup"
 	"github.com/eloylp/agents/internal/store"
@@ -152,6 +153,24 @@ func run() error {
 	srv.WithRuntimeState(obs)
 	srv.WithStore(db, scheduler)
 
+	// Construct the fleet handler externally and wire it via WithFleet so
+	// the webhook package stays free of any internal/server/fleet import.
+	fleetHandler := serverfleet.New(srv, srv, schedulerStatusAdapter{scheduler}, obs, logger)
+	fleetHandler.SetDB(db)
+	fleetHandler.RefreshOrphansFromCfg(cfg)
+	srv.WithFleet(
+		fleetHandler,
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodGet {
+				fleetHandler.HandleAgentsView(w, r)
+				return
+			}
+			fleetHandler.HandleAgentsCreate(w, r)
+		},
+		fleetOrphansAdapter{fleetHandler},
+		fleetHandler.RefreshOrphansFromCfg,
+	)
+
 	// Wire the memory backend into the server for the /memory endpoint and
 	// attach an SSE notifier so the UI stream stays live.
 	mem := memBackend.(*sqliteMemory)
@@ -181,9 +200,9 @@ func run() error {
 		Memory:        &sqliteMcpReader{db: db},
 		ConfigBytes:   srv.Cfg(),
 		ConfigImport:  srv.Cfg(),
-		AgentWrite:    srv.Fleet(),
-		SkillWrite:    srv.Fleet(),
-		BackendWrite:  srv.Fleet(),
+		AgentWrite:    fleetHandler,
+		SkillWrite:    fleetHandler,
+		BackendWrite:  fleetHandler,
 		RepoWrite:     srv.Repos(),
 		BindingWrite:  srv.Repos(),
 		Logger:        logger,
@@ -378,4 +397,24 @@ func (a schedulerStatusAdapter) AgentStatuses() []server.AgentStatus {
 		out[i] = server.AgentStatus(s)
 	}
 	return out
+}
+
+// fleetOrphansAdapter bridges serverfleet.Handler's concrete orphan snapshot
+// type to the cross-package server.OrphansSnapshot shape /status uses, so
+// the webhook server doesn't need to import internal/server/fleet.
+type fleetOrphansAdapter struct {
+	h *serverfleet.Handler
+}
+
+func (a fleetOrphansAdapter) OrphansSnapshot() server.OrphansSnapshot {
+	snap := a.h.OrphansSnapshot()
+	return server.OrphansSnapshot{GeneratedAt: snap.GeneratedAt, Count: snap.Count}
+}
+
+func (a fleetOrphansAdapter) RefreshOrphansFromDB() (server.OrphansSnapshot, error) {
+	snap, err := a.h.RefreshOrphansFromDB()
+	if err != nil {
+		return server.OrphansSnapshot{}, err
+	}
+	return server.OrphansSnapshot{GeneratedAt: snap.GeneratedAt, Count: snap.Count}, nil
 }

--- a/internal/server/types.go
+++ b/internal/server/types.go
@@ -11,7 +11,10 @@ package server
 import (
 	"context"
 	"errors"
+	"net/http"
 	"time"
+
+	"github.com/gorilla/mux"
 
 	"github.com/eloylp/agents/internal/fleet"
 	"github.com/eloylp/agents/internal/workflow"
@@ -72,6 +75,32 @@ var ErrMemoryNotFound = errors.New("server: memory not found")
 // X-Memory-Mtime response header; a zero value means the timestamp is unknown.
 type MemoryReader interface {
 	ReadMemory(agent, repo string) (string, time.Time, error)
+}
+
+// HandlerRegister is the shape every domain handler package satisfies so
+// the composing server can mount its routes uniformly. fleet, repos,
+// config, observe, and the GitHub webhook handler each provide a concrete
+// *Handler that implements RegisterRoutes with this signature.
+type HandlerRegister interface {
+	RegisterRoutes(r *mux.Router, withTimeout func(http.Handler) http.Handler)
+}
+
+// OrphansSnapshot is the cross-package summary the /status endpoint surfaces
+// for the orphan cache. It mirrors the shape of fleet.OrphanedAgentsSnapshot
+// without dragging the fleet package into the composing server's import
+// graph; the fleet handler adapts its concrete type to this one via a small
+// bridge constructed by cmd/agents.
+type OrphansSnapshot struct {
+	GeneratedAt time.Time
+	Count       int
+}
+
+// OrphansSource is implemented by the fleet handler. The composing server
+// queries it during /status assembly and via the route at
+// /agents/orphans/status (handled directly by the fleet package).
+type OrphansSource interface {
+	OrphansSnapshot() OrphansSnapshot
+	RefreshOrphansFromDB() (OrphansSnapshot, error)
 }
 
 // WriteCoordinator runs a CRUD write under the same lock that protects the

--- a/internal/webhook/api_test.go
+++ b/internal/webhook/api_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
-	"github.com/rs/zerolog"
 
 	"github.com/eloylp/agents/internal/config"
 	"github.com/eloylp/agents/internal/fleet"
@@ -19,7 +18,6 @@ import (
 	"github.com/eloylp/agents/internal/server"
 	serverobserve "github.com/eloylp/agents/internal/server/observe"
 	"github.com/eloylp/agents/internal/store"
-	"github.com/eloylp/agents/internal/workflow"
 )
 
 // ── /api/agents ────────────────────────────────────────────────────────────
@@ -98,11 +96,10 @@ func TestHandleAPIAgentsAttachesScheduleForCronBindings(t *testing.T) {
 			},
 		}
 	})
-	dc := workflow.NewDataChannels(1)
 	provider := &stubStatusProvider{statuses: []server.AgentStatus{
 		{Name: "worker", Repo: "owner/repo", LastRun: &now, NextRun: next, LastStatus: "ok"},
 	}}
-	srv := NewServer(cfg, NewDeliveryStore(time.Hour), dc, provider, nil, zerolog.Nop())
+	srv, _ := newTestServerWithProvider(cfg, provider)
 
 	req := httptest.NewRequest(http.MethodGet, "/agents", nil)
 	rec := httptest.NewRecorder()
@@ -154,12 +151,11 @@ func TestHandleAPIAgentsMultiRepoSchedulePreserved(t *testing.T) {
 			},
 		}
 	})
-	dc := workflow.NewDataChannels(1)
 	provider := &stubStatusProvider{statuses: []server.AgentStatus{
 		{Name: "worker", Repo: "owner/repo-a", LastRun: &now, NextRun: next1, LastStatus: "ok"},
 		{Name: "worker", Repo: "owner/repo-b", NextRun: next2, LastStatus: "pending"},
 	}}
-	srv := NewServer(cfg, NewDeliveryStore(time.Hour), dc, provider, nil, zerolog.Nop())
+	srv, _ := newTestServerWithProvider(cfg, provider)
 
 	req := httptest.NewRequest(http.MethodGet, "/agents", nil)
 	rec := httptest.NewRecorder()
@@ -310,8 +306,10 @@ func TestHandleAPIAgentsCurrentStatusRunningWhenActive(t *testing.T) {
 	cfg := testCfg(func(c *config.Config) {
 		c.Agents = []fleet.Agent{{Name: "coder", Backend: "claude"}}
 	})
-	srv, _ := newTestServer(cfg)
-	srv.WithRuntimeState(&stubRuntimeState{running: map[string]bool{"coder": true}})
+	srv, _, fleetHandler := newTestServerExposingFleet(cfg, nil)
+	rs := &stubRuntimeState{running: map[string]bool{"coder": true}}
+	srv.WithRuntimeState(rs)
+	fleetHandler.SetRuntimeState(rs)
 
 	req := httptest.NewRequest(http.MethodGet, "/agents", nil)
 	rec := httptest.NewRecorder()

--- a/internal/webhook/crud.go
+++ b/internal/webhook/crud.go
@@ -80,7 +80,9 @@ func (s *Server) reloadCron() error {
 	newCfg.Daemon.AIBackends = backends
 	s.cfg = &newCfg
 	s.cfgMu.Unlock()
-	s.fleet.RefreshOrphansFromCfg(&newCfg)
+	if s.onConfigReload != nil {
+		s.onConfigReload(&newCfg)
+	}
 
 	return nil
 }

--- a/internal/webhook/crud_test.go
+++ b/internal/webhook/crud_test.go
@@ -23,7 +23,9 @@ import (
 )
 
 // openCRUDTestServer creates a test server wired with an in-memory SQLite
-// store.
+// store. Mirrors the wiring cmd/agents performs: NewServer + WithStore +
+// fleet handler attached via WithFleet (with SetDB invoked after the
+// store is open).
 func openCRUDTestServer(t *testing.T) *Server {
 	t.Helper()
 	dir := t.TempDir()
@@ -35,8 +37,11 @@ func openCRUDTestServer(t *testing.T) *Server {
 
 	cfg := crudMinimalConfig()
 	dc := workflow.NewDataChannels(1)
-	s := NewServer(cfg, NewDeliveryStore(0), dc, nil, nil, zerolog.Nop())
+	logger := zerolog.Nop()
+	s := NewServer(cfg, NewDeliveryStore(0), dc, nil, nil, logger)
 	s.WithStore(db, nil) // nil reloader — cron hot-reload not exercised here
+	fleetHandler := wireFleetForTest(s, cfg, nil, logger)
+	fleetHandler.SetDB(db)
 	return s
 }
 
@@ -869,8 +874,11 @@ func openCRUDTestServerWithReloader(t *testing.T, reloader server.CronReloader) 
 
 	cfg := crudMinimalConfig()
 	dc := workflow.NewDataChannels(1)
-	s := NewServer(cfg, NewDeliveryStore(0), dc, nil, nil, zerolog.Nop())
+	logger := zerolog.Nop()
+	s := NewServer(cfg, NewDeliveryStore(0), dc, nil, nil, logger)
 	s.WithStore(db, reloader)
+	fleetHandler := wireFleetForTest(s, cfg, nil, logger)
+	fleetHandler.SetDB(db)
 	return s
 }
 
@@ -1021,8 +1029,11 @@ func TestStoreCRUDPostBodySizeLimit(t *testing.T) {
 	t.Cleanup(func() { db.Close() })
 
 	dc := workflow.NewDataChannels(1)
-	s := NewServer(cfg, NewDeliveryStore(0), dc, nil, nil, zerolog.Nop())
+	logger := zerolog.Nop()
+	s := NewServer(cfg, NewDeliveryStore(0), dc, nil, nil, logger)
 	s.WithStore(db, nil)
+	fleetHandler := wireFleetForTest(s, cfg, nil, logger)
+	fleetHandler.SetDB(db)
 
 	tests := []struct {
 		name string
@@ -1080,8 +1091,11 @@ func TestStoreCRUDPostBodyTrailingGarbageRejected(t *testing.T) {
 	t.Cleanup(func() { db.Close() })
 
 	dc := workflow.NewDataChannels(1)
-	s := NewServer(cfg, NewDeliveryStore(0), dc, nil, nil, zerolog.Nop())
+	logger := zerolog.Nop()
+	s := NewServer(cfg, NewDeliveryStore(0), dc, nil, nil, logger)
 	s.WithStore(db, nil)
+	fleetHandler := wireFleetForTest(s, cfg, nil, logger)
+	fleetHandler.SetDB(db)
 
 	endpoints := []string{
 		"/agents",

--- a/internal/webhook/server.go
+++ b/internal/webhook/server.go
@@ -19,7 +19,6 @@ import (
 	"github.com/eloylp/agents/internal/observe"
 	"github.com/eloylp/agents/internal/server"
 	serverconfig "github.com/eloylp/agents/internal/server/config"
-	serverfleet "github.com/eloylp/agents/internal/server/fleet"
 	serverrepos "github.com/eloylp/agents/internal/server/repos"
 	"github.com/eloylp/agents/internal/workflow"
 )
@@ -45,9 +44,16 @@ type Server struct {
 	// WithObserveRegister. cmd/agents constructs the observe handler
 	// externally so this server doesn't import internal/server/observe.
 	observeRegister func(*mux.Router, func(http.Handler) http.Handler)
-	repos         *serverrepos.Handler  // constructed in WithStore; nil until then
-	fleet         *serverfleet.Handler  // constructed in NewServer (cfg-only mode); db wired by WithStore
-	config        *serverconfig.Handler // constructed in NewServer (cfg-only mode); db wired by WithStore
+	// fleet is the registered fleet handler. cmd/agents constructs the
+	// concrete *internal/server/fleet.Handler externally and supplies it
+	// (along with cross-domain hooks below) via WithFleet so this package
+	// stays free of any dependency on internal/server/fleet.
+	fleet            server.HandlerRegister
+	agentsDispatcher http.HandlerFunc                                 // GET vs POST /agents — supplied by WithFleet
+	orphansSource    server.OrphansSource                             // /status orphan summary — supplied by WithFleet
+	onConfigReload   func(*config.Config)                             // reloadCron post-hook — supplied by WithFleet
+	repos            *serverrepos.Handler                             // constructed in WithStore; nil until then
+	config           *serverconfig.Handler                            // constructed in NewServer (cfg-only mode); db wired by WithStore
 	// storeMu serializes the "DB write → snapshot read → in-memory Reload"
 	// sequence so that concurrent write requests cannot interleave their
 	// snapshots and leave the scheduler in a stale or inconsistent state.
@@ -85,46 +91,47 @@ func (s *Server) WithObserveRegister(register func(*mux.Router, func(http.Handle
 	s.observeRegister = register
 }
 
-// WithRuntimeState attaches an optional runtime-state provider used by
-// /api/agents to report which agents are currently running.
+// WithRuntimeState records an optional runtime-state provider on the server.
+// It is no longer forwarded to the fleet handler — cmd/agents calls
+// fleetHandler.SetRuntimeState directly before WithFleet so the wiring stays
+// in one place.
 func (s *Server) WithRuntimeState(rsp server.RuntimeStateProvider) {
 	s.runtimeState = rsp
-	if s.fleet != nil {
-		s.fleet.SetRuntimeState(rsp)
-	}
 }
 
-// WithStore attaches a SQLite database and an optional CronReloader.
-// When set, the server registers /api/store/* CRUD endpoints for agents,
-// skills, backends, and repos. Writes to repos or agents also call
-// r.Reload so that cron schedules take effect immediately. r may be nil
-// if hot-reload is not needed.
-//
-// WithStore also wires the database into the per-domain handlers so their
-// CRUD routes (which were skipped at construction time when no database was
-// attached) become available, and constructs the repos handler.
+// WithStore attaches a SQLite database and an optional CronReloader. The
+// database backs reloadCron and is forwarded to the still-locally-owned
+// repos and config handlers. The fleet handler is wired externally by
+// cmd/agents (which calls SetDB on it directly before WithFleet), so this
+// method no longer touches it.
 func (s *Server) WithStore(db *sql.DB, r server.CronReloader) {
 	s.db = db
 	s.cronReloader = r
 	s.repos = serverrepos.New(db, s, s, s.logger)
-	if s.fleet != nil {
-		s.fleet.SetDB(db)
-	}
 	if s.config != nil {
 		s.config.SetDB(db)
 	}
+}
+
+// WithFleet registers the fleet handler and the three hooks the composing
+// server needs from it: the GET-vs-POST dispatcher for /agents, the orphan
+// snapshot source used by /status, and the post-reload callback that
+// refreshes the orphan cache after every CRUD write.
+//
+// cmd/agents constructs the concrete internal/server/fleet.Handler and
+// supplies thin adapters here so this package stays free of any
+// internal/server/fleet import.
+func (s *Server) WithFleet(h server.HandlerRegister, dispatcher http.HandlerFunc, orphans server.OrphansSource, onReload func(*config.Config)) {
+	s.fleet = h
+	s.agentsDispatcher = dispatcher
+	s.orphansSource = orphans
+	s.onConfigReload = onReload
 }
 
 // Repos returns the repos handler so the daemon's MCP wiring can satisfy the
 // mcp.RepoWriter and mcp.BindingWriter interfaces with the same instance the
 // HTTP router uses. Nil when WithStore has not been called.
 func (s *Server) Repos() *serverrepos.Handler { return s.repos }
-
-// Fleet returns the fleet (agents/skills/backends) handler so the daemon's
-// MCP wiring can satisfy the mcp.AgentWriter, mcp.SkillWriter, and
-// mcp.BackendWriter interfaces with the same instance the HTTP router uses.
-// Nil when WithStore has not been called.
-func (s *Server) Fleet() *serverfleet.Handler { return s.fleet }
 
 // Cfg returns the config handler so the daemon's MCP wiring can satisfy the
 // mcp.ConfigBytes / mcp.ConfigImporter interfaces with the same instance the
@@ -174,15 +181,10 @@ func NewServer(cfg *config.Config, delivery *DeliveryStore, channels server.Even
 		dispatchStats: dispatchStats,
 		startTime:     time.Now(),
 	}
-	// Construct the fleet handler upfront so the orphan cache and fleet
-	// snapshot view work in cfg-only mode (e.g. tests that never call
-	// WithStore). The database is wired later by WithStore; until then the
-	// CRUD routes are skipped at registration time.
-	s.fleet = serverfleet.New(s, s, provider, nil, s.logger)
-	s.fleet.RefreshOrphansFromCfg(cfg)
-	// Config handler also boots in cfg-only mode so /config serves the
+	// Config handler boots in cfg-only mode so /config serves the
 	// effective YAML-loaded snapshot before WithStore wires /export +
-	// /import.
+	// /import. Fleet is wired externally (see WithFleet) by cmd/agents
+	// so this package no longer imports internal/server/fleet.
 	s.config = serverconfig.New(s, s, s.logger)
 	// GitHub webhook receiver — pure event-parsing + HMAC + delivery dedupe.
 	// The server delegates handleGitHubWebhook to it so existing tests that
@@ -247,11 +249,11 @@ func (s *Server) buildHandler() http.Handler {
 	// fleet handler for both.
 	router.Handle("/agents", withTimeout(http.HandlerFunc(s.handleAgents))).Methods(http.MethodGet, http.MethodPost)
 
-	// Domain handler packages own their routes. Fleet always exists (the
-	// orphan cache and snapshot view work in cfg-only mode); its CRUD
-	// routes self-skip when no database is attached. Repos is only present
-	// once WithStore has wired the database.
-	s.fleet.RegisterRoutes(router, withTimeout)
+	// Domain handler packages own their routes. Fleet is wired via
+	// WithFleet by the composing caller; repos is wired by WithStore.
+	if s.fleet != nil {
+		s.fleet.RegisterRoutes(router, withTimeout)
+	}
 	if s.repos != nil {
 		s.repos.RegisterRoutes(router, withTimeout)
 	}
@@ -304,15 +306,14 @@ func (s *Server) buildHandler() http.Handler {
 }
 
 // handleAgents dispatches GET to the fleet snapshot view and POST to the
-// fleet handler's CRUD create. Both delegate to the same handler so the
-// composing server keeps a single mux entry for /agents.
+// fleet handler's CRUD create. The dispatcher closure is supplied by
+// WithFleet so this package doesn't import internal/server/fleet.
 func (s *Server) handleAgents(w http.ResponseWriter, r *http.Request) {
-	switch r.Method {
-	case http.MethodGet:
-		s.fleet.HandleAgentsView(w, r)
-	case http.MethodPost:
-		s.fleet.HandleAgentsCreate(w, r)
+	if s.agentsDispatcher == nil {
+		http.NotFound(w, r)
+		return
 	}
+	s.agentsDispatcher(w, r)
 }
 
 func (s *Server) Run(ctx context.Context) error {
@@ -391,18 +392,18 @@ func (s *Server) buildStatus() statusJSON {
 		},
 		Agents: agents,
 	}
-	orphans := s.fleet.OrphansSnapshot()
-	if fresh, err := s.fleet.RefreshOrphansFromDB(); err != nil {
-		s.logger.Warn().Err(err).Msg("status: orphan snapshot refresh failed")
-	} else {
-		orphans = fresh
-	}
-	resp.OrphanedAgents = statusOrphanSummaryJSON{
-		Count: orphans.Count,
-	}
-	if !orphans.GeneratedAt.IsZero() {
-		at := orphans.GeneratedAt
-		resp.OrphanedAgents.UpdatedAt = &at
+	if s.orphansSource != nil {
+		orphans := s.orphansSource.OrphansSnapshot()
+		if fresh, err := s.orphansSource.RefreshOrphansFromDB(); err != nil {
+			s.logger.Warn().Err(err).Msg("status: orphan snapshot refresh failed")
+		} else {
+			orphans = fresh
+		}
+		resp.OrphanedAgents = statusOrphanSummaryJSON{Count: orphans.Count}
+		if !orphans.GeneratedAt.IsZero() {
+			at := orphans.GeneratedAt
+			resp.OrphanedAgents.UpdatedAt = &at
+		}
 	}
 	if s.dispatchStats != nil {
 		stats := s.dispatchStats.DispatchStats()

--- a/internal/webhook/server_test.go
+++ b/internal/webhook/server_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/eloylp/agents/internal/config"
 	"github.com/eloylp/agents/internal/fleet"
 	"github.com/eloylp/agents/internal/server"
+	serverfleet "github.com/eloylp/agents/internal/server/fleet"
 	"github.com/eloylp/agents/internal/workflow"
 )
 
@@ -50,8 +51,68 @@ func signatureForTests(body []byte, secret string) string {
 }
 
 func newTestServer(cfg *config.Config) (*Server, *workflow.DataChannels) {
+	return newTestServerWithProvider(cfg, nil)
+}
+
+// newTestServerWithProvider mirrors what cmd/agents wires: a Server plus a
+// fleet handler attached via WithFleet. Tests that need a custom status
+// provider use this directly; tests that don't go through newTestServer.
+func newTestServerWithProvider(cfg *config.Config, provider server.StatusProvider) (*Server, *workflow.DataChannels) {
+	srv, dc, _ := newTestServerExposingFleet(cfg, provider)
+	return srv, dc
+}
+
+// newTestServerExposingFleet is the variant for tests that need to call
+// methods on the fleet handler directly (e.g. SetRuntimeState after the
+// fact, or assertions on the orphan cache).
+func newTestServerExposingFleet(cfg *config.Config, provider server.StatusProvider) (*Server, *workflow.DataChannels, *serverfleet.Handler) {
 	dc := workflow.NewDataChannels(1)
-	return NewServer(cfg, NewDeliveryStore(time.Hour), dc, nil, nil, zerolog.Nop()), dc
+	logger := zerolog.Nop()
+	srv := NewServer(cfg, NewDeliveryStore(time.Hour), dc, provider, nil, logger)
+	fleetHandler := wireFleetForTest(srv, cfg, provider, logger)
+	return srv, dc, fleetHandler
+}
+
+// wireFleetForTest constructs a fleet handler in cfg-only mode and attaches
+// it to srv via WithFleet, mirroring the wiring cmd/agents performs. Used
+// by every test helper that exercises the full router. Returns the handler
+// so CRUD-mode helpers can SetDB on it after WithStore.
+func wireFleetForTest(srv *Server, cfg *config.Config, provider server.StatusProvider, logger zerolog.Logger) *serverfleet.Handler {
+	fleetHandler := serverfleet.New(srv, srv, provider, nil, logger)
+	fleetHandler.RefreshOrphansFromCfg(cfg)
+	srv.WithFleet(
+		fleetHandler,
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodGet {
+				fleetHandler.HandleAgentsView(w, r)
+				return
+			}
+			fleetHandler.HandleAgentsCreate(w, r)
+		},
+		fleetOrphansBridge{fleetHandler},
+		fleetHandler.RefreshOrphansFromCfg,
+	)
+	return fleetHandler
+}
+
+// fleetOrphansBridge converts serverfleet.Handler's concrete orphan
+// snapshot type to the cross-package server.OrphansSnapshot shape /status
+// uses, mirroring the adapter cmd/agents installs.
+type fleetOrphansBridge struct {
+	h *serverfleet.Handler
+}
+
+func (b fleetOrphansBridge) OrphansSnapshot() server.OrphansSnapshot {
+	snap := b.h.OrphansSnapshot()
+	return server.OrphansSnapshot{GeneratedAt: snap.GeneratedAt, Count: snap.Count}
+}
+
+func (b fleetOrphansBridge) RefreshOrphansFromDB() (server.OrphansSnapshot, error) {
+	snap, err := b.h.RefreshOrphansFromDB()
+	if err != nil {
+		return server.OrphansSnapshot{}, err
+	}
+	return server.OrphansSnapshot{GeneratedAt: snap.GeneratedAt, Count: snap.Count}, nil
 }
 
 // webhookRequest builds a signed POST request to /webhooks/github.


### PR DESCRIPTION
## Summary
- \`webhook.Server\` stops constructing \`internal/server/fleet.Handler\` internally; \`cmd/agents\` builds it externally and wires it via the new \`WithFleet(handler, dispatcher, orphans, onReload)\` method.
- Three new cross-package shapes in \`internal/server/types.go\`: \`HandlerRegister\` (mux-mounting contract), \`OrphansSnapshot\`, and \`OrphansSource\` — the bridge types so the composing server queries fleet without importing it.
- \`Server.Fleet()\` accessor is gone; cmd/agents uses its local \`fleetHandler\` reference for MCP wiring.
- Webhook tests get \`wireFleetForTest\` + \`fleetOrphansBridge\` helpers that mirror cmd/agents' wiring. Three view tests and four CRUD tests use them.

## Why
Step 4b-2a-2 of the webhook split (#250). After #320 lifted observe out, this is the trickiest of the four sub-package extractions because the fleet handler has 4 cross-domain hooks the composing server uses (vs. observe's 1). Solving it here validates the closure+adapter pattern for the remaining two (repos, config) which are simpler.

After this PR, \`internal/webhook\` no longer imports \`internal/server/fleet\`. Two sub-package imports remain (\`server/repos\`, \`server/config\`) — the next two PRs lift each, then 4b-2b is a near-mechanical \`git mv\`.

## Scope
- \`internal/server/types.go\`: +29 lines (three new types + their imports).
- \`internal/webhook/server.go\`: -1 import (serverfleet), refactored Server struct, replaced typed-method calls with closures/interface dispatch.
- \`internal/webhook/crud.go\`: 1-line change in \`reloadCron\` to call \`onConfigReload\` closure.
- \`cmd/agents/main.go\`: +1 import (serverfleet), +1 adapter struct (\`fleetOrphansAdapter\`), reworked fleet wiring before MCP.
- \`internal/webhook/server_test.go\`: +1 import (serverfleet), new helpers (\`wireFleetForTest\`, \`fleetOrphansBridge\`, \`newTestServerExposingFleet\`).
- \`internal/webhook/crud_test.go\`: \`openCRUDTestServer\`, \`openCRUDTestServerWithReloader\`, and two body-limit tests call the new helpers.
- \`internal/webhook/api_test.go\`: three /agents-view tests use \`newTestServerWithProvider\`; one runtime-state test uses \`newTestServerExposingFleet\`.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./... -race -count=1\` green across every package

## What's next
- 4b-2a-3: lift repos handler — same pattern, simpler (just \`HandlerRegister\` + \`SetDB\`).
- 4b-2a-4: lift config handler — same pattern.
- 4b-2b: \`git mv internal/webhook/server.go internal/server/server.go\` plus package rename + test moves. Should be mechanical at that point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)