### PR TITLE
refactor: replace magic time format with time.RFC3339 in daemon fleet view

### DIFF
--- a/internal/daemon/fleet/view.go
+++ b/internal/daemon/fleet/view.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/eloylp/agents/internal/scheduler"
 )
@@ -113,11 +114,11 @@ func (h *Handler) HandleAgentsView(w http.ResponseWriter, _ *http.Request) {
 				if b.IsCron() {
 					if st, ok := scheduleByKey[a.Name+"\x00"+repo.Name]; ok {
 						j := &agentScheduleJSON{
-							NextRun:    st.NextRun.UTC().Format("2006-01-02T15:04:05Z"),
+							NextRun:    st.NextRun.UTC().Format(time.RFC3339),
 							LastStatus: st.LastStatus,
 						}
 						if st.LastRun != nil {
-							lr := st.LastRun.UTC().Format("2006-01-02T15:04:05Z")
+							lr := st.LastRun.UTC().Format(time.RFC3339)
 							j.LastRun = &lr
 						}
 						binding.Schedule = j


### PR DESCRIPTION
## Summary

`HandleAgentsView` in `internal/daemon/fleet/view.go` formatted schedule
timestamps using the magic layout `"2006-01-02T15:04:05Z"` — the RFC 3339
format written out by hand in two places:

```go
NextRun: st.NextRun.UTC().Format("2006-01-02T15:04:05Z"),
...
lr := st.LastRun.UTC().Format("2006-01-02T15:04:05Z")
```

Replace both with `time.RFC3339` and add the `"time"` import. The same
change was already applied to `internal/server/fleet/view.go` in a prior
refactor; this brings the daemon-layer counterpart in line.

- One file touched (`internal/daemon/fleet/view.go`), 3 lines changed.
- No behaviour change — `time.RFC3339 = "2006-01-02T15:04:05Z"` by definition.

## Test plan

- [ ] CI green (`go test -race ./...`)
- [ ] No behaviour change — pure constant substitution