### PR TITLE
refactor: extract validateDispatchWiring into a package-level function

### DIFF
--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -176,19 +176,19 @@ func (c *Config) validateAgents() error {
 		}
 	}
 	// Validate can_dispatch references after all agents are seen.
-	return c.validateDispatchWiring()
+	return validateDispatchWiring(c.Agents)
 }
 
 // validateDispatchWiring checks cross-agent dispatch references:
-//   - can_dispatch entries must reference real agents in this config
+//   - can_dispatch entries must reference real agents
 //   - can_dispatch must not include the agent itself
 //   - agents referenced in any can_dispatch list must have a description
-func (c *Config) validateDispatchWiring() error {
-	agentByName := make(map[string]fleet.Agent, len(c.Agents))
-	for _, a := range c.Agents {
+func validateDispatchWiring(agents []fleet.Agent) error {
+	agentByName := make(map[string]fleet.Agent, len(agents))
+	for _, a := range agents {
 		agentByName[a.Name] = a
 	}
-	for _, a := range c.Agents {
+	for _, a := range agents {
 		for _, t := range a.CanDispatch {
 			target, ok := agentByName[t]
 			if !ok {

--- a/internal/config/validate_entities.go
+++ b/internal/config/validate_entities.go
@@ -136,8 +136,7 @@ func ValidateEntities(agents []fleet.Agent, repos []fleet.Repo, skills map[strin
 			return fmt.Errorf("config: agent %q: prompt is empty after resolution", a.Name)
 		}
 	}
-	// Dispatch wiring reuses the Config method which only reads c.Agents.
-	if err := (&Config{Agents: agents}).validateDispatchWiring(); err != nil {
+	if err := validateDispatchWiring(agents); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## What

`validateDispatchWiring` was a method on `*Config` that only ever accessed `c.Agents` — it never read any other field of the receiver. Making it a package-level function with an explicit `agents []fleet.Agent` parameter makes the dependency honest and removes a misleading method binding.

The main payoff is in `validate_entities.go`, which previously had to construct a throwaway `*Config` just to reach this logic:

```go
// before
if err := (&Config{Agents: agents}).validateDispatchWiring(); err != nil {
```

```go
// after
if err := validateDispatchWiring(agents); err != nil {
```

## Changes

- `internal/config/validate.go` — drop `(c *Config)` receiver, add `agents []fleet.Agent` parameter, update call site in `validateAgents`, update doc comment
- `internal/config/validate_entities.go` — replace `(&Config{Agents: agents}).validateDispatchWiring()` with `validateDispatchWiring(agents)`, remove now-obsolete comment explaining the construct

No behaviour change; all existing tests cover the same paths.