### PR TITLE
refactor: replace sort.Slice with slices.SortFunc in RunDiagnostics

### DIFF
--- a/internal/backends/discovery.go
+++ b/internal/backends/discovery.go
@@ -10,7 +10,6 @@ import (
 	"os/exec"
 	"regexp"
 	"slices"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -127,7 +126,9 @@ func RunDiagnostics(ctx context.Context, existing map[string]fleet.Backend) Diag
 	wg.Wait()
 
 	diag.Backends = backendsOut
-	sort.Slice(diag.Backends, func(i, j int) bool { return diag.Backends[i].Name < diag.Backends[j].Name })
+	slices.SortFunc(diag.Backends, func(a, b BackendStatus) int {
+		return strings.Compare(a.Name, b.Name)
+	})
 	return diag
 }
 


### PR DESCRIPTION
## Summary

`RunDiagnostics` in `internal/backends/discovery.go` sorts the discovered backends with `sort.Slice` — the pre-1.21 idiom for struct slices:

```go
sort.Slice(diag.Backends, func(i, j int) bool { return diag.Backends[i].Name < diag.Backends[j].Name })
```

The file already imports `slices` and `strings`. Using `slices.SortFunc` with `strings.Compare` is the idiomatic Go 1.21+ equivalent and removes the now-unused `"sort"` import:

```go
slices.SortFunc(diag.Backends, func(a, b BackendStatus) int {
    return strings.Compare(a.Name, b.Name)
})
```

The same pattern is already applied in `internal/server/fleet/orphans.go` (`slices.SortFunc` with `strings.Compare`). This brings `discovery.go` in line with it.

**Changes:**
- Remove `"sort"` import
- Replace `sort.Slice` with `slices.SortFunc` + `strings.Compare`

No behaviour change — sort key (`BackendStatus.Name`) and order (ascending) are identical.

## Test plan

- [ ] CI green (`go test -race ./...`)
- [ ] No behaviour change — pure idiom update

@pr-reviewer please review.