### PR TITLE
refactor: use for-range over integer in TestConcurrentWritesAllCommit

### DIFF
--- a/internal/daemon/crud_test.go
+++ b/internal/daemon/crud_test.go
@@ -1076,7 +1076,7 @@ func TestConcurrentWritesAllCommit(t *testing.T) {
 	const n = 20
 	var wg sync.WaitGroup
 	wg.Add(n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		name := "agent-concurrent-" + string(rune('a'+i))
 		go func(agentName string) {
 			defer wg.Done()


### PR DESCRIPTION
Go 1.22 lets you range directly over an integer, replacing the C-style three-clause loop. The loop variable `i` is still needed (used to build unique agent names), so this is `for i := range n {` rather than `for range n {`.

**Before**
```go
for i := 0; i < n; i++ {
```

**After**
```go
for i := range n {
```

No behaviour change — pure readability improvement.