### PR TITLE
refactor: lift repos handler construction out of webhook.Server

### DIFF
--- a/cmd/agents/main.go
+++ b/cmd/agents/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/eloylp/agents/internal/server"
 	serverfleet "github.com/eloylp/agents/internal/server/fleet"
 	serverobserve "github.com/eloylp/agents/internal/server/observe"
+	serverrepos "github.com/eloylp/agents/internal/server/repos"
 	"github.com/eloylp/agents/internal/setup"
 	"github.com/eloylp/agents/internal/store"
 	"github.com/eloylp/agents/internal/ui"
@@ -171,6 +172,10 @@ func run() error {
 		fleetHandler.RefreshOrphansFromCfg,
 	)
 
+	// Same pattern for repos: construct externally, wire via WithRepos.
+	reposHandler := serverrepos.New(db, srv, srv, logger)
+	srv.WithRepos(reposHandler)
+
 	// Wire the memory backend into the server for the /memory endpoint and
 	// attach an SSE notifier so the UI stream stays live.
 	mem := memBackend.(*sqliteMemory)
@@ -203,8 +208,8 @@ func run() error {
 		AgentWrite:    fleetHandler,
 		SkillWrite:    fleetHandler,
 		BackendWrite:  fleetHandler,
-		RepoWrite:     srv.Repos(),
-		BindingWrite:  srv.Repos(),
+		RepoWrite:     reposHandler,
+		BindingWrite:  reposHandler,
 		Logger:        logger,
 	}))
 

--- a/internal/webhook/crud_test.go
+++ b/internal/webhook/crud_test.go
@@ -18,14 +18,14 @@ import (
 	"github.com/eloylp/agents/internal/config"
 	"github.com/eloylp/agents/internal/fleet"
 	"github.com/eloylp/agents/internal/server"
+	serverrepos "github.com/eloylp/agents/internal/server/repos"
 	"github.com/eloylp/agents/internal/store"
 	"github.com/eloylp/agents/internal/workflow"
 )
 
 // openCRUDTestServer creates a test server wired with an in-memory SQLite
 // store. Mirrors the wiring cmd/agents performs: NewServer + WithStore +
-// fleet handler attached via WithFleet (with SetDB invoked after the
-// store is open).
+// the fleet/repos handlers attached externally via WithFleet / WithRepos.
 func openCRUDTestServer(t *testing.T) *Server {
 	t.Helper()
 	dir := t.TempDir()
@@ -42,6 +42,7 @@ func openCRUDTestServer(t *testing.T) *Server {
 	s.WithStore(db, nil) // nil reloader — cron hot-reload not exercised here
 	fleetHandler := wireFleetForTest(s, cfg, nil, logger)
 	fleetHandler.SetDB(db)
+	s.WithRepos(serverrepos.New(db, s, s, logger))
 	return s
 }
 
@@ -878,6 +879,7 @@ func openCRUDTestServerWithReloader(t *testing.T, reloader server.CronReloader) 
 	s := NewServer(cfg, NewDeliveryStore(0), dc, nil, nil, logger)
 	s.WithStore(db, reloader)
 	fleetHandler := wireFleetForTest(s, cfg, nil, logger)
+	s.WithRepos(serverrepos.New(db, s, s, logger))
 	fleetHandler.SetDB(db)
 	return s
 }
