### PR TITLE
refactor: export AnyFieldSet on AgentPatch/BackendPatch; drop duplicate helpers

### DIFF
--- a/internal/daemon/fleet/fleet.go
+++ b/internal/daemon/fleet/fleet.go
@@ -164,7 +164,10 @@ type AgentPatch struct {
 	AllowMemory   *bool     `json:"allow_memory,omitempty"`
 }
 
-func (p AgentPatch) anyFieldSet() bool {
+// AnyFieldSet reports whether at least one patch field is non-nil. Used by
+// both the REST PATCH handler and the MCP update_agent tool to reject empty
+// payloads before hitting the store.
+func (p AgentPatch) AnyFieldSet() bool {
 	return p.Backend != nil || p.Model != nil || p.Skills != nil || p.Prompt != nil ||
 		p.AllowPRs != nil || p.AllowDispatch != nil || p.CanDispatch != nil ||
 		p.Description != nil || p.AllowMemory != nil
@@ -238,7 +241,7 @@ func (h *Handler) handleAgentPatch(w http.ResponseWriter, r *http.Request, name 
 	if !decodeBody(w, r, h.maxBodyBytes, &req) {
 		return
 	}
-	if !req.anyFieldSet() {
+	if !req.AnyFieldSet() {
 		http.Error(w, "at least one field is required", http.StatusBadRequest)
 		return
 	}
@@ -487,7 +490,10 @@ type BackendPatch struct {
 	MaxPromptChars *int      `json:"max_prompt_chars,omitempty"`
 }
 
-func (p BackendPatch) anyFieldSet() bool {
+// AnyFieldSet reports whether at least one patch field is non-nil. Used by
+// both the REST PATCH handler and the MCP update_backend tool to reject empty
+// payloads before hitting the store.
+func (p BackendPatch) AnyFieldSet() bool {
 	return p.Command != nil || p.Version != nil || p.Models != nil || p.Healthy != nil ||
 		p.HealthDetail != nil || p.LocalModelURL != nil || p.TimeoutSeconds != nil ||
 		p.MaxPromptChars != nil
@@ -692,7 +698,7 @@ func (h *Handler) handleBackendPatch(w http.ResponseWriter, r *http.Request) {
 	if !decodeBody(w, r, h.maxBodyBytes, &req) {
 		return
 	}
-	if !req.anyFieldSet() {
+	if !req.AnyFieldSet() {
 		http.Error(w, "at least one field is required", http.StatusBadRequest)
 		return
 	}

--- a/internal/mcp/tools_crud.go
+++ b/internal/mcp/tools_crud.go
@@ -109,7 +109,7 @@ func toolUpdateAgent(deps Deps) server.ToolHandlerFunc {
 		} else if errMsg != "" {
 			return mcpgo.NewToolResultError(errMsg), nil
 		}
-		if !agentPatchHasField(patch) {
+		if !patch.AnyFieldSet() {
 			return mcpgo.NewToolResultError("at least one field is required"), nil
 		}
 		canonical, uerr := deps.Fleet.UpdateAgentPatch(name, patch)
@@ -118,12 +118,6 @@ func toolUpdateAgent(deps Deps) server.ToolHandlerFunc {
 		}
 		return jsonResult(agentJSON(canonical))
 	}
-}
-
-func agentPatchHasField(p daemonfleet.AgentPatch) bool {
-	return p.Backend != nil || p.Model != nil || p.Skills != nil || p.Prompt != nil ||
-		p.AllowPRs != nil || p.AllowDispatch != nil || p.CanDispatch != nil ||
-		p.Description != nil || p.AllowMemory != nil
 }
 
 // toolDeleteAgent removes an agent through the same path as DELETE
@@ -298,7 +292,7 @@ func toolUpdateBackend(deps Deps) server.ToolHandlerFunc {
 		} else if errMsg != "" {
 			return mcpgo.NewToolResultError(errMsg), nil
 		}
-		if !backendPatchHasField(patch) {
+		if !patch.AnyFieldSet() {
 			return mcpgo.NewToolResultError("at least one field is required"), nil
 		}
 		canonicalName, canonical, uerr := deps.Fleet.UpdateBackendPatch(name, patch)
@@ -307,12 +301,6 @@ func toolUpdateBackend(deps Deps) server.ToolHandlerFunc {
 		}
 		return jsonResult(backendJSON(canonicalName, canonical))
 	}
-}
-
-func backendPatchHasField(p daemonfleet.BackendPatch) bool {
-	return p.Command != nil || p.Version != nil || p.Models != nil || p.Healthy != nil ||
-		p.HealthDetail != nil || p.LocalModelURL != nil || p.TimeoutSeconds != nil ||
-		p.MaxPromptChars != nil
 }
 
 // toolDeleteBackend removes a backend through the same path as DELETE

--- a/internal/mcp/tools_fleet.go
+++ b/internal/mcp/tools_fleet.go
@@ -197,15 +197,15 @@ func toolTriggerAgent(deps Deps) server.ToolHandlerFunc {
 		}
 		want := fleet.NormalizeRepoName(repoName)
 		var repo fleet.Repo
-		var ok bool
+		var found bool
 		for _, r := range repos {
 			if r.Name == want {
 				repo = r
-				ok = true
+				found = true
 				break
 			}
 		}
-		if !ok || !repo.Enabled {
+		if !found || !repo.Enabled {
 			return mcpgo.NewToolResultErrorf("repo %q not found or disabled", repoName), nil
 		}
 


### PR DESCRIPTION
## Summary

Replaces closed #355 (went stale when `BackendPatch.RedactionSaltEnv` was removed from `daemon/fleet/fleet.go` after the branch was cut).

`internal/mcp/tools_crud.go` had two private helpers, `agentPatchHasField` and `backendPatchHasField`, whose bodies were exact duplicates of the private `anyFieldSet()` methods already defined on `AgentPatch` and `BackendPatch` in `internal/daemon/fleet/fleet.go`. This added ~10 lines that had to be kept in sync manually.

## Changes

- `internal/daemon/fleet/fleet.go`: export `anyFieldSet` → `AnyFieldSet` on both `AgentPatch` and `BackendPatch`; add one-line doc comment; update the two internal call sites within the same file.
- `internal/mcp/tools_crud.go`: replace `agentPatchHasField(patch)` → `patch.AnyFieldSet()` and `backendPatchHasField(patch)` → `patch.AnyFieldSet()`; delete both now-redundant helper functions.

No behaviour change — the boolean logic is identical.

## Test plan

- [ ] CI green (`go test -race ./...`)
- [ ] No behaviour change — pure deduplication