### PR TITLE
feat(ui): make TranscriptFilter sticky in scroll containers

### DIFF
--- a/internal/ui/src/components/StreamCard.tsx
+++ b/internal/ui/src/components/StreamCard.tsx
@@ -58,7 +58,19 @@ export function TranscriptFilter({
   const reset = () => onChange(new Set(presentKinds))
 
   return (
-    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px', marginBottom: '0.5rem', alignItems: 'center' }}>
+    <div style={{
+      display: 'flex',
+      flexWrap: 'wrap',
+      gap: '4px',
+      marginBottom: '0.5rem',
+      alignItems: 'center',
+      position: 'sticky',
+      top: 0,
+      zIndex: 1,
+      background: 'var(--bg-card)',
+      paddingBottom: '6px',
+      borderBottom: '1px solid var(--border-subtle)',
+    }}>
       {presentKinds.map(k => {
         const meta = kindMeta[k]
         const on = visibleKinds.has(k)


### PR DESCRIPTION
Makes the `TranscriptFilter` chip row sticky so it follows the user while scrolling through a long transcript, on both surfaces that use it.

**Problem:** The filter pills scroll away in two contexts:
- `LiveStreamModal` on `/runners/` — auto-scrolls to latest output, so toggling a filter required scrolling back to the top mid-stream.
- `TranscriptCollapsible` on `/traces/` — long transcripts push the pills off-screen.

**Change:** Add `position: sticky; top: 0; z-index: 1` to `TranscriptFilter`'s outer container in `internal/ui/src/components/StreamCard.tsx`, with `background: var(--bg-card)` so cards don't bleed through, `paddingBottom: 6px` for breathing room, and `borderBottom: 1px solid var(--border-subtle)` to visually separate it from scrolling content.

**Why this works on both surfaces:**
- `LiveStreamModal` scroll container is an `overflowY: auto` div — sticky resolves to that container.
- `TranscriptCollapsible` is in normal page flow — sticky resolves to the viewport, pinning below the NavBar once it scrolls away.

No JS or backend changes. One component, two surfaces fixed.

Closes #410