### PR TITLE
refactor: use slices.IndexFunc in Dispatcher.lookupAgent

### DIFF
--- a/internal/workflow/dispatch.go
+++ b/internal/workflow/dispatch.go
@@ -449,12 +449,11 @@ func (d *Dispatcher) lookupAgent(name string) (fleet.Agent, bool) {
 		d.logger.Error().Err(err).Msg("dispatcher: read agents")
 		return fleet.Agent{}, false
 	}
-	for _, a := range agents {
-		if a.Name == name {
-			return a, true
-		}
+	idx := slices.IndexFunc(agents, func(a fleet.Agent) bool { return a.Name == name })
+	if idx < 0 {
+		return fleet.Agent{}, false
 	}
-	return fleet.Agent{}, false
+	return agents[idx], true
 }
 
 // ProcessDispatches validates and enqueues each dispatch request from a single


### PR DESCRIPTION
Replace the manual range loop in `Dispatcher.lookupAgent` with `slices.IndexFunc`. The `slices` package is already imported in this file (used by `slices.Contains` in `ProcessDispatches`), so there is no new dependency.

**Before**
```go
for _, a := range agents {
    if a.Name == name {
        return a, true
    }
}
return fleet.Agent{}, false
```

**After**
```go
idx := slices.IndexFunc(agents, func(a fleet.Agent) bool { return a.Name == name })
if idx < 0 {
    return fleet.Agent{}, false
}
return agents[idx], true
```

No behaviour change.