### PR TITLE
refactor: inline mapKeys one-caller helper using maps.Keys

### DIFF
--- a/internal/observe/observe_test.go
+++ b/internal/observe/observe_test.go
@@ -3,8 +3,10 @@ package observe_test
 import (
 	"context"
 	"encoding/json"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -437,7 +439,7 @@ func TestStoreRecordEventSSEUsesLowercaseJSON(t *testing.T) {
 
 	for _, key := range []string{"at", "id", "repo", "kind", "number", "actor"} {
 		if _, ok := fields[key]; !ok {
-			t.Errorf("SSE payload missing lowercase key %q; got keys: %v", key, mapKeys(fields))
+			t.Errorf("SSE payload missing lowercase key %q; got keys: %v", key, slices.Sorted(maps.Keys(fields)))
 		}
 	}
 	// Ensure no uppercase duplicates leaked through.
@@ -634,13 +636,4 @@ func TestStoreRecordStepsNoOpOnEmpty(t *testing.T) {
 	if got != nil {
 		t.Fatalf("want nil after no-op records, got %v", got)
 	}
-}
-
-// mapKeys returns the sorted keys of a map for use in error messages.
-func mapKeys(m map[string]any) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	return keys
 }


### PR DESCRIPTION
## Summary

`mapKeys` in `internal/observe/observe_test.go` was a private helper called exactly once — in an error message inside `TestStoreRecordEventSSEUsesLowercaseJSON`. Per the project's refactoring guidelines, one-caller abstractions are noise until a second caller appears.

Go 1.23 provides `slices.Sorted(maps.Keys(m))` which expresses the same intent inline, removing the 6-line helper entirely.

**Changes:**
- Add `"maps"` and `"slices"` imports
- Replace `mapKeys(fields)` call with `slices.Sorted(maps.Keys(fields))` at the call site
- Delete the `mapKeys` function

The inline form also produces **deterministic sorted output**, which is strictly better for human-readable test failure messages than the original random-order slice.

No behaviour change — the value is only used in `t.Errorf` formatting.

## Test plan

- [ ] CI green (`go test -race ./...`)
- [ ] No behaviour change — pure dead-code removal

@pr-reviewer please review.