@@ -1033,6 +1035,7 @@ func TestStoreCRUDPostBodySizeLimit(t *testing.T) {
 	s := NewServer(cfg, NewDeliveryStore(0), dc, nil, nil, logger)
 	s.WithStore(db, nil)
 	fleetHandler := wireFleetForTest(s, cfg, nil, logger)
+	s.WithRepos(serverrepos.New(db, s, s, logger))
 	fleetHandler.SetDB(db)
 
 	tests := []struct {
@@ -1095,6 +1098,7 @@ func TestStoreCRUDPostBodyTrailingGarbageRejected(t *testing.T) {
 	s := NewServer(cfg, NewDeliveryStore(0), dc, nil, nil, logger)
 	s.WithStore(db, nil)
 	fleetHandler := wireFleetForTest(s, cfg, nil, logger)
+	s.WithRepos(serverrepos.New(db, s, s, logger))
 	fleetHandler.SetDB(db)
 
 	endpoints := []string{

--- a/internal/webhook/server.go
+++ b/internal/webhook/server.go
@@ -19,7 +19,6 @@ import (
 	"github.com/eloylp/agents/internal/observe"
 	"github.com/eloylp/agents/internal/server"
 	serverconfig "github.com/eloylp/agents/internal/server/config"
-	serverrepos "github.com/eloylp/agents/internal/server/repos"
 	"github.com/eloylp/agents/internal/workflow"
 )
 
@@ -52,7 +51,7 @@ type Server struct {
 	agentsDispatcher http.HandlerFunc                                 // GET vs POST /agents — supplied by WithFleet
 	orphansSource    server.OrphansSource                             // /status orphan summary — supplied by WithFleet
 	onConfigReload   func(*config.Config)                             // reloadCron post-hook — supplied by WithFleet
-	repos            *serverrepos.Handler                             // constructed in WithStore; nil until then
+	repos            server.HandlerRegister                           // wired via WithRepos by the composing caller
 	config           *serverconfig.Handler                            // constructed in NewServer (cfg-only mode); db wired by WithStore
 	// storeMu serializes the "DB write → snapshot read → in-memory Reload"
 	// sequence so that concurrent write requests cannot interleave their
@@ -100,14 +99,13 @@ func (s *Server) WithRuntimeState(rsp server.RuntimeStateProvider) {
 }
 
 // WithStore attaches a SQLite database and an optional CronReloader. The
-// database backs reloadCron and is forwarded to the still-locally-owned
-// repos and config handlers. The fleet handler is wired externally by
-// cmd/agents (which calls SetDB on it directly before WithFleet), so this
-// method no longer touches it.
+// database backs reloadCron and gets forwarded to the still-locally-owned
+// config handler. The fleet and repos handlers are wired externally by
+// cmd/agents (which calls SetDB / supplies the concrete handler directly),
+// so this method no longer touches them.
 func (s *Server) WithStore(db *sql.DB, r server.CronReloader) {
 	s.db = db
 	s.cronReloader = r
-	s.repos = serverrepos.New(db, s, s, s.logger)
 	if s.config != nil {
 		s.config.SetDB(db)
 	}
@@ -128,10 +126,12 @@ func (s *Server) WithFleet(h server.HandlerRegister, dispatcher http.HandlerFunc
 	s.onConfigReload = onReload
 }
 
-// Repos returns the repos handler so the daemon's MCP wiring can satisfy the
-// mcp.RepoWriter and mcp.BindingWriter interfaces with the same instance the
-// HTTP router uses. Nil when WithStore has not been called.
-func (s *Server) Repos() *serverrepos.Handler { return s.repos }
+// WithRepos registers the repos handler. cmd/agents constructs the
+// concrete internal/server/repos.Handler externally so this package stays
+// free of any internal/server/repos import.
+func (s *Server) WithRepos(h server.HandlerRegister) {
+	s.repos = h
+}
 
 // Cfg returns the config handler so the daemon's MCP wiring can satisfy the
 // mcp.ConfigBytes / mcp.ConfigImporter interfaces with the same instance the


### PR DESCRIPTION
## Summary
- \`webhook.Server\` stops constructing \`internal/server/repos.Handler\` internally; \`cmd/agents\` builds it externally and wires it via the new \`WithRepos(h server.HandlerRegister)\` method.
- \`Server.Repos()\` accessor is gone; cmd/agents uses its local \`reposHandler\` reference for MCP wiring.

## Why
Step 4b-2a-3 of the webhook split (#250). The smallest of the four lift-out PRs — repos has no cross-domain hooks, just \`RegisterRoutes\`, so this is essentially the pattern from #320 (observe) applied to a CRUD handler.

After this PR \`internal/webhook\` imports only one sub-package: \`server/config\`. The next PR lifts that one, then 4b-2b is the file move.

## Scope
- \`internal/webhook/server.go\`: -1 import, typed field → \`HandlerRegister\` interface, dropped construction in \`WithStore\`, dropped \`Repos()\` accessor, added \`WithRepos\` setter.
- \`cmd/agents/main.go\`: +1 import (\`serverrepos\`), constructs the handler externally and wires via \`WithRepos\`.
- \`internal/webhook/crud_test.go\`: +1 import, each of the 4 CRUD-mode test helpers calls \`s.WithRepos(serverrepos.New(...))\`.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./... -race -count=1\` green across every package

## What's next
- 4b-2a-4: lift config handler (last sub-package import).
- 4b-2b: \`git mv\` \`internal/webhook/server.go\` → \`internal/server/server.go\`. Mechanical at that point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)