### PR TITLE
refactor: use slices.IndexFunc for coder agent lookup in TestImportLoad

### DIFF
--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
@@ -423,12 +424,11 @@ func TestImportLoad(t *testing.T) {
 	if len(out.Agents) != 2 {
 		t.Fatalf("agents: got %d, want 2", len(out.Agents))
 	}
-	var coder fleet.Agent
-	for _, a := range out.Agents {
-		if a.Name == "coder" {
-			coder = a
-		}
+	idx := slices.IndexFunc(out.Agents, func(a fleet.Agent) bool { return a.Name == "coder" })
+	if idx < 0 {
+		t.Fatal("coder agent not found after load")
 	}
+	coder := out.Agents[idx]
 	if !coder.AllowPRs {
 		t.Error("coder.allow_prs: want true")
 	}


### PR DESCRIPTION
## Summary

- Replace the manual `for-range` loop in `TestImportLoad` that searched for the `\"coder\"` agent by name with `slices.IndexFunc` + an explicit `t.Fatal` when not found.
- Add `\"slices\"` to the import block.

## Why

The original loop silently fell through to a zero-value `fleet.Agent{}` when `\"coder\"` was absent from the loaded slice (e.g. after a refactor that renamed the agent). Subsequent assertions would then fail with misleading messages like `coder.allow_prs: want true` instead of identifying the missing agent as the root cause.

`slices.IndexFunc` is the idiomatic Go 1.21+ alternative to hand-written linear search, consistent with how other lookups in this codebase are done.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)