### PR TITLE
fix: propagate GITHUB_TOKEN to AI subprocesses, rename from GITHUB_PAT_TOKEN

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ YAML config is import/export only, not a runtime input. To seed an empty fleet, 
 ## Environment Variables
 
 - `GITHUB_WEBHOOK_SECRET`, HMAC shared secret for the webhook receiver (`daemon.http.webhook_secret_env`).
-- `GITHUB_PAT_TOKEN`, Personal Access Token used by the GitHub MCP server inside the container. Required by `scripts/setup.sh` (hard-fails if unset). `repo` scope minimum; add `workflow` if agents touch CI. Codex resolves at runtime; Claude stores in `~/.claude.json` on the `agents-home` volume.
+- `GITHUB_TOKEN`, Personal Access Token used by the GitHub MCP server inside the container, by the `gh` CLI fallback, and forwarded into AI backend subprocesses through the env allowlist (`internal/ai/cmdrunner.go`). Required by `scripts/setup.sh` (hard-fails if unset). `repo` scope minimum; add `workflow` if agents touch CI. Codex resolves it at runtime; Claude stores it in `~/.claude.json`; `gh auth login --with-token` runs during setup so agents have a working CLI fallback when GitHub MCP tools fail to register. All credentials live on the `agents-home` volume.
 
 ## Architecture Notes
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
       - "8080:8080"
     environment:
       - HOME=/home/agents
-      - GITHUB_PAT_TOKEN=${GITHUB_PAT_TOKEN}
+      - GITHUB_TOKEN=${GITHUB_TOKEN}
     volumes:
       # SQLite database (daemon config + fleet + agent memory).
       - agents-data:/var/lib/agents

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -227,7 +227,7 @@ Create a `.env` file in the project root (loaded automatically):
 
 ```bash
 GITHUB_WEBHOOK_SECRET=your-webhook-secret  # HMAC shared secret for /webhooks/github
-GITHUB_PAT_TOKEN=ghp_...                   # Personal Access Token used by the GitHub MCP server (repo scope)
+GITHUB_TOKEN=ghp_...                       # Personal Access Token used by the GitHub MCP server, the `gh` CLI fallback, and forwarded into AI backend subprocesses (repo scope, +workflow if agents touch CI)
 ```
 
 ## Importing and exporting

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -13,7 +13,7 @@ cd agents
 # Webhook secret: random per install. PAT: from https://github.com/settings/tokens with repo scope.
 cat > .env <<EOF
 GITHUB_WEBHOOK_SECRET=$(openssl rand -hex 32)
