### PR TITLE
refactor: drop duplicate interfaces from server/observe; use server.* directly

### DIFF
--- a/internal/server/observe/observe.go
+++ b/internal/server/observe/observe.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/eloylp/agents/internal/config"
 	obstore "github.com/eloylp/agents/internal/observe"
-	"github.com/eloylp/agents/internal/scheduler"
 	"github.com/eloylp/agents/internal/server"
 	"github.com/eloylp/agents/internal/workflow"
 )

--- a/internal/server/observe/observe.go
+++ b/internal/server/observe/observe.go
@@ -402,8 +402,3 @@ func ServeSSEWithInterval(w http.ResponseWriter, r *http.Request, hub SSEHub, he
 		}
 	}
 }
-
-// MemoryChangeEvent is published to the MemorySSE hub when an agent's memory
-// is updated. Kept here so observe_test.go and production callers share the
-// same wire type without importing internal/observe directly.
-type MemoryChangeEvent = obstore.MemoryChangeEvent

--- a/internal/server/observe/observe.go
+++ b/internal/server/observe/observe.go
@@ -33,31 +33,15 @@ type ConfigGetter interface {
 	Config() *config.Config
 }
 
-// StatusProvider, RuntimeStateProvider, and DispatchStatsProvider are all
-// kept as interfaces in this package (rather than the concrete
-// *scheduler.Scheduler / *observe.Store / *workflow.Engine) because
-// observe_test.go stubs each one with test-controlled values.
-type StatusProvider interface {
-	AgentStatuses() []scheduler.AgentStatus
-}
-
-type RuntimeStateProvider interface {
-	IsRunning(name string) bool
-}
-
-type DispatchStatsProvider interface {
-	DispatchStats() workflow.DispatchStats
-}
-
 // Handler implements the observability HTTP endpoints. Construct via New and
 // mount with RegisterRoutes. Handlers are read-only and safe for concurrent
 // use; the type holds no mutable state.
 type Handler struct {
 	store         *obstore.Store
 	cfg           ConfigGetter
-	provider      StatusProvider
-	runtimeState  RuntimeStateProvider
-	dispatchStats DispatchStatsProvider
+	provider      server.StatusProvider
+	runtimeState  server.RuntimeStateProvider
+	dispatchStats server.DispatchStatsProvider
 	memReader     server.MemoryReader
 }
 
@@ -68,9 +52,9 @@ type Handler struct {
 func New(
 	store *obstore.Store,
 	cfg ConfigGetter,
-	provider StatusProvider,
-	runtimeState RuntimeStateProvider,
-	dispatchStats DispatchStatsProvider,
+	provider server.StatusProvider,
+	runtimeState server.RuntimeStateProvider,
+	dispatchStats server.DispatchStatsProvider,
 	memReader server.MemoryReader,
 ) *Handler {
 	return &Handler{
@@ -418,3 +402,8 @@ func ServeSSEWithInterval(w http.ResponseWriter, r *http.Request, hub SSEHub, he
 		}
 	}
 }
+
+// MemoryChangeEvent is published to the MemorySSE hub when an agent's memory
+// is updated. Kept here so observe_test.go and production callers share the
+// same wire type without importing internal/observe directly.
+type MemoryChangeEvent = obstore.MemoryChangeEvent


### PR DESCRIPTION
## Summary

`internal/server/observe/observe.go` defined three local interfaces that were
byte-for-byte identical to interfaces already declared in
`internal/server/types.go`:

| Local (deleted) | Canonical (kept) |
|---|---|
| `StatusProvider` | `server.StatusProvider` |
| `RuntimeStateProvider` | `server.RuntimeStateProvider` |
| `DispatchStatsProvider` | `server.DispatchStatsProvider` |

The observe package already imports `server`, so there is no reason to maintain
local copies. This PR:

- Deletes the 3 duplicate local interface declarations and their comment block
- Changes `Handler` struct fields and `New` constructor parameters to use the
  `server.*` types directly
- Drops the now-unused `scheduler` import from the production file (it was only
  needed to name `scheduler.AgentStatus` inside the deleted local interface)

No test changes required: the existing stubs in `observe_test.go` satisfy the
`server.*` interfaces by structural typing.

## Test plan

- [ ] CI passes (`go test ./...` including `-race`)
- [ ] `internal/server/observe` package builds without unused-import errors
