### PR TITLE
refactor: consolidate duplicate storeErrStatus into server.StoreErrStatus

### DIFF
--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -381,7 +381,7 @@ func (h *Handler) HandleImport(w http.ResponseWriter, r *http.Request) {
 	}
 	counts, err := h.ImportYAML(body, r.URL.Query().Get("mode"))
 	if err != nil {
-		http.Error(w, err.Error(), storeErrStatus(err))
+		http.Error(w, err.Error(), server.StoreErrStatus(err))
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -423,23 +423,4 @@ func (h *Handler) ImportYAML(body []byte, mode string) (map[string]int, error) {
 		"repos":    len(payload.Repos),
 		"backends": len(backends),
 	}, nil
-}
-
-// storeErrStatus maps a store error to an HTTP status. Validation and
-// not-found errors surface as 400 and 404; conflict errors as 409;
-// everything else as 500.
-func storeErrStatus(err error) int {
-	var v *store.ErrValidation
-	if errors.As(err, &v) {
-		return http.StatusBadRequest
-	}
-	var n *store.ErrNotFound
-	if errors.As(err, &n) {
-		return http.StatusNotFound
-	}
-	var c *store.ErrConflict
-	if errors.As(err, &c) {
-		return http.StatusConflict
-	}
-	return http.StatusInternalServerError
 }

--- a/internal/server/fleet/fleet.go
+++ b/internal/server/fleet/fleet.go
@@ -649,7 +649,7 @@ func (h *Handler) handleBackendsDiscover(w http.ResponseWriter, r *http.Request)
 		return nil
 	})
 	if err != nil {
-		status := storeErrStatus(err)
+		status := server.StoreErrStatus(err)
 		h.logger.Error().Err(err).Msg("backend discovery failed")
 		http.Error(w, fmt.Sprintf("backend discovery: %v", err), status)
 		return
@@ -723,7 +723,7 @@ func (h *Handler) handleBackendsLocal(w http.ResponseWriter, r *http.Request) {
 		return nil
 	})
 	if err != nil {
-		status := storeErrStatus(err)
+		status := server.StoreErrStatus(err)
 		h.logger.Error().Err(err).Msg("local backend upsert failed")
 		http.Error(w, fmt.Sprintf("local backend upsert or cron reload: %v", err), status)
 		return
@@ -849,23 +849,7 @@ func (h *Handler) DeleteBackend(name string) error {
 
 func (h *Handler) writeErr(w http.ResponseWriter, err error, op string) {
 	h.logger.Error().Err(err).Msgf("store crud: %s failed", op)
-	http.Error(w, fmt.Sprintf("%s: %v", op, err), storeErrStatus(err))
-}
-
-func storeErrStatus(err error) int {
-	var v *store.ErrValidation
-	if errors.As(err, &v) {
-		return http.StatusBadRequest
-	}
-	var n *store.ErrNotFound
-	if errors.As(err, &n) {
-		return http.StatusNotFound
-	}
-	var c *store.ErrConflict
-	if errors.As(err, &c) {
-		return http.StatusConflict
-	}
-	return http.StatusInternalServerError
+	http.Error(w, fmt.Sprintf("%s: %v", op, err), server.StoreErrStatus(err))
 }
 
 func decodeBody[T any](w http.ResponseWriter, r *http.Request, limit int64, out *T) bool {

--- a/internal/server/repos/repos.go
+++ b/internal/server/repos/repos.go
@@ -450,26 +450,7 @@ func boolToInt(b bool) int {
 // operators see the same context.
 func (h *Handler) writeErr(w http.ResponseWriter, err error, op string) {
 	h.logger.Error().Err(err).Msgf("store crud: %s failed", op)
-	http.Error(w, fmt.Sprintf("%s: %v", op, err), storeErrStatus(err))
-}
-
-// storeErrStatus maps a store error to an HTTP status. Validation and
-// not-found errors surface as 400 and 404 respectively; conflict errors as
-// 409. Everything else falls back to 500 so unexpected failures are loud.
-func storeErrStatus(err error) int {
-	var v *store.ErrValidation
-	if errors.As(err, &v) {
-		return http.StatusBadRequest
-	}
-	var n *store.ErrNotFound
-	if errors.As(err, &n) {
-		return http.StatusNotFound
-	}
-	var c *store.ErrConflict
-	if errors.As(err, &c) {
-		return http.StatusConflict
-	}
-	return http.StatusInternalServerError
+	http.Error(w, fmt.Sprintf("%s: %v", op, err), server.StoreErrStatus(err))
 }
 
 // decodeBody reads and decodes a JSON body up to limit bytes. On error it

--- a/internal/server/server_crud.go
+++ b/internal/server/server_crud.go
@@ -10,11 +10,11 @@ import (
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-// storeErrStatus maps store mutation errors to the appropriate HTTP status
+// StoreErrStatus maps store mutation errors to the appropriate HTTP status
 // code. ErrValidation (bad field values) → 400, ErrConflict (invariant
 // violations, referenced-by failures) → 409, ErrNotFound → 404,
 // anything else → 500.
-func storeErrStatus(err error) int {
+func StoreErrStatus(err error) int {
 	var valErr *store.ErrValidation
 	if errors.As(err, &valErr) {
 		return http.StatusBadRequest
@@ -36,7 +36,7 @@ func storeErrStatus(err error) int {
 // HTTP error body so callers and operators see the same context.
 func (s *Server) storeWriteErr(w http.ResponseWriter, err error, op string) {
 	s.logger.Error().Err(err).Msgf("store crud: %s failed", op)
-	http.Error(w, fmt.Sprintf("%s: %v", op, err), storeErrStatus(err))
+	http.Error(w, fmt.Sprintf("%s: %v", op, err), StoreErrStatus(err))
 }
 
 // reloadCron re-reads the full config from the DB as a consistent snapshot


### PR DESCRIPTION
## What

`storeErrStatus` (maps store typed errors → HTTP status codes) was
defined privately in four separate files:

- `internal/server/server_crud.go` (the canonical definition)
- `internal/server/fleet/fleet.go` (duplicate)
- `internal/server/repos/repos.go` (duplicate)
- `internal/server/config/config.go` (duplicate)

All three sub-packages already imported `internal/server`, so the
duplicates existed purely because the original function was unexported.

## Change

- Export `storeErrStatus` → `StoreErrStatus` in `server_crud.go`.
- Delete the three private copies in `fleet`, `repos`, and `config`.
- Update all call sites to `server.StoreErrStatus(err)`.

No behaviour change — all four copies had identical mapping logic.
No new imports required in any file.
