### PR TITLE
refactor: use slices.IndexFunc for agent lookup in fleet handler

### DIFF
--- a/internal/daemon/fleet/fleet.go
+++ b/internal/daemon/fleet/fleet.go
@@ -17,6 +17,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 
 	"github.com/gorilla/mux"
@@ -215,13 +216,12 @@ func (h *Handler) handleAgent(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, fmt.Sprintf("read agents: %v", err), http.StatusInternalServerError)
 			return
 		}
-		for _, a := range agents {
-			if a.Name == name {
-				writeJSON(w, http.StatusOK, agentToStoreJSON(a))
-				return
-			}
+		idx := slices.IndexFunc(agents, func(a fleet.Agent) bool { return a.Name == name })
+		if idx < 0 {
+			http.NotFound(w, r)
+			return
 		}
-		http.NotFound(w, r)
+		writeJSON(w, http.StatusOK, agentToStoreJSON(agents[idx]))
 
 	case http.MethodPatch:
 		h.handleAgentPatch(w, r, name)
@@ -282,17 +282,11 @@ func (h *Handler) updateAgent(name string, patch AgentPatch) (fleet.Agent, error
 	if err != nil {
 		return fleet.Agent{}, err
 	}
-	var existing *fleet.Agent
-	for i := range agents {
-		if agents[i].Name == normalized {
-			existing = &agents[i]
-			break
-		}
-	}
-	if existing == nil {
+	idx := slices.IndexFunc(agents, func(a fleet.Agent) bool { return a.Name == normalized })
+	if idx < 0 {
 		return fleet.Agent{}, &store.ErrNotFound{Msg: fmt.Sprintf("agent %q not found", normalized)}
 	}
-	merged := *existing
+	merged := agents[idx]
 	patch.apply(&merged)
 	if err := h.store.UpsertAgent(merged); err != nil {
 		return fleet.Agent{}, err
@@ -459,7 +453,7 @@ func (h *Handler) DeleteSkill(name string) error {
 // ── Backend wire types ───────────────────────────────────────────────────────
 
 type storeBackendJSON struct {
-	Name             string   `json:"name"`
+	Name           string   `json:"name"`
 	Command        string   `json:"command"`
 	Version        string   `json:"version,omitempty"`
 	Models         []string `json:"models,omitempty"`


### PR DESCRIPTION
## Summary

Two agent-by-name lookups in `internal/daemon/fleet/fleet.go` used hand-written `for` loops:

- `handleAgent` (GET case) scanned agents and returned early on match, then fell through to `http.NotFound`.
- `updateAgent` maintained a `var existing *fleet.Agent` sentinel, iterated with `for i := range`, set the pointer on match, then checked for nil after the loop.

Both are replaced with `slices.IndexFunc`, which expresses the lookup intent directly and eliminates the intermediate pointer variable and the nil-sentinel pattern. The `slices` import is added to the file.

No behaviour change — the same normalization, error types, and response shapes apply.