-GITHUB_PAT_TOKEN=ghp_paste_your_token_here
+GITHUB_TOKEN=ghp_paste_your_token_here
 EOF
 docker compose up -d
 ```

--- a/internal/ai/cmdrunner.go
+++ b/internal/ai/cmdrunner.go
@@ -819,7 +819,7 @@ func extractToolResultText(raw json.RawMessage) string {
 // locale) are permitted; everything else is excluded.
 func allowCommandEnvKey(key string) bool {
 	switch key {
-	case "PATH", "HOME", "USER", "SHELL", "TMPDIR", "TMP", "TEMP", "LANG", "TERM", "NO_COLOR", "COLORTERM", "EDITOR", "VISUAL", "PAGER", "SSH_AUTH_SOCK", "CODEX_API_KEY", "ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "ANTHROPIC_MODEL", "OPENAI_API_KEY", "OPENAI_BASE_URL", "OPENAI_MODEL", "GH_TOKEN", "GH_HOST", "XDG_CONFIG_HOME", "XDG_CACHE_HOME", "XDG_DATA_HOME", "GITHUB_API_URL":
+	case "PATH", "HOME", "USER", "SHELL", "TMPDIR", "TMP", "TEMP", "LANG", "TERM", "NO_COLOR", "COLORTERM", "EDITOR", "VISUAL", "PAGER", "SSH_AUTH_SOCK", "CODEX_API_KEY", "ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "ANTHROPIC_MODEL", "OPENAI_API_KEY", "OPENAI_BASE_URL", "OPENAI_MODEL", "GITHUB_TOKEN", "GH_TOKEN", "GH_HOST", "XDG_CONFIG_HOME", "XDG_CACHE_HOME", "XDG_DATA_HOME", "GITHUB_API_URL":
 		return true
 	default:
 		return strings.HasPrefix(key, "LC_")

--- a/internal/backends/discovery_test.go
+++ b/internal/backends/discovery_test.go
@@ -40,7 +40,7 @@ github: https://api.githubcopilot.com/mcp (HTTP) - ✓ Connected`,
 		{
 			name: "codex table output enabled bearer token",
 			output: `Name    Url                                 Bearer Token Env Var  Status   Auth
-github  https://api.githubcopilot.com/mcp/  GITHUB_PAT_TOKEN      enabled  Bearer token`,
+github  https://api.githubcopilot.com/mcp/  GITHUB_TOKEN          enabled  Bearer token`,
 			wantFound:  true,
 			wantOnline: true,
 		},

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -143,9 +143,9 @@ phase_pick_backends() {
 
 phase_check_pat() {
   phase "2.5" "verify GitHub Personal Access Token"
-  info "looking for GITHUB_PAT_TOKEN in the container environment..."
-  if [[ -z "${GITHUB_PAT_TOKEN:-}" ]]; then
-    err "GITHUB_PAT_TOKEN is not set."
+  info "looking for GITHUB_TOKEN in the container environment..."
+  if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+    err "GITHUB_TOKEN is not set."
     say ""
     say "  The GitHub MCP server needs a Personal Access Token to talk to"
     say "  GitHub on behalf of your agents. Generate one at:"
@@ -153,7 +153,7 @@ phase_check_pat() {
     say "  with at least the ${c_bold}repo${c_rst} scope (and ${c_bold}workflow${c_rst} if your agents will touch CI)."
     say ""
     say "  Then add it to your .env (next to docker-compose.yaml):"
-    say "      ${c_bold}GITHUB_PAT_TOKEN=ghp_...${c_rst}"
+    say "      ${c_bold}GITHUB_TOKEN=ghp_...${c_rst}"
     say ""
     say "  Restart the container so the env var is visible inside:"
     say "      ${c_bold}docker compose up -d${c_rst}"
@@ -161,9 +161,9 @@ phase_check_pat() {
     say "  Then re-run agents-setup."
     exit 1
   fi
-  ok "GITHUB_PAT_TOKEN is present (${#GITHUB_PAT_TOKEN} chars)"
+  ok "GITHUB_TOKEN is present (${#GITHUB_TOKEN} chars)"
   note "claude stores the token in ~/.claude.json on the agents-home volume."
-  note "codex resolves it from \$GITHUB_PAT_TOKEN at runtime (token never on disk)."
+  note "codex resolves it from \$GITHUB_TOKEN at runtime (token never on disk)."
 }
 
 # ── phase 3, per-backend login + GitHub MCP wiring ──────────────────
@@ -192,7 +192,7 @@ setup_claude() {
     local mcp_json
     mcp_json=$(jq -nc \
       --arg url "$GITHUB_MCP_URL" \
-      --arg auth "Bearer $GITHUB_PAT_TOKEN" \
+      --arg auth "Bearer $GITHUB_TOKEN" \
       '{type:"http", url:$url, headers:{Authorization:$auth}}')
     claude mcp add-json github -s user "$mcp_json" \
       || { err "claude mcp add-json failed"; return 1; }
@@ -225,18 +225,15 @@ setup_codex() {
   codex login --device-auth || { err "codex login failed"; return 1; }
   ok "codex authenticated"
 
-  info "checking whether GitHub MCP is already registered for codex..."
-  if codex mcp list 2>/dev/null | grep -qE '^github\b'; then
-    ok "GitHub MCP already registered (skipping add)"
-  else
-    info "registering GitHub MCP via codex mcp add (HTTP + bearer-token-env-var)..."
-    note "codex resolves the PAT from \$GITHUB_PAT_TOKEN at runtime, not at rest."
-    codex mcp add github \
-      --url "$GITHUB_MCP_URL/" \
-      --bearer-token-env-var GITHUB_PAT_TOKEN \
-      || { err "codex mcp add failed"; return 1; }
-    ok "GitHub MCP registered for codex"
-  fi
+  info "ensuring codex GitHub MCP is registered with the current GITHUB_TOKEN binding..."
+  note "codex resolves the PAT from \$GITHUB_TOKEN at runtime, not at rest."
+  note "remove + re-add is idempotent and self-heals stale bearer-token-env-var bindings."
+  codex mcp remove github 2>/dev/null || true
+  codex mcp add github \
+    --url "$GITHUB_MCP_URL/" \
+    --bearer-token-env-var GITHUB_TOKEN \
+    || { err "codex mcp add failed"; return 1; }
+  ok "GitHub MCP registered for codex"
 
   info "verifying codex MCP listing..."
   say ""


### PR DESCRIPTION
## Summary

- Add `GITHUB_TOKEN` to the AI-subprocess env allowlist in `internal/ai/cmdrunner.go` so codex's GitHub MCP server can authenticate. Without it, codex received an empty bearer token, dropped `mcp__github__*` from its tool registry, and agents concluded "no MCP available".
- Rename canonical env var from project-specific `GITHUB_PAT_TOKEN` to plain `GITHUB_TOKEN` (the name read natively by `gh`, Octokit, GitHub Actions, and most GitHub tooling). One name, no aliasing.
- Make codex MCP registration in `scripts/setup.sh` idempotent (remove + re-add) so re-running `agents-setup` self-heals stale `--bearer-token-env-var GITHUB_PAT_TOKEN` bindings on existing `agents-home` volumes.

## Background

The daemon's env allowlist is default-deny so unrelated host secrets don't leak into AI CLI subprocesses (and from there, into MCP servers the CLI spawns). The bug was an omission: the GitHub PAT was never listed, so codex's MCP config silently received nothing at runtime. The failure surfaced as the model running bash recon and saying "GitHub MCP not available" rather than as a clear auth error, which made it hard to diagnose.

Verified end-to-end on the production fleet: a manual `pr-reviewer` trigger on `eloylp/goomerang` after the fix completed in ~1m20s with `artifacts_stored=6` (six APPROVE comments + `human review ready` labels posted via real MCP calls).

## Operational rollout

Existing installs need:

1. Update the env var name in `.env` (or compose `environment:` block): `GITHUB_PAT_TOKEN` → `GITHUB_TOKEN`.
2. `docker compose up -d` to restart the container with the new env.
3. `docker compose exec -it agents agents-setup` so codex's GitHub MCP entry rebinds to `GITHUB_TOKEN`. The setup script's codex section is idempotent now, so this is safe to re-run on volumes that already had a stale binding.

## Test plan

- [x] `go test ./... -race -count=1` green
- [x] `npx tsc --noEmit` (UI) clean
- [x] Built `linux/amd64` image, deployed to production, daemon starts cleanly
- [x] Manual `pr-reviewer` trigger on goomerang completes via codex + GitHub MCP, posts 6 real review comments and labels
- [x] `docker compose exec agents codex mcp list` shows `github  https://api.githubcopilot.com/mcp/  GITHUB_TOKEN  enabled  Bearer token`

🤖 Generated with [Claude Code](https://claude.com/claude-code)