### PR TITLE
refactor: use slices.IndexFunc in webhook repoByName lookup

### DIFF
--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -62,10 +63,8 @@ func (h *Handler) repoByName(name string) (fleet.Repo, bool) {
 		return fleet.Repo{}, false
 	}
 	want := fleet.NormalizeRepoName(name)
-	for _, r := range repos {
-		if r.Name == want {
-			return r, true
-		}
+	if i := slices.IndexFunc(repos, func(r fleet.Repo) bool { return r.Name == want }); i >= 0 {
+		return repos[i], true
 	}
 	return fleet.Repo{}, false
 }


### PR DESCRIPTION
The `repoByName` helper in `internal/webhook/handler.go` uses a manual for/return loop to find a repo by name — the same linear-search idiom already replaced with `slices.IndexFunc` in:

- `internal/mcp/tools_fleet.go` (#377)
- `internal/daemon/repos/repos.go` (#378)
- `internal/daemon/fleet/fleet.go` (#384)

This PR applies the same replacement here. The `slices` package is added to the import block; no other file is touched.

No behaviour change.