### PR TITLE
refactor: use boolToInt/intToBool helpers in guardrails.go

### DIFF
--- a/internal/store/guardrails.go
+++ b/internal/store/guardrails.go
@@ -65,14 +65,8 @@ func UpsertGuardrail(db *sql.DB, g fleet.Guardrail) error {
 	if g.Content == "" {
 		return &ErrValidation{Msg: fmt.Sprintf("store: guardrail %q: content is required", g.Name)}
 	}
-	enabled := 0
-	if g.Enabled {
-		enabled = 1
-	}
-	isBuiltin := 0
-	if g.IsBuiltin {
-		isBuiltin = 1
-	}
+	enabled := boolToInt(g.Enabled)
+	isBuiltin := boolToInt(g.IsBuiltin)
 	var defaultContent any = g.DefaultContent
 	if g.DefaultContent == "" {
 		defaultContent = nil
@@ -170,7 +164,7 @@ func scanGuardrailRow(r rowScanner) (fleet.Guardrail, error) {
 	if err := r.Scan(&g.Name, &g.Description, &g.Content, &g.DefaultContent, &isBuiltin, &enabled, &g.Position); err != nil {
 		return fleet.Guardrail{}, err
 	}
-	g.IsBuiltin = isBuiltin == 1
-	g.Enabled = enabled == 1
+	g.IsBuiltin = intToBool(isBuiltin)
+	g.Enabled = intToBool(enabled)
 	return g, nil
 }


### PR DESCRIPTION
`UpsertGuardrail` inlined the same if-then-assign pattern that the package-local `boolToInt` helper already encapsulates. `scanGuardrailRow` compared scanned integers against the literal `1` where `intToBool` expresses the same intent and matches every other scan site in the package.

Both helpers live in `store.go` in the same package. Using them consistently keeps the `bool ↔ int` conversion logic in one place and removes the inline duplication.

**Changes**
- `UpsertGuardrail`: replace `enabled := 0; if g.Enabled { enabled = 1 }` and the equivalent for `isBuiltin` with `boolToInt` calls
- `scanGuardrailRow`: replace `isBuiltin == 1` / `enabled == 1` with `intToBool` calls