### PR TITLE
refactor: use slices.Clone in stubLastRunRecorder.snapshot

### DIFF
--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"context"
 	"errors"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -835,9 +836,7 @@ func (s *stubLastRunRecorder) RecordLastRun(agent, repo string, _ time.Time, sta
 func (s *stubLastRunRecorder) snapshot() []struct{ agent, repo, status string } {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	out := make([]struct{ agent, repo, status string }, len(s.calls))
-	copy(out, s.calls)
-	return out
+	return slices.Clone(s.calls)
 }
 
 // autonomousEvent builds an Event for a cron-fired autonomous run, matching
@@ -917,7 +916,7 @@ func TestHandleEventNonAutonomousSkipsLastRunRecorder(t *testing.T) {
 }
 
 // TestHandleEventAutonomousReportsErrorStatus verifies a runner failure
-// surfaces as status="error" in the LastRunRecorder callback so the schedule
+// surfaces as status=\"error\" in the LastRunRecorder callback so the schedule
 // view distinguishes broken from healthy bindings without a separate fetch.
 func TestHandleEventAutonomousReportsErrorStatus(t *testing.T) {
 	t.Parallel()

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -916,7 +916,7 @@ func TestHandleEventNonAutonomousSkipsLastRunRecorder(t *testing.T) {
 }
 
 // TestHandleEventAutonomousReportsErrorStatus verifies a runner failure
-// surfaces as status=\"error\" in the LastRunRecorder callback so the schedule
+// surfaces as status="error" in the LastRunRecorder callback so the schedule
 // view distinguishes broken from healthy bindings without a separate fetch.
 func TestHandleEventAutonomousReportsErrorStatus(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

`stubLastRunRecorder.snapshot()` in `internal/workflow/engine_test.go` copies its call log with the older `make`+`copy` idiom. `slices.Clone` expresses the same intent in a single call and has been idiomatic since Go 1.21.

```go
// before
out := make([]struct{ agent, repo, status string }, len(s.calls))
copy(out, s.calls)
return out

// after
return slices.Clone(s.calls)
```

`"slices"` is added to the import block (sorted alphabetically with the other stdlib imports).

No behaviour change — test assertions that check `len(calls)` are unaffected.