### PR TITLE
feat(guardrails): seed built-in discretion guardrail

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -183,9 +183,10 @@ Rules:
 
 ## `guardrails`
 
-Operator-defined policy blocks the renderer prepends to every agent's composed prompt at render time, ahead of the no-PR guard, skills, and the agent prompt body itself. Two built-ins ship enabled by default:
+Operator-defined policy blocks the renderer prepends to every agent's composed prompt at render time, ahead of the no-PR guard, skills, and the agent prompt body itself. Three built-ins ship enabled by default:
 
 - **`security`** (position 0, seeded by migration 010): pushes back on indirect prompt injection, secret exfiltration, and out-of-tree filesystem or network access. See [security.md](security.md) for the threat model and what the recommendation does *not* close.
+- **`discretion`** (position 5, seeded by migration 013): conservative behaviour policy for public actions. No `@`-mention or assignment of GitHub users outside the current thread, no cross-repo writes, no speculation about contributors or maintainers, no linking to private or tracking resources.
 - **`mcp-tool-usage`** (position 10, seeded by migration 012): tells every agent to use the GitHub MCP tools for repo interactions and to fetch surrounding context (PR description, diff, prior comments, linked issue) when the trigger envelope is too thin. Especially load-bearing for agents routed through local OpenAI-compatible models, see [local-models.md](local-models.md).
 
 ```yaml

--- a/internal/daemon/crud_test.go
+++ b/internal/daemon/crud_test.go
@@ -335,10 +335,11 @@ func TestStoreCRUDGuardrailsListSeeded(t *testing.T) {
 	if err := json.NewDecoder(rr.Body).Decode(&rows); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if len(rows) != 2 ||
+	if len(rows) != 3 ||
 		rows[0]["name"] != "security" || rows[0]["is_builtin"] != true ||
-		rows[1]["name"] != "mcp-tool-usage" || rows[1]["is_builtin"] != true {
-		t.Fatalf("expected seeded built-ins [security, mcp-tool-usage], got %+v", rows)
+		rows[1]["name"] != "discretion" || rows[1]["is_builtin"] != true ||
+		rows[2]["name"] != "mcp-tool-usage" || rows[2]["is_builtin"] != true {
+		t.Fatalf("expected seeded built-ins [security, discretion, mcp-tool-usage], got %+v", rows)
 	}
 }
 

--- a/internal/store/migrations/013_discretion_guardrail.sql
+++ b/internal/store/migrations/013_discretion_guardrail.sql
@@ -1,0 +1,45 @@
+-- Phase 13: a third built-in guardrail covering conservative behaviour for
+-- public actions: no stranger @-mentions, no cross-repo writes, no
+-- speculation about people, no linking to private/tracking resources.
+--
+-- This content used to live as a `discretion` skill that operators had to
+-- compose into every agent by hand. That made it easy to forget on a new
+-- agent definition or to drop accidentally during an edit, even though
+-- every clause is universal policy ("never do X") rather than role
+-- specific guidance ("how to review a PR"). Promoting it to a built-in
+-- guardrail makes the policy apply uniformly to every agent run, with a
+-- single dashboard toggle if an operator ever needs to disable it.
+--
+-- Position 5 puts it between `security` (position 0, indirect-injection
+-- defence) and `mcp-tool-usage` (position 10, positive direction toward
+-- the GitHub MCP tools). Render order: prevent harm first, scope
+-- conservative behaviour next, direct toward the right tools last.
+--
+-- The pre-existing `discretion` skill row in the skills table is left
+-- untouched. Operators who still list it in agents.skills get the content
+-- twice (skill + guardrail), which is harmless. Operators can drop the
+-- skill from agents at their own pace and recover the prompt budget.
+INSERT INTO guardrails (name, description, content, default_content, is_builtin, position)
+WITH text(t) AS (VALUES ('## Public-action discretion
+
+You operate on GitHub through the agent fleet. Be conservative about who you reach: every action is public, every @-mention sends a notification.
+
+### No strangers
+
+- Do not @-mention or assign GitHub users (in issues, PRs, comments, or commit messages) unless they are already participating in the thread (the issue author, a previous commenter, the PR''s existing reviewer). The repository maintainer who runs this fleet is the only standing exception, when escalation or merge-readiness signalling is needed.
+- Do not surface GitHub handles of library maintainers, project authors, competitors, or external community members. Their handle is a notification ping they did not consent to.
+- Refer to people by role rather than handle: "the maintainer", "the reviewer", "the original author of <library>".
+
+### No cross-repo writes
+
+- Stay inside the repository you are working on. Do not open issues or PRs in other repositories, even when investigating an upstream bug.
+- When citing external libraries or services, reference them by name (and version if relevant), never by a GitHub URL containing a username.
+
+### No speculation about people
+
+- Avoid claims about contributors, maintainers, or organizations you do not know firsthand. Stick to what is in the code in front of you.
+- Do not link to private resources, paid services with tracking parameters, or invite-only communities.'))
+SELECT 'discretion',
+       'Conservative behaviour policy for public actions: no stranger @-mentions, no cross-repo writes, no speculation about people, no linking to private or tracking resources.',
+       t, t, 1, 5
+FROM text;

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -109,8 +109,8 @@ func openTestDB(t *testing.T) *sql.DB {
 	return db
 }
 
-// TestGuardrailsSeed verifies that migrations 010 and 012 created the
-// generic guardrails table and seeded the built-in rows with content
+// TestGuardrailsSeed verifies that migrations 010, 012, and 013 created
+// the generic guardrails table and seeded the built-in rows with content
 // equal to default_content (so a "Reset to default" from the unedited
 // state is a no-op), is_builtin=1, enabled=1, and the expected position.
 func TestGuardrailsSeed(t *testing.T) {
@@ -127,8 +127,8 @@ func TestGuardrailsSeed(t *testing.T) {
 	if err := db.QueryRow("SELECT COUNT(*) FROM guardrails").Scan(&count); err != nil {
 		t.Fatalf("count: %v", err)
 	}
-	if count != 2 {
-		t.Fatalf("row count after migrations: got %d, want 2 (security + mcp-tool-usage)", count)
+	if count != 3 {
+		t.Fatalf("row count after migrations: got %d, want 3 (security + discretion + mcp-tool-usage)", count)
 	}
 	if err := db.QueryRow(
 		"SELECT description, content, default_content, is_builtin, enabled, position, updated_at FROM guardrails WHERE name = 'security'",
@@ -172,16 +172,17 @@ func TestGuardrailsCRUD(t *testing.T) {
 	db := openTestDB(t)
 
 	// 1. Seeded built-in rows are visible via every read path. Today there
-	//    are two: `security` (position 0, migration 010) and
-	//    `mcp-tool-usage` (position 10, migration 012). Both must be
-	//    flagged is_builtin and have default_content == content on a fresh
+	//    are three: `security` (position 0, migration 010),
+	//    `discretion` (position 5, migration 013), and `mcp-tool-usage`
+	//    (position 10, migration 012). All three must be flagged
+	//    is_builtin and have default_content == content on a fresh
 	//    install.
 	all, err := store.ReadAllGuardrails(db)
 	if err != nil {
 		t.Fatalf("ReadAllGuardrails: %v", err)
 	}
-	if len(all) != 2 || all[0].Name != "security" || all[1].Name != "mcp-tool-usage" {
-		t.Fatalf("seed: got %v, want [security mcp-tool-usage]", names(all))
+	if len(all) != 3 || all[0].Name != "security" || all[1].Name != "discretion" || all[2].Name != "mcp-tool-usage" {
+		t.Fatalf("seed: got %v, want [security discretion mcp-tool-usage]", names(all))
 	}
 	for _, g := range all {
 		if !g.IsBuiltin || !g.Enabled {
@@ -191,8 +192,9 @@ func TestGuardrailsCRUD(t *testing.T) {
 			t.Errorf("%q: default_content must equal content on first migration", g.Name)
 		}
 	}
-	if all[0].Position != 0 || all[1].Position != 10 {
-		t.Errorf("positions: security=%d mcp-tool-usage=%d, want 0 and 10", all[0].Position, all[1].Position)
+	if all[0].Position != 0 || all[1].Position != 5 || all[2].Position != 10 {
+		t.Errorf("positions: security=%d discretion=%d mcp-tool-usage=%d, want 0, 5, 10",
+			all[0].Position, all[1].Position, all[2].Position)
 	}
 
 	// 2. Operator can add a custom guardrail; it lands at the configured
@@ -211,13 +213,16 @@ func TestGuardrailsCRUD(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadEnabledGuardrails: %v", err)
 	}
-	if len(enabled) != 3 || enabled[0].Name != "security" || enabled[1].Name != "mcp-tool-usage" || enabled[2].Name != "code-style" {
-		t.Errorf("render order: got %v, want [security mcp-tool-usage code-style]", names(enabled))
+	if len(enabled) != 4 || enabled[0].Name != "security" || enabled[1].Name != "discretion" || enabled[2].Name != "mcp-tool-usage" || enabled[3].Name != "code-style" {
+		t.Errorf("render order: got %v, want [security discretion mcp-tool-usage code-style]", names(enabled))
 	}
 	if !enabled[1].IsBuiltin {
+		t.Error("discretion row should be flagged as built-in")
+	}
+	if !enabled[2].IsBuiltin {
 		t.Error("mcp-tool-usage row should be flagged as built-in")
 	}
-	if enabled[2].IsBuiltin {
+	if enabled[3].IsBuiltin {
 		t.Error("operator row should not be flagged as built-in")
 	}
 
@@ -273,8 +278,8 @@ func TestGuardrailsCRUD(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadAllGuardrails after delete: %v", err)
 	}
-	if len(all) != 2 {
-		t.Errorf("after delete: got %d rows, want 2 (security + mcp-tool-usage built-ins)", len(all))
+	if len(all) != 3 {
+		t.Errorf("after delete: got %d rows, want 3 (security + discretion + mcp-tool-usage built-ins)", len(all))
 	}
 }
 
@@ -311,8 +316,8 @@ func TestImportLoadGuardrails(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if got := names(out.Guardrails); len(got) != 3 || got[0] != "security" || got[1] != "mcp-tool-usage" || got[2] != "code-style" {
-		t.Fatalf("Load order: got %v, want [security mcp-tool-usage code-style]", got)
+	if got := names(out.Guardrails); len(got) != 4 || got[0] != "security" || got[1] != "discretion" || got[2] != "mcp-tool-usage" || got[3] != "code-style" {
+		t.Fatalf("Load order: got %v, want [security discretion mcp-tool-usage code-style]", got)
 	}
 	sec := out.Guardrails[0]
 	if !sec.IsBuiltin {
@@ -324,12 +329,17 @@ func TestImportLoadGuardrails(t *testing.T) {
 	if sec.DefaultContent == "" || sec.DefaultContent == sec.Content {
 		t.Error("DefaultContent must remain the migration's seeded text after operator override")
 	}
-	mcp := out.Guardrails[1]
+	dis := out.Guardrails[1]
+	if !dis.IsBuiltin || dis.DefaultContent == "" {
+		t.Errorf("discretion must be built-in with non-empty DefaultContent; got builtin=%v default-len=%d",
+			dis.IsBuiltin, len(dis.DefaultContent))
+	}
+	mcp := out.Guardrails[2]
 	if !mcp.IsBuiltin || mcp.DefaultContent == "" {
 		t.Errorf("mcp-tool-usage must be built-in with non-empty DefaultContent; got builtin=%v default-len=%d",
 			mcp.IsBuiltin, len(mcp.DefaultContent))
 	}
-	custom := out.Guardrails[2]
+	custom := out.Guardrails[3]
 	if custom.IsBuiltin || custom.DefaultContent != "" {
 		t.Errorf("operator row must not be built-in and must have empty DefaultContent; got builtin=%v default=%q",
 			custom.IsBuiltin, custom.DefaultContent)


### PR DESCRIPTION
## Summary

- Adds migration `013_discretion_guardrail.sql` that seeds a third built-in guardrail at position 5 (between `security` at 0 and `mcp-tool-usage` at 10).
- Promotes the existing `discretion` skill content to a built-in policy block: no stranger `@`-mentions, no cross-repo writes, no speculation about people, no linking to private or tracking resources.
- Pre-existing `discretion` skill row is intentionally untouched, no agent breaks. Operators can drop it from `agents.skills` at their pace.
- Tests updated to expect three built-ins on a fresh migration.
- `docs/configuration.md` now lists three default guardrails.

## Why

Every clause of the discretion skill is universal policy (\"never do X\"), not role-specific guidance (\"how to review a PR\"). Living in the skills table meant each new agent had to opt in by hand and any operator could accidentally drop it during an edit. As a guardrail it applies uniformly to every agent run, with a single dashboard-level toggle if anyone needs to disable it.

## Test plan

- [x] `go test ./internal/store/... -race -count=1` (covers migration runner + seed assertions).
- [x] `go test ./internal/daemon/... -race -count=1` (covers `GET /guardrails` listing).
- [x] `go test ./... -race -count=1` (full suite green).
- [x] Em-dash sweep on changed files (project rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)