### PR TITLE
refactor: add TriggerCount() to fleet.Binding, remove countBindingTriggers

### DIFF
--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -230,7 +230,7 @@ func (c *Config) validateRepos() error {
 			if !b.IsCron() && !b.IsLabel() && !b.IsEvent() {
 				return fmt.Errorf("config: repo %q: binding for agent %q has no trigger (set cron, labels, or events)", r.Name, b.Agent)
 			}
-			if countBindingTriggers(b) > 1 {
+			if b.TriggerCount() > 1 {
 				return fmt.Errorf("config: repo %q: binding for agent %q mixes multiple trigger types (labels, events, cron); each binding must use exactly one trigger", r.Name, b.Agent)
 			}
 			for _, kind := range b.Events {
@@ -242,21 +242,6 @@ func (c *Config) validateRepos() error {
 		}
 	}
 	return nil
-}
-
-// countBindingTriggers returns the number of trigger types (labels, events, cron) set on b.
-func countBindingTriggers(b fleet.Binding) int {
-	n := 0
-	if b.IsLabel() {
-		n++
-	}
-	if b.IsEvent() {
-		n++
-	}
-	if b.IsCron() {
-		n++
-	}
-	return n
 }
 
 func isSupportedBackend(name string, backend fleet.Backend) bool {

--- a/internal/config/validate_entities.go
+++ b/internal/config/validate_entities.go
@@ -157,7 +157,7 @@ func ValidateEntities(agents []fleet.Agent, repos []fleet.Repo, skills map[strin
 			if !b.IsCron() && !b.IsLabel() && !b.IsEvent() {
 				return fmt.Errorf("config: repo %q: binding for agent %q has no trigger (set cron, labels, or events)", r.Name, b.Agent)
 			}
-			if countBindingTriggers(b) > 1 {
+			if b.TriggerCount() > 1 {
 				return fmt.Errorf("config: repo %q: binding for agent %q mixes multiple trigger types (labels, events, cron); each binding must use exactly one trigger", r.Name, b.Agent)
 			}
 			for _, kind := range b.Events {

--- a/internal/fleet/binding.go
+++ b/internal/fleet/binding.go
@@ -34,3 +34,20 @@ func (b Binding) IsLabel() bool { return len(b.Labels) > 0 }
 
 // IsEvent reports whether this binding is event-triggered (via the events: field).
 func (b Binding) IsEvent() bool { return len(b.Events) > 0 }
+
+// TriggerCount returns the number of trigger types (cron, labels, events) set
+// on this binding. Bindings must use exactly one trigger; callers use
+// TriggerCount to enforce that invariant without repeating the three IsX checks.
+func (b Binding) TriggerCount() int {
+	n := 0
+	if b.IsLabel() {
+		n++
+	}
+	if b.IsEvent() {
+		n++
+	}
+	if b.IsCron() {
+		n++
+	}
+	return n
+}

--- a/internal/store/crud.go
+++ b/internal/store/crud.go
@@ -522,20 +522,11 @@ func validateBindingShape(b fleet.Binding) error {
 	if strings.TrimSpace(b.Agent) == "" {
 		return &ErrValidation{Msg: "agent is required"}
 	}
-	triggerCount := 0
-	if b.IsLabel() {
-		triggerCount++
-	}
-	if b.IsEvent() {
-		triggerCount++
-	}
-	if b.IsCron() {
-		triggerCount++
-	}
-	if triggerCount == 0 {
+	n := b.TriggerCount()
+	if n == 0 {
 		return &ErrValidation{Msg: "binding has no trigger (set cron, labels, or events)"}
 	}
-	if triggerCount > 1 {
+	if n > 1 {
 		return &ErrValidation{Msg: "binding mixes multiple trigger types (labels, events, cron); each binding must use exactly one trigger"}
 	}
 	if b.IsCron() {


### PR DESCRIPTION
## Summary

- Adds `TriggerCount() int` to `fleet.Binding`, alongside its sibling `IsCron()`, `IsLabel()`, and `IsEvent()` predicates — the counting logic belongs on the type that already owns the trigger fields.
- Removes `countBindingTriggers(b fleet.Binding) int` from `internal/config/validate.go` — a private helper that duplicated the same three-if block.
- Replaces `countBindingTriggers(b)` in `internal/config/validate_entities.go` with `b.TriggerCount()`.
- Replaces the inline `triggerCount` variable block in `internal/store/crud.go`'s `validateBindingShape` with a single `n := b.TriggerCount()` call.

The same "count how many of {cron, labels, events} are set" logic appeared in three places. Centralising it on `fleet.Binding` removes the duplication and means a future trigger type only needs to be added in one location.

Replaces #372 (closed — that branch went dirty against main).

## Test plan

- [ ] CI passes (existing tests cover the validation paths — no behaviour changed, only counting is delegated to the method)

🤖 Generated with [Claude Code](https://claude.com/claude-code)