### PR TITLE
refactor: inline newActiveRuns into NewStore

### DIFF
--- a/internal/observe/observe.go
+++ b/internal/observe/observe.go
@@ -146,10 +146,6 @@ type ActiveRuns struct {
 	runs map[string]int // agent name → count of active concurrent runs
 }
 
-func newActiveRuns() *ActiveRuns {
-	return &ActiveRuns{runs: make(map[string]int)}
-}
-
 // StartRun increments the in-flight run count for agentName.
 func (a *ActiveRuns) StartRun(agentName string) {
 	a.mu.Lock()
@@ -194,7 +190,7 @@ func NewStore(db *sql.DB) *Store {
 		EventsSSE:  NewSSEHub(64),
 		TracesSSE:  NewSSEHub(64),
 		MemorySSE:  NewSSEHub(32),
-		ActiveRuns: newActiveRuns(),
+		ActiveRuns: &ActiveRuns{runs: make(map[string]int)},
 	}
 }
 


### PR DESCRIPTION
The `newActiveRuns` private constructor was called from exactly one place (`NewStore`). Its single-line body — `&ActiveRuns{runs: make(map[string]int)}` — adds no clarity beyond what the type name already provides, so remove the wrapper and inline the expression directly.

No behaviour change; all existing tests cover `ActiveRuns` through `NewStore` and remain unaffected.