### PR TITLE
refactor: merge repeated deps.Fleet/Repos nil checks in registerTools

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -230,8 +230,6 @@ func registerTools(srv *server.MCPServer, deps Deps) {
 			),
 			toolDeleteSkill(deps),
 		)
-	}
-	if deps.Fleet != nil {
 		srv.AddTool(
 			mcpgo.NewTool("create_backend",
 				mcpgo.WithDescription("Create or update an AI backend. Upsert semantics: a write to an existing name overwrites it. Returns the canonical (normalized) backend persisted by the store. Same path as POST /backends."),
@@ -309,8 +307,6 @@ func registerTools(srv *server.MCPServer, deps Deps) {
 			),
 			toolDeleteBackend(deps),
 		)
-	}
-	if deps.Fleet != nil {
 		srv.AddTool(
 			mcpgo.NewTool("create_agent",
 				mcpgo.WithDescription("Create or update an agent. Upsert semantics: a write to an existing name overwrites it. Returns the canonical (normalized) agent persisted by the store. Same path as POST /agents."),
@@ -455,8 +451,6 @@ func registerTools(srv *server.MCPServer, deps Deps) {
 			),
 			toolDeleteRepo(deps),
 		)
-	}
-	if deps.Repos != nil {
 		srv.AddTool(
 			mcpgo.NewTool("get_binding",
 				mcpgo.WithDescription("Fetch one binding by ID, verifying it belongs to the given repo. Same path as GET /repos/{owner}/{repo}/bindings/{id}."),


### PR DESCRIPTION
## Summary

`registerTools` in `internal/mcp/tools.go` contained three separate
`if deps.Fleet != nil` blocks (skills, backends, agents) and two
separate `if deps.Repos != nil` blocks (repos, bindings) — each
re-checking the same pointer.

This PR merges each group into a single block, so a reader immediately
sees that all skill/backend/agent tool registrations share one gate and
all repo/binding registrations share another. The repeated checks added
no safety; they just made the grouping of tools invisible.

- No behavior change — identical nil checks, identical registrations, identical order.
- One file touched (`internal/mcp/tools.go`), ~10 lines removed.
