### PR TITLE
refactor: extract private normalize helper in fleet package

### DIFF
--- a/internal/fleet/normalize.go
+++ b/internal/fleet/normalize.go
@@ -13,24 +13,28 @@ const (
 	DefaultMaxPromptChars   = 12000
 )
 
+func normalize(name string) string {
+	return strings.ToLower(strings.TrimSpace(name))
+}
+
 // NormalizeAgentName returns the canonical form of an agent name (lowercase,
 // trimmed). CRUD callers should normalise path-parameter names before lookups
 // or deletes so HTTP routes follow the same case-insensitive semantics as the
 // in-memory lookups.
 func NormalizeAgentName(name string) string {
-	return strings.ToLower(strings.TrimSpace(name))
+	return normalize(name)
 }
 
 // NormalizeSkillName returns the canonical form of a skill map key
 // (lowercase, trimmed). CRUD callers should normalise the key before writing.
 func NormalizeSkillName(name string) string {
-	return strings.ToLower(strings.TrimSpace(name))
+	return normalize(name)
 }
 
 // NormalizeBackendName returns the canonical form of a backend map key
 // (lowercase, trimmed). CRUD callers should normalise the key before writing.
 func NormalizeBackendName(name string) string {
-	return strings.ToLower(strings.TrimSpace(name))
+	return normalize(name)
 }
 
 // NormalizeRepoName returns the canonical form of a repo full name
@@ -38,7 +42,7 @@ func NormalizeBackendName(name string) string {
 // before lookups or deletes so HTTP routes follow the same case-insensitive
 // semantics as the in-memory lookups.
 func NormalizeRepoName(name string) string {
-	return strings.ToLower(strings.TrimSpace(name))
+	return normalize(name)
 }
 
 // NormalizeAgent applies the same name/field normalization that the YAML
@@ -91,7 +95,7 @@ func NormalizeRepo(r *Repo) {
 		r.Use[i].Agent = NormalizeAgentName(r.Use[i].Agent)
 		r.Use[i].Cron = strings.TrimSpace(r.Use[i].Cron)
 		for k := range r.Use[i].Events {
-			r.Use[i].Events[k] = strings.ToLower(strings.TrimSpace(r.Use[i].Events[k]))
+			r.Use[i].Events[k] = normalize(r.Use[i].Events[k])
 		}
 	}
 }


### PR DESCRIPTION
## Why

`NormalizeAgentName`, `NormalizeSkillName`, `NormalizeBackendName`, and `NormalizeRepoName` all had identical bodies:

```go
return strings.ToLower(strings.TrimSpace(name))
```

Three of those four implementations were duplicates. Additionally, `NormalizeRepo`'s Events loop used the same expression inline without delegating to any of the named functions.

## What changed

- Added a private `normalize(string) string` helper with the shared body.
- Each of the four exported functions now delegates to `normalize`; their signatures and doc comments are unchanged.
- `NormalizeRepo`'s Events loop now calls `normalize(...)` instead of the inline `strings.ToLower(strings.TrimSpace(...))`.

One file touched (`internal/fleet/normalize.go`), no callers changed, no behavior change.