### PR TITLE
refactor: simplify isSupportedBackend to single boolean return

### DIFF
--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -245,8 +245,5 @@ func (c *Config) validateRepos() error {
 }
 
 func isSupportedBackend(name string, backend fleet.Backend) bool {
-	if slices.Contains(validAIBackendNames, name) {
-		return true
-	}
-	return strings.TrimSpace(backend.LocalModelURL) != ""
+	return slices.Contains(validAIBackendNames, name) || strings.TrimSpace(backend.LocalModelURL) != ""
 }


### PR DESCRIPTION
## Summary

`isSupportedBackend` in `internal/config/validate.go` used the verbose early-return-true pattern:

```go
func isSupportedBackend(name string, backend fleet.Backend) bool {
    if slices.Contains(validAIBackendNames, name) {
        return true
    }
    return strings.TrimSpace(backend.LocalModelURL) != ""
}
```

When the two branches form a simple disjunction, a direct boolean expression is clearer:

```go
func isSupportedBackend(name string, backend fleet.Backend) bool {
    return slices.Contains(validAIBackendNames, name) || strings.TrimSpace(backend.LocalModelURL) != ""
}
```

Three lines fewer, same semantics.

Supersedes #366, which had drifted dirty against main and accumulated unrelated scope (an `ok` -> `found` rename in `internal/mcp/tools_fleet.go` that no longer applies on main, since that function was refactored to use `slices.IndexFunc` and the local loop is gone).

## Test plan

- [ ] CI green (`go vet ./...` + `go test -race ./...`)
- [ ] No behaviour change - pure simplification