### PR TITLE
refactor: export AnyFieldSet on AgentPatch/BackendPatch, drop mcp duplicates

### DIFF
--- a/internal/mcp/tools_crud.go
+++ b/internal/mcp/tools_crud.go
@@ -109,7 +109,7 @@ func toolUpdateAgent(deps Deps) server.ToolHandlerFunc {
 		} else if errMsg != "" {
 			return mcpgo.NewToolResultError(errMsg), nil
 		}
-		if !agentPatchHasField(patch) {
+		if !patch.AnyFieldSet() {
 			return mcpgo.NewToolResultError("at least one field is required"), nil
 		}
 		canonical, uerr := deps.Fleet.UpdateAgentPatch(name, patch)
@@ -118,12 +118,6 @@ func toolUpdateAgent(deps Deps) server.ToolHandlerFunc {
 		}
 		return jsonResult(agentJSON(canonical))
 	}
-}
-
-func agentPatchHasField(p serverfleet.AgentPatch) bool {
-	return p.Backend != nil || p.Model != nil || p.Skills != nil || p.Prompt != nil ||
-		p.AllowPRs != nil || p.AllowDispatch != nil || p.CanDispatch != nil ||
-		p.Description != nil || p.AllowMemory != nil
 }
 
 // toolDeleteAgent removes an agent through the same path as DELETE
@@ -302,7 +296,7 @@ func toolUpdateBackend(deps Deps) server.ToolHandlerFunc {
 		} else if errMsg != "" {
 			return mcpgo.NewToolResultError(errMsg), nil
 		}
-		if !backendPatchHasField(patch) {
+		if !patch.AnyFieldSet() {
 			return mcpgo.NewToolResultError("at least one field is required"), nil
 		}
 		canonicalName, canonical, uerr := deps.Fleet.UpdateBackendPatch(name, patch)
@@ -311,12 +305,6 @@ func toolUpdateBackend(deps Deps) server.ToolHandlerFunc {
 		}
 		return jsonResult(backendJSON(canonicalName, canonical))
 	}
-}
-
-func backendPatchHasField(p serverfleet.BackendPatch) bool {
-	return p.Command != nil || p.Version != nil || p.Models != nil || p.Healthy != nil ||
-		p.HealthDetail != nil || p.LocalModelURL != nil || p.TimeoutSeconds != nil ||
-		p.MaxPromptChars != nil || p.RedactionSaltEnv != nil
 }
 
 // toolDeleteBackend removes a backend through the same path as DELETE

--- a/internal/server/fleet/fleet.go
+++ b/internal/server/fleet/fleet.go
@@ -188,7 +188,10 @@ type AgentPatch struct {
 	AllowMemory   *bool     `json:"allow_memory,omitempty"`
 }
 
-func (p AgentPatch) anyFieldSet() bool {
+// AnyFieldSet reports whether at least one patch field is non-nil. Used by
+// both the REST PATCH handler and the MCP update_agent tool to reject empty
+// payloads before hitting the store.
+func (p AgentPatch) AnyFieldSet() bool {
 	return p.Backend != nil || p.Model != nil || p.Skills != nil || p.Prompt != nil ||
 		p.AllowPRs != nil || p.AllowDispatch != nil || p.CanDispatch != nil ||
 		p.Description != nil || p.AllowMemory != nil
@@ -262,7 +265,7 @@ func (h *Handler) handleAgentPatch(w http.ResponseWriter, r *http.Request, name 
 	if !decodeBody(w, r, h.srv.Config().Daemon.HTTP.MaxBodyBytes, &req) {
 		return
 	}
-	if !req.anyFieldSet() {
+	if !req.AnyFieldSet() {
 		http.Error(w, "at least one field is required", http.StatusBadRequest)
 		return
 	}
@@ -533,7 +536,10 @@ type BackendPatch struct {
 	RedactionSaltEnv *string   `json:"redaction_salt_env,omitempty"`
 }
 
-func (p BackendPatch) anyFieldSet() bool {
+// AnyFieldSet reports whether at least one patch field is non-nil. Used by
+// both the REST PATCH handler and the MCP update_backend tool to reject empty
+// payloads before hitting the store.
+func (p BackendPatch) AnyFieldSet() bool {
 	return p.Command != nil || p.Version != nil || p.Models != nil || p.Healthy != nil ||
 		p.HealthDetail != nil || p.LocalModelURL != nil || p.TimeoutSeconds != nil ||
 		p.MaxPromptChars != nil || p.RedactionSaltEnv != nil
@@ -756,7 +762,7 @@ func (h *Handler) handleBackendPatch(w http.ResponseWriter, r *http.Request) {
 	if !decodeBody(w, r, h.srv.Config().Daemon.HTTP.MaxBodyBytes, &req) {
 		return
 	}
-	if !req.anyFieldSet() {
+	if !req.AnyFieldSet() {
 		http.Error(w, "at least one field is required", http.StatusBadRequest)
 		return
 	}


### PR DESCRIPTION
## What

`AgentPatch` and `BackendPatch` in `internal/server/fleet` already had
private `anyFieldSet()` methods. The `mcp` package couldn't call them
cross-package, so `tools_crud.go` carried two free-function duplicates
(`agentPatchHasField` / `backendPatchHasField`) with identical logic.

This PR:
- Renames `anyFieldSet` → `AnyFieldSet` on both patch types (4 call
  sites inside `fleet.go` updated in the same commit)
- Deletes `agentPatchHasField` and `backendPatchHasField` from
  `tools_crud.go` and replaces their single call sites with
  `patch.AnyFieldSet()`

Net: −10 lines, one canonical location for each check.

## Why it's safe

- Pure rename + deletion; no logic change anywhere
- The condition body is identical in all four copies (verified by diff)
- `SkillPatch.anyFieldSet` is not exported — the mcp layer already
  inlines the single-field check (`patch.Prompt == nil`) so no
  cross-package call is needed there