### PR TITLE
refactor: use errors.Is for sql.ErrNoRows in ReadMemory

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -613,7 +613,7 @@ func ReadMemory(db *sql.DB, agent, repo string) (string, bool, time.Time, error)
 	err := db.QueryRow(
 		"SELECT content, updated_at FROM memory WHERE agent=? AND repo=?", agent, repo,
 	).Scan(&content, &updatedAt)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return "", false, time.Time{}, nil
 	}
 	if err != nil {


### PR DESCRIPTION
## Summary

- `ReadMemory` in `internal/store/store.go` compared `err == sql.ErrNoRows` directly; every other `sql.ErrNoRows` check in the store package (`crud.go`, `runners.go`) uses `errors.Is`.
- Replace the direct comparison with `errors.Is(err, sql.ErrNoRows)` for consistency and to respect any future error wrapping by the driver.

## Test plan

- [ ] Existing store tests (`go test ./internal/store/...`) cover the `ReadMemory` path and continue to pass unchanged — behaviour is identical since `sql.ErrNoRows` is an unwrapped sentinel today.