### PR TITLE
refactor: use slices.Clone in buildStatus instead of append idiom

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -31,6 +31,7 @@ import (
 	"io"
 	"io/fs"
 	"net/http"
+	"slices"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -511,7 +512,7 @@ func (d *Daemon) buildStatus() statusJSON {
 		Queues: map[string]statusQueueJSON{
 			"events": {Buffered: q.Buffered, Capacity: q.Capacity},
 		},
-		Agents: append([]scheduler.AgentStatus{}, d.scheduler.AgentStatuses()...),
+		Agents: slices.Clone(d.scheduler.AgentStatuses()),
 	}
 
 	orphans, err := d.fleet.OrphanedAgents()


### PR DESCRIPTION
## What

Replace the pre-1.21 slice-copy idiom in `buildStatus` with `slices.Clone`:

```go
// before
Agents: append([]scheduler.AgentStatus{}, d.scheduler.AgentStatuses()...),

// after
Agents: slices.Clone(d.scheduler.AgentStatuses()),
```

Adds `"slices"` to the import block.

## Why

`append([]T{}, src...)` is the old hand-written copy trick; `slices.Clone` has been in the stdlib since Go 1.21 and communicates intent directly — it's a clone, not an append-of-nothing. The two are semantically equivalent when `src` is non-nil, which is always the case here (`AgentStatuses` initialises its result with `make`).