### PR TITLE
refactor: use boolToInt in Store.EnableRepo

### DIFF
--- a/internal/store/facade.go
+++ b/internal/store/facade.go
@@ -70,14 +70,10 @@ func (s *Store) ReadBinding(id int64) (string, fleet.Binding, bool, error) {
 	return ReadBinding(s.db, id)
 }
 
-// EnableRepo flips a repo's enabled flag without rewriting bindings , 
+// EnableRepo flips a repo's enabled flag without rewriting bindings ,
 // the dedicated path that PATCH /repos/{owner}/{repo} relies on.
 func (s *Store) EnableRepo(name string, enabled bool) error {
-	v := 0
-	if enabled {
-		v = 1
-	}
-	_, err := s.db.Exec("UPDATE repos SET enabled=? WHERE name=?", v, name)
+	_, err := s.db.Exec("UPDATE repos SET enabled=? WHERE name=?", boolToInt(enabled), name)
 	return err
 }
 


### PR DESCRIPTION
`Store.EnableRepo` was the only method in the `store` package that still used an inline 0/1 bool conversion instead of the `boolToInt` helper defined in this same package. All other callers (`importBackends`, `importAgents`, `importRepos`, `importGuardrails`) already go through the helper.

## Change

```go
// before
v := 0
if enabled {
    v = 1
}
_, err := s.db.Exec("UPDATE repos SET enabled=? WHERE name=?", v, name)

// after
_, err := s.db.Exec("UPDATE repos SET enabled=? WHERE name=?", boolToInt(enabled), name)
```

No behaviour change. The intermediate variable served no purpose beyond the conversion.