### PR TITLE
refactor: extract DecodeBody helper into server package

### DIFF
--- a/internal/server/fleet/fleet.go
+++ b/internal/server/fleet/fleet.go
@@ -15,7 +15,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -109,7 +108,7 @@ func (h *Handler) HandleAgentsCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req storeAgentJSON
-	if !decodeBody(w, r, h.srv.Config().Daemon.HTTP.MaxBodyBytes, &req) {
+	if !server.DecodeBody(w, r, h.srv.Config().Daemon.HTTP.MaxBodyBytes, &req) {
 		return
 	}
 	canonical, err := h.UpsertAgent(req.toConfig())
@@ -259,7 +258,7 @@ func (h *Handler) handleAgent(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) handleAgentPatch(w http.ResponseWriter, r *http.Request, name string) {
 	var req AgentPatch
-	if !decodeBody(w, r, h.srv.Config().Daemon.HTTP.MaxBodyBytes, &req) {
+	if !server.DecodeBody(w, r, h.srv.Config().Daemon.HTTP.MaxBodyBytes, &req) {
 		return
 	}
 	if !req.anyFieldSet() {
@@ -382,7 +381,7 @@ func (h *Handler) handleSkills(w http.ResponseWriter, r *http.Request) {
 
 	case http.MethodPost:
 		var req storeSkillJSON
-		if !decodeBody(w, r, h.srv.Config().Daemon.HTTP.MaxBodyBytes, &req) {
+		if !server.DecodeBody(w, r, h.srv.Config().Daemon.HTTP.MaxBodyBytes, &req) {
 			return
 		}
 		name, sk, err := h.UpsertSkill(req.Name, fleet.Skill{Prompt: req.Prompt})
@@ -424,7 +423,7 @@ func (h *Handler) handleSkill(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) handleSkillPatch(w http.ResponseWriter, r *http.Request, name string) {
 	var req SkillPatch
-	if !decodeBody(w, r, h.srv.Config().Daemon.HTTP.MaxBodyBytes, &req) {
+	if !server.DecodeBody(w, r, h.srv.Config().Daemon.HTTP.MaxBodyBytes, &req) {
 		return
 	}
 	if !req.anyFieldSet() {
@@ -616,7 +615,7 @@ func (h *Handler) handleBackends(w http.ResponseWriter, r *http.Request) {
 
 	case http.MethodPost:
 		var req storeBackendJSON
-		if !decodeBody(w, r, h.srv.Config().Daemon.HTTP.MaxBodyBytes, &req) {
+		if !server.DecodeBody(w, r, h.srv.Config().Daemon.HTTP.MaxBodyBytes, &req) {
 			return
 		}
 		name, b, err := h.UpsertBackend(req.Name, req.toConfig())
@@ -659,7 +658,7 @@ func (h *Handler) handleBackendsDiscover(w http.ResponseWriter, r *http.Request)
 
 func (h *Handler) handleBackendsLocal(w http.ResponseWriter, r *http.Request) {
 	var req localBackendRequest
-	if !decodeBody(w, r, h.srv.Config().Daemon.HTTP.MaxBodyBytes, &req) {
+	if !server.DecodeBody(w, r, h.srv.Config().Daemon.HTTP.MaxBodyBytes, &req) {
 		return
 	}
 	name := fleet.NormalizeBackendName(req.Name)
@@ -753,7 +752,7 @@ func (h *Handler) handleBackendGet(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) handleBackendPatch(w http.ResponseWriter, r *http.Request) {
 	name := backendPathName(r)
 	var req BackendPatch
-	if !decodeBody(w, r, h.srv.Config().Daemon.HTTP.MaxBodyBytes, &req) {
+	if !server.DecodeBody(w, r, h.srv.Config().Daemon.HTTP.MaxBodyBytes, &req) {
 		return
 	}
 	if !req.anyFieldSet() {
@@ -866,25 +865,6 @@ func storeErrStatus(err error) int {
 		return http.StatusConflict
 	}
 	return http.StatusInternalServerError
-}
-
-func decodeBody[T any](w http.ResponseWriter, r *http.Request, limit int64, out *T) bool {
-	r.Body = http.MaxBytesReader(w, r.Body, limit)
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		var maxErr *http.MaxBytesError
-		if errors.As(err, &maxErr) {
-			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
-			return false
-		}
-		http.Error(w, fmt.Sprintf("read request: %v", err), http.StatusBadRequest)
-		return false
-	}
-	if err := json.Unmarshal(body, out); err != nil {
-		http.Error(w, fmt.Sprintf("decode request: %v", err), http.StatusBadRequest)
-		return false
-	}
-	return true
 }
 
 func writeJSON(w http.ResponseWriter, status int, v any) {

--- a/internal/server/repos/repos.go
+++ b/internal/server/repos/repos.go
@@ -15,7 +15,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -148,7 +147,7 @@ func (h *Handler) handleRepos(w http.ResponseWriter, r *http.Request) {
 
 	case http.MethodPost:
 		var req storeRepoJSON
-		if !decodeBody(w, r, h.srv.Config().Daemon.HTTP.MaxBodyBytes, &req) {
+		if !server.DecodeBody(w, r, h.srv.Config().Daemon.HTTP.MaxBodyBytes, &req) {
 			return
 		}
 		canonical, err := h.UpsertRepo(req.toConfig())
@@ -180,7 +179,7 @@ func (h *Handler) handleRepo(w http.ResponseWriter, r *http.Request) {
 
 	case http.MethodPatch:
 		var req repoRuntimeSettingsJSON
-		if !decodeBody(w, r, h.srv.Config().Daemon.HTTP.MaxBodyBytes, &req) {
+		if !server.DecodeBody(w, r, h.srv.Config().Daemon.HTTP.MaxBodyBytes, &req) {
 			return
 		}
 		if req.Enabled == nil {
@@ -206,7 +205,7 @@ func (h *Handler) handleRepo(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) handleCreateBinding(w http.ResponseWriter, r *http.Request) {
 	repoName := repoNameFromVars(r)
 	var req storeBindingJSON
-	if !decodeBody(w, r, h.srv.Config().Daemon.HTTP.MaxBodyBytes, &req) {
+	if !server.DecodeBody(w, r, h.srv.Config().Daemon.HTTP.MaxBodyBytes, &req) {
 		return
 	}
 	// Ignore any ID the client sends — the store picks it.
@@ -244,7 +243,7 @@ func (h *Handler) handleUpdateBinding(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req storeBindingJSON
-	if !decodeBody(w, r, h.srv.Config().Daemon.HTTP.MaxBodyBytes, &req) {
+	if !server.DecodeBody(w, r, h.srv.Config().Daemon.HTTP.MaxBodyBytes, &req) {
 		return
 	}
 	b, err := h.UpdateBinding(repoName, id, req.toConfig())
@@ -470,28 +469,6 @@ func storeErrStatus(err error) int {
 		return http.StatusConflict
 	}
 	return http.StatusInternalServerError
-}
-
-// decodeBody reads and decodes a JSON body up to limit bytes. On error it
-// writes the response and returns false; callers must not write further.
-// Bodies larger than limit surface as 413; malformed JSON as 400.
-func decodeBody[T any](w http.ResponseWriter, r *http.Request, limit int64, out *T) bool {
-	r.Body = http.MaxBytesReader(w, r.Body, limit)
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		var maxErr *http.MaxBytesError
-		if errors.As(err, &maxErr) {
-			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
-			return false
-		}
-		http.Error(w, fmt.Sprintf("read request: %v", err), http.StatusBadRequest)
-		return false
-	}
-	if err := json.Unmarshal(body, out); err != nil {
-		http.Error(w, fmt.Sprintf("decode request: %v", err), http.StatusBadRequest)
-		return false
-	}
-	return true
 }
 
 // writeJSON encodes v as JSON and writes it with the given status.

--- a/internal/server/server_crud.go
+++ b/internal/server/server_crud.go
@@ -1,8 +1,10 @@
 package server
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/eloylp/agents/internal/store"
@@ -85,4 +87,26 @@ func (s *Server) reloadCron() error {
 	}
 
 	return nil
+}
+
+// DecodeBody reads and decodes a JSON body up to limit bytes. On error it
+// writes the response and returns false; callers must not write further.
+// Bodies larger than limit surface as 413; malformed JSON as 400.
+func DecodeBody[T any](w http.ResponseWriter, r *http.Request, limit int64, out *T) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, limit)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+			return false
+		}
+		http.Error(w, fmt.Sprintf("read request: %v", err), http.StatusBadRequest)
+		return false
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		http.Error(w, fmt.Sprintf("decode request: %v", err), http.StatusBadRequest)
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
## What

`fleet/fleet.go` and `repos/repos.go` each carried a byte-for-byte identical `decodeBody[T any]` helper — 14 lines of non-trivial error-handling logic (MaxBytesReader, MaxBytesError detection, JSON unmarshal) copy-pasted across two files.

This PR moves the function to `internal/server/server_crud.go` as the exported `DecodeBody[T any]`, and updates all 11 call sites (7 in fleet, 4 in repos) to call `server.DecodeBody`. The `"io"` import is dropped from both sub-packages.

Both sub-packages already import `server`, so no new import cycle is introduced.

## Changes

- `internal/server/server_crud.go` — add `"encoding/json"` + `"io"` imports; add exported `DecodeBody[T any]`
- `internal/server/fleet/fleet.go` — drop `"io"` import; remove private `decodeBody`; update 7 call sites
- `internal/server/repos/repos.go` — drop `"io"` import; remove private `decodeBody` (+ doc comment); update 4 call sites

## Behaviour

No behaviour change. The function body is identical to both removed copies.