### PR TITLE
refactor: replace private sanitizeName with fleet.NormalizeAgentName in workflow/dispatch.go

### DIFF
--- a/internal/workflow/dispatch.go
+++ b/internal/workflow/dispatch.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -469,7 +468,7 @@ func (d *Dispatcher) ProcessDispatches(
 	var errs []error
 	fanout := 0
 	for _, req := range requests {
-		req.Agent = sanitizeName(req.Agent)
+		req.Agent = fleet.NormalizeAgentName(req.Agent)
 		d.counters.requestedTotal.Add(1)
 
 		// When the agent omits number (zero value), fall back to the originating
@@ -646,11 +645,6 @@ func (d *Dispatcher) FinalizeAutonomousRun(agentName, repo string) {
 // Stats returns a snapshot of the current dispatch counters.
 func (d *Dispatcher) Stats() DispatchStats {
 	return d.counters.snapshot()
-}
-
-// sanitizeName lowercases and trims a name for safe comparison.
-func sanitizeName(s string) string {
-	return strings.ToLower(strings.TrimSpace(s))
 }
 
 // GenEventID returns a short random hex string suitable for use as a root


### PR DESCRIPTION
## What

Removes the private `sanitizeName` helper from `internal/workflow/dispatch.go` and replaces its single call site with `fleet.NormalizeAgentName`.

## Why

`sanitizeName` had exactly one caller (`ProcessDispatches`) and duplicated `fleet.NormalizeAgentName` verbatim — both do `strings.ToLower(strings.TrimSpace(s))`. The `fleet` package is already imported. Using the canonical normalization function makes the intent explicit (this is the same normalization applied everywhere else in the codebase) and removes a private abstraction that existed for its own sake.

The `"strings"` import is dropped as a consequence — it was only used by the deleted function.