### PR TITLE
refactor: use trimmedString in toolTriggerAgent, drop "strings" import

### DIFF
--- a/internal/mcp/tools_fleet.go
+++ b/internal/mcp/tools_fleet.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"maps"
 	"slices"
-	"strings"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -184,18 +183,13 @@ func toolGetStatus(deps Deps) server.ToolHandlerFunc {
 // correlate with trace data later.
 func toolTriggerAgent(deps Deps) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
-		agent, err := req.RequireString("agent")
-		if err != nil {
-			return mcpgo.NewToolResultError(err.Error()), nil
+		agent, ok := trimmedString(req, "agent")
+		if !ok {
+			return mcpgo.NewToolResultError("agent is required"), nil
 		}
-		repoName, err := req.RequireString("repo")
-		if err != nil {
-			return mcpgo.NewToolResultError(err.Error()), nil
-		}
-		agent = strings.TrimSpace(agent)
-		repoName = strings.TrimSpace(repoName)
-		if agent == "" || repoName == "" {
-			return mcpgo.NewToolResultError("agent and repo are required"), nil
+		repoName, ok := trimmedString(req, "repo")
+		if !ok {
+			return mcpgo.NewToolResultError("repo is required"), nil
 		}
 
 		cfg := deps.Server.Config()


### PR DESCRIPTION
## What

`toolTriggerAgent` in `internal/mcp/tools_fleet.go` validated its two required arguments with a verbose pattern:

```go
agent, err := req.RequireString("agent")
if err != nil {
    return mcpgo.NewToolResultError(err.Error()), nil
}
repoName, err := req.RequireString("repo")
if err != nil {
    return mcpgo.NewToolResultError(err.Error()), nil
}
agent = strings.TrimSpace(agent)
repoName = strings.TrimSpace(repoName)
if agent == "" || repoName == "" {
    return mcpgo.NewToolResultError("agent and repo are required"), nil
}
```

Every other tool in the package delegates this exact pattern to the `trimmedString` helper (defined in `tools.go`). Replace the 12-line block with two `trimmedString` calls and remove the now-unused `"strings"` import.

## Why it's safe

- `trimmedString` wraps `RequireString` + `TrimSpace` + empty-check, so the validation semantics are identical.
- Error messages become per-field (`"agent is required"` / `"repo is required"`) instead of the combined `"agent and repo are required"` — strictly more precise.
- No behaviour change at the call site: callers that pass valid non-empty values see no difference.

## Test plan

- [ ] CI green (`go test -race ./...`)
- [ ] No behaviour change — pure idiom consistency fix

@pr-reviewer please review.