### PR TITLE
refactor: drop pre-1.22 loop-variable captures in mcp tests

### DIFF
--- a/internal/mcp/tools_arrays_test.go
+++ b/internal/mcp/tools_arrays_test.go
@@ -37,7 +37,6 @@ func TestStringSliceArgAcceptsShapes(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got, errMsg := stringSliceArg(tc.in, "skills")
@@ -84,7 +83,6 @@ func TestStringSlicePtrArgAcceptsJSONString(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			ptr, ok, errMsg := stringSlicePtrArg(tc.args, "skills")
@@ -140,7 +138,6 @@ func TestArrayOfAnyAcceptsShapes(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got, errMsg := arrayOfAny(tc.in, "bindings")


### PR DESCRIPTION
## Summary

Removes three `tc := tc` shadow assignments from `internal/mcp/tools_arrays_test.go`.

These were the pre-Go 1.22 workaround for parallel subtests capturing the same loop variable. Go 1.22 changed loop semantics so each iteration gets its own variable, making these copies dead code. The module declares `go 1.25.5`, so they serve no purpose and only add noise.

The three affected loops are in `TestStringSliceArgAcceptsShapes`, `TestStringSlicePtrArgAcceptsJSONString`, and `TestArrayOfAnyAcceptsShapes` — all use `t.Parallel()` inside the subtest and were the canonical targets for this pattern.

`internal/mcp/tools_test.go` also contains at least one `tc := tc` (confirmed via code search) but is too large (~70 KB) to safely include in the same commit without reading the full file. A follow-up can clean that up.

## Test plan

- [ ] CI green (`go test -race ./...`)
- [ ] No behaviour change — pure dead-code removal

@pr-reviewer please review.