### PR TITLE
feat(ui): add per-repo filter to Runners page

### DIFF
--- a/internal/ui/src/app/runners/page.tsx
+++ b/internal/ui/src/app/runners/page.tsx
@@ -1,9 +1,10 @@
 'use client'
 import { Suspense, useEffect, useMemo, useRef, useState } from 'react'
-import { useSearchParams } from 'next/navigation'
+import { useSearchParams, useRouter } from 'next/navigation'
 import Link from 'next/link'
 import Card from '@/components/Card'
 import Modal from '@/components/Modal'
+import RepoFilter from '@/components/RepoFilter'
 import { StreamCard, TranscriptFilter, allStreamCardKinds, parseStreamLine, type StreamCardEntry, type StreamCardKind } from '@/components/StreamCard'
 import { fmtDuration } from '@/lib/format'
 
@@ -212,7 +213,16 @@ function LiveStreamModal({ span, onClose }: { span: { id: string; agent: string;
 
 function RunnersInner() {
   const params = useSearchParams()
+  const router = useRouter()
   const focusEvent = params.get('event') ?? ''
+  const repoParam = params.get('repo') ?? ''
+
+  const setRepoFilter = (repo: string) => {
+    const p = new URLSearchParams(params.toString())
+    if (repo) p.set('repo', repo)
+    else p.delete('repo')
+    router.push(`/runners?${p.toString()}`)
+  }
 
   const [rows, setRows] = useState<RunnerRow[]>([])
   const [total, setTotal] = useState(0)
@@ -265,10 +275,12 @@ function RunnersInner() {
     return () => window.clearTimeout(t)
   }, [focusEvent, rows.length, highlighted])
 
-  const filtered = useMemo(
-    () => focusEvent ? rows.filter(r => r.event_id === focusEvent) : rows,
-    [rows, focusEvent],
-  )
+  const filtered = useMemo(() => {
+    let result = rows
+    if (focusEvent) result = result.filter(r => r.event_id === focusEvent)
+    if (repoParam) result = result.filter(r => r.repo === repoParam)
+    return result
+  }, [rows, focusEvent, repoParam])
 
   // Native browser confirm()/alert() are jarring against the dashboard
   // styling, plus they block the JS event loop. Drive every confirm /
@@ -344,13 +356,17 @@ function RunnersInner() {
         </div>
         <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
           {focusEvent && (
-            <Link href="/runners/" style={{
-              background: 'var(--bg-card)', border: '1px solid var(--border)',
-              color: 'var(--text-muted)', padding: '4px 10px', borderRadius: '4px',
-              fontSize: '0.8rem', textDecoration: 'none',
-            }}>Clear filter</Link>
+            <Link
+              href={repoParam ? `/runners?repo=${encodeURIComponent(repoParam)}` : '/runners/'}
+              style={{
+                background: 'var(--bg-card)', border: '1px solid var(--border)',
+                color: 'var(--text-muted)', padding: '4px 10px', borderRadius: '4px',
+                fontSize: '0.8rem', textDecoration: 'none',
+              }}
+            >Clear filter</Link>
           )}
-          {(['', 'enqueued', 'running', 'completed'] as const).map(s => (
+          <RepoFilter selected={repoParam} onChange={setRepoFilter} />
+          {([\'\'\', 'enqueued', 'running', 'completed'] as const).map(s => (
             <button key={s || 'all'} onClick={() => setStatus(s)} style={{
               background: status === s ? 'var(--btn-primary-bg)' : 'var(--bg-card)',
               border: '1px solid var(--border)',

--- a/internal/ui/src/app/runners/page.tsx
+++ b/internal/ui/src/app/runners/page.tsx
@@ -76,6 +76,10 @@ export default function RunnersPage() {
   )
 }
 
+// LiveStreamEntry is one parsed event from the stream, either a known
+// shape (claude/codex) or a raw fallback. The UI renders each entry as
+// a card; unknown shapes still show as collapsible JSON so nothing is
+// lost.
 function LiveStreamModal({ span, onClose }: { span: { id: string; agent: string; repo: string; kind: string }; onClose: () => void }) {
   const [entries, setEntries] = useState<StreamCardEntry[]>([])
   const [status, setStatus] = useState<'connecting' | 'live' | 'ended' | 'error'>('connecting')
@@ -96,6 +100,8 @@ function LiveStreamModal({ span, onClose }: { span: { id: string; agent: string;
       es.close()
     })
     es.onerror = () => {
+      // EventSource auto-retries on transient failures; only surface the
+      // error state when the connection genuinely fails to establish.
       if (es.readyState === EventSource.CLOSED) setStatus('error')
     }
     return () => es.close()
@@ -250,6 +256,11 @@ function RunnersInner() {
     return () => window.clearInterval(id)
   }, [status]) // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Trigger highlight pulse when arriving with ?event=X. Wait until
+  // the first batch of rows lands, otherwise the animation runs while
+  // the page still shows "Loading..." and the user never sees it. Once
+  // we've kicked it off for a given focus, don't re-fire on every
+  // subsequent poll (rows.length stays > 0).
   const [highlighted, setHighlighted] = useState(false)
   useEffect(() => {
     if (!focusEvent) {
@@ -271,6 +282,9 @@ function RunnersInner() {
     return result
   }, [rows, focusEvent, repoParam])
 
+  // Native browser confirm()/alert() are jarring against the dashboard
+  // styling, plus they block the JS event loop. Drive every confirm /
+  // failure surface through a single Modal-state machine instead.
   type DialogState =
     | null
     | { kind: 'confirm-delete'; id: number }

--- a/internal/ui/src/app/runners/page.tsx
+++ b/internal/ui/src/app/runners/page.tsx
@@ -76,10 +76,6 @@ export default function RunnersPage() {
   )
 }
 
-// LiveStreamEntry is one parsed event from the stream, either a known
-// shape (claude/codex) or a raw fallback. The UI renders each entry as
-// a card; unknown shapes still show as collapsible JSON so nothing is
-// lost.
 function LiveStreamModal({ span, onClose }: { span: { id: string; agent: string; repo: string; kind: string }; onClose: () => void }) {
   const [entries, setEntries] = useState<StreamCardEntry[]>([])
   const [status, setStatus] = useState<'connecting' | 'live' | 'ended' | 'error'>('connecting')
@@ -100,8 +96,6 @@ function LiveStreamModal({ span, onClose }: { span: { id: string; agent: string;
       es.close()
     })
     es.onerror = () => {
-      // EventSource auto-retries on transient failures; only surface the
-      // error state when the connection genuinely fails to establish.
       if (es.readyState === EventSource.CLOSED) setStatus('error')
     }
     return () => es.close()
@@ -256,11 +250,6 @@ function RunnersInner() {
     return () => window.clearInterval(id)
   }, [status]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Trigger highlight pulse when arriving with ?event=X. Wait until
-  // the first batch of rows lands, otherwise the animation runs while
-  // the page still shows "Loading..." and the user never sees it. Once
-  // we've kicked it off for a given focus, don't re-fire on every
-  // subsequent poll (rows.length stays > 0).
   const [highlighted, setHighlighted] = useState(false)
   useEffect(() => {
     if (!focusEvent) {
@@ -282,9 +271,6 @@ function RunnersInner() {
     return result
   }, [rows, focusEvent, repoParam])
 
-  // Native browser confirm()/alert() are jarring against the dashboard
-  // styling, plus they block the JS event loop. Drive every confirm /
-  // failure surface through a single Modal-state machine instead.
   type DialogState =
     | null
     | { kind: 'confirm-delete'; id: number }
@@ -366,7 +352,7 @@ function RunnersInner() {
             >Clear filter</Link>
           )}
           <RepoFilter selected={repoParam} onChange={setRepoFilter} />
-          {([\'\'\', 'enqueued', 'running', 'completed'] as const).map(s => (
+          {(['', 'enqueued', 'running', 'completed'] as const).map(s => (
             <button key={s || 'all'} onClick={() => setStatus(s)} style={{
               background: status === s ? 'var(--btn-primary-bg)' : 'var(--bg-card)',
               border: '1px solid var(--border)',


### PR DESCRIPTION
## Summary

- Adds `RepoFilter` to `internal/ui/src/app/runners/page.tsx`, matching the existing pattern on the Fleet and Traces pages.
- Repo selection is stored in the URL query string (`?repo=owner/name`) so filtered views are shareable and bookmarkable — consistent with the `?event=` deep-link already present on this page.
- The repo filter combines with the existing status pills (server-side) and `?event=` focus (client-side): rendered rows must satisfy all active constraints simultaneously.
- Clearing the `?event=` focus preserves an active `?repo=` param so the repo filter is not silently lost.
- No backend changes. `/runners` already returns `repo` on every row; filtering is client-side, same as Fleet and Traces.
- `RepoFilter.tsx` is reused as-is (no modifications).

## Test plan

- [ ] With a single-repo fleet: `RepoFilter` returns `null` (component hides itself), page is unchanged.
- [ ] With a multi-repo fleet: dropdown appears in the header; selecting a repo narrows the row list.
- [ ] `/runners?repo=owner/name` opens with that repo pre-selected.
- [ ] Combining `?repo=` with status pill ("running") shows only running rows for that repo.
- [ ] `?event=X&repo=Y`: event filter + repo filter both apply; "Clear filter" link drops event but keeps `?repo=Y`.
- [ ] `?event=X` without repo: "Clear filter" links to `/runners/` as before.

Closes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)