### PR TITLE
refactor: use slices.Clone in buildStatus instead of append copy idiom

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -516,11 +516,11 @@ func (d *Daemon) buildStatus() statusJSON {
 		Agents: slices.Clone(d.scheduler.AgentStatuses()),
 	}
 
-	orphan_list, err := d.fleet.OrphanedAgents()
+	orphans, err := d.fleet.OrphanedAgents()
 	if err != nil {
 		d.logger.Warn().Err(err).Msg("status: orphan computation failed")
 	}
-	resp.OrphanedAgents = statusOrphanSummaryJSON{Count: len(orphan_list)}
+	resp.OrphanedAgents = statusOrphanSummaryJSON{Count: len(orphans)}
 
 	stats := d.engine.DispatchStats()
 	resp.Dispatch = &stats

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -513,14 +513,14 @@ func (d *Daemon) buildStatus() statusJSON {
 		Queues: map[string]statusQueueJSON{
 			"events": {Buffered: q.Buffered, Capacity: q.Capacity},
 		},
-		Agents: append([]scheduler.AgentStatus{}, d.scheduler.AgentStatuses()...),
+		Agents: slices.Clone(d.scheduler.AgentStatuses()),
 	}
 
-	orphans, err := d.fleet.OrphanedAgents()
+	orphanagents, err := d.fleet.OrphanedAgents()
 	if err != nil {
 		d.logger.Warn().Err(err).Msg("status: orphan computation failed")
 	}
-	resp.OrphanedAgents = statusOrphanSummaryJSON{Count: len(orphans)}
+	resp.OrphanedAgents = statusOrphanSummaryJSON{Count: len(orphanagents)}
 
 	stats := d.engine.DispatchStats()
 	resp.Dispatch = &stats

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -516,11 +516,11 @@ func (d *Daemon) buildStatus() statusJSON {
 		Agents: slices.Clone(d.scheduler.AgentStatuses()),
 	}
 
-	orphanagents, err := d.fleet.OrphanedAgents()
+	orphan_list, err := d.fleet.OrphanedAgents()
 	if err != nil {
 		d.logger.Warn().Err(err).Msg("status: orphan computation failed")
 	}
-	resp.OrphanedAgents = statusOrphanSummaryJSON{Count: len(orphanagents)}
+	resp.OrphanedAgents = statusOrphanSummaryJSON{Count: len(orphan_list)}
 
 	stats := d.engine.DispatchStats()
 	resp.Dispatch = &stats


### PR DESCRIPTION
## What

Replace the manual slice-copy idiom in `buildStatus()` with `slices.Clone`:

```go
// before
Agents: append([]scheduler.AgentStatus{}, d.scheduler.AgentStatuses()...),

// after
Agents: slices.Clone(d.scheduler.AgentStatuses()),
```

## Why

`slices.Clone` is the idiomatic Go 1.21+ way to shallow-copy a slice. The `append([]T{}, src...)` pattern predates the stdlib helper and is more verbose without being clearer. The `slices` package is already imported in this file (used by `slices.IndexFunc` in `handleAgentsRun`), so this adds no new dependency.

No behaviour change — `slices.Clone` returns a new slice backed by a fresh array, identical to what the append idiom produced.