### PR TITLE
refactor: use time.DateTime constant in ReadMemory fallback parse

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -622,7 +622,7 @@ func ReadMemory(db *sql.DB, agent, repo string) (string, bool, time.Time, error)
 	// the bare "YYYY-MM-DD HH:MM:SS" SQLite text format as a safety net.
 	t, parseErr := time.Parse(time.RFC3339, updatedAt)
 	if parseErr != nil {
-		t, _ = time.Parse("2006-01-02 15:04:05", updatedAt)
+		t, _ = time.Parse(time.DateTime, updatedAt)
 	}
 	return content, true, t.UTC(), nil
 }


### PR DESCRIPTION
## What

Replace the magic string `"2006-01-02 15:04:05"` in `ReadMemory` with the stdlib constant `time.DateTime`.

```go
// before
t, _ = time.Parse("2006-01-02 15:04:05", updatedAt)

// after
t, _ = time.Parse(time.DateTime, updatedAt)
```

## Why

`time.DateTime` (Go 1.20) is exactly this layout. Using the named constant pairs naturally with `time.RFC3339` on the line above, makes the fallback intent self-documenting, and follows the same pattern as PR #336 which swapped the same magic string in `internal/server/fleet/view.go`.

No behaviour change — the format string is identical.