### PR TITLE
refactor: simplify isSupportedBackend to single boolean return

### DIFF
--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -260,8 +260,5 @@ func countBindingTriggers(b fleet.Binding) int {
 }
 
 func isSupportedBackend(name string, backend fleet.Backend) bool {
-	if slices.Contains(validAIBackendNames, name) {
-		return true
-	}
-	return strings.TrimSpace(backend.LocalModelURL) != ""
+	return slices.Contains(validAIBackendNames, name) || strings.TrimSpace(backend.LocalModelURL) != ""
 }

--- a/internal/mcp/tools_fleet.go
+++ b/internal/mcp/tools_fleet.go
@@ -197,15 +197,15 @@ func toolTriggerAgent(deps Deps) server.ToolHandlerFunc {
 		}
 		want := fleet.NormalizeRepoName(repoName)
 		var repo fleet.Repo
-		var ok bool
+		var found bool
 		for _, r := range repos {
 			if r.Name == want {
 				repo = r
-				ok = true
+				found = true
 				break
 			}
 		}
-		if !ok || !repo.Enabled {
+		if !found || !repo.Enabled {
 			return mcpgo.NewToolResultErrorf("repo %q not found or disabled", repoName), nil
 		}
 


### PR DESCRIPTION
## Summary

`isSupportedBackend` in `internal/config/validate.go` used the verbose early-return-true pattern:

```go
func isSupportedBackend(name string, backend fleet.Backend) bool {
    if slices.Contains(validAIBackendNames, name) {
        return true
    }
    return strings.TrimSpace(backend.LocalModelURL) != ""
}
```

This is non-idiomatic when the two branches are a simple disjunction. Replace with a direct boolean expression:

```go
func isSupportedBackend(name string, backend fleet.Backend) bool {
    return slices.Contains(validAIBackendNames, name) || strings.TrimSpace(backend.LocalModelURL) != ""
}
```

-3 lines, same semantics, clearer intent.

## Test plan

- [ ] CI green (`go vet ./...` + `go test -race ./...`)
- [ ] No behaviour change — pure simplification