### PR TITLE
refactor: use slices.Delete in runStream history ring buffer

### DIFF
--- a/internal/observe/observe.go
+++ b/internal/observe/observe.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"slices"
 	"sync"
 	"time"
 
@@ -242,8 +243,7 @@ func (r *runStream) publish(line []byte) {
 		return
 	}
 	if len(r.history) >= runStreamHistoryCap {
-		// drop oldest
-		r.history = append(r.history[:0], r.history[1:]...)
+		r.history = slices.Delete(r.history, 0, 1)
 	}
 	r.history = append(r.history, cp)
 	for ch := range r.subs {


### PR DESCRIPTION
## Summary

- Replace `append(r.history[:0], r.history[1:]...)` with `slices.Delete(r.history, 0, 1)` in `runStream.publish`
- Add `"slices"` import to `internal/observe/observe.go`

The manual `append` idiom for dropping the first slice element predates the `slices` package (Go 1.21). `slices.Delete(s, 0, 1)` is the direct stdlib equivalent and makes the intent — delete one element at index 0 — immediately legible. As a bonus, `slices.Delete` zeroes out the vacated slot in the backing array, allowing the GC to collect the old `[]byte` sooner.

The `slices` package is already used elsewhere in the module (e.g. `internal/fleet/normalize.go`, `internal/config/validate.go`).

No behaviour change.