### PR TITLE
refactor: use bytes.Clone in runStream.publish

### DIFF
--- a/internal/observe/observe.go
+++ b/internal/observe/observe.go
@@ -234,8 +234,7 @@ func newRunStream() *runStream {
 // subscribers. A full subscriber channel drops the line silently —
 // observability must not back-pressure the runner.
 func (r *runStream) publish(line []byte) {
-	cp := make([]byte, len(line))
-	copy(cp, line)
+	cp := bytes.Clone(line)
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.closed {


### PR DESCRIPTION
Replace the two-step `make([]byte, len(line))` + `copy` idiom in `runStream.publish` with `bytes.Clone`, the idiomatic Go 1.20+ way to defensively copy a byte slice.

`bytes` is already imported in the file, so no import changes are needed.

```go
// before
cp := make([]byte, len(line))
copy(cp, line)

// after
cp := bytes.Clone(line)
```