### PR TITLE
refactor: merge 3 repeated deps.Fleet nil checks into one

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -230,8 +230,6 @@ func registerTools(srv *server.MCPServer, deps Deps) {
 			),
 			toolDeleteSkill(deps),
 		)
-	}
-	if deps.Fleet != nil {
 		srv.AddTool(
 			mcpgo.NewTool("create_backend",
 				mcpgo.WithDescription("Create or update an AI backend. Upsert semantics: a write to an existing name overwrites it. Returns the canonical (normalized) backend persisted by the store. Same path as POST /backends."),
@@ -309,8 +307,6 @@ func registerTools(srv *server.MCPServer, deps Deps) {
 			),
 			toolDeleteBackend(deps),
 		)
-	}
-	if deps.Fleet != nil {
 		srv.AddTool(
 			mcpgo.NewTool("create_agent",
 				mcpgo.WithDescription("Create or update an agent. Upsert semantics: a write to an existing name overwrites it. Returns the canonical (normalized) agent persisted by the store. Same path as POST /agents."),


### PR DESCRIPTION
## Summary

`registerTools` in `internal/mcp/tools.go` had three consecutive
`if deps.Fleet != nil` blocks (skills, backends, agents) — each
re-checking the same pointer before registering the next group of tools.

Remove the two redundant closing braces and re-opening guards so a
reader immediately sees that all skill, backend, and agent tool
registrations share a single gate.

- One file touched (`internal/mcp/tools.go`), 4 lines removed.
- No behaviour change — identical nil check, identical registrations, identical order.

The two `deps.Repos` blocks are left separate because `registerQueueTools`
now sits between them; merging them would move that call inside the nil
guard and change behaviour.

Replaces #351 (which was opened against an older base and went dirty
when `registerQueueTools` was inserted between the Repos blocks).

## Test plan

- [ ] CI green (`go test -race ./...`)
- [ ] No behaviour change — pure dead-code removal