### PR TITLE
refactor: use bytes.Clone+append in addLine instead of make+copy+set

### DIFF
--- a/internal/ai/cmdrunner.go
+++ b/internal/ai/cmdrunner.go
@@ -480,9 +480,7 @@ type lineCapture struct {
 
 // addLine records a single line (without trailing newline) and its arrival time.
 func (c *lineCapture) addLine(data []byte) {
-	line := make([]byte, len(data)+1)
-	copy(line, data)
-	line[len(data)] = '\n'
+	line := append(bytes.Clone(data), '\n')
 	c.lines = append(c.lines, timedLine{data: line, at: time.Now()})
 	c.all.Write(line)
 }

--- a/internal/ai/cmdrunner_test.go
+++ b/internal/ai/cmdrunner_test.go
@@ -502,10 +502,10 @@ func TestBuildDeliveryRespectsTotalBudget(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-			t.Run(tc.name, func(t *testing.T) {
-				t.Parallel()
-				r := NewCommandRunner(tc.backendName, "command", "true", nil, 10, tc.maxChars, zerolog.Nop())
-				args, stdin := r.buildDelivery(Request{System: tc.system, User: tc.user})
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r := NewCommandRunner(tc.backendName, "command", "true", nil, 10, tc.maxChars, zerolog.Nop())
+			args, stdin := r.buildDelivery(Request{System: tc.system, User: tc.user})
 			if stdin != tc.wantStdin {
 				t.Errorf("stdin = %q, want %q", stdin, tc.wantStdin)
 			}
@@ -572,10 +572,10 @@ func TestBuildDeliveryClaudeAndCodexSameTruncationBoundary(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-			t.Run(tc.name, func(t *testing.T) {
-				t.Parallel()
-				claude := NewCommandRunner("claude", "command", "true", nil, 10, tc.maxChars, zerolog.Nop())
-				codex := NewCommandRunner("codex", "command", "true", nil, 10, tc.maxChars, zerolog.Nop())
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			claude := NewCommandRunner("claude", "command", "true", nil, 10, tc.maxChars, zerolog.Nop())
+			codex := NewCommandRunner("codex", "command", "true", nil, 10, tc.maxChars, zerolog.Nop())
 
 			claudeArgs, claudeStdin := claude.buildDelivery(Request{System: tc.system, User: tc.user})
 			_, codexStdin := codex.buildDelivery(Request{System: tc.system, User: tc.user})
@@ -640,9 +640,7 @@ func TestParseClaudeSteps(t *testing.T) {
 			if len(raw) == 0 {
 				continue
 			}
-			line := make([]byte, len(raw)+1)
-			copy(line, raw)
-			line[len(raw)] = '\n'
+			line := append(bytes.Clone(raw), '\n')
 			tls = append(tls, timedLine{data: line, at: base})
 			base = base.Add(step)
 		}


### PR DESCRIPTION
## Summary

- `lineCapture.addLine` in `internal/ai/cmdrunner.go` used a three-step `make` / `copy` / index-set idiom to produce a newline-terminated copy of an incoming byte slice. `append(bytes.Clone(data), '\n')` expresses the same intent in one line with no manual length arithmetic.
- The mirroring `toTimedLines` helper in `cmdrunner_test.go` carried the identical pattern and is updated in the same commit.

`bytes` is already imported in both files; no new dependencies.

## Test plan

- [ ] CI passes (`go test ./...` with `-race`)
- [ ] No behaviour change: `addLine` still appends a `'\n'`-terminated copy; existing `TestParseClaudeSteps` cases cover the round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)