### PR TITLE
refactor: inline sanitizeName one-caller helper in dispatch.go

### DIFF
--- a/internal/workflow/dispatch.go
+++ b/internal/workflow/dispatch.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -469,7 +468,7 @@ func (d *Dispatcher) ProcessDispatches(
 	var errs []error
 	fanout := 0
 	for _, req := range requests {
-		req.Agent = sanitizeName(req.Agent)
+		req.Agent = fleet.NormalizeAgentName(req.Agent)
 		d.counters.requestedTotal.Add(1)
 
 		// When the agent omits number (zero value), fall back to the originating
@@ -646,11 +645,6 @@ func (d *Dispatcher) FinalizeAutonomousRun(agentName, repo string) {
 // Stats returns a snapshot of the current dispatch counters.
 func (d *Dispatcher) Stats() DispatchStats {
 	return d.counters.snapshot()
-}
-
-// sanitizeName lowercases and trims a name for safe comparison.
-func sanitizeName(s string) string {
-	return strings.ToLower(strings.TrimSpace(s))
 }
 
 // GenEventID returns a short random hex string suitable for use as a root


### PR DESCRIPTION
## Summary

- `sanitizeName` in `internal/workflow/dispatch.go` had exactly one call site (`req.Agent = sanitizeName(req.Agent)`) and an identical body to `fleet.NormalizeAgentName` (`strings.ToLower(strings.TrimSpace(s))`).
- `fleet` was already imported. Replace the call with `fleet.NormalizeAgentName` directly, remove the now-dead private helper and its comment, and drop the no-longer-needed `"strings"` import.

No behaviour change — the normalization algorithm is identical.

## Test plan

- [ ] CI green (`go test ./...` with `-race`)
- [ ] No test changes needed — callers and existing dispatch tests are unaffected
