### PR TITLE
refactor: inline parseStatus into List; use typed RunnerStatus constants

### DIFF
--- a/internal/daemon/runners/runners.go
+++ b/internal/daemon/runners/runners.go
@@ -75,18 +75,18 @@ func (h *Handler) RegisterRoutes(r *mux.Router, withTimeout func(http.Handler) h
 //   - "enqueued" / "running": event is in flight, no trace yet
 //   - "success" / "error":     trace exists, run finished with that outcome
 type RunnerRow struct {
-	ID            int64           `json:"id"`
-	EventID       string          `json:"event_id"`
-	Kind          string          `json:"kind"`
-	Repo          string          `json:"repo"`
-	Number        int             `json:"number,omitempty"`
-	Actor         string          `json:"actor,omitempty"`
-	TargetAgent   string          `json:"target_agent,omitempty"`
-	Status        string          `json:"status"`
-	EnqueuedAt    time.Time       `json:"enqueued_at"`
-	StartedAt     *time.Time      `json:"started_at,omitempty"`
-	CompletedAt   *time.Time      `json:"completed_at,omitempty"`
-	Payload       json.RawMessage `json:"payload,omitempty"`
+	ID          int64           `json:"id"`
+	EventID     string          `json:"event_id"`
+	Kind        string          `json:"kind"`
+	Repo        string          `json:"repo"`
+	Number      int             `json:"number,omitempty"`
+	Actor       string          `json:"actor,omitempty"`
+	TargetAgent string          `json:"target_agent,omitempty"`
+	Status      string          `json:"status"`
+	EnqueuedAt  time.Time       `json:"enqueued_at"`
+	StartedAt   *time.Time      `json:"started_at,omitempty"`
+	CompletedAt *time.Time      `json:"completed_at,omitempty"`
+	Payload     json.RawMessage `json:"payload,omitempty"`
 
 	// Trace-derived fields, populated only when CompletedAt != nil and a
 	// matching span exists. Agent is the canonical "which runner is this".
@@ -123,9 +123,11 @@ var ErrRunnerRunning = errors.New("runners: cannot retry running event")
 // Each event_queue row produces 0..N output rows depending on whether
 // traces have been recorded for it (see package doc).
 func (h *Handler) List(status string, limit, offset int) (ListResponse, error) {
-	st, err := parseStatus(status)
-	if err != nil {
-		return ListResponse{}, err
+	st := store.RunnerStatus(status)
+	switch st {
+	case "", store.RunnerEnqueued, store.RunnerRunning, store.RunnerCompleted:
+	default:
+		return ListResponse{}, fmt.Errorf("invalid status %q", status)
 	}
 	events, err := h.store.ListRunners(st, limit, offset)
 	if err != nil {
@@ -294,14 +296,6 @@ func pathID(r *http.Request) (int64, error) {
 		return 0, fmt.Errorf("invalid id %q", raw)
 	}
 	return id, nil
-}
-
-func parseStatus(s string) (store.RunnerStatus, error) {
-	switch s {
-	case "", "enqueued", "running", "completed":
-		return store.RunnerStatus(s), nil
-	}
-	return "", fmt.Errorf("invalid status %q", s)
 }
 
 func writeJSON(w http.ResponseWriter, code int, body any) {


### PR DESCRIPTION
`parseStatus` in `internal/daemon/runners/runners.go` had exactly one caller (`List`). Per the project's refactoring guidelines, one-caller abstractions are noise until a second caller appears.

## Changes

- Remove the 8-line `parseStatus` private function.
- Inline the validation directly into `List` using a `switch` with a `default` early-return — the idiomatic Go pattern for validating a value against a known set.
- As a secondary benefit, the inline version uses the typed `store.RunnerEnqueued`, `store.RunnerRunning`, and `store.RunnerCompleted` constants that already exist in the `store` package, replacing the raw string literals (`"enqueued"`, `"running"`, `"completed"`) that `parseStatus` used.

No behaviour change — the valid inputs, error message, and typed `store.RunnerStatus` passed to `ListRunners`/`CountRunners` are identical.

## Test plan

- [ ] CI green (`go test -race ./...`)
- [ ] No behaviour change — pure one-caller inline