### PR TITLE
Use slices.Clone in runStream.subscribe (internal/observe/observe.go)

### DIFF
--- a/internal/observe/observe.go
+++ b/internal/observe/observe.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"slices"
 	"sync"
 	"time"
 
@@ -280,8 +281,7 @@ func (r *runStream) end() {
 func (r *runStream) subscribe() ([][]byte, chan []byte) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	hist := make([][]byte, len(r.history))
-	copy(hist, r.history)
+	hist := slices.Clone(r.history)
 	if r.closed {
 		// Run finished, return history but no live channel. Hand back
 		// a closed channel so the caller's range loop exits cleanly


### PR DESCRIPTION
## What

Replace the two-line `make+copy` idiom in `runStream.subscribe` with `slices.Clone`:

```go
// before
hist := make([][]byte, len(r.history))
copy(hist, r.history)

// after
hist := slices.Clone(r.history)
```

Also adds `"slices"` to the import block (alphabetically between `"log"` and `"sync"`).

## Why

`slices.Clone` is the idiomatic Go 1.21+ way to shallow-copy a slice. It's shorter, self-documenting, and removes the length-must-match coupling between `make` and `copy`.

## Safety

`r.history` is always initialised non-nil in `newRunStream()` (`make([][]byte, 0, 64)`), so the `slices.Clone(nil) → nil` edge case never arises. All callers use `len(hist)` / range, which treat nil and empty identically — no behaviour change.

This is a pure refactor; no logic is altered.