### PR TITLE
refactor: move HTTP server lifecycle from webhook to internal/server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,12 +39,12 @@ internal/
   backends/                     # backend discovery: CLI probing, GitHub MCP health checks, orphan detection
   store/                        # SQLite-backed config store: Open, Import, Load, CRUD
   workflow/                     # event routing engine (single event queue), processor, dispatcher
-  server/                       # shared HTTP server types (cross-cutting interfaces, error sentinels, WriteCoordinator)
+  server/                       # central HTTP server: lifecycle, router, /status, /run, proxy + UI + MCP mounts; cross-cutting types
   server/observe/               # observability HTTP handlers (events, traces, graph, dispatches, memory, SSE)
   server/config/                # /config snapshot, /export, /import HTTP handlers and methods
   server/fleet/                 # agents/skills/backends CRUD + GET /agents fleet view + orphans cache (incl. /agents/orphans/status)
   server/repos/                 # repos + per-binding HTTP CRUD handlers and methods
-  webhook/                      # HTTP server, HMAC signature verification, delivery dedupe, /status, /run, proxy + UI mounts (final slim still in progress)
+  webhook/                      # GitHub webhook receiver only: HMAC signature verification, delivery dedupe, /webhooks/github event parsing
   mcp/                          # MCP server exposing fleet-management tools at /mcp
   ui/                           # embedded Next.js web dashboard (static assets served at /ui/)
   setup/                        # interactive first-time setup command
@@ -99,12 +99,12 @@ When making common classes of changes, update all of these at once:
 |---|---|
 | Domain entities (`internal/fleet/`: Agent, Repo, Skill, Backend, Binding) | The struct itself, the SQLite store columns, the YAML tags, all CRUD wire shapes, tests |
 | Config schema (top-level `Config`, `Daemon*` in `internal/config/config.go`) | Validation, `normalize()`, defaults, `config.example.yaml`, README, tests in `internal/config/config_test.go` |
-| New webhook event kind | Decoder in `internal/webhook/server.go`, acceptance in `internal/workflow/engine.go`, README event table, validation in `internal/config/config.go` |
+| New webhook event kind | Decoder in `internal/webhook/handler.go`, acceptance in `internal/workflow/engine.go`, README event table, validation in `internal/config/config.go` |
 | New AI backend behavior | `internal/ai/cmdrunner.go`, allowlist if new env vars, backend registration in `cmd/agents/main.go`, config example |
 | Agent prompt contract | Prompts in SQLite (edit via UI or CRUD API), runner parser in `internal/ai/cmdrunner.go`, `internal/ai/types.go`, `internal/ai/response-schema.json`, AGENTS.md runner-contract section, tests |
 | Memory contract | `internal/autonomous/memory.go` (MemoryBackend interface), `internal/store/store.go` (SQLite path), `cmd/agents/main.go` (wiring), agent prompts "Memory hygiene" sections, `internal/ai/types.go` |
 | Dispatch semantics | `internal/workflow/dispatch.go` (runtime), `internal/config/config.go` (load-time validation), agent response schema in `internal/ai/types.go`, README dispatch section, all prompt "Response format" sections, tests on both paths |
-| SQLite store schema | `internal/store/migrations/`, `internal/store/store.go`, `internal/store/crud.go`, `internal/webhook/crud.go`, tests |
+| SQLite store schema | `internal/store/migrations/`, `internal/store/store.go`, `internal/store/crud.go`, the per-domain handlers under `internal/server/{fleet,repos,config}`, tests |
 | Proxy translation behavior | `internal/anthropic_proxy/{types,translate,handler}.go`, unit tests for the affected shape, `docs/local-models.md` if user-visible |
 | Anything in the README | Also check `CLAUDE.md`, `AGENTS.md`, `config.example.yaml` — these four should stay in sync |
 
@@ -112,7 +112,7 @@ When making common classes of changes, update all of these at once:
 
 - **Run `go test ./... -race` before every commit.** Race detection is cheap and catches real bugs in the concurrent event processing and dispatch paths.
 - **Table-driven tests** for anything with more than two interesting input shapes (config validation, label parsing, event decoding, translation, dispatch rejection reasons). `t.Parallel()` where independent; **not** when using `t.Setenv`.
-- **Use `httptest.Server` for HTTP integration tests.** See `internal/webhook/server_test.go` and `internal/server/observe/observe_test.go` for the patterns.
+- **Use `httptest.Server` for HTTP integration tests.** See `internal/server/server_test.go` and `internal/server/observe/observe_test.go` for the patterns.
 - **No `-short` or skipped tests on main.** If a test needs external services, gate it behind a build tag or an explicit env var check.
 - **Do not mock what you do not own.** Wrap third-party clients behind an interface you control, then mock that interface. `internal/ai.Runner` is the canonical example.
 - **Test error paths, not just the happy path.** Dispatch rejection modes each deserve a dedicated test.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,12 +18,12 @@ internal/
   backends/                 # Backend discovery: CLI probing, GitHub MCP health checks, orphan detection
   store/                    # SQLite-backed config store: Open, Import, Load, CRUD
   workflow/                 # Event routing engine, single event queue, processor, dispatcher
-  server/                   # Shared HTTP server types (cross-cutting interfaces, error sentinels, WriteCoordinator)
+  server/                   # Central HTTP server: lifecycle, router, /status, /run, proxy + UI + MCP mounts; cross-cutting types (StatusProvider, EventQueue, WriteCoordinator, ...)
   server/observe/           # Observability HTTP handlers (events, traces, graph, dispatches, memory, SSE)
   server/config/            # /config snapshot, /export, /import HTTP handlers and methods
   server/fleet/             # Agents/skills/backends CRUD + GET /agents fleet view + orphans cache (incl. /agents/orphans/status)
   server/repos/             # Repos + per-binding HTTP CRUD handlers and methods
-  webhook/                  # HTTP server, HMAC verification, delivery dedupe, /status, /run, proxy + UI mounts (final slim still in progress)
+  webhook/                  # GitHub webhook receiver only: HMAC verification, delivery dedupe, /webhooks/github event parsing
   mcp/                      # MCP server exposing fleet-management tools at /mcp
   ui/                       # Embedded Next.js web dashboard (served at /ui/)
   setup/                    # Interactive first-time setup command

