### PR TITLE
refactor: delete unused nilSafeStrings helper from server/repos

### DIFF
--- a/internal/server/repos/repos.go
+++ b/internal/server/repos/repos.go
@@ -500,12 +500,3 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(v)
 }
-
-// nilSafeStrings returns an empty slice when in is nil so encoded JSON shows
-// `[]` rather than `null`.
-func nilSafeStrings(in []string) []string {
-	if in == nil {
-		return []string{}
-	}
-	return in
-}


### PR DESCRIPTION
## Summary

`nilSafeStrings` in `internal/server/repos/repos.go` was defined but never called anywhere in the package.

The function was presumably intended to ensure `Labels` and `Events` fields serialise as `[]` rather than `null` in JSON. However `bindingToStoreJSON` assigns those fields directly from `fleet.Binding` without going through this helper, so the guard was never wired in and the function is unreachable dead code.

`nilSafeStrings` also exists as independent local copies in `internal/store/crud.go` and `internal/server/fleet/fleet.go` where it *is* called — those are unaffected.

**Changes:**
- Delete the 7-line `nilSafeStrings` function from `repos.go`

## Test plan

- [ ] CI green (`go test -race ./...`)
- [ ] No behaviour change — pure dead-code removal

@pr-reviewer please review.