### PR TITLE
refactor: inline newActiveRuns into NewStore

### DIFF
--- a/internal/mcp/tools_fleet.go
+++ b/internal/mcp/tools_fleet.go
@@ -197,15 +197,15 @@ func toolTriggerAgent(deps Deps) server.ToolHandlerFunc {
 		}
 		want := fleet.NormalizeRepoName(repoName)
 		var repo fleet.Repo
-		var ok bool
+		var found bool
 		for _, r := range repos {
 			if r.Name == want {
 				repo = r
-				ok = true
+				found = true
 				break
 			}
 		}
-		if !ok || !repo.Enabled {
+		if !found || !repo.Enabled {
 			return mcpgo.NewToolResultErrorf("repo %q not found or disabled", repoName), nil
 		}
 

--- a/internal/observe/observe.go
+++ b/internal/observe/observe.go
@@ -164,10 +164,6 @@ type ActiveRuns struct {
 	runs map[string]int // agent name → count of active concurrent runs
 }
 
-func newActiveRuns() *ActiveRuns {
-	return &ActiveRuns{runs: make(map[string]int)}
-}
-
 // StartRun increments the in-flight run count for agentName.
 func (a *ActiveRuns) StartRun(agentName string) {
 	a.mu.Lock()
@@ -437,7 +433,7 @@ func NewStore(db *sql.DB) *Store {
 		EventsSSE:  NewSSEHub(64),
 		TracesSSE:  NewSSEHub(64),
 		MemorySSE:  NewSSEHub(32),
-		ActiveRuns: newActiveRuns(),
+		ActiveRuns: &ActiveRuns{runs: make(map[string]int)},
 		Runs:       newRunRegistry(),
 	}
 }


### PR DESCRIPTION
## Summary

Replaces closed #358 (went dirty when `RunRegistry` and the live-stream hub were added to the file after the branch was cut).

The `newActiveRuns` private constructor was called from exactly one place (`NewStore`). Its single-line body — `&ActiveRuns{runs: make(map[string]int)}` — adds no clarity beyond what the type name already provides, so remove the wrapper and inline the expression directly.

No behaviour change; all existing tests cover `ActiveRuns` through `NewStore` and remain unaffected.

## Test plan

- [ ] CI green (`go test -race ./...`)
- [ ] No behaviour change — pure one-caller inline