--- a/cmd/agents/main.go
+++ b/cmd/agents/main.go
@@ -149,11 +149,12 @@ func run() error {
 	scheduler.WithTraceRecorder(obs)
 
 	deliveryStore := webhook.NewDeliveryStore(time.Duration(cfg.Daemon.HTTP.DeliveryTTLSeconds) * time.Second)
-	srv := webhook.NewServer(cfg, deliveryStore, dataChannels, schedulerStatusAdapter{scheduler}, engine, logger)
+	srv := server.NewServer(cfg, dataChannels, schedulerStatusAdapter{scheduler}, engine, logger)
 	srv.WithUI(ui.FS)
 	srv.WithObserve(obs)
 	srv.WithRuntimeState(obs)
 	srv.WithStore(db, scheduler)
+	srv.WithWebhook(webhook.NewHandler(deliveryStore, dataChannels, srv, logger))
 
 	// Construct the fleet handler externally and wire it via WithFleet so
 	// the webhook package stays free of any internal/server/fleet import.

--- a/internal/server/allow_memory_test.go
+++ b/internal/server/allow_memory_test.go
@@ -1,4 +1,4 @@
-package webhook
+package server_test
 
 import (
 	"encoding/json"

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -1,4 +1,4 @@
-package webhook
+package server_test
 
 import (
 	"bufio"
@@ -49,7 +49,7 @@ func TestHandleAPIAgentsReturnsConfiguredAgents(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/agents", nil)
 	rec := httptest.NewRecorder()
-	srv.buildHandler().ServeHTTP(rec, req)
+	srv.Handler().ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d", rec.Code)
@@ -103,7 +103,7 @@ func TestHandleAPIAgentsAttachesScheduleForCronBindings(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/agents", nil)
 	rec := httptest.NewRecorder()
-	srv.buildHandler().ServeHTTP(rec, req)
+	srv.Handler().ServeHTTP(rec, req)
 
 	var agents []viewAgentJSON
 	if err := json.NewDecoder(rec.Body).Decode(&agents); err != nil {
@@ -159,7 +159,7 @@ func TestHandleAPIAgentsMultiRepoSchedulePreserved(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/agents", nil)
 	rec := httptest.NewRecorder()
-	srv.buildHandler().ServeHTTP(rec, req)
+	srv.Handler().ServeHTTP(rec, req)
 
 	var agents []viewAgentJSON
 	if err := json.NewDecoder(rec.Body).Decode(&agents); err != nil {
@@ -230,7 +230,7 @@ func TestHandleAPIAgentsSkipsDisabledRepos(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/agents", nil)
 	rec := httptest.NewRecorder()
-	srv.buildHandler().ServeHTTP(rec, req)
+	srv.Handler().ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d", rec.Code)
@@ -259,7 +259,7 @@ func TestHandleAPIAgentsEmptyWhenNoAgents(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/agents", nil)
 	rec := httptest.NewRecorder()
-	srv.buildHandler().ServeHTTP(rec, req)
+	srv.Handler().ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d", rec.Code)
@@ -280,7 +280,7 @@ func TestHandleAPIAgentsCurrentStatusIdleWhenNotRunning(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/agents", nil)
 	rec := httptest.NewRecorder()
-	srv.buildHandler().ServeHTTP(rec, req)
+	srv.Handler().ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d", rec.Code)
@@ -313,7 +313,7 @@ func TestHandleAPIAgentsCurrentStatusRunningWhenActive(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/agents", nil)
 	rec := httptest.NewRecorder()
-	srv.buildHandler().ServeHTTP(rec, req)
+	srv.Handler().ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d", rec.Code)
@@ -362,7 +362,7 @@ func TestHandleAPIConfigRedactsSecrets(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/config", nil)
 	rec := httptest.NewRecorder()
-	srv.buildHandler().ServeHTTP(rec, req)
+	srv.Handler().ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d", rec.Code)
@@ -408,7 +408,7 @@ func TestHandleAPIConfigOmitsProxyExtraBody(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/config", nil)
 	rec := httptest.NewRecorder()
-	srv.buildHandler().ServeHTTP(rec, req)
+	srv.Handler().ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d", rec.Code)
@@ -435,7 +435,7 @@ func TestHandleAPIConfigNoSecretsWhenNotSet(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/config", nil)
 	rec := httptest.NewRecorder()
-	srv.buildHandler().ServeHTTP(rec, req)
+	srv.Handler().ServeHTTP(rec, req)
 
 	body := rec.Body.String()
 	if strings.Contains(body, "[redacted]") {
@@ -448,7 +448,7 @@ func TestHandleAPIConfigContentType(t *testing.T) {
 	srv, _ := newTestServer(testCfg(nil))
 	req := httptest.NewRequest(http.MethodGet, "/config", nil)
 	rec := httptest.NewRecorder()
-	srv.buildHandler().ServeHTTP(rec, req)
+	srv.Handler().ServeHTTP(rec, req)
 
 	ct := rec.Header().Get("Content-Type")
 	if ct != "application/json" {
@@ -475,7 +475,7 @@ func TestHandleAPIConfigRepoBindingDefaultEnabled(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/config", nil)
 	rec := httptest.NewRecorder()
-	srv.buildHandler().ServeHTTP(rec, req)
+	srv.Handler().ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d", rec.Code)
@@ -543,7 +543,7 @@ func TestBuildHandlerSSETimeoutSplit(t *testing.T) {
 	srv, _ := newTestServer(cfg)
 	wireObserveForTest(srv, obs)
 
-	ts := httptest.NewServer(srv.buildHandler())
+	ts := httptest.NewServer(srv.Handler())
 	t.Cleanup(ts.Close)
 
 	resp, err := http.Get(ts.URL + "/events/stream") //nolint:noctx
@@ -620,7 +620,7 @@ func TestServeSSEClearsServerWriteDeadline(t *testing.T) {
 	srv, _ := newTestServer(testCfg(nil))
 	wireObserveForTest(srv, obs)
 
-	ts := httptest.NewUnstartedServer(srv.buildHandler())
+	ts := httptest.NewUnstartedServer(srv.Handler())
 	ts.Config.WriteTimeout = 200 * time.Millisecond
 	ts.Start()
 	t.Cleanup(ts.Close)
@@ -700,7 +700,7 @@ func newTestObserve(t *testing.T) *observe.Store {
 // handler construction lives outside this package now (cmd/agents wires it
 // via WithObserveRegister); tests do the same so the routes are reachable
 // when integration tests exercise the full router.
-func wireObserveForTest(srv *Server, obs *observe.Store) {
+func wireObserveForTest(srv *server.Server, obs *observe.Store) {
 	srv.WithObserve(obs)
 	srv.WithObserveRegister(func(r *mux.Router, withTimeout func(http.Handler) http.Handler) {
 		obh := serverobserve.New(obs, srv, nil, nil, nil, nil)

--- a/internal/server/crud_test.go
+++ b/internal/server/crud_test.go
@@ -1,4 +1,4 @@
-package webhook
+package server_test
 
 import (
 	"bytes"
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/rs/zerolog"
 
@@ -21,16 +22,17 @@ import (
 	serverconfig "github.com/eloylp/agents/internal/server/config"
 	serverrepos "github.com/eloylp/agents/internal/server/repos"
 	"github.com/eloylp/agents/internal/store"
+	"github.com/eloylp/agents/internal/webhook"
 	"github.com/eloylp/agents/internal/workflow"
 )
 
 // openCRUDTestServer creates a test server wired with an in-memory SQLite
 // store. Mirrors the wiring cmd/agents performs: NewServer + WithStore +
 // the fleet/repos handlers attached externally via WithFleet / WithRepos.
-func openCRUDTestServer(t *testing.T) *Server {
+func openCRUDTestServer(t *testing.T) *server.Server {
 	t.Helper()
 	dir := t.TempDir()
-	db, err := store.Open(filepath.Join(dir, "test.db"))
+	db, err := store.Open(filepath.Join(dir, "test.DB()"))
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
@@ -39,7 +41,8 @@ func openCRUDTestServer(t *testing.T) *Server {
 	cfg := crudMinimalConfig()
 	dc := workflow.NewDataChannels(1)
 	logger := zerolog.Nop()
-	s := NewServer(cfg, NewDeliveryStore(0), dc, nil, nil, logger)
+	s := server.NewServer(cfg, dc, nil, nil, logger)
+	s.WithWebhook(webhook.NewHandler(webhook.NewDeliveryStore(time.Hour), dc, s, logger))
 	s.WithStore(db, nil) // nil reloader — cron hot-reload not exercised here
 	fleetHandler := wireFleetForTest(s, cfg, nil, logger)
 	fleetHandler.SetDB(db)
@@ -52,23 +55,23 @@ func openCRUDTestServer(t *testing.T) *Server {
 
 // seedStoreBackend inserts a minimal backend into the server's store directly
 // so that subsequent agent upserts that reference it pass cross-ref validation.
-func seedStoreBackend(t *testing.T, s *Server, name string) {
+func seedStoreBackend(t *testing.T, s *server.Server, name string) {
 	t.Helper()
 	b := fleet.Backend{Command: name}
-	if err := store.UpsertBackend(s.db, name, b); err != nil {
+	if err := store.UpsertBackend(s.DB(), name, b); err != nil {
 		t.Fatalf("seedStoreBackend %s: %v", name, err)
 	}
 }
 
 // seedStoreSkill inserts a minimal skill into the server's store directly.
-func seedStoreSkill(t *testing.T, s *Server, name string) {
+func seedStoreSkill(t *testing.T, s *server.Server, name string) {
 	t.Helper()
-	if err := store.UpsertSkill(s.db, name, fleet.Skill{Prompt: "skill prompt"}); err != nil {
+	if err := store.UpsertSkill(s.DB(), name, fleet.Skill{Prompt: "skill prompt"}); err != nil {
 		t.Fatalf("seedStoreSkill %s: %v", name, err)
 	}
 }
 
-func doCRUDRequest(t *testing.T, s *Server, method, path string, body any) *httptest.ResponseRecorder {
+func doCRUDRequest(t *testing.T, s *server.Server, method, path string, body any) *httptest.ResponseRecorder {
 	t.Helper()
 	var buf bytes.Buffer
 	if body != nil {
@@ -78,7 +81,7 @@ func doCRUDRequest(t *testing.T, s *Server, method, path string, body any) *http
 	}
 	req := httptest.NewRequest(method, path, &buf)
 	rr := httptest.NewRecorder()
-	s.buildHandler().ServeHTTP(rr, req)
+	s.Handler().ServeHTTP(rr, req)
 	return rr
 }
 
@@ -441,7 +444,7 @@ func TestStoreCRUDBackendPatchRuntimeSettings(t *testing.T) {
 		t.Fatalf("response max_prompt_chars = %d, want 45000", out.MaxPromptChars)
 	}
 
-	backends, err := store.ReadBackends(s.db)
+	backends, err := store.ReadBackends(s.DB())
 	if err != nil {
 		t.Fatalf("ReadBackends: %v", err)
 	}
@@ -495,7 +498,7 @@ func TestBackendsLocalCreateNamedAndDelete(t *testing.T) {
 	s := openCRUDTestServer(t)
 
 	// Local backend creation requires a discovered claude backend.
-	if err := store.UpsertBackend(s.db, "claude", fleet.Backend{
+	if err := store.UpsertBackend(s.DB(), "claude", fleet.Backend{
 		Command: "/bin/sh",
 	}); err != nil {
 		t.Fatalf("seed claude backend: %v", err)
@@ -534,7 +537,7 @@ func TestBackendsLocalRejectReservedName(t *testing.T) {
 	t.Parallel()
 	s := openCRUDTestServer(t)
 
-	if err := store.UpsertBackend(s.db, "claude", fleet.Backend{
+	if err := store.UpsertBackend(s.DB(), "claude", fleet.Backend{
 		Command: "/bin/sh",
 	}); err != nil {
 		t.Fatalf("seed claude backend: %v", err)
@@ -620,7 +623,7 @@ func TestStoreCRUDRepoCreateAndDelete(t *testing.T) {
 
 // seedBindingTestRepo creates a repo + agent pair so the binding test can
 // target the /repos/{owner}/{repo}/bindings routes directly.
-func seedBindingTestRepo(t *testing.T, s *Server) {
+func seedBindingTestRepo(t *testing.T, s *server.Server) {
 	t.Helper()
 	seedStoreBackend(t, s, "claude")
 	if rr := doCRUDRequest(t, s, http.MethodPost, "/agents", map[string]any{
@@ -868,10 +871,10 @@ func (r *errCronReloader) Reload([]fleet.Repo, []fleet.Agent, map[string]fleet.S
 
 // openCRUDTestServerWithReloader creates a test server wired with a SQLite
 // store and the given server.CronReloader.
-func openCRUDTestServerWithReloader(t *testing.T, reloader server.CronReloader) *Server {
+func openCRUDTestServerWithReloader(t *testing.T, reloader server.CronReloader) *server.Server {
 	t.Helper()
 	dir := t.TempDir()
-	db, err := store.Open(filepath.Join(dir, "test.db"))
+	db, err := store.Open(filepath.Join(dir, "test.DB()"))
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
@@ -880,7 +883,8 @@ func openCRUDTestServerWithReloader(t *testing.T, reloader server.CronReloader) 
 	cfg := crudMinimalConfig()
 	dc := workflow.NewDataChannels(1)
 	logger := zerolog.Nop()
-	s := NewServer(cfg, NewDeliveryStore(0), dc, nil, nil, logger)
+	s := server.NewServer(cfg, dc, nil, nil, logger)
+	s.WithWebhook(webhook.NewHandler(webhook.NewDeliveryStore(time.Hour), dc, s, logger))
 	s.WithStore(db, reloader)
 	fleetHandler := wireFleetForTest(s, cfg, nil, logger)
 	s.WithRepos(serverrepos.New(db, s, s, logger))
@@ -905,7 +909,7 @@ func TestStoreCRUDReloadFailureReturns500(t *testing.T) {
 		method string
 		path   string
 		body   any
-		setup  func(t *testing.T, s *Server)
+		setup  func(t *testing.T, s *server.Server)
 	}{
 		{
 			name:   "POST agent",
@@ -914,7 +918,7 @@ func TestStoreCRUDReloadFailureReturns500(t *testing.T) {
 			body:   map[string]any{"name": "agent-x", "backend": "claude", "prompt": "x"},
 			// Seed the backend so cross-ref validation passes and the test
 			// genuinely exercises reload failure, not validation failure.
-			setup: func(t *testing.T, s *Server) { seedStoreBackend(t, s, "claude") },
+			setup: func(t *testing.T, s *server.Server) { seedStoreBackend(t, s, "claude") },
 		},
 		{
 			name:   "DELETE agent",
@@ -943,7 +947,7 @@ func TestStoreCRUDReloadFailureReturns500(t *testing.T) {
 			body: map[string]any{"name": "codex", "command": "codex", "args": []string{}, "env": map[string]string{}},
 			// Seed claude so there is already one backend, making the new backend
 			// a valid addition (fleet validation requires at least one).
-			setup: func(t *testing.T, s *Server) { seedStoreBackend(t, s, "claude") },
+			setup: func(t *testing.T, s *server.Server) { seedStoreBackend(t, s, "claude") },
 		},
 		{
 			name:   "DELETE backend",
@@ -952,7 +956,7 @@ func TestStoreCRUDReloadFailureReturns500(t *testing.T) {
 			body:   nil,
 			// Seed two backends so deleting one still leaves the fleet valid;
 			// the reload failure is the only reason the handler should return 500.
-			setup: func(t *testing.T, s *Server) {
+			setup: func(t *testing.T, s *server.Server) {
 				seedStoreBackend(t, s, "claude")
 				seedStoreBackend(t, s, "codex")
 			},
@@ -1000,7 +1004,7 @@ func TestStoreCRUDReloadFailureDoesNotUpdateServerCfg(t *testing.T) {
 	s := openCRUDTestServerWithReloader(t, reloader)
 
 	// Pre-condition: server starts with no repos.
-	if got := len(s.loadCfg().Repos); got != 0 {
+	if got := len(s.Config().Repos); got != 0 {
 		t.Fatalf("precondition: want 0 repos, got %d", got)
 	}
 
@@ -1013,7 +1017,7 @@ func TestStoreCRUDReloadFailureDoesNotUpdateServerCfg(t *testing.T) {
 	}
 
 	// s.cfg must still reflect the pre-write state (no repos).
-	if got := len(s.loadCfg().Repos); got != 0 {
+	if got := len(s.Config().Repos); got != 0 {
 		t.Errorf("server cfg must not be updated on reload failure: want 0 repos, got %d", got)
 	}
 }
@@ -1031,7 +1035,7 @@ func TestStoreCRUDPostBodySizeLimit(t *testing.T) {
 	cfg.Daemon.HTTP.MaxBodyBytes = 10 // very small limit for the test
 
 	dir := t.TempDir()
-	db, err := store.Open(filepath.Join(dir, "test.db"))
+	db, err := store.Open(filepath.Join(dir, "test.DB()"))
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
@@ -1039,7 +1043,8 @@ func TestStoreCRUDPostBodySizeLimit(t *testing.T) {
 
 	dc := workflow.NewDataChannels(1)
 	logger := zerolog.Nop()
-	s := NewServer(cfg, NewDeliveryStore(0), dc, nil, nil, logger)
+	s := server.NewServer(cfg, dc, nil, nil, logger)
+	s.WithWebhook(webhook.NewHandler(webhook.NewDeliveryStore(time.Hour), dc, s, logger))
 	s.WithStore(db, nil)
 	fleetHandler := wireFleetForTest(s, cfg, nil, logger)
 	s.WithRepos(serverrepos.New(db, s, s, logger))
@@ -1097,7 +1102,7 @@ func TestStoreCRUDPostBodyTrailingGarbageRejected(t *testing.T) {
 	cfg.Daemon.HTTP.MaxBodyBytes = 15 // {"name":"x"} is 12 bytes; +5 garbage exceeds limit
 
 	dir := t.TempDir()
-	db, err := store.Open(filepath.Join(dir, "test.db"))
+	db, err := store.Open(filepath.Join(dir, "test.DB()"))
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
@@ -1105,7 +1110,8 @@ func TestStoreCRUDPostBodyTrailingGarbageRejected(t *testing.T) {
 
 	dc := workflow.NewDataChannels(1)
 	logger := zerolog.Nop()
-	s := NewServer(cfg, NewDeliveryStore(0), dc, nil, nil, logger)
+	s := server.NewServer(cfg, dc, nil, nil, logger)
+	s.WithWebhook(webhook.NewHandler(webhook.NewDeliveryStore(time.Hour), dc, s, logger))
 	s.WithStore(db, nil)
 	fleetHandler := wireFleetForTest(s, cfg, nil, logger)
 	s.WithRepos(serverrepos.New(db, s, s, logger))
@@ -1129,7 +1135,7 @@ func TestStoreCRUDPostBodyTrailingGarbageRejected(t *testing.T) {
 			rawBody := []byte(`{"name":"x"}XXXXX`)
 			req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(rawBody))
 			rr := httptest.NewRecorder()
-			s.buildHandler().ServeHTTP(rr, req)
+			s.Handler().ServeHTTP(rr, req)
 			if rr.Code != http.StatusRequestEntityTooLarge {
 				t.Errorf("POST %s with valid JSON + trailing garbage: want 413, got %d: %s",
 					path, rr.Code, rr.Body.String())
@@ -1149,7 +1155,7 @@ func TestStoreCRUDValidationErrorReturns400(t *testing.T) {
 		name  string
 		path  string
 		body  any
-		setup func(t *testing.T, s *Server)
+		setup func(t *testing.T, s *server.Server)
 	}{
 		{
 			name: "backend with empty command",
@@ -1161,7 +1167,7 @@ func TestStoreCRUDValidationErrorReturns400(t *testing.T) {
 			path: "/agents",
 			body: map[string]any{"name": "coder", "backend": "claude", "prompt": "",
 				"skills": []string{}, "can_dispatch": []string{}},
-			setup: func(t *testing.T, s *Server) { seedStoreBackend(t, s, "claude") },
+			setup: func(t *testing.T, s *server.Server) { seedStoreBackend(t, s, "claude") },
 		},
 		{
 			name: "agent with unknown backend",
@@ -1176,7 +1182,7 @@ func TestStoreCRUDValidationErrorReturns400(t *testing.T) {
 				"name": "owner/repo", "enabled": true,
 				"bindings": []map[string]any{{"agent": "coder"}},
 			},
-			setup: func(t *testing.T, s *Server) {
+			setup: func(t *testing.T, s *server.Server) {
 				seedStoreBackend(t, s, "claude")
 				if rr := doCRUDRequest(t, s, http.MethodPost, "/agents", map[string]any{
 					"name": "coder", "backend": "claude", "prompt": "p",
@@ -1211,12 +1217,12 @@ func TestStoreCRUDConflictErrorReturns409(t *testing.T) {
 	tests := []struct {
 		name  string
 		path  string
-		setup func(t *testing.T, s *Server)
+		setup func(t *testing.T, s *server.Server)
 	}{
 		{
 			name: "delete last backend",
 			path: "/backends/claude",
-			setup: func(t *testing.T, s *Server) {
+			setup: func(t *testing.T, s *server.Server) {
 				if rr := doCRUDRequest(t, s, http.MethodPost, "/backends", map[string]any{
 					"name": "claude", "command": "claude", "args": []string{}, "env": map[string]string{},
 				}); rr.Code != http.StatusOK {
@@ -1227,7 +1233,7 @@ func TestStoreCRUDConflictErrorReturns409(t *testing.T) {
 		{
 			name: "delete last agent",
 			path: "/agents/coder",
-			setup: func(t *testing.T, s *Server) {
+			setup: func(t *testing.T, s *server.Server) {
 				seedStoreBackend(t, s, "claude")
 				if rr := doCRUDRequest(t, s, http.MethodPost, "/agents", map[string]any{
 					"name": "coder", "backend": "claude", "prompt": "p",
@@ -1240,7 +1246,7 @@ func TestStoreCRUDConflictErrorReturns409(t *testing.T) {
 		{
 			name: "delete backend referenced by agent",
 			path: "/backends/claude",
-			setup: func(t *testing.T, s *Server) {
+			setup: func(t *testing.T, s *server.Server) {
 				seedStoreBackend(t, s, "claude")
 				seedStoreBackend(t, s, "codex")
 				if rr := doCRUDRequest(t, s, http.MethodPost, "/agents", map[string]any{
@@ -1322,7 +1328,7 @@ func TestConcurrentWriteReloadSerialisation(t *testing.T) {
 
 	// The last recorded snapshot must include all n agents (monotonic guarantee:
 	// the final Reload saw the DB state that includes every committed write).
-	agents, err := store.ReadAgents(s.db)
+	agents, err := store.ReadAgents(s.DB())
 	if err != nil {
 		t.Fatalf("read agents: %v", err)
 	}
@@ -1660,8 +1666,8 @@ func TestServerCfgUpdatedAfterCRUDWrite(t *testing.T) {
 
 	s := openCRUDTestServer(t)
 	// Confirm the initial config has no repos and no agents.
-	if len(s.loadCfg().Repos) != 0 {
-		t.Fatalf("precondition: expected 0 repos, got %d", len(s.loadCfg().Repos))
+	if len(s.Config().Repos) != 0 {
+		t.Fatalf("precondition: expected 0 repos, got %d", len(s.Config().Repos))
 	}
 
 	// Seed backend and create agent + repo via CRUD API.
@@ -1680,7 +1686,7 @@ func TestServerCfgUpdatedAfterCRUDWrite(t *testing.T) {
 	}
 
 	// Verify the in-memory config was updated: the new repo must be present.
-	cfg := s.loadCfg()
+	cfg := s.Config()
 	if len(cfg.Repos) != 1 || cfg.Repos[0].Name != "owner/newrepo" {
 		t.Fatalf("server cfg not updated: repos = %v", cfg.Repos)
 	}
@@ -1724,7 +1730,7 @@ func TestServerCfgUpdatedAfterCRUDWrite(t *testing.T) {
 	// false and the handler returns 401 — which proves the routing reached the
 	// signature check gate, i.e., the repo was found in the updated config.
 	rr2 := httptest.NewRecorder()
-	s.buildHandler().ServeHTTP(rr2, req)
+	s.Handler().ServeHTTP(rr2, req)
 	// 401 means signature check ran, which only happens after the repo gate
 	// passes: the new repo was found in the post-write in-memory config.
 	if rr2.Code != http.StatusUnauthorized {
@@ -1840,7 +1846,7 @@ skills:
 	req := httptest.NewRequest(http.MethodPost, "/import", strings.NewReader(yaml))
 	req.Header.Set("Content-Type", "application/x-yaml")
 	rr := httptest.NewRecorder()
-	s.buildHandler().ServeHTTP(rr, req)
+	s.Handler().ServeHTTP(rr, req)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("import: got %d — %s", rr.Code, rr.Body.String())
 	}
@@ -1906,7 +1912,7 @@ repos:
 	req := httptest.NewRequest(http.MethodPost, "/import?mode=replace", strings.NewReader(yamlBody))
 	req.Header.Set("Content-Type", "application/x-yaml")
 	rr := httptest.NewRecorder()
-	s.buildHandler().ServeHTTP(rr, req)
+	s.Handler().ServeHTTP(rr, req)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("replace import: got %d — %s", rr.Code, rr.Body.String())
 	}
@@ -1944,7 +1950,7 @@ func TestStoreImportRejectsEmptyFleetOnBlankStore(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/import", strings.NewReader(yamlBody))
 	req.Header.Set("Content-Type", "application/x-yaml")
 	rr := httptest.NewRecorder()
-	s.buildHandler().ServeHTTP(rr, req)
+	s.Handler().ServeHTTP(rr, req)
 	if rr.Code != http.StatusBadRequest {
 		t.Errorf("import skills-only on blank store: want 400, got %d — %s", rr.Code, rr.Body.String())
 	}
@@ -1979,7 +1985,7 @@ func TestStoreReplaceRejectsEmptyAgentList(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/import?mode=replace", strings.NewReader(yamlBody))
 	req.Header.Set("Content-Type", "application/x-yaml")
 	rr := httptest.NewRecorder()
-	s.buildHandler().ServeHTTP(rr, req)
+	s.Handler().ServeHTTP(rr, req)
 	if rr.Code != http.StatusBadRequest {
 		t.Errorf("replace with no agents: want 400, got %d — %s", rr.Code, rr.Body.String())
 	}
@@ -1999,7 +2005,7 @@ func TestStoreImportRejectsInvalidMode(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/import?mode=replce", strings.NewReader("{}"))
 	req.Header.Set("Content-Type", "application/x-yaml")
 	rr := httptest.NewRecorder()
-	s.buildHandler().ServeHTTP(rr, req)
+	s.Handler().ServeHTTP(rr, req)
 	if rr.Code != http.StatusBadRequest {
 		t.Errorf("invalid mode: want 400, got %d — %s", rr.Code, rr.Body.String())
 	}
@@ -2048,7 +2054,7 @@ repos:
 	req := httptest.NewRequest(http.MethodPost, "/import", strings.NewReader(yamlBody))
 	req.Header.Set("Content-Type", "application/x-yaml")
 	rr := httptest.NewRecorder()
-	s.buildHandler().ServeHTTP(rr, req)
+	s.Handler().ServeHTTP(rr, req)
 	if rr.Code != http.StatusBadRequest {
 		t.Errorf("merge import with invalid cron: want 400, got %d — %s", rr.Code, rr.Body.String())
 	}
@@ -2100,7 +2106,7 @@ repos:
 	req := httptest.NewRequest(http.MethodPost, "/import?mode=replace", strings.NewReader(yamlBody))
 	req.Header.Set("Content-Type", "application/x-yaml")
 	rr := httptest.NewRecorder()
-	s.buildHandler().ServeHTTP(rr, req)
+	s.Handler().ServeHTTP(rr, req)
 	if rr.Code != http.StatusBadRequest {
 		t.Errorf("replace import with invalid cron: want 400, got %d — %s", rr.Code, rr.Body.String())
 	}

--- a/internal/server/crud_wire_test.go
+++ b/internal/server/crud_wire_test.go
@@ -1,4 +1,4 @@
-package webhook
+package server_test
 
 // Test-side mirrors of the wire shapes produced by the CRUD endpoints. The
 // concrete types live in internal/server/fleet, but importing them would

--- a/internal/server/orphans_test.go
+++ b/internal/server/orphans_test.go
@@ -1,4 +1,4 @@
-package webhook
+package server_test
 
 import (
 	"encoding/json"
@@ -26,7 +26,7 @@ func TestAgentsOrphansEndpointAndStatusSummary(t *testing.T) {
 		}
 	})
 	srv, _ := newTestServer(cfg)
-	h := srv.buildHandler()
+	h := srv.Handler()
 
 	rr := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/agents/orphans/status", nil)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,4 +1,4 @@
-package webhook
+package server
 
 import (
 	"context"
@@ -17,26 +17,24 @@ import (
 	anthropicproxy "github.com/eloylp/agents/internal/anthropic_proxy"
 	"github.com/eloylp/agents/internal/config"
 	"github.com/eloylp/agents/internal/observe"
-	"github.com/eloylp/agents/internal/server"
 	"github.com/eloylp/agents/internal/workflow"
 )
 
 type Server struct {
 	cfg           *config.Config
-	delivery      *DeliveryStore
 	logger        zerolog.Logger
-	channels      server.EventQueue
-	h             *Handler // GitHub webhook receiver — owns event parsing, HMAC, dedupe
-	provider      server.StatusProvider
-	runtimeState  server.RuntimeStateProvider // optional; used by /api/agents for live run status
-	dispatchStats server.DispatchStatsProvider
+	channels      EventQueue
+	webhook       HandlerRegister // GitHub webhook receiver — wired via WithWebhook
+	provider      StatusProvider
+	runtimeState  RuntimeStateProvider // optional; used by /api/agents for live run status
+	dispatchStats DispatchStatsProvider
 	startTime     time.Time
 	proxy         *anthropicproxy.Handler
 	uiFS          fs.FS               // optional; when set, /ui/ serves these static files
 	observeStore  *observe.Store      // optional; when set, enables observability endpoints
 	db            *sql.DB             // optional; when set, enables /api/store/* CRUD endpoints
-	cronReloader  server.CronReloader // optional; called after repo/agent writes to reload cron
-	memReader     server.MemoryReader // optional; when set, /api/memory reads from this (SQLite mode)
+	cronReloader  CronReloader // optional; called after repo/agent writes to reload cron
+	memReader     MemoryReader // optional; when set, /api/memory reads from this (SQLite mode)
 	mcp           http.Handler        // optional; when set, /mcp serves this MCP handler
 	// observeRegister mounts the observability routes when set via
 	// WithObserveRegister. cmd/agents constructs the observe handler
@@ -46,12 +44,12 @@ type Server struct {
 	// concrete *internal/server/fleet.Handler externally and supplies it
 	// (along with cross-domain hooks below) via WithFleet so this package
 	// stays free of any dependency on internal/server/fleet.
-	fleet            server.HandlerRegister
+	fleet            HandlerRegister
 	agentsDispatcher http.HandlerFunc                                 // GET vs POST /agents — supplied by WithFleet
-	orphansSource    server.OrphansSource                             // /status orphan summary — supplied by WithFleet
+	orphansSource    OrphansSource                             // /status orphan summary — supplied by WithFleet
 	onConfigReload   func(*config.Config)                             // reloadCron post-hook — supplied by WithFleet
-	repos            server.HandlerRegister                           // wired via WithRepos by the composing caller
-	config           server.HandlerRegister                           // wired via WithConfig by the composing caller
+	repos            HandlerRegister                           // wired via WithRepos by the composing caller
+	config           HandlerRegister                           // wired via WithConfig by the composing caller
 	// storeMu serializes the "DB write → snapshot read → in-memory Reload"
 	// sequence so that concurrent write requests cannot interleave their
 	// snapshots and leave the scheduler in a stale or inconsistent state.
@@ -93,7 +91,7 @@ func (s *Server) WithObserveRegister(register func(*mux.Router, func(http.Handle
 // It is no longer forwarded to the fleet handler — cmd/agents calls
 // fleetHandler.SetRuntimeState directly before WithFleet so the wiring stays
 // in one place.
-func (s *Server) WithRuntimeState(rsp server.RuntimeStateProvider) {
+func (s *Server) WithRuntimeState(rsp RuntimeStateProvider) {
 	s.runtimeState = rsp
 }
 
@@ -102,7 +100,7 @@ func (s *Server) WithRuntimeState(rsp server.RuntimeStateProvider) {
 // All three domain handlers (fleet, repos, config) are wired externally by
 // cmd/agents — which calls SetDB / supplies the concrete handler directly —
 // so this method no longer touches any of them.
-func (s *Server) WithStore(db *sql.DB, r server.CronReloader) {
+func (s *Server) WithStore(db *sql.DB, r CronReloader) {
 	s.db = db
 	s.cronReloader = r
 }
@@ -115,7 +113,7 @@ func (s *Server) WithStore(db *sql.DB, r server.CronReloader) {
 // cmd/agents constructs the concrete internal/server/fleet.Handler and
 // supplies thin adapters here so this package stays free of any
 // internal/server/fleet import.
-func (s *Server) WithFleet(h server.HandlerRegister, dispatcher http.HandlerFunc, orphans server.OrphansSource, onReload func(*config.Config)) {
+func (s *Server) WithFleet(h HandlerRegister, dispatcher http.HandlerFunc, orphans OrphansSource, onReload func(*config.Config)) {
 	s.fleet = h
 	s.agentsDispatcher = dispatcher
 	s.orphansSource = orphans
@@ -125,15 +123,23 @@ func (s *Server) WithFleet(h server.HandlerRegister, dispatcher http.HandlerFunc
 // WithRepos registers the repos handler. cmd/agents constructs the
 // concrete internal/server/repos.Handler externally so this package stays
 // free of any internal/server/repos import.
-func (s *Server) WithRepos(h server.HandlerRegister) {
+func (s *Server) WithRepos(h HandlerRegister) {
 	s.repos = h
 }
 
 // WithConfig registers the config handler. cmd/agents constructs the
 // concrete internal/server/config.Handler externally so this package stays
 // free of any internal/server/config import.
-func (s *Server) WithConfig(h server.HandlerRegister) {
+func (s *Server) WithConfig(h HandlerRegister) {
 	s.config = h
+}
+
+// WithWebhook registers the GitHub webhook handler. cmd/agents constructs
+// the concrete internal/webhook.Handler externally and supplies it via this
+// method so the central server type stays free of any internal/webhook
+// import.
+func (s *Server) WithWebhook(h HandlerRegister) {
+	s.webhook = h
 }
 
 // Do runs fn under the server's CRUD write lock and, on success, triggers a
@@ -151,7 +157,7 @@ func (s *Server) Do(fn func() error) error {
 
 // WithMemoryReader attaches a MemoryReader used by /api/memory/{agent}/{repo}
 // when the daemon is running in --db mode.
-func (s *Server) WithMemoryReader(r server.MemoryReader) {
+func (s *Server) WithMemoryReader(r MemoryReader) {
 	s.memReader = r
 }
 
@@ -169,21 +175,20 @@ func (s *Server) Config() *config.Config {
 	return s.loadCfg()
 }
 
-func NewServer(cfg *config.Config, delivery *DeliveryStore, channels server.EventQueue, provider server.StatusProvider, dispatchStats server.DispatchStatsProvider, logger zerolog.Logger) *Server {
+// DB returns the SQLite database attached via WithStore (or nil). Exported
+// for tests that need to seed the store directly without going through the
+// CRUD HTTP surface; production callers use the domain handlers.
+func (s *Server) DB() *sql.DB { return s.db }
+
+func NewServer(cfg *config.Config, channels EventQueue, provider StatusProvider, dispatchStats DispatchStatsProvider, logger zerolog.Logger) *Server {
 	s := &Server{
 		cfg:           cfg,
-		delivery:      delivery,
-		logger:        logger.With().Str("component", "webhook_server").Logger(),
+		logger:        logger.With().Str("component", "http_server").Logger(),
 		channels:      channels,
 		provider:      provider,
 		dispatchStats: dispatchStats,
 		startTime:     time.Now(),
 	}
-	// GitHub webhook receiver — pure event-parsing + HMAC + delivery dedupe.
-	// The server delegates handleGitHubWebhook to it so existing tests that
-	// call s.handleGitHubWebhook keep working unchanged; future PRs will
-	// drop that delegate and mount h.RegisterRoutes directly.
-	s.h = NewHandler(delivery, channels, s, logger)
 	if cfg.Daemon.Proxy.Enabled {
 		up := cfg.Daemon.Proxy.Upstream
 		s.proxy = anthropicproxy.NewHandler(anthropicproxy.UpstreamConfig{
@@ -207,6 +212,11 @@ func (s *Server) loadCfg() *config.Config {
 	s.cfgMu.RUnlock()
 	return cfg
 }
+
+// Handler builds and returns the HTTP router as an http.Handler. Exported
+// so tests (and any external composing caller) can exercise the routing
+// surface without starting a real TCP listener via Run.
+func (s *Server) Handler() http.Handler { return s.buildHandler() }
 
 // buildHandler constructs the HTTP router for the server and returns it as
 // an http.Handler. It is separated from Run so tests can exercise routing
@@ -234,8 +244,10 @@ func (s *Server) buildHandler() http.Handler {
 
 	router := mux.NewRouter()
 	router.Handle(cfg.Daemon.HTTP.StatusPath, withTimeout(http.HandlerFunc(s.handleStatus))).Methods(http.MethodGet)
-	router.Handle(cfg.Daemon.HTTP.WebhookPath, withTimeout(http.HandlerFunc(s.handleGitHubWebhook))).Methods(http.MethodPost)
 	router.Handle("/run", withTimeout(http.HandlerFunc(s.handleAgentsRun))).Methods(http.MethodPost)
+	if s.webhook != nil {
+		s.webhook.RegisterRoutes(router, withTimeout)
+	}
 
 	// /agents merges the read-only fleet snapshot view (GET) with the CRUD
 	// create (POST) on a single mux entry; the dispatcher delegates to the
@@ -361,7 +373,7 @@ type statusJSON struct {
 	Status         string                     `json:"status"`
 	UptimeSeconds  int64                      `json:"uptime_seconds"`
 	Queues         map[string]statusQueueJSON `json:"queues"`
-	Agents         []server.AgentStatus       `json:"agents"`
+	Agents         []AgentStatus       `json:"agents"`
 	Dispatch       *workflow.DispatchStats    `json:"dispatch,omitempty"`
 	OrphanedAgents statusOrphanSummaryJSON    `json:"orphaned_agents"`
 }
@@ -372,7 +384,7 @@ type statusJSON struct {
 func (s *Server) buildStatus() statusJSON {
 	q := s.channels.QueueStats()
 
-	agents := []server.AgentStatus{}
+	agents := []AgentStatus{}
 	if s.provider != nil {
 		if got := s.provider.AgentStatuses(); len(got) > 0 {
 			agents = got
@@ -469,13 +481,4 @@ func (s *Server) handleAgentsRun(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// handleGitHubWebhook delegates to the package-internal Handler, which
-// owns HMAC verification, delivery dedupe, and per-event-type parsing.
-// Kept on the Server type so existing tests that call s.handleGitHubWebhook
-// directly continue to work; the route in buildHandler still goes through
-// here for the same reason. A follow-up PR will mount h.RegisterRoutes
-// directly and drop this method.
-func (s *Server) handleGitHubWebhook(w http.ResponseWriter, r *http.Request) {
-	s.h.handleGitHubWebhook(w, r)
-}
 

--- a/internal/server/server_crud.go
+++ b/internal/server/server_crud.go
@@ -1,4 +1,4 @@
-package webhook
+package server
 
 import (
 	"errors"

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,4 +1,4 @@
-package webhook
+package server_test
 
 import (
 	"context"
@@ -20,6 +20,7 @@ import (
 	"github.com/eloylp/agents/internal/server"
 	serverconfig "github.com/eloylp/agents/internal/server/config"
 	serverfleet "github.com/eloylp/agents/internal/server/fleet"
+	"github.com/eloylp/agents/internal/webhook"
 	"github.com/eloylp/agents/internal/workflow"
 )
 
@@ -51,14 +52,14 @@ func signatureForTests(body []byte, secret string) string {
 	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
 }
 
-func newTestServer(cfg *config.Config) (*Server, *workflow.DataChannels) {
+func newTestServer(cfg *config.Config) (*server.Server, *workflow.DataChannels) {
 	return newTestServerWithProvider(cfg, nil)
 }
 
 // newTestServerWithProvider mirrors what cmd/agents wires: a Server plus a
-// fleet handler attached via WithFleet. Tests that need a custom status
-// provider use this directly; tests that don't go through newTestServer.
-func newTestServerWithProvider(cfg *config.Config, provider server.StatusProvider) (*Server, *workflow.DataChannels) {
+// fleet handler attached via WithFleet, the GitHub webhook handler attached
+// via WithWebhook, and a config handler attached via WithConfig.
+func newTestServerWithProvider(cfg *config.Config, provider server.StatusProvider) (*server.Server, *workflow.DataChannels) {
 	srv, dc, _ := newTestServerExposingFleet(cfg, provider)
 	return srv, dc
 }
@@ -66,10 +67,11 @@ func newTestServerWithProvider(cfg *config.Config, provider server.StatusProvide
 // newTestServerExposingFleet is the variant for tests that need to call
 // methods on the fleet handler directly (e.g. SetRuntimeState after the
 // fact, or assertions on the orphan cache).
-func newTestServerExposingFleet(cfg *config.Config, provider server.StatusProvider) (*Server, *workflow.DataChannels, *serverfleet.Handler) {
+func newTestServerExposingFleet(cfg *config.Config, provider server.StatusProvider) (*server.Server, *workflow.DataChannels, *serverfleet.Handler) {
 	dc := workflow.NewDataChannels(1)
 	logger := zerolog.Nop()
-	srv := NewServer(cfg, NewDeliveryStore(time.Hour), dc, provider, nil, logger)
+	srv := server.NewServer(cfg, dc, provider, nil, logger)
+	srv.WithWebhook(webhook.NewHandler(webhook.NewDeliveryStore(time.Hour), dc, srv, logger))
 	fleetHandler := wireFleetForTest(srv, cfg, provider, logger)
 	srv.WithConfig(serverconfig.New(srv, srv, logger))
 	return srv, dc, fleetHandler
@@ -79,7 +81,7 @@ func newTestServerExposingFleet(cfg *config.Config, provider server.StatusProvid
 // it to srv via WithFleet, mirroring the wiring cmd/agents performs. Used
 // by every test helper that exercises the full router. Returns the handler
 // so CRUD-mode helpers can SetDB on it after WithStore.
-func wireFleetForTest(srv *Server, cfg *config.Config, provider server.StatusProvider, logger zerolog.Logger) *serverfleet.Handler {
+func wireFleetForTest(srv *server.Server, cfg *config.Config, provider server.StatusProvider, logger zerolog.Logger) *serverfleet.Handler {
 	fleetHandler := serverfleet.New(srv, srv, provider, nil, logger)
 	fleetHandler.RefreshOrphansFromCfg(cfg)
 	srv.WithFleet(
@@ -159,13 +161,13 @@ func TestHandleIssueWebhookDeduplicatesDelivery(t *testing.T) {
 	body := `{"action":"labeled","label":{"name":"ai:refine"},"repository":{"full_name":"owner/repo"},"issue":{"number":1},"sender":{"login":"octocat"}}`
 
 	rr := httptest.NewRecorder()
-	server.handleGitHubWebhook(rr, webhookRequest(t, "issues", "delivery-1", body))
+	server.Handler().ServeHTTP(rr, webhookRequest(t, "issues", "delivery-1", body))
 	if rr.Code != http.StatusAccepted {
 		t.Fatalf("first delivery: got %d, want %d", rr.Code, http.StatusAccepted)
 	}
 
 	rr2 := httptest.NewRecorder()
-	server.handleGitHubWebhook(rr2, webhookRequest(t, "issues", "delivery-1", body))
+	server.Handler().ServeHTTP(rr2, webhookRequest(t, "issues", "delivery-1", body))
 	if rr2.Code != http.StatusAccepted {
 		t.Fatalf("dedup delivery: got %d, want %d", rr2.Code, http.StatusAccepted)
 	}
@@ -181,7 +183,7 @@ func TestHandleIssuesLabeledEnqueuesEventWithLabel(t *testing.T) {
 
 	body := `{"action":"labeled","label":{"name":"ai:refine"},"repository":{"full_name":"owner/repo"},"issue":{"number":7},"sender":{"login":"octocat"}}`
 	rr := httptest.NewRecorder()
-	server.handleGitHubWebhook(rr, webhookRequest(t, "issues", "d-1", body))
+	server.Handler().ServeHTTP(rr, webhookRequest(t, "issues", "d-1", body))
 	if rr.Code != http.StatusAccepted {
 		t.Fatalf("got %d, want %d", rr.Code, http.StatusAccepted)
 	}
@@ -207,7 +209,7 @@ func TestHandleIssuesOpenedEnqueuesEvent(t *testing.T) {
 
 	body := `{"action":"opened","repository":{"full_name":"owner/repo"},"issue":{"number":10,"title":"Bug","body":"desc"},"sender":{"login":"dev"}}`
 	rr := httptest.NewRecorder()
-	server.handleGitHubWebhook(rr, webhookRequest(t, "issues", "d-opened", body))
+	server.Handler().ServeHTTP(rr, webhookRequest(t, "issues", "d-opened", body))
 	if rr.Code != http.StatusAccepted {
 		t.Fatalf("got %d, want %d", rr.Code, http.StatusAccepted)
 	}
@@ -260,7 +262,7 @@ func TestHandleNonAILabelEnqueues(t *testing.T) {
 			t.Parallel()
 			server, dc := newTestServer(testCfg(nil))
 			rr := httptest.NewRecorder()
-			server.handleGitHubWebhook(rr, webhookRequest(t, tc.event, tc.delivery, tc.body))
+			server.Handler().ServeHTTP(rr, webhookRequest(t, tc.event, tc.delivery, tc.body))
 			if rr.Code != http.StatusAccepted {
 				t.Fatalf("got %d, want %d", rr.Code, http.StatusAccepted)
 			}
@@ -311,7 +313,7 @@ func TestHandleIssuesEventDropsPRBackedIssueActions(t *testing.T) {
 			t.Parallel()
 			server, dc := newTestServer(testCfg(nil))
 			rr := httptest.NewRecorder()
-			server.handleGitHubWebhook(rr, webhookRequest(t, "issues", "d-pr-"+tc.name, tc.body))
+			server.Handler().ServeHTTP(rr, webhookRequest(t, "issues", "d-pr-"+tc.name, tc.body))
 			if rr.Code != http.StatusAccepted {
 				t.Fatalf("action %q: got %d, want %d", tc.name, rr.Code, http.StatusAccepted)
 			}
@@ -328,7 +330,7 @@ func TestHandlePullRequestLabeledEnqueuesEvent(t *testing.T) {
 
 	body := `{"action":"labeled","label":{"name":"ai:review"},"repository":{"full_name":"owner/repo"},"pull_request":{"number":5},"sender":{"login":"bot"}}`
 	rr := httptest.NewRecorder()
-	server.handleGitHubWebhook(rr, webhookRequest(t, "pull_request", "d-pr-labeled", body))
+	server.Handler().ServeHTTP(rr, webhookRequest(t, "pull_request", "d-pr-labeled", body))
 	if rr.Code != http.StatusAccepted {
 		t.Fatalf("got %d, want %d", rr.Code, http.StatusAccepted)
 	}
@@ -348,7 +350,7 @@ func TestHandleDraftPRWebhookDoesNotEnqueue(t *testing.T) {
 
 	body := `{"action":"labeled","label":{"name":"ai:review"},"repository":{"full_name":"owner/repo"},"pull_request":{"number":5,"draft":true}}`
 	rr := httptest.NewRecorder()
-	server.handleGitHubWebhook(rr, webhookRequest(t, "pull_request", "delivery-draft", body))
+	server.Handler().ServeHTTP(rr, webhookRequest(t, "pull_request", "delivery-draft", body))
 	if rr.Code != http.StatusAccepted {
 		t.Fatalf("got %d, want %d", rr.Code, http.StatusAccepted)
 	}
@@ -361,7 +363,7 @@ func TestHandlePullRequestOpenedEnqueuesEvent(t *testing.T) {
 
 	body := `{"action":"opened","repository":{"full_name":"owner/repo"},"pull_request":{"number":8,"title":"feat","draft":false},"sender":{"login":"dev"}}`
 	rr := httptest.NewRecorder()
-	server.handleGitHubWebhook(rr, webhookRequest(t, "pull_request", "d-pr-opened", body))
+	server.Handler().ServeHTTP(rr, webhookRequest(t, "pull_request", "d-pr-opened", body))
 	if rr.Code != http.StatusAccepted {
 		t.Fatalf("got %d, want %d", rr.Code, http.StatusAccepted)
 	}
@@ -396,7 +398,7 @@ func TestHandlePullRequestClosedPayloadIncludesMerged(t *testing.T) {
 			}
 			body := `{"action":"closed","repository":{"full_name":"owner/repo"},"pull_request":{"number":12,"title":"feat","draft":false,"merged":` + mergedVal + `},"sender":{"login":"dev"}}`
 			rr := httptest.NewRecorder()
-			server.handleGitHubWebhook(rr, webhookRequest(t, "pull_request", tc.deliveryID, body))
+			server.Handler().ServeHTTP(rr, webhookRequest(t, "pull_request", tc.deliveryID, body))
 			if rr.Code != http.StatusAccepted {
 				t.Fatalf("got %d, want %d", rr.Code, http.StatusAccepted)
 			}
@@ -468,7 +470,7 @@ func TestHandleCommentAndReviewEventsEnqueue(t *testing.T) {
 			t.Parallel()
 			server, dc := newTestServer(testCfg(nil))
 			rr := httptest.NewRecorder()
-			server.handleGitHubWebhook(rr, webhookRequest(t, tc.eventType, tc.deliveryID, tc.body))
+			server.Handler().ServeHTTP(rr, webhookRequest(t, tc.eventType, tc.deliveryID, tc.body))
 			if rr.Code != http.StatusAccepted {
 				t.Fatalf("got %d, want %d", rr.Code, http.StatusAccepted)
 			}
@@ -525,7 +527,7 @@ func TestHandleNonTriggeringActionsIgnored(t *testing.T) {
 			t.Parallel()
 			server, dc := newTestServer(testCfg(nil))
 			rr := httptest.NewRecorder()
-			server.handleGitHubWebhook(rr, webhookRequest(t, tc.eventType, tc.deliveryID, tc.body))
+			server.Handler().ServeHTTP(rr, webhookRequest(t, tc.eventType, tc.deliveryID, tc.body))
 			if rr.Code != http.StatusAccepted {
 				t.Fatalf("got %d, want %d", rr.Code, http.StatusAccepted)
 			}
@@ -542,7 +544,7 @@ func TestHandlePushEnqueuesEvent(t *testing.T) {
 
 	body := `{"ref":"refs/heads/main","after":"abc123","repository":{"full_name":"owner/repo"},"sender":{"login":"pusher"}}`
 	rr := httptest.NewRecorder()
-	server.handleGitHubWebhook(rr, webhookRequest(t, "push", "d-push", body))
+	server.Handler().ServeHTTP(rr, webhookRequest(t, "push", "d-push", body))
 	if rr.Code != http.StatusAccepted {
 		t.Fatalf("got %d, want %d", rr.Code, http.StatusAccepted)
 	}
@@ -579,7 +581,7 @@ func TestHandlePushIgnoresNonBranchRefs(t *testing.T) {
 			server, dc := newTestServer(testCfg(nil))
 			body := `{"ref":"` + tc.ref + `","after":"` + tc.sha + `","repository":{"full_name":"owner/repo"},"sender":{"login":"pusher"}}`
 			rr := httptest.NewRecorder()
-			server.handleGitHubWebhook(rr, webhookRequest(t, "push", "d-push-"+tc.name, body))
+			server.Handler().ServeHTTP(rr, webhookRequest(t, "push", "d-push-"+tc.name, body))
 			if rr.Code != http.StatusAccepted {
 				t.Fatalf("got %d, want %d", rr.Code, http.StatusAccepted)
 			}
@@ -596,7 +598,7 @@ func TestHandleUnknownEventReturnsAccepted(t *testing.T) {
 
 	body := `{"action":"something"}`
 	rr := httptest.NewRecorder()
-	server.handleGitHubWebhook(rr, webhookRequest(t, "unknown_event", "d-unknown", body))
+	server.Handler().ServeHTTP(rr, webhookRequest(t, "unknown_event", "d-unknown", body))
 	if rr.Code != http.StatusAccepted {
 		t.Fatalf("got %d, want %d", rr.Code, http.StatusAccepted)
 	}
@@ -617,11 +619,13 @@ func TestHandleWebhookReturnsServiceUnavailableWhenQueueFull(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("preload event queue: %v", err)
 	}
-	server := NewServer(cfg, NewDeliveryStore(time.Hour), dc, nil, nil, zerolog.Nop())
+	logger := zerolog.Nop()
+	srv := server.NewServer(cfg, dc, nil, nil, logger)
+	srv.WithWebhook(webhook.NewHandler(webhook.NewDeliveryStore(time.Hour), dc, srv, logger))
 
 	body := `{"action":"labeled","label":{"name":"ai:refine"},"repository":{"full_name":"owner/repo"},"issue":{"number":2}}`
 	rr := httptest.NewRecorder()
-	server.handleGitHubWebhook(rr, webhookRequest(t, "issues", "delivery-queue-full", body))
+	srv.Handler().ServeHTTP(rr, webhookRequest(t, "issues", "delivery-queue-full", body))
 	if rr.Code != http.StatusServiceUnavailable {
 		t.Fatalf("queue full: got %d, want %d body=%s", rr.Code, http.StatusServiceUnavailable, rr.Body.String())
 	}
@@ -629,7 +633,7 @@ func TestHandleWebhookReturnsServiceUnavailableWhenQueueFull(t *testing.T) {
 	// Delivery ID must be released so a retry can succeed.
 	<-dc.EventChan()
 	rr2 := httptest.NewRecorder()
-	server.handleGitHubWebhook(rr2, webhookRequest(t, "issues", "delivery-queue-full", body))
+	srv.Handler().ServeHTTP(rr2, webhookRequest(t, "issues", "delivery-queue-full", body))
 	if rr2.Code != http.StatusAccepted {
 		t.Fatalf("retry: got %d, want %d", rr2.Code, http.StatusAccepted)
 	}
@@ -637,9 +641,10 @@ func TestHandleWebhookReturnsServiceUnavailableWhenQueueFull(t *testing.T) {
 
 // ─── /agents/run endpoint tests ───────────────────────────────────────────────
 
-func newRunServer() *Server {
+func newRunServer() *server.Server {
 	cfg := testCfg(nil)
-	return NewServer(cfg, NewDeliveryStore(time.Hour), workflow.NewDataChannels(10), nil, nil, zerolog.Nop())
+	srv, _ := newTestServer(cfg)
+	return srv
 }
 
 func newRequest(method, path, body string) *http.Request {
@@ -652,7 +657,7 @@ func TestHandleAgentsRunEnqueuesEvent(t *testing.T) {
 
 	req := newRequest(http.MethodPost, "/run", `{"agent":"coder","repo":"owner/repo"}`)
 	rr := httptest.NewRecorder()
-	server.handleAgentsRun(rr, req)
+	server.Handler().ServeHTTP(rr, req)
 
 	if rr.Code != http.StatusAccepted {
 		t.Fatalf("expected %d, got %d: %s", http.StatusAccepted, rr.Code, rr.Body.String())
@@ -687,7 +692,7 @@ func TestHandleAgentsRunReturnsBadRequestOnMissingFields(t *testing.T) {
 			server := newRunServer()
 			req := newRequest(http.MethodPost, "/run", tc.body)
 			rr := httptest.NewRecorder()
-			server.handleAgentsRun(rr, req)
+			server.Handler().ServeHTTP(rr, req)
 			if rr.Code != http.StatusBadRequest {
 				t.Fatalf("got %d, want %d", rr.Code, http.StatusBadRequest)
 			}
@@ -700,29 +705,9 @@ func TestHandleAgentsRunReturnsNotFoundForUnknownRepo(t *testing.T) {
 	server := newRunServer()
 	req := newRequest(http.MethodPost, "/run", `{"agent":"coder","repo":"unknown/repo"}`)
 	rr := httptest.NewRecorder()
-	server.handleAgentsRun(rr, req)
+	server.Handler().ServeHTTP(rr, req)
 	if rr.Code != http.StatusNotFound {
 		t.Fatalf("got %d, want %d", rr.Code, http.StatusNotFound)
-	}
-}
-
-// ─── signature verification ───────────────────────────────────────────────────
-
-func TestVerifySignature(t *testing.T) {
-	t.Parallel()
-	body := []byte(`{"hello":"world"}`)
-	secret := "secret"
-	mac := hmac.New(sha256.New, []byte(secret))
-	mac.Write(body)
-	sig := "sha256=" + hex.EncodeToString(mac.Sum(nil))
-	if !verifySignature(body, secret, sig) {
-		t.Fatalf("expected signature to verify")
-	}
-	if verifySignature(body, secret, "sha256=deadbeef") {
-		t.Fatalf("bad signature should not verify")
-	}
-	if verifySignature(body, "", sig) {
-		t.Fatalf("empty secret must not verify")
 	}
 }
 
@@ -737,7 +722,7 @@ func TestInvalidSignatureDoesNotPoisonDeliveryDedupe(t *testing.T) {
 	reqBad.Header.Set("X-GitHub-Delivery", "delivery-poison")
 	reqBad.Header.Set("X-Hub-Signature-256", "sha256=deadbeef")
 	rrBad := httptest.NewRecorder()
-	server.handleGitHubWebhook(rrBad, reqBad)
+	server.Handler().ServeHTTP(rrBad, reqBad)
 	if rrBad.Code != http.StatusUnauthorized {
 		t.Fatalf("bad signature: got %d, want %d", rrBad.Code, http.StatusUnauthorized)
 	}
@@ -749,7 +734,7 @@ func TestInvalidSignatureDoesNotPoisonDeliveryDedupe(t *testing.T) {
 	reqGood.Header.Set("X-GitHub-Delivery", "delivery-poison")
 	reqGood.Header.Set("X-Hub-Signature-256", sig)
 	rrGood := httptest.NewRecorder()
-	server.handleGitHubWebhook(rrGood, reqGood)
+	server.Handler().ServeHTTP(rrGood, reqGood)
 	if rrGood.Code != http.StatusAccepted {
 		t.Fatalf("retry with good sig: got %d body=%s", rrGood.Code, rrGood.Body.String())
 	}
@@ -769,7 +754,7 @@ func TestUISlashlessRedirect(t *testing.T) {
 	srv, _ := newTestServer(testCfg(nil))
 	srv.WithUI(uiFS)
 
-	ts := httptest.NewServer(srv.buildHandler())
+	ts := httptest.NewServer(srv.Handler())
 	defer ts.Close()
 
 	client := &http.Client{
@@ -808,7 +793,7 @@ func TestBuildHandlerObservabilityRoutesAreOpen(t *testing.T) {
 	srv.WithUI(uiFS)
 	wireObserveForTest(srv, newTestObserve(t))
 
-	ts := httptest.NewServer(srv.buildHandler())
+	ts := httptest.NewServer(srv.Handler())
 	t.Cleanup(ts.Close)
 
 	// These read-only routes must NOT require a Bearer token.
@@ -850,7 +835,7 @@ func TestBuildHandlerMCPMountsWhenSet(t *testing.T) {
 	t.Run("not mounted by default", func(t *testing.T) {
 		t.Parallel()
 		srv, _ := newTestServer(testCfg(nil))
-		ts := httptest.NewServer(srv.buildHandler())
+		ts := httptest.NewServer(srv.Handler())
 		t.Cleanup(ts.Close)
 
 		resp, err := http.Post(ts.URL+"/mcp", "application/json", strings.NewReader(`{}`))
@@ -871,7 +856,7 @@ func TestBuildHandlerMCPMountsWhenSet(t *testing.T) {
 		})
 		srv.WithMCP(marker)
 
-		ts := httptest.NewServer(srv.buildHandler())
+		ts := httptest.NewServer(srv.Handler())
 		t.Cleanup(ts.Close)
 
 		resp, err := http.Post(ts.URL+"/mcp", "application/json", strings.NewReader(`{}`))

--- a/internal/webhook/handler_test.go
+++ b/internal/webhook/handler_test.go
@@ -1,0 +1,28 @@
+package webhook
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+)
+
+// TestVerifySignature exercises the HMAC-SHA256 signature check that gates
+// every incoming GitHub webhook delivery.
+func TestVerifySignature(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"hello":"world"}`)
+	secret := "secret"
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	sig := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+	if !verifySignature(body, secret, sig) {
+		t.Fatalf("expected signature to verify")
+	}
+	if verifySignature(body, secret, "sha256=deadbeef") {
+		t.Fatalf("bad signature should not verify")
+	}
+	if verifySignature(body, "", sig) {
+		t.Fatalf("empty secret must not verify")
+	}
+}


### PR DESCRIPTION
## Summary
- \`internal/webhook/server.go\` → \`internal/server/server.go\` (and \`webhook/crud.go\` → \`server/server_crud.go\`).
- \`webhook.Server\` becomes \`server.Server\`. \`webhook.NewServer\` becomes \`server.NewServer\` and drops its \`delivery *DeliveryStore\` parameter — \`cmd/agents\` constructs the webhook handler externally and wires it via the new \`Server.WithWebhook(h server.HandlerRegister)\`, matching the pattern already used for fleet/repos/config.
- Server gains \`Handler() http.Handler\` and \`DB() *sql.DB\` accessors so the moved tests (now \`package server_test\`) can exercise the router and seed the store without unexported access.
- All six lifecycle test files move from \`internal/webhook/\` to \`internal/server/\`. \`srv.handleGitHubWebhook(...)\` and \`srv.handleAgentsRun(...)\` call sites are rewritten to \`srv.Handler().ServeHTTP(...)\`.
- \`TestVerifySignature\` moves to a new \`internal/webhook/handler_test.go\` (it tests a webhook-package free function).

## Result
- \`internal/webhook/\` is now exactly 4 files (\`handler.go\`, \`handler_test.go\`, \`delivery_store.go\`, \`delivery_store_test.go\`, ~734 lines). It owns **only** GitHub-webhook handling: HMAC verification, delivery dedupe, event parsing.
- \`internal/server/\` owns the central HTTP server lifecycle (router, \`With*\` setters, \`Run()\`, \`/status\`, \`/run\`, proxy/UI/MCP mounts) and the cross-cutting types every domain handler needs.
- The architectural sketch we drew mid-refactor (the diagram showing webhook as a small leaf, server as the composing root, domain handlers as siblings) is now the actual layout.

## Why a separate PR
Step 4b-2b of the webhook split (#250). The four prior PRs (#320 observe, #321 fleet, #322 repos, #323 config) removed every \`internal/server/X\` import from \`webhook.Server\` so the file could move without creating cycles. This PR is the move itself plus follow-on test churn — mostly mechanical given the dependency work that landed first.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./... -race -count=1\` green across every package
- [x] \`internal/webhook/\` no longer imports any \`internal/server/X\` sub-package in production code
- [x] Architecture diagram from earlier in the refactor is now the literal repo layout

## What's next
Optional polish (4b-3): doc updates beyond the touch-ups in this PR, any leftover dead helpers, and a final \`go vet\` pass. Could also consider exporting fewer fields/methods than I exposed for tests (\`DB()\`, \`Handler()\`) once the test surface settles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)