### PR TITLE
refactor: lift config handler construction out of webhook.Server

### DIFF
--- a/cmd/agents/main.go
+++ b/cmd/agents/main.go
@@ -26,6 +26,7 @@ import (
 	mcpserver "github.com/eloylp/agents/internal/mcp"
 	"github.com/eloylp/agents/internal/observe"
 	"github.com/eloylp/agents/internal/server"
+	serverconfig "github.com/eloylp/agents/internal/server/config"
 	serverfleet "github.com/eloylp/agents/internal/server/fleet"
 	serverobserve "github.com/eloylp/agents/internal/server/observe"
 	serverrepos "github.com/eloylp/agents/internal/server/repos"
@@ -176,6 +177,12 @@ func run() error {
 	reposHandler := serverrepos.New(db, srv, srv, logger)
 	srv.WithRepos(reposHandler)
 
+	// Same pattern for config: construct externally with db, wire via
+	// WithConfig.
+	configHandler := serverconfig.New(srv, srv, logger)
+	configHandler.SetDB(db)
+	srv.WithConfig(configHandler)
+
 	// Wire the memory backend into the server for the /memory endpoint and
 	// attach an SSE notifier so the UI stream stays live.
 	mem := memBackend.(*sqliteMemory)
@@ -203,8 +210,8 @@ func run() error {
 		Observe:       obs,
 		DispatchStats: engine,
 		Memory:        &sqliteMcpReader{db: db},
-		ConfigBytes:   srv.Cfg(),
-		ConfigImport:  srv.Cfg(),
+		ConfigBytes:   configHandler,
+		ConfigImport:  configHandler,
 		AgentWrite:    fleetHandler,
 		SkillWrite:    fleetHandler,
 		BackendWrite:  fleetHandler,

--- a/internal/webhook/crud_test.go
+++ b/internal/webhook/crud_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/eloylp/agents/internal/config"
 	"github.com/eloylp/agents/internal/fleet"
 	"github.com/eloylp/agents/internal/server"
+	serverconfig "github.com/eloylp/agents/internal/server/config"
 	serverrepos "github.com/eloylp/agents/internal/server/repos"
 	"github.com/eloylp/agents/internal/store"
 	"github.com/eloylp/agents/internal/workflow"
@@ -43,6 +44,9 @@ func openCRUDTestServer(t *testing.T) *Server {
 	fleetHandler := wireFleetForTest(s, cfg, nil, logger)
 	fleetHandler.SetDB(db)
 	s.WithRepos(serverrepos.New(db, s, s, logger))
+	configHandler := serverconfig.New(s, s, logger)
+	configHandler.SetDB(db)
+	s.WithConfig(configHandler)
 	return s
 }
 
@@ -880,6 +884,9 @@ func openCRUDTestServerWithReloader(t *testing.T, reloader server.CronReloader) 
 	s.WithStore(db, reloader)
 	fleetHandler := wireFleetForTest(s, cfg, nil, logger)
 	s.WithRepos(serverrepos.New(db, s, s, logger))
+	configHandler := serverconfig.New(s, s, logger)
+	configHandler.SetDB(db)
+	s.WithConfig(configHandler)
 	fleetHandler.SetDB(db)
 	return s
 }
@@ -1036,6 +1043,9 @@ func TestStoreCRUDPostBodySizeLimit(t *testing.T) {
 	s.WithStore(db, nil)
 	fleetHandler := wireFleetForTest(s, cfg, nil, logger)
 	s.WithRepos(serverrepos.New(db, s, s, logger))
+	configHandler := serverconfig.New(s, s, logger)
+	configHandler.SetDB(db)
+	s.WithConfig(configHandler)
 	fleetHandler.SetDB(db)
 
 	tests := []struct {
@@ -1099,6 +1109,9 @@ func TestStoreCRUDPostBodyTrailingGarbageRejected(t *testing.T) {
 	s.WithStore(db, nil)
 	fleetHandler := wireFleetForTest(s, cfg, nil, logger)
 	s.WithRepos(serverrepos.New(db, s, s, logger))
+	configHandler := serverconfig.New(s, s, logger)
+	configHandler.SetDB(db)
+	s.WithConfig(configHandler)
 	fleetHandler.SetDB(db)
 
 	endpoints := []string{

--- a/internal/webhook/server.go
+++ b/internal/webhook/server.go
@@ -18,7 +18,6 @@ import (
 	"github.com/eloylp/agents/internal/config"
 	"github.com/eloylp/agents/internal/observe"
 	"github.com/eloylp/agents/internal/server"
-	serverconfig "github.com/eloylp/agents/internal/server/config"
 	"github.com/eloylp/agents/internal/workflow"
 )
 
@@ -52,7 +51,7 @@ type Server struct {
 	orphansSource    server.OrphansSource                             // /status orphan summary — supplied by WithFleet
 	onConfigReload   func(*config.Config)                             // reloadCron post-hook — supplied by WithFleet
 	repos            server.HandlerRegister                           // wired via WithRepos by the composing caller
-	config           *serverconfig.Handler                            // constructed in NewServer (cfg-only mode); db wired by WithStore
+	config           server.HandlerRegister                           // wired via WithConfig by the composing caller
 	// storeMu serializes the "DB write → snapshot read → in-memory Reload"
 	// sequence so that concurrent write requests cannot interleave their
 	// snapshots and leave the scheduler in a stale or inconsistent state.
@@ -99,16 +98,13 @@ func (s *Server) WithRuntimeState(rsp server.RuntimeStateProvider) {
 }
 
 // WithStore attaches a SQLite database and an optional CronReloader. The
-// database backs reloadCron and gets forwarded to the still-locally-owned
-// config handler. The fleet and repos handlers are wired externally by
-// cmd/agents (which calls SetDB / supplies the concrete handler directly),
-// so this method no longer touches them.
+// database backs reloadCron and the in-memory config swap on every write.
+// All three domain handlers (fleet, repos, config) are wired externally by
+// cmd/agents — which calls SetDB / supplies the concrete handler directly —
+// so this method no longer touches any of them.
 func (s *Server) WithStore(db *sql.DB, r server.CronReloader) {
 	s.db = db
 	s.cronReloader = r
-	if s.config != nil {
-		s.config.SetDB(db)
-	}
 }
 
 // WithFleet registers the fleet handler and the three hooks the composing
@@ -133,10 +129,12 @@ func (s *Server) WithRepos(h server.HandlerRegister) {
 	s.repos = h
 }
 
-// Cfg returns the config handler so the daemon's MCP wiring can satisfy the
-// mcp.ConfigBytes / mcp.ConfigImporter interfaces with the same instance the
-// HTTP router uses.
-func (s *Server) Cfg() *serverconfig.Handler { return s.config }
+// WithConfig registers the config handler. cmd/agents constructs the
+// concrete internal/server/config.Handler externally so this package stays
+// free of any internal/server/config import.
+func (s *Server) WithConfig(h server.HandlerRegister) {
+	s.config = h
+}
 
 // Do runs fn under the server's CRUD write lock and, on success, triggers a
 // scheduler reload + in-memory config swap. Implements server.WriteCoordinator
@@ -181,11 +179,6 @@ func NewServer(cfg *config.Config, delivery *DeliveryStore, channels server.Even
 		dispatchStats: dispatchStats,
 		startTime:     time.Now(),
 	}
-	// Config handler boots in cfg-only mode so /config serves the
-	// effective YAML-loaded snapshot before WithStore wires /export +
-	// /import. Fleet is wired externally (see WithFleet) by cmd/agents
-	// so this package no longer imports internal/server/fleet.
-	s.config = serverconfig.New(s, s, s.logger)
 	// GitHub webhook receiver — pure event-parsing + HMAC + delivery dedupe.
 	// The server delegates handleGitHubWebhook to it so existing tests that
 	// call s.handleGitHubWebhook keep working unchanged; future PRs will
@@ -265,7 +258,9 @@ func (s *Server) buildHandler() http.Handler {
 		s.observeRegister(router, withTimeout)
 	}
 
-	s.config.RegisterRoutes(router, withTimeout)
+	if s.config != nil {
+		s.config.RegisterRoutes(router, withTimeout)
+	}
 
 	// Static UI: served from the embedded dist/ tree when a UI FS is provided.
 	// Unauthenticated — same reasoning as the /api/* routes above.

--- a/internal/webhook/server_test.go
+++ b/internal/webhook/server_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/eloylp/agents/internal/config"
 	"github.com/eloylp/agents/internal/fleet"
 	"github.com/eloylp/agents/internal/server"
+	serverconfig "github.com/eloylp/agents/internal/server/config"
 	serverfleet "github.com/eloylp/agents/internal/server/fleet"
 	"github.com/eloylp/agents/internal/workflow"
 )
@@ -70,6 +71,7 @@ func newTestServerExposingFleet(cfg *config.Config, provider server.StatusProvid
 	logger := zerolog.Nop()
 	srv := NewServer(cfg, NewDeliveryStore(time.Hour), dc, provider, nil, logger)
 	fleetHandler := wireFleetForTest(srv, cfg, provider, logger)
+	srv.WithConfig(serverconfig.New(srv, srv, logger))
 	return srv, dc, fleetHandler
 }
 


### PR DESCRIPTION
## Summary
- \`webhook.Server\` stops constructing \`internal/server/config.Handler\` internally; \`cmd/agents\` builds it externally and wires it via the new \`WithConfig(h server.HandlerRegister)\` method.
- \`Server.Cfg()\` accessor is gone; cmd/agents uses its local \`configHandler\` reference for MCP wiring.
- \`WithStore\` no longer forwards \`SetDB\` anywhere — every sub-handler is now wired externally.

## Why
Step 4b-2a-4 of the webhook split (#250). Last of the four lift-out PRs. After this lands, \`internal/webhook/\` imports zero \`internal/server/X\` sub-packages in production code, removing the cycle blocker that prevented \`webhook.Server\` from moving to \`internal/server\`.

The next PR (4b-2b) is the file move itself — \`git mv webhook/server.go internal/server/server.go\` plus package rename + test moves. Mechanical at that point.

## Scope
- \`internal/webhook/server.go\`: -1 import, typed field → \`HandlerRegister\` interface, dropped construction in \`NewServer\`, dropped SetDB forwarding in \`WithStore\`, dropped \`Cfg()\` accessor, added \`WithConfig\` setter + nil-check at route registration.
- \`cmd/agents/main.go\`: +1 import, constructs the handler externally with \`SetDB\` before \`WithConfig\`.
- \`internal/webhook/server_test.go\`: +1 import, \`newTestServerExposingFleet\` calls \`WithConfig\` so /config tests work in cfg-only mode.
- \`internal/webhook/crud_test.go\`: +1 import, each of the 4 CRUD-mode helpers constructs a config handler and calls \`WithConfig\`.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./... -race -count=1\` green across every package
- [x] \`grep "internal/server/" internal/webhook/{server,handler,crud,delivery_store}.go\` returns no production imports — only doc-comment mentions.

## What's next
4b-2b: \`git mv internal/webhook/server.go internal/server/server.go\`. The Server type's location finally matches its purpose. Tests in webhook that exercise the lifecycle move alongside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)