### PR TITLE
fix: rename ok→found in toolTriggerAgent to resolve go vet redeclaration

### DIFF
--- a/internal/mcp/tools_fleet.go
+++ b/internal/mcp/tools_fleet.go
@@ -197,15 +197,15 @@ func toolTriggerAgent(deps Deps) server.ToolHandlerFunc {
 		}
 		want := fleet.NormalizeRepoName(repoName)
 		var repo fleet.Repo
-		var ok bool
+		var found bool
 		for _, r := range repos {
 			if r.Name == want {
 				repo = r
-				ok = true
+				found = true
 				break
 			}
 		}
-		if !ok || !repo.Enabled {
+		if !found || !repo.Enabled {
 			return mcpgo.NewToolResultErrorf("repo %q not found or disabled", repoName), nil
 		}
 


### PR DESCRIPTION
## Problem

PR #344 replaced the verbose `RequireString`/`TrimSpace`/empty-check block in `toolTriggerAgent` with two `trimmedString` calls. Those calls declare `ok` via `:=`:

```go
agent, ok := trimmedString(req, "agent")
repoName, ok := trimmedString(req, "repo")
```

But the repo-search loop variable `var ok bool` further down was not removed, redeclaring `ok` in the same function scope. `go vet` catches this as a compile-time error, breaking CI for all PRs tested against current main.

## Fix

Rename the loop sentinel from `ok` to `found` (`var found bool`, `found = true`, `!found || !repo.Enabled`). No behaviour change — identical runtime semantics.

## Test plan

- [ ] CI green (`go vet ./...` + `go test -race ./...`)
- [ ] No behaviour change — pure rename of a local variable