### PR TITLE
refactor: inline isValidBackendName one-caller helper

### DIFF
--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -262,12 +262,8 @@ func countBindingTriggers(b fleet.Binding) int {
 	return n
 }
 
-func isValidBackendName(name string) bool {
-	return slices.Contains(validAIBackendNames, name)
-}
-
 func isSupportedBackend(name string, backend fleet.Backend) bool {
-	if isValidBackendName(name) {
+	if slices.Contains(validAIBackendNames, name) {
 		return true
 	}
 	return strings.TrimSpace(backend.LocalModelURL) != ""


### PR DESCRIPTION
## Summary

`isValidBackendName` in `internal/config/validate.go` wraps a single `slices.Contains(validAIBackendNames, name)` call and has exactly one caller (`isSupportedBackend`). Inlining it removes an unnecessary indirection — `validAIBackendNames` already makes the intent obvious at the call site.

- Remove `isValidBackendName` function
- Inline `slices.Contains(validAIBackendNames, name)` directly into `isSupportedBackend`
- No behaviour change