### PR TITLE
refactor: replace magic format string with time.RFC3339 in fleet view

### DIFF
--- a/internal/server/fleet/view.go
+++ b/internal/server/fleet/view.go
@@ -3,6 +3,7 @@ package fleet
 import (
 	"encoding/json"
 	"net/http"
+	"time"
 
 	"github.com/eloylp/agents/internal/scheduler"
 )
@@ -108,11 +109,11 @@ func (h *Handler) HandleAgentsView(w http.ResponseWriter, _ *http.Request) {
 				if b.IsCron() {
 					if st, ok := scheduleByKey[a.Name+"\x00"+repo.Name]; ok {
 						j := &agentScheduleJSON{
-							NextRun:    st.NextRun.UTC().Format("2006-01-02T15:04:05Z"),
+							NextRun:    st.NextRun.UTC().Format(time.RFC3339),
 							LastStatus: st.LastStatus,
 						}
 						if st.LastRun != nil {
-							lr := st.LastRun.UTC().Format("2006-01-02T15:04:05Z")
+							lr := st.LastRun.UTC().Format(time.RFC3339)
 							j.LastRun = &lr
 						}
 						binding.Schedule = j


### PR DESCRIPTION
## Summary

`HandleAgentsView` in `internal/server/fleet/view.go` formatted cron schedule timestamps using a hardcoded layout string `"2006-01-02T15:04:05Z"` — a magic string that is functionally identical to `time.RFC3339` for UTC times (which `.UTC()` guarantees before the format call). The struct field comments already document the intent as "RFC3339".

**Changes:**
- Add `"time"` import
- Replace `"2006-01-02T15:04:05Z"` (×2) with `time.RFC3339`

No behaviour change: for UTC times, `time.RFC3339` (`"2006-01-02T15:04:05Z07:00"`) collapses the zone offset to `"Z"`, producing output identical to the literal string.

## Test plan

- [ ] CI green (`go test -race ./...`)
- [ ] No behaviour change — pure idiom update

@pr-reviewer please review.