### PR TITLE
refactor: use slices.IndexFunc in toolTriggerAgent repo lookup

### DIFF
--- a/internal/mcp/tools_fleet.go
+++ b/internal/mcp/tools_fleet.go
@@ -196,18 +196,11 @@ func toolTriggerAgent(deps Deps) server.ToolHandlerFunc {
 			return mcpgo.NewToolResultErrorFromErr("read repos", err), nil
 		}
 		want := fleet.NormalizeRepoName(repoName)
-		var repo fleet.Repo
-		var found bool
-		for _, r := range repos {
-			if r.Name == want {
-				repo = r
-				found = true
-				break
-			}
-		}
-		if !found || !repo.Enabled {
+		idx := slices.IndexFunc(repos, func(r fleet.Repo) bool { return r.Name == want })
+		if idx == -1 || !repos[idx].Enabled {
 			return mcpgo.NewToolResultErrorf("repo %q not found or disabled", repoName), nil
 		}
+		repo := repos[idx]
 
 		ev := workflow.Event{
 			ID:    workflow.GenEventID(),


### PR DESCRIPTION
## What

Replace the manual `found`/`var` search loop in `toolTriggerAgent` with `slices.IndexFunc`, matching the style already used by `toolGetAgent` and `toolGetRepo` in the same file.

**Before:**
```go
var repo fleet.Repo
var found bool
for _, r := range repos {
    if r.Name == want {
        repo = r
        found = true
        break
    }
}
if !found || !repo.Enabled {
    return mcpgo.NewToolResultErrorf("repo %q not found or disabled", repoName), nil
}
```

**After:**
```go
idx := slices.IndexFunc(repos, func(r fleet.Repo) bool { return r.Name == want })
if idx == -1 || !repos[idx].Enabled {
    return mcpgo.NewToolResultErrorf("repo %q not found or disabled", repoName), nil
}
repo := repos[idx]
```

## Why

The sentinel `found bool` + zero-value `var repo` pattern is the pre-`slices` idiom. The rest of the file already uses `slices.IndexFunc` for the same pattern — this makes `toolTriggerAgent` consistent and removes 5 lines with no behaviour change. No new imports are needed; `slices` was already imported.