### PR TITLE
fix: remove ok redeclaration in toolTriggerAgent (unblocks CI)

### DIFF
--- a/internal/mcp/tools_fleet.go
+++ b/internal/mcp/tools_fleet.go
@@ -196,18 +196,11 @@ func toolTriggerAgent(deps Deps) server.ToolHandlerFunc {
 			return mcpgo.NewToolResultErrorFromErr("read repos", err), nil
 		}
 		want := fleet.NormalizeRepoName(repoName)
-		var repo fleet.Repo
-		var ok bool
-		for _, r := range repos {
-			if r.Name == want {
-				repo = r
-				ok = true
-				break
-			}
-		}
-		if !ok || !repo.Enabled {
+		idx := slices.IndexFunc(repos, func(r fleet.Repo) bool { return r.Name == want })
+		if idx < 0 || !repos[idx].Enabled {
 			return mcpgo.NewToolResultErrorf("repo %q not found or disabled", repoName), nil
 		}
+		repo := repos[idx]
 
 		ev := workflow.Event{
 			ID:    workflow.GenEventID(),


### PR DESCRIPTION
## Root cause

PR #344 replaced the verbose `RequireString`/`TrimSpace` block in
`toolTriggerAgent` with two `trimmedString` calls, which declared `ok`
in the closure scope via `:=`. The old `var ok bool` loop variable was
left in place below, causing this compilation error on every build
since:

```
internal/mcp/tools_fleet.go:XX:XX: ok redeclared in this block
```

Because `internal/mcp` did not compile, `go vet ./...` and
`go test ./...` both failed, breaking CI on every open PR branched from
main (currently #337, #361, #362, #363).

## Fix

Replace the manual linear search (`var repo fleet.Repo; var ok bool;
for loop`) with `slices.IndexFunc`, consistent with the identical repo
lookup already done in `daemon.go` (PR #360). The redeclaration is gone
and the loop variable is gone with it.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>