### PR TITLE
refactor: export GuardrailPatch.AnyFieldSet to match AgentPatch and BackendPatch

### DIFF
--- a/internal/daemon/fleet/guardrails.go
+++ b/internal/daemon/fleet/guardrails.go
@@ -47,7 +47,10 @@ type GuardrailPatch struct {
 	Position    *int    `json:"position,omitempty"`
 }
 
-func (p GuardrailPatch) anyFieldSet() bool {
+// AnyFieldSet reports whether at least one patch field is non-nil. Used by
+// both the REST PATCH handler and the MCP update_guardrail tool to reject
+// empty payloads before hitting the store.
+func (p GuardrailPatch) AnyFieldSet() bool {
 	return p.Description != nil || p.Content != nil || p.Enabled != nil || p.Position != nil
 }
 
@@ -133,7 +136,7 @@ func (h *Handler) handleGuardrailPatch(w http.ResponseWriter, r *http.Request, n
 	if !decodeBody(w, r, h.maxBodyBytes, &req) {
 		return
 	}
-	if !req.anyFieldSet() {
+	if !req.AnyFieldSet() {
 		http.Error(w, "at least one field is required", http.StatusBadRequest)
 		return
 	}

--- a/internal/mcp/tools_guardrails.go
+++ b/internal/mcp/tools_guardrails.go
@@ -107,7 +107,7 @@ func toolUpdateGuardrail(deps Deps) server.ToolHandlerFunc {
 			pos := int(n)
 			patch.Position = &pos
 		}
-		if patch.Description == nil && patch.Content == nil && patch.Enabled == nil && patch.Position == nil {
+		if !patch.AnyFieldSet() {
 			return mcpgo.NewToolResultError("at least one field is required"), nil
 		}
 		canonical, err := deps.Fleet.UpdateGuardrailPatch(name, patch)


### PR DESCRIPTION
## Summary

`AgentPatch` and `BackendPatch` both expose `AnyFieldSet()` as an exported method so the REST PATCH handler and the MCP update tool can share the same empty-payload guard. `GuardrailPatch.anyFieldSet` was left unexported in the new guardrails feature, which forced `toolUpdateGuardrail` in `tools_guardrails.go` to inline its own 4-way nil check instead of calling the method — a pattern that silently becomes stale if `GuardrailPatch` ever gains more fields.

**Changes (2 files):**

- `internal/daemon/fleet/guardrails.go`: rename `anyFieldSet` → `AnyFieldSet`, add doc comment matching `AgentPatch`/`BackendPatch`, update call in `handleGuardrailPatch`
- `internal/mcp/tools_guardrails.go`: replace `if patch.Description == nil && patch.Content == nil && patch.Enabled == nil && patch.Position == nil` with `if !patch.AnyFieldSet()` in `toolUpdateGuardrail`

No behaviour change — pure consistency fix.

## Test plan

- [ ] CI green (`go vet ./...` + `go test -race ./...`)
- [ ] No behaviour change — semantics of the guard are identical