### PR TITLE
refactor: drop DispatchAlreadyClaimed and MarkAutonomousRun (superseded by TryMarkAutonomousRun)

### DIFF
--- a/internal/workflow/dispatch.go
+++ b/internal/workflow/dispatch.go
@@ -570,7 +570,7 @@ func (d *Dispatcher) ProcessDispatches(
 			continue
 		}
 
-		// Enqueue succeeded — commit the claim so the autonomous scheduler skips
+		// Enqueue succeeded; commit the claim so the autonomous scheduler skips
 		// a duplicate run for this target.
 		d.dedup.CommitClaim(req.Agent, ev.Repo.FullName, number)
 

--- a/internal/workflow/dispatch.go
+++ b/internal/workflow/dispatch.go
@@ -72,7 +72,7 @@ func (c *dispatchCounters) snapshot() DispatchStats {
 // dispatchEntry records a dedup slot in the store.
 // committed indicates whether the slot is backed by a real enqueued event.
 // Pending (committed==false) entries block concurrent duplicate TryClaim calls
-// but are invisible to DispatchAlreadyClaimed until committed.
+// but are invisible to SeesPendingOrCommitted until committed.
 type dispatchEntry struct {
 	expiresAt time.Time
 	committed bool
@@ -178,7 +178,7 @@ func (s *DispatchDedupStore) SeesPendingOrCommitted(target, repo string, number 
 // proceeding past the dedup gate.
 //
 // A successful TryClaim creates a pending entry that blocks future TryClaim
-// calls but is invisible to DispatchAlreadyClaimed until CommitClaim is
+// calls but is invisible to SeesPendingOrCommitted until CommitClaim is
 // called. On enqueue failure call AbandonClaim to release the pending slot.
 func (s *DispatchDedupStore) TryClaim(target, repo string, number int, now time.Time) bool {
 	key := dispatchStoreKey(target, repo, number)
@@ -192,7 +192,7 @@ func (s *DispatchDedupStore) TryClaim(target, repo string, number int, now time.
 }
 
 // CommitClaim upgrades a pending claim to committed, making it visible to
-// DispatchAlreadyClaimed. Must be called after a successful PushEvent.
+// SeesPendingOrCommitted callers. Must be called after a successful PushEvent.
 func (s *DispatchDedupStore) CommitClaim(target, repo string, number int) {
 	key := dispatchStoreKey(target, repo, number)
 	s.mu.Lock()
@@ -335,8 +335,7 @@ func (s *DispatchDedupStore) SeenCronRun(agent, repo string, number int, now tim
 // Returns false if a dispatch claim, pending or committed, exists within
 // the TTL window (caller should skip the run; dispatch-first ordering).
 //
-// Unlike the split DispatchAlreadyClaimed → MarkAutonomousRun sequence, this
-// single-lock operation eliminates the TOCTOU window where the cron path
+// A single-lock operation eliminates the TOCTOU window where the cron path
 // could observe no dispatch claim and the dispatch path could observe no cron
 // mark before either had written, allowing both to proceed concurrently.
 //
@@ -564,15 +563,15 @@ func (d *Dispatcher) ProcessDispatches(
 
 		if _, err := d.queue.PushEvent(ctx, dispatchEv); err != nil {
 			// Release the pending claim so future retries are not blocked and
-			// DispatchAlreadyClaimed never sees a phantom committed slot.
+			// SeesPendingOrCommitted never sees a phantom committed slot.
 			d.dedup.AbandonClaim(req.Agent, ev.Repo.FullName, number)
 			logBase.Error().Err(err).Msg("failed to enqueue dispatch event")
 			errs = append(errs, fmt.Errorf("dispatch %q: %w", req.Agent, err))
 			continue
 		}
 
-		// Enqueue succeeded, commit the claim so DispatchAlreadyClaimed returns
-		// true and the autonomous scheduler skips a duplicate run for this target.
+		// Enqueue succeeded — commit the claim so the autonomous scheduler skips
+		// a duplicate run for this target.
 		d.dedup.CommitClaim(req.Agent, ev.Repo.FullName, number)
 
 		// Record the dispatch edge in the interaction graph if an observer is set.
@@ -587,41 +586,11 @@ func (d *Dispatcher) ProcessDispatches(
 	return errors.Join(errs...)
 }
 
-// DispatchAlreadyClaimed returns true if a dispatch has claimed (pending or
-// committed) the (agentName, repo, 0) slot in the dispatch dedup namespace
-// within the current dedup window (dispatch-first ordering). Checking pending
-// claims too ensures that a dispatch which has successfully TryClaim'd but has
-// not yet called CommitClaim (PushEvent still in flight) still blocks a
-// concurrent cron/manual run from starting.
-//
-// This is a read-only check; it does not write to the store. Call
-// MarkAutonomousRun separately, only once the run is confirmed to proceed.
-func (d *Dispatcher) DispatchAlreadyClaimed(agentName, repo string, now time.Time) bool {
-	return d.dedup.SeesPendingOrCommitted(agentName, repo, 0, now)
-}
-
-// MarkAutonomousRun writes a cron-namespace activity mark for (agentName,
-// repo, 0) that persists for the full dedup_window_seconds. It must be
-// called before the run starts (after backend and runner resolution succeed)
-// so that dispatches arriving during the in-flight run are suppressed. If the
-// run fails, call RollbackAutonomousRun to remove the mark so that future
-// dispatches are not spuriously suppressed for the full dedup window.
-//
-// The cron mark lives in a different key namespace from dispatch entries,
-// so repeated cron runs are never blocked by this mark, only dispatches
-// that share the same item context (number=0, the autonomous context) are.
-func (d *Dispatcher) MarkAutonomousRun(agentName, repo string, now time.Time) {
-	d.dedup.MarkCronRun(agentName, repo, 0, now)
-}
-
 // TryMarkAutonomousRun atomically checks whether a dispatch has already
 // claimed the (agentName, repo, 0) slot and, if not, writes a cron-namespace
 // mark. Returns true if the mark was written and the caller may proceed with
 // the run. Returns false if a dispatch claim exists (caller should return
 // ErrDispatchSkipped).
-//
-// This replaces the split DispatchAlreadyClaimed → MarkAutonomousRun sequence
-// with a single-lock operation, closing the TOCTOU race between the two paths.
 //
 // If the run fails before completing, call RollbackAutonomousRun to remove the
 // mark so that future dispatches are not spuriously suppressed.
@@ -630,9 +599,9 @@ func (d *Dispatcher) TryMarkAutonomousRun(agentName, repo string, now time.Time)
 }
 
 // RollbackAutonomousRun removes the cron-namespace mark written by
-// MarkAutonomousRun or TryMarkAutonomousRun. It must be called when a run
-// fails so that the stale mark does not suppress autonomous-context dispatches
-// for the full dedup_window_seconds.
+// TryMarkAutonomousRun. It must be called when a run fails so that the stale
+// mark does not suppress autonomous-context dispatches for the full
+// dedup_window_seconds.
 func (d *Dispatcher) RollbackAutonomousRun(agentName, repo string) {
 	d.dedup.RemoveCronMark(agentName, repo, 0)
 }

--- a/internal/workflow/dispatch_test.go
+++ b/internal/workflow/dispatch_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/eloylp/agents/internal/store"
 )
 
-// ─── helpers ─────────────────────────────────────────────────────────────────────────────
+// ─── helpers ────────────────────────────────────────────────────────────────────────────────────
 
 type fakeQueue struct {
 	mu     sync.Mutex
@@ -135,7 +135,7 @@ func testEvent(repo string, number int) Event {
 	}
 }
 
-// ─── Dispatcher tests ───────────────────────────────────────────────────────────────────────────────
+// ─── Dispatcher tests ───────────────────────────────────────────────────────────────────────────────────────────────
 
 func TestDispatcherEnqueuesValidRequest(t *testing.T) {
 	t.Parallel()
@@ -336,7 +336,7 @@ func TestDispatcherDeduplicatesWithinWindow(t *testing.T) {
 	}
 }
 
-// ─── DispatchDedupStore tests ─────────────────────────────────────────────────────────────────────────────
+// ─── DispatchDedupStore tests ─────────────────────────────────────────────────────────────────────────────────────────
 
 func TestDispatchDedupStoreSeenOrAdd(t *testing.T) {
 	t.Parallel()
@@ -389,7 +389,7 @@ func TestDispatchDedupStoreBackgroundEviction(t *testing.T) {
 	}
 }
 
-// ─── Engine dispatch handling tests ─────────────────────────────────────────────────────────────────────────────
+// ─── Engine dispatch handling tests ───────────────────────────────────────────────────────────────────────────────────────────────────
 
 func TestEngineHandlesAgentDispatchEvent(t *testing.T) {
 	t.Parallel()
@@ -611,10 +611,10 @@ func TestDispatcherRetrySucceedsAfterEnqueueFailure(t *testing.T) {
 
 // TestDispatchClaimOnlyVisibleAfterSuccessfulEnqueue is a regression test for
 // the lost-work race: if ProcessDispatches fails to enqueue a dispatch event,
-// DispatchAlreadyClaimed must return false so the autonomous scheduler can
-// still run the target. Previously, SeenOrAdd was called before PushEvent and
-// a failed enqueue followed by a dedup rollback still left a brief window where
-// DispatchAlreadyClaimed could return true, causing both paths to skip.
+// no dispatch claim must be visible so the autonomous scheduler can still run
+// the target. Previously, SeenOrAdd was called before PushEvent and a failed
+// enqueue followed by a dedup rollback still left a brief window where a
+// pending claim could remain, causing both paths to skip.
 func TestDispatchClaimOnlyVisibleAfterSuccessfulEnqueue(t *testing.T) {
 	t.Parallel()
 	q := &fakeQueue{err: errors.New("queue full")}
@@ -624,28 +624,26 @@ func TestDispatchClaimOnlyVisibleAfterSuccessfulEnqueue(t *testing.T) {
 	d.ProcessDispatches(context.Background(), originatorAgent("coder"), testEvent("owner/repo", 0), "root-1", 0, "", reqs)
 
 	// The enqueue failed, so the dispatch slot must NOT be claimed.
-	if d.DispatchAlreadyClaimed("pr-reviewer", "owner/repo", time.Now()) {
-		t.Error("DispatchAlreadyClaimed returned true after a failed enqueue: phantom claim left by failed dispatch")
+	if d.dedup.SeesPendingOrCommitted("pr-reviewer", "owner/repo", 0, time.Now()) {
+		t.Error("SeesPendingOrCommitted returned true after a failed enqueue: phantom claim left by failed dispatch")
 	}
 }
 
 // TestMarkAutonomousRunSuppressesNearSimultaneousDispatch is a regression
 // test for the cron-first dedup ordering: when an autonomous run starts and
-// MarkAutonomousRun writes a cron-namespace mark, dispatches targeting the
+// TryMarkAutonomousRun writes a cron-namespace mark, dispatches targeting the
 // same agent/repo with number=0 (autonomous context) must be suppressed for
-// the full dedup_window_seconds, both while the run is in-flight and after
+// the full dedup_window_seconds — both while the run is in-flight and after
 // it completes.
 func TestMarkAutonomousRunSuppressesNearSimultaneousDispatch(t *testing.T) {
 	t.Parallel()
 	q := &fakeQueue{}
 	d := testDispatcher(t, q)
 
-	// Simulate: cron run confirms it will proceed and writes the cron-namespace mark.
-	alreadyClaimed := d.DispatchAlreadyClaimed("coder", "owner/repo", time.Now())
-	if alreadyClaimed {
-		t.Fatal("DispatchAlreadyClaimed: expected false on first call (no prior dispatch)")
+	// Simulate: cron run atomically checks for a dispatch claim and writes the cron-namespace mark.
+	if !d.TryMarkAutonomousRun("coder", "owner/repo", time.Now()) {
+		t.Fatal("TryMarkAutonomousRun: expected to succeed on first call (no prior dispatch)")
 	}
-	d.MarkAutonomousRun("coder", "owner/repo", time.Now())
 
 	// Dispatches targeting the same agent/repo with number=0 must be suppressed
 	// for the full dedup window (coder dispatching to itself is not allowed, so use
@@ -678,11 +676,11 @@ func TestMarkAutonomousRunDoesNotSuppressDispatchForDifferentNumber(t *testing.T
 	q := &fakeQueue{}
 	d := testDispatcher(t, q)
 
-	// Cron run for pr-reviewer marks (pr-reviewer, owner/repo, 0).
-	d.MarkAutonomousRun("coder", "owner/repo", time.Now())
+	// Cron run marks (coder, owner/repo, 0).
+	d.TryMarkAutonomousRun("coder", "owner/repo", time.Now())
 
 	// A dispatch targeting coder for PR #42 (number=42) must still be enqueued
-	//, it is a different item context from the autonomous cron run (number=0).
+	// — it is a different item context from the autonomous cron run (number=0).
 	originator := originatorAgent("pr-reviewer")
 	ev := testEvent("owner/repo", 42)
 	d.ProcessDispatches(context.Background(), originator, ev, "root-pr42", 0, "", []ai.DispatchRequest{
@@ -710,14 +708,13 @@ func TestPostRunDispatchSuppressedWithinDedupWindow(t *testing.T) {
 	q := &fakeQueue{}
 	d := NewDispatcher(cfg, seedAgentMap(t, agents), dedup, q, zerolog.Nop())
 
-	// Autonomous run confirms it will proceed and writes the cron mark.
+	// Autonomous run atomically checks for a dispatch claim and writes the cron mark.
 	now := time.Now()
-	if d.DispatchAlreadyClaimed("coder", "owner/repo", now) {
-		t.Fatal("DispatchAlreadyClaimed: expected false on first call (no prior dispatch)")
+	if !d.TryMarkAutonomousRun("coder", "owner/repo", now) {
+		t.Fatal("TryMarkAutonomousRun: expected to succeed on first call (no prior dispatch)")
 	}
-	d.MarkAutonomousRun("coder", "owner/repo", now)
 
-	// Dispatch arriving after the run, still within the TTL window, must be suppressed.
+	// Dispatch arriving after the run — still within the TTL window — must be suppressed.
 	originator := agents["pr-reviewer"]
 	ev := Event{Repo: RepoRef{FullName: "owner/repo", Enabled: true}, Kind: "cron", Number: 0}
 	d.ProcessDispatches(context.Background(), originator, ev, "root-1", 0, "", []ai.DispatchRequest{
@@ -800,8 +797,8 @@ func TestRemoveCronMarkWithOverlappingRunsRefcount(t *testing.T) {
 
 	now := time.Now()
 	// Simulate two overlapping autonomous runs for the same (agent, repo).
-	d.MarkAutonomousRun("coder", "owner/repo", now)
-	d.MarkAutonomousRun("coder", "owner/repo", now)
+	d.TryMarkAutonomousRun("coder", "owner/repo", now)
+	d.TryMarkAutonomousRun("coder", "owner/repo", now)
 
 	// First run fails: rolls back. The second run is still in flight, so
 	// dispatches must still be suppressed.
@@ -833,7 +830,7 @@ func TestRemoveCronMarkWithOverlappingRunsRefcount(t *testing.T) {
 // TestLongRunningCronMarkBlocksDispatchPastTTL is a regression test for the
 // case where an autonomous run outlasts its dedup_window_seconds TTL. Without
 // the refcount-based guard, the sweeper would evict the cron entry once its
-// expiresAt passed, and TryClaimForDispatch would no longer see the mark , 
+// expiresAt passed, and TryClaimForDispatch would no longer see the mark,
 // allowing a dispatch to race the still-in-flight cron run.
 func TestLongRunningCronMarkBlocksDispatchPastTTL(t *testing.T) {
 	t.Parallel()
@@ -851,7 +848,7 @@ func TestLongRunningCronMarkBlocksDispatchPastTTL(t *testing.T) {
 
 	// Autonomous run starts; writes cron mark.
 	start := time.Now()
-	d.MarkAutonomousRun("coder", "owner/repo", start)
+	d.TryMarkAutonomousRun("coder", "owner/repo", start)
 
 	// Simulate the sweeper running after the TTL has elapsed but before the
 	// run completes. The cron mark's refcount is still 1, so it must NOT be
@@ -871,7 +868,7 @@ func TestLongRunningCronMarkBlocksDispatchPastTTL(t *testing.T) {
 	}
 
 	// Once the run completes successfully, the refcount is decremented via
-	// FinalizeAutonomousRun. The entry itself is kept until the TTL expires , 
+	// FinalizeAutonomousRun. The entry itself is kept until the TTL expires,
 	// but since we advanced past the TTL in the simulation, the next eviction
 	// pass will remove it and dispatches may then proceed.
 	d.FinalizeAutonomousRun("coder", "owner/repo")
@@ -912,7 +909,7 @@ func TestFinalizeAutonomousRunKeepsTTLBlocksDispatchWithinWindow(t *testing.T) {
 	d1.FinalizeAutonomousRun("coder", "owner/repo")
 
 	// Within the TTL window, a dispatch to the same (agent, repo, 0) slot must
-	// still be suppressed, the entry is kept for the full dedup window.
+	// still be suppressed — the entry is kept for the full dedup window.
 	q2 := &fakeQueue{}
 	d2 := NewDispatcher(cfg, seedAgentMap(t, agents), dedup, q2, zerolog.Nop())
 	d2.ProcessDispatches(context.Background(), originator, ev, "root-post-run", 0, "", []ai.DispatchRequest{

--- a/internal/workflow/dispatch_test.go
+++ b/internal/workflow/dispatch_test.go
@@ -116,7 +116,7 @@ func seedAgentMap(t *testing.T, m map[string]fleet.Agent) *store.Store {
 		}
 		agents = append(agents, a)
 	}
-	if err := st.ImportAll(agents, nil, map[string]fleet.Skill{}, map[string]fleet.Backend{"claude": {Command: "claude"}}, nil); err != nil {
+	if err := st.ImportAll(agents, nil, map[string]fleet.Skill{}, map[string]fleet.Backend{"claude": {Command: "claude"}}, nil, nil); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 	return st

--- a/internal/workflow/dispatch_test.go
+++ b/internal/workflow/dispatch_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/eloylp/agents/internal/store"
 )
 
-// ─── helpers ────────────────────────────────────────────────────────────────────────────────────
+// ─── helpers ─────────────────────────────────────────────────────────────────────
 
 type fakeQueue struct {
 	mu     sync.Mutex
@@ -135,7 +135,7 @@ func testEvent(repo string, number int) Event {
 	}
 }
 
-// ─── Dispatcher tests ───────────────────────────────────────────────────────────────────────────────────────────────
+// ─── Dispatcher tests ──────────────────────────────────────────────────────────────────────────────────
 
 func TestDispatcherEnqueuesValidRequest(t *testing.T) {
 	t.Parallel()
@@ -336,7 +336,7 @@ func TestDispatcherDeduplicatesWithinWindow(t *testing.T) {
 	}
 }
 
-// ─── DispatchDedupStore tests ─────────────────────────────────────────────────────────────────────────────────────────
+// ─── DispatchDedupStore tests ──────────────────────────────────────────────────────────────────────────────
 
 func TestDispatchDedupStoreSeenOrAdd(t *testing.T) {
 	t.Parallel()
@@ -389,7 +389,7 @@ func TestDispatchDedupStoreBackgroundEviction(t *testing.T) {
 	}
 }
 
-// ─── Engine dispatch handling tests ───────────────────────────────────────────────────────────────────────────────────────────────────
+// ─── Engine dispatch handling tests ───────────────────────────────────────────────────────────────────────────────────────
 
 func TestEngineHandlesAgentDispatchEvent(t *testing.T) {
 	t.Parallel()
@@ -633,7 +633,7 @@ func TestDispatchClaimOnlyVisibleAfterSuccessfulEnqueue(t *testing.T) {
 // test for the cron-first dedup ordering: when an autonomous run starts and
 // TryMarkAutonomousRun writes a cron-namespace mark, dispatches targeting the
 // same agent/repo with number=0 (autonomous context) must be suppressed for
-// the full dedup_window_seconds — both while the run is in-flight and after
+// the full dedup_window_seconds, both while the run is in-flight and after
 // it completes.
 func TestMarkAutonomousRunSuppressesNearSimultaneousDispatch(t *testing.T) {
 	t.Parallel()
@@ -679,8 +679,8 @@ func TestMarkAutonomousRunDoesNotSuppressDispatchForDifferentNumber(t *testing.T
 	// Cron run marks (coder, owner/repo, 0).
 	d.TryMarkAutonomousRun("coder", "owner/repo", time.Now())
 
-	// A dispatch targeting coder for PR #42 (number=42) must still be enqueued
-	// — it is a different item context from the autonomous cron run (number=0).
+	// A dispatch targeting coder for PR #42 (number=42) must still be enqueued;
+	// it is a different item context from the autonomous cron run (number=0).
 	originator := originatorAgent("pr-reviewer")
 	ev := testEvent("owner/repo", 42)
 	d.ProcessDispatches(context.Background(), originator, ev, "root-pr42", 0, "", []ai.DispatchRequest{
@@ -714,7 +714,7 @@ func TestPostRunDispatchSuppressedWithinDedupWindow(t *testing.T) {
 		t.Fatal("TryMarkAutonomousRun: expected to succeed on first call (no prior dispatch)")
 	}
 
-	// Dispatch arriving after the run — still within the TTL window — must be suppressed.
+	// Dispatch arriving after the run, still within the TTL window, must be suppressed.
 	originator := agents["pr-reviewer"]
 	ev := Event{Repo: RepoRef{FullName: "owner/repo", Enabled: true}, Kind: "cron", Number: 0}
 	d.ProcessDispatches(context.Background(), originator, ev, "root-1", 0, "", []ai.DispatchRequest{
@@ -909,7 +909,7 @@ func TestFinalizeAutonomousRunKeepsTTLBlocksDispatchWithinWindow(t *testing.T) {
 	d1.FinalizeAutonomousRun("coder", "owner/repo")
 
 	// Within the TTL window, a dispatch to the same (agent, repo, 0) slot must
-	// still be suppressed — the entry is kept for the full dedup window.
+	// still be suppressed: the entry is kept for the full dedup window.
 	q2 := &fakeQueue{}
 	d2 := NewDispatcher(cfg, seedAgentMap(t, agents), dedup, q2, zerolog.Nop())
 	d2.ProcessDispatches(context.Background(), originator, ev, "root-post-run", 0, "", []ai.DispatchRequest{


### PR DESCRIPTION
Removes `DispatchAlreadyClaimed` and `MarkAutonomousRun` from `Dispatcher`; both are superseded by the atomic `TryMarkAutonomousRun` which was introduced to close the TOCTOU gap between the two.

Changes:
- `internal/workflow/dispatch.go`: removed `DispatchAlreadyClaimed` and `MarkAutonomousRun` methods; updated 6 doc-comments that still referenced the old names
- `internal/workflow/dispatch_test.go`: updated 6 tests to use `TryMarkAutonomousRun` / `d.dedup.SeesPendingOrCommitted` instead of the removed methods

Supersedes dirty PR #374 (same change, rebased onto current main).