### PR TITLE
refactor: use slices.IndexFunc in toolTriggerAgent repo lookup

### DIFF
--- a/internal/mcp/tools_fleet.go
+++ b/internal/mcp/tools_fleet.go
@@ -196,18 +196,11 @@ func toolTriggerAgent(deps Deps) server.ToolHandlerFunc {
 			return mcpgo.NewToolResultErrorFromErr("read repos", err), nil
 		}
 		want := fleet.NormalizeRepoName(repoName)
-		var repo fleet.Repo
-		var found bool
-		for _, r := range repos {
-			if r.Name == want {
-				repo = r
-				found = true
-				break
-			}
-		}
-		if !found || !repo.Enabled {
+		idx := slices.IndexFunc(repos, func(r fleet.Repo) bool { return r.Name == want })
+		if idx < 0 || !repos[idx].Enabled {
 			return mcpgo.NewToolResultErrorf("repo %q not found or disabled", repoName), nil
 		}
+		repo := repos[idx]
 
 		ev := workflow.Event{
 			ID:    workflow.GenEventID(),


### PR DESCRIPTION
`toolGetAgent` and `toolGetRepo` in the same file already use `slices.IndexFunc` for the \"find by normalized name\" pattern. `toolTriggerAgent` was the only outlier, using a manual loop with a `found` flag and a `break`. This makes all three lookup patterns consistent.\n\nNo behaviour change — the early-return condition (`idx < 0 || !repos[idx].Enabled`) is equivalent to the old `!found || !repo.Enabled`.