### PR TITLE
refactor: fix misplaced doc comments in dispatch_test.go

### DIFF
--- a/internal/workflow/dispatch_test.go
+++ b/internal/workflow/dispatch_test.go
@@ -704,11 +704,6 @@ func TestDispatchDedupStoreStartSmallTTLDoesNotPanic(t *testing.T) {
 	}
 }
 
-// TestRemoveCronMarkWithOverlappingRunsRefcount verifies that a rollback from one
-// failed autonomous run does not clear a cron mark that a second overlapping run
-// is still relying on. Without refcount semantics, the first rollback would delete
-// the shared key and allow dispatches to slip through while the second run is
-// still in flight.
 // TestConcurrentDispatchesDoNotDuplicateEnqueue is a regression test for the
 // non-atomic Seen+PushEvent+SeenOrAdd race: two concurrent ProcessDispatches
 // calls for the same (target, repo, number) must enqueue exactly one event, not
@@ -744,6 +739,11 @@ func TestConcurrentDispatchesDoNotDuplicateEnqueue(t *testing.T) {
 	}
 }
 
+// TestRemoveCronMarkWithOverlappingRunsRefcount verifies that a rollback from one
+// failed autonomous run does not clear a cron mark that a second overlapping run
+// is still relying on. Without refcount semantics, the first rollback would delete
+// the shared key and allow dispatches to slip through while the second run is
+// still in flight.
 func TestRemoveCronMarkWithOverlappingRunsRefcount(t *testing.T) {
 	t.Parallel()
 	q := &fakeQueue{}


### PR DESCRIPTION
## What

The description for `TestRemoveCronMarkWithOverlappingRunsRefcount` was
concatenated directly onto `TestConcurrentDispatchesDoNotDuplicateEnqueue`'s
comment block, with no blank line separator. Go treats a contiguous `//` block
immediately above a declaration as that declaration's doc comment, so:

- `TestConcurrentDispatchesDoNotDuplicateEnqueue` carried both descriptions
- `TestRemoveCronMarkWithOverlappingRunsRefcount` had no doc comment at all

## Change

Split the combined block so each function has its own doc comment immediately
above it. No Go code was changed — pure documentation fix.

## Why it matters

`go doc` and IDE hover surfaces the wrong description for
`TestConcurrentDispatchesDoNotDuplicateEnqueue` and shows nothing for
`TestRemoveCronMarkWithOverlappingRunsRefcount`.