### PR TITLE
refactor: drop redundant strings.ToLower in RepoByName

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -168,7 +168,7 @@ func Load(path string) (*Config, error) {
 func (c *Config) RepoByName(name string) (fleet.Repo, bool) {
 	name = strings.ToLower(strings.TrimSpace(name))
 	for _, r := range c.Repos {
-		if strings.ToLower(r.Name) == name {
+		if r.Name == name {
 			return r, true
 		}
 	}


### PR DESCRIPTION
## Summary

`RepoByName` in `internal/config/config.go` normalises the incoming `name`
to lowercase at the top of the function, then compares it against
`strings.ToLower(r.Name)` in the loop — making the inner `ToLower` dead code.

`r.Name` is already lowercase: `normalize()` calls `fleet.NormalizeRepo`
which applies `strings.ToLower(strings.TrimSpace(...))` to every repo name
before any lookup is expected. `AgentByName` in the same file already trusts
this invariant (`if a.Name == name`) — `RepoByName` should be consistent.

**Changes:**
- Replace `strings.ToLower(r.Name) == name` with `r.Name == name` in `RepoByName`

No imports change (strings is still needed for the input normalisation).
No behaviour change — repos are always normalised before lookups.

## Test plan

- [ ] CI green (`go test -race ./...`)
- [ ] No behaviour change — pure dead-code removal

@pr-reviewer please review.