### PR TITLE
refactor: use slices.Clone in AgentStatuses instead of make+copy

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"slices"
 	"sync"
 	"time"
 
@@ -293,8 +294,7 @@ func (s *Scheduler) AgentStatuses() []AgentStatus {
 	}
 
 	s.bindMu.RLock()
-	agentEntries := make([]agentEntry, len(s.agentEntries))
-	copy(agentEntries, s.agentEntries)
+	agentEntries := slices.Clone(s.agentEntries)
 	s.bindMu.RUnlock()
 
 	statuses := make([]AgentStatus, 0, len(agentEntries))


### PR DESCRIPTION
## Summary

`AgentStatuses` in `internal/scheduler/scheduler.go` copies `s.agentEntries` under the read lock using the two-step `make + copy` pattern:

```go
agentEntries := make([]agentEntry, len(s.agentEntries))
copy(agentEntries, s.agentEntries)
```

`slices.Clone` is the stdlib expression of exactly this operation. The cloned slice is only range-iterated (never serialised or returned directly), so the nil-vs-empty distinction is irrelevant.

```go
agentEntries := slices.Clone(s.agentEntries)
```

The file already imports `maps` for `maps.Clone` higher in the same function, so adding `slices` is consistent with existing style.