### PR TITLE
refactor: use slices.Clone in stringSliceArg []string case

### DIFF
--- a/internal/mcp/tools_crud.go
+++ b/internal/mcp/tools_crud.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -716,9 +717,7 @@ func stringSliceArg(v any, keyForErr string) ([]string, string) {
 		}
 		return out, ""
 	case []string:
-		cp := make([]string, len(raw))
-		copy(cp, raw)
-		return cp, ""
+		return slices.Clone(raw), ""
 	case string:
 		var decoded []string
 		if err := json.Unmarshal([]byte(raw), &decoded); err == nil {


### PR DESCRIPTION
The `[]string` branch in `stringSliceArg` (internal/mcp/tools_crud.go) uses the manual `make`+`copy` idiom to produce an independent copy:\n\n```go\ncase []string:\n    cp := make([]string, len(raw))\n    copy(cp, raw)\n    return cp, \"\"\n```\n\n`slices.Clone` is the idiomatic Go 1.21+ equivalent and reads more clearly at the call site:\n\n```go\ncase []string:\n    return slices.Clone(raw), \"\"\n```\n\nNo behaviour change — both produce a fresh slice of the same length with the same elements.