### PR TITLE
refactor: alias workflow.TraceStep to ai.TraceStep, drop conversion loop

### DIFF
--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -837,11 +837,7 @@ func (e *Engine) runAgent(ctx context.Context, ev Event, agent fleet.Agent, cfg 
 
 	// Record transcript steps when available.
 	if e.stepRec != nil && len(resp.Steps) > 0 {
-		wsteps := make([]TraceStep, len(resp.Steps))
-		for i, s := range resp.Steps {
-			wsteps[i] = TraceStep(s)
-		}
-		e.stepRec.RecordSteps(spanID, wsteps)
+		e.stepRec.RecordSteps(spanID, resp.Steps)
 	}
 
 	if runErr != nil {

--- a/internal/workflow/steps.go
+++ b/internal/workflow/steps.go
@@ -1,11 +1,7 @@
 package workflow
 
-// TraceStep records one tool call in an agent's tool loop.
-// It is used by StepRecorder implementations to persist and serve the
-// per-span tool-loop transcript.
-type TraceStep struct {
-	ToolName      string `json:"tool_name"`
-	InputSummary  string `json:"input_summary"`
-	OutputSummary string `json:"output_summary"`
-	DurationMs    int64  `json:"duration_ms"`
-}
+import "github.com/eloylp/agents/internal/ai"
+
+// TraceStep aliases ai.TraceStep so the workflow and observe packages share
+// one definition without a conversion step in the engine's step-recording path.
+type TraceStep = ai.TraceStep


### PR DESCRIPTION
`workflow.TraceStep` was an independent struct definition with fields and JSON tags identical to `ai.TraceStep`. Because the types were distinct, the engine had to manually convert `[]ai.TraceStep` → `[]workflow.TraceStep` element by element before calling `StepRecorder.RecordSteps`.

## Changes

**`internal/workflow/steps.go`** — replace the 9-line duplicate struct with a one-line type alias:
```go
type TraceStep = ai.TraceStep
```

**`internal/workflow/engine.go`** — remove the 4-line conversion loop in `runAgent`; `resp.Steps` (`[]ai.TraceStep`) is now directly assignable as `[]workflow.TraceStep`:
```go
// before
wsteps := make([]TraceStep, len(resp.Steps))
for i, s := range resp.Steps {
    wsteps[i] = TraceStep(s)
}
e.stepRec.RecordSteps(spanID, wsteps)

// after
e.stepRec.RecordSteps(spanID, resp.Steps)
```

All packages that reference `workflow.TraceStep` by name (`internal/observe`, `internal/daemon/observe`) continue to compile unchanged — the alias preserves the exported name while making the two types identical to the compiler.