### PR TITLE
refactor: drop pre-1.22 loop-variable captures in tools_test

### DIFF
--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -1655,7 +1655,6 @@ func TestToolCreateRepoRejectsBadBindingsShape(t *testing.T) {
 		{"element not object", []any{"coder"}, "bindings[0]: must be an object"},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			deps := testFixture(t)
@@ -1704,7 +1703,6 @@ func TestToolCreateRepoRejectsBadBindingFieldTypes(t *testing.T) {
 		{"events element not string", map[string]any{"agent": "coder", "events": []any{true}}, "bindings[0].events[0] must be a string"},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			deps := testFixture(t)


### PR DESCRIPTION
## Summary

Removes two `tc := tc` shadow assignments from `internal/mcp/tools_test.go`.

These are the pre-Go 1.22 workaround for parallel subtests capturing the same loop variable. Go 1.22 changed loop semantics so each iteration gets its own variable, making these copies dead code. The module declares `go 1.25.5`, so they serve no purpose and only add noise.

The two affected loops are in `TestToolCreateRepoRejectsBadBindingsShape` and `TestToolCreateRepoRejectsBadBindingFieldTypes` — both use `t.Parallel()` inside the subtest and were the canonical targets for this pattern.

This is the follow-up to #325, which cleaned the same pattern from `tools_arrays_test.go`.

## Test plan

- [ ] CI green (`go test -race ./...`)
- [ ] No behaviour change — pure dead-code removal

@pr-reviewer please review.