### PR TITLE
refactor: drop unused nilSafeStrings from daemon/repos

### DIFF
--- a/internal/daemon/repos/repos.go
+++ b/internal/daemon/repos/repos.go
@@ -442,12 +442,3 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(v)
 }
-
-// nilSafeStrings returns an empty slice when in is nil so encoded JSON shows
-// `[]` rather than `null`.
-func nilSafeStrings(in []string) []string {
-	if in == nil {
-		return []string{}
-	}
-	return in
-}


### PR DESCRIPTION
`nilSafeStrings` is defined in `internal/daemon/repos/repos.go` but never called. Binding fields (`Labels`, `Events`) are assigned directly in `bindingToStoreJSON`; no nil-guarding helper is needed there.

Deletes the 7-line function and its doc comment.

Same dead code was removed from `internal/server/repos/repos.go` in PR #329.