### PR TITLE
refactor: alias workflow.TraceStep to ai.TraceStep, drop conversion loop in engine

### DIFF
--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -842,11 +842,7 @@ func (e *Engine) runAgent(ctx context.Context, ev Event, agent fleet.Agent, cfg 
 
 	// Record transcript steps when available.
 	if e.stepRec != nil && len(resp.Steps) > 0 {
-		wsteps := make([]TraceStep, len(resp.Steps))
-		for i, s := range resp.Steps {
-			wsteps[i] = TraceStep(s)
-		}
-		e.stepRec.RecordSteps(spanID, wsteps)
+		e.stepRec.RecordSteps(spanID, resp.Steps)
 	}
 
 	if runErr != nil {

--- a/internal/workflow/steps.go
+++ b/internal/workflow/steps.go
@@ -1,25 +1,10 @@
 package workflow
 
-// TraceStep records one event in an agent's tool loop. Two kinds are
-// emitted today:
-//
-//   - "tool":     a paired tool_use + tool_result. ToolName is the tool
-//                 name; InputSummary is the call args; OutputSummary is
-//                 the tool's reply; DurationMs is the round-trip time.
-//   - "thinking": a text block the assistant emitted between tool calls.
-//                 ToolName is empty; InputSummary carries the text;
-//                 OutputSummary and DurationMs are empty.
-//
-// The persisted row preserves the full content of each field; the UI
-// (StreamCard) decides how much to show by default and exposes an
-// expand affordance to recover the rest.
-type TraceStep struct {
-	Kind          string `json:"kind"`
-	ToolName      string `json:"tool_name,omitempty"`
-	InputSummary  string `json:"input_summary,omitempty"`
-	OutputSummary string `json:"output_summary,omitempty"`
-	DurationMs    int64  `json:"duration_ms,omitempty"`
-}
+import "github.com/eloylp/agents/internal/ai"
+
+// TraceStep aliases ai.TraceStep so the workflow and observe packages share
+// one definition without a conversion step in the engine's step-recording path.
+type TraceStep = ai.TraceStep
 
 // Step kind constants.
 const (


### PR DESCRIPTION
Replaces the standalone `workflow.TraceStep` struct with a type alias to `ai.TraceStep`, eliminating the duplicate struct definition and the 4-line conversion loop in the engine's step-recording path.

Changes:
- `internal/workflow/steps.go`: `type TraceStep = ai.TraceStep` (alias, not definition); `StepKindTool`/`StepKindThinking` constants kept
- `internal/workflow/engine.go`: `resp.Steps` (`[]ai.TraceStep`) is now directly assignable as `[]workflow.TraceStep`; conversion loop removed

Supersedes dirty PR #370 (same change, rebased onto current main).

Closes #370