### PR TITLE
refactor: use type conversion for ai.TraceStep → workflow.TraceStep

### DIFF
--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -727,17 +727,11 @@ func (e *Engine) runAgent(ctx context.Context, ev Event, agent fleet.Agent, cfg 
 		)
 	}
 
-	// Record transcript steps when available. Translate from the runner-internal
-	// ai.TraceStep to the domain-level workflow.TraceStep at this boundary.
+	// Record transcript steps when available.
 	if e.stepRec != nil && len(resp.Steps) > 0 {
 		wsteps := make([]TraceStep, len(resp.Steps))
 		for i, s := range resp.Steps {
-			wsteps[i] = TraceStep{
-				ToolName:      s.ToolName,
-				InputSummary:  s.InputSummary,
-				OutputSummary: s.OutputSummary,
-				DurationMs:    s.DurationMs,
-			}
+			wsteps[i] = TraceStep(s)
 		}
 		e.stepRec.RecordSteps(spanID, wsteps)
 	}


### PR DESCRIPTION
## Summary

`ai.TraceStep` and `workflow.TraceStep` are structurally identical — same field names, same field types, same JSON tags, same order. The engine's step-recording loop was copying all four fields by name:

```go
wsteps[i] = TraceStep{
    ToolName:      s.ToolName,
    InputSummary:  s.InputSummary,
    OutputSummary: s.OutputSummary,
    DurationMs:    s.DurationMs,
}
```

This is verbose and implies the types differ in some meaningful way. The Go spec allows direct conversion between named struct types with identical underlying types (struct tags are ignored for this purpose), so the idiomatic form is:

```go
wsteps[i] = TraceStep(s)
```

This makes the structural identity explicit and removes the noise of a 4-field copy. No behaviour change.

Also removed the comment that described *what* was happening ("Translate from the runner-internal ai.TraceStep to the domain-level workflow.TraceStep at this boundary") — `TraceStep(s)` is self-documenting; the comment was just restating the code.