### PR TITLE
Refactor daemon routes by HTTP method

### DIFF
--- a/internal/daemon/config/budgets.go
+++ b/internal/daemon/config/budgets.go
@@ -30,36 +30,38 @@ func (r tokenBudgetPatchRequest) toStorePatch() store.TokenBudgetPatch {
 	}
 }
 
-// handleTokenBudgets dispatches GET /token_budgets and POST /token_budgets.
-func (h *Handler) handleTokenBudgets(w http.ResponseWriter, r *http.Request) {
-	switch r.Method {
-	case http.MethodGet:
-		h.listTokenBudgets(w, r)
-	case http.MethodPost:
-		h.createTokenBudget(w, r)
-	default:
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-	}
-}
-
-// handleTokenBudget dispatches GET/PATCH/DELETE /token_budgets/{id}.
-func (h *Handler) handleTokenBudget(w http.ResponseWriter, r *http.Request) {
+func tokenBudgetID(w http.ResponseWriter, r *http.Request) (int64, bool) {
 	idStr := mux.Vars(r)["id"]
 	id, err := strconv.ParseInt(idStr, 10, 64)
 	if err != nil {
 		http.Error(w, "invalid id", http.StatusBadRequest)
+		return 0, false
+	}
+	return id, true
+}
+
+func (h *Handler) getTokenBudgetByID(w http.ResponseWriter, r *http.Request) {
+	id, ok := tokenBudgetID(w, r)
+	if !ok {
 		return
 	}
-	switch r.Method {
-	case http.MethodGet:
-		h.getTokenBudget(w, r, id)
-	case http.MethodPatch:
-		h.updateTokenBudget(w, r, id)
-	case http.MethodDelete:
-		h.deleteTokenBudget(w, r, id)
-	default:
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	h.getTokenBudget(w, r, id)
+}
+
+func (h *Handler) updateTokenBudgetByID(w http.ResponseWriter, r *http.Request) {
+	id, ok := tokenBudgetID(w, r)
+	if !ok {
+		return
 	}
+	h.updateTokenBudget(w, r, id)
+}
+
+func (h *Handler) deleteTokenBudgetByID(w http.ResponseWriter, r *http.Request) {
+	id, ok := tokenBudgetID(w, r)
+	if !ok {
+		return
+	}
+	h.deleteTokenBudget(w, r, id)
 }
 
 func (h *Handler) listTokenBudgets(w http.ResponseWriter, _ *http.Request) {

--- a/internal/daemon/config/config.go
+++ b/internal/daemon/config/config.go
@@ -49,9 +49,12 @@ func (h *Handler) RegisterRoutes(r *mux.Router, withTimeout func(http.Handler) h
 	r.Handle("/config", withTimeout(http.HandlerFunc(h.HandleConfig))).Methods(http.MethodGet)
 	r.Handle("/export", withTimeout(http.HandlerFunc(h.HandleExport))).Methods(http.MethodGet)
 	r.Handle("/import", withTimeout(http.HandlerFunc(h.HandleImport))).Methods(http.MethodPost)
-	r.Handle("/token_budgets", withTimeout(http.HandlerFunc(h.handleTokenBudgets))).Methods(http.MethodGet, http.MethodPost)
+	r.Handle("/token_budgets", withTimeout(http.HandlerFunc(h.listTokenBudgets))).Methods(http.MethodGet)
+	r.Handle("/token_budgets", withTimeout(http.HandlerFunc(h.createTokenBudget))).Methods(http.MethodPost)
 	r.Handle("/token_budgets/alerts", withTimeout(http.HandlerFunc(h.handleTokenBudgetAlerts))).Methods(http.MethodGet)
-	r.Handle("/token_budgets/{id:[0-9]+}", withTimeout(http.HandlerFunc(h.handleTokenBudget))).Methods(http.MethodGet, http.MethodPatch, http.MethodDelete)
+	r.Handle("/token_budgets/{id:[0-9]+}", withTimeout(http.HandlerFunc(h.getTokenBudgetByID))).Methods(http.MethodGet)
+	r.Handle("/token_budgets/{id:[0-9]+}", withTimeout(http.HandlerFunc(h.updateTokenBudgetByID))).Methods(http.MethodPatch)
+	r.Handle("/token_budgets/{id:[0-9]+}", withTimeout(http.HandlerFunc(h.deleteTokenBudgetByID))).Methods(http.MethodDelete)
 	r.Handle("/token_leaderboard", withTimeout(http.HandlerFunc(h.handleTokenLeaderboard))).Methods(http.MethodGet)
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -432,9 +432,8 @@ func (d *Daemon) buildRouter() http.Handler {
 	router.Handle("/run", withTimeout(http.HandlerFunc(d.handleAgentsRun))).Methods(http.MethodPost)
 	d.webhook.RegisterRoutes(router, withTimeout)
 
-	// /agents merges the read-only fleet snapshot view (GET) with CRUD
-	// create (POST) on a single mux entry.
-	router.Handle("/agents", withTimeout(http.HandlerFunc(d.handleAgents))).Methods(http.MethodGet, http.MethodPost)
+	router.Handle("/agents", withTimeout(http.HandlerFunc(d.fleet.HandleAgentsView))).Methods(http.MethodGet)
+	router.Handle("/agents", withTimeout(http.HandlerFunc(d.fleet.HandleAgentsCreate))).Methods(http.MethodPost)
 
 	d.fleet.RegisterRoutes(router, withTimeout)
 	d.repos.RegisterRoutes(router, withTimeout)
@@ -470,16 +469,6 @@ func (d *Daemon) buildRouter() http.Handler {
 		d.logger.Info().Str("path", "/mcp").Msg("mcp server enabled")
 	}
 	return router
-}
-
-// handleAgents dispatches GET to the fleet snapshot view and POST to the
-// fleet handler's CRUD create. Single mux entry covers both methods.
-func (d *Daemon) handleAgents(w http.ResponseWriter, r *http.Request) {
-	if r.Method == http.MethodGet {
-		d.fleet.HandleAgentsView(w, r)
-		return
-	}
-	d.fleet.HandleAgentsCreate(w, r)
 }
 
 // ── /status ─────────────────────────────────────────────────────────────

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gorilla/mux"
+
 	"github.com/eloylp/agents/internal/config"
 	"github.com/eloylp/agents/internal/daemon"
 	"github.com/eloylp/agents/internal/daemon/daemontest"
@@ -44,6 +46,89 @@ func newTestServer(t *testing.T, cfg *config.Config) (*daemon.Daemon, *workflow.
 	t.Helper()
 	srv := daemontest.New(t, cfg)
 	return srv, srv.Channels()
+}
+
+func TestBuildRouterRegistersExpectedRoutes(t *testing.T) {
+	t.Parallel()
+
+	srv, _ := newTestServer(t, testCfg(nil))
+	router, ok := srv.Handler().(*mux.Router)
+	if !ok {
+		t.Fatalf("handler type = %T, want *mux.Router", srv.Handler())
+	}
+
+	expected := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/status"},
+		{http.MethodPost, "/run"},
+		{http.MethodPost, "/webhooks/github"},
+		{http.MethodGet, "/agents"},
+		{http.MethodPost, "/agents"},
+		{http.MethodGet, "/agents/orphans/status"},
+		{http.MethodGet, "/agents/coder"},
+		{http.MethodPatch, "/agents/coder"},
+		{http.MethodDelete, "/agents/coder"},
+		{http.MethodGet, "/skills"},
+		{http.MethodPost, "/skills"},
+		{http.MethodGet, "/skills/reviewer"},
+		{http.MethodPatch, "/skills/reviewer"},
+		{http.MethodDelete, "/skills/reviewer"},
+		{http.MethodGet, "/guardrails"},
+		{http.MethodPost, "/guardrails"},
+		{http.MethodGet, "/guardrails/security"},
+		{http.MethodPatch, "/guardrails/security"},
+		{http.MethodDelete, "/guardrails/security"},
+		{http.MethodPost, "/guardrails/security/reset"},
+		{http.MethodGet, "/backends"},
+		{http.MethodPost, "/backends"},
+		{http.MethodGet, "/backends/status"},
+		{http.MethodPost, "/backends/discover"},
+		{http.MethodPost, "/backends/local"},
+		{http.MethodGet, "/backends/claude"},
+		{http.MethodPatch, "/backends/claude"},
+		{http.MethodDelete, "/backends/claude"},
+		{http.MethodGet, "/repos"},
+		{http.MethodPost, "/repos"},
+		{http.MethodGet, "/repos/owner/repo"},
+		{http.MethodPatch, "/repos/owner/repo"},
+		{http.MethodDelete, "/repos/owner/repo"},
+		{http.MethodPost, "/repos/owner/repo/bindings"},
+		{http.MethodGet, "/repos/owner/repo/bindings/1"},
+		{http.MethodPatch, "/repos/owner/repo/bindings/1"},
+		{http.MethodDelete, "/repos/owner/repo/bindings/1"},
+		{http.MethodGet, "/config"},
+		{http.MethodGet, "/export"},
+		{http.MethodPost, "/import"},
+		{http.MethodGet, "/token_budgets"},
+		{http.MethodPost, "/token_budgets"},
+		{http.MethodGet, "/token_budgets/alerts"},
+		{http.MethodGet, "/token_budgets/1"},
+		{http.MethodPatch, "/token_budgets/1"},
+		{http.MethodDelete, "/token_budgets/1"},
+		{http.MethodGet, "/token_leaderboard"},
+		{http.MethodGet, "/events"},
+		{http.MethodGet, "/traces"},
+		{http.MethodGet, "/traces/root-1"},
+		{http.MethodGet, "/traces/span-1/steps"},
+		{http.MethodGet, "/traces/span-1/prompt"},
+		{http.MethodGet, "/graph"},
+		{http.MethodGet, "/dispatches"},
+		{http.MethodGet, "/memory/coder/owner_repo"},
+		{http.MethodGet, "/runners"},
+		{http.MethodDelete, "/runners/1"},
+		{http.MethodPost, "/runners/1/retry"},
+	}
+
+	for _, tc := range expected {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			if !router.Match(req, &mux.RouteMatch{}) {
+				t.Fatalf("route not registered")
+			}
+		})
+	}
 }
 
 // webhookRequest builds a signed POST request to /webhooks/github.
@@ -425,10 +510,10 @@ func TestHandleCommentAndReviewEventsEnqueue(t *testing.T) {
 func TestHandleNonTriggeringActionsIgnored(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name      string
-		eventType string
+		name       string
+		eventType  string
 		deliveryID string
-		body      string
+		body       string
 	}{
 		{
 			name:       "issue_comment non-created action ignored",
@@ -598,7 +683,6 @@ func TestHandleAgentsRunEnqueuesEvent(t *testing.T) {
 	}
 }
 
-
 func TestHandleAgentsRunReturnsBadRequestOnMissingFields(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -735,5 +819,3 @@ func TestBuildHandlerObservabilityRoutesAreOpen(t *testing.T) {
 		})
 	}
 }
-
-

--- a/internal/daemon/fleet/fleet.go
+++ b/internal/daemon/fleet/fleet.go
@@ -57,22 +57,29 @@ func New(st *store.Store, maxBodyBytes int64, sched *scheduler.Scheduler, obs *o
 // on r. withTimeout wraps each handler in an http.TimeoutHandler matching
 // the daemon's HTTP write-timeout setting.
 //
-// GET /agents is mounted by the composing daemon's dispatcher (which also
-// handles POST /agents) so both share one mux entry; the dispatcher
-// delegates to HandleAgentsView for the read-only fleet snapshot and to
-// HandleAgentsCreate for POST.
+// GET /agents and POST /agents are mounted by the composing daemon so the
+// top-level route can combine the read-only fleet snapshot with CRUD create.
 func (h *Handler) RegisterRoutes(r *mux.Router, withTimeout func(http.Handler) http.Handler) {
 	r.Handle("/agents/orphans/status", withTimeout(http.HandlerFunc(h.HandleOrphansStatus))).Methods(http.MethodGet)
-	r.Handle("/agents/{name}", withTimeout(http.HandlerFunc(h.handleAgent))).Methods(http.MethodGet, http.MethodPatch, http.MethodDelete)
+	r.Handle("/agents/{name}", withTimeout(http.HandlerFunc(h.handleAgentGet))).Methods(http.MethodGet)
+	r.Handle("/agents/{name}", withTimeout(http.HandlerFunc(h.handleAgentPatchByName))).Methods(http.MethodPatch)
+	r.Handle("/agents/{name}", withTimeout(http.HandlerFunc(h.handleAgentDelete))).Methods(http.MethodDelete)
 
-	r.Handle("/skills", withTimeout(http.HandlerFunc(h.handleSkills))).Methods(http.MethodGet, http.MethodPost)
-	r.Handle("/skills/{name}", withTimeout(http.HandlerFunc(h.handleSkill))).Methods(http.MethodGet, http.MethodPatch, http.MethodDelete)
+	r.Handle("/skills", withTimeout(http.HandlerFunc(h.handleSkillsList))).Methods(http.MethodGet)
+	r.Handle("/skills", withTimeout(http.HandlerFunc(h.handleSkillCreate))).Methods(http.MethodPost)
+	r.Handle("/skills/{name}", withTimeout(http.HandlerFunc(h.handleSkillGet))).Methods(http.MethodGet)
+	r.Handle("/skills/{name}", withTimeout(http.HandlerFunc(h.handleSkillPatchByName))).Methods(http.MethodPatch)
+	r.Handle("/skills/{name}", withTimeout(http.HandlerFunc(h.handleSkillDelete))).Methods(http.MethodDelete)
 
-	r.Handle("/guardrails", withTimeout(http.HandlerFunc(h.handleGuardrails))).Methods(http.MethodGet, http.MethodPost)
-	r.Handle("/guardrails/{name}", withTimeout(http.HandlerFunc(h.handleGuardrail))).Methods(http.MethodGet, http.MethodPatch, http.MethodDelete)
+	r.Handle("/guardrails", withTimeout(http.HandlerFunc(h.handleGuardrailsList))).Methods(http.MethodGet)
+	r.Handle("/guardrails", withTimeout(http.HandlerFunc(h.handleGuardrailCreate))).Methods(http.MethodPost)
+	r.Handle("/guardrails/{name}", withTimeout(http.HandlerFunc(h.handleGuardrailGet))).Methods(http.MethodGet)
+	r.Handle("/guardrails/{name}", withTimeout(http.HandlerFunc(h.handleGuardrailPatchByName))).Methods(http.MethodPatch)
+	r.Handle("/guardrails/{name}", withTimeout(http.HandlerFunc(h.handleGuardrailDelete))).Methods(http.MethodDelete)
 	r.Handle("/guardrails/{name}/reset", withTimeout(http.HandlerFunc(h.handleGuardrailReset))).Methods(http.MethodPost)
 
-	r.Handle("/backends", withTimeout(http.HandlerFunc(h.handleBackends))).Methods(http.MethodGet, http.MethodPost)
+	r.Handle("/backends", withTimeout(http.HandlerFunc(h.handleBackendsList))).Methods(http.MethodGet)
+	r.Handle("/backends", withTimeout(http.HandlerFunc(h.handleBackendCreate))).Methods(http.MethodPost)
 	r.Handle("/backends/status", withTimeout(http.HandlerFunc(h.handleBackendsStatus))).Methods(http.MethodGet)
 	r.Handle("/backends/discover", withTimeout(http.HandlerFunc(h.handleBackendsDiscover))).Methods(http.MethodPost)
 	r.Handle("/backends/local", withTimeout(http.HandlerFunc(h.handleBackendsLocal))).Methods(http.MethodPost)
@@ -211,33 +218,34 @@ func (p AgentPatch) apply(a *fleet.Agent) {
 
 // ── Agent handlers ────────────────────────────────────────────────────────────────────────────────────
 
-func (h *Handler) handleAgent(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) handleAgentGet(w http.ResponseWriter, r *http.Request) {
 	name := fleet.NormalizeAgentName(mux.Vars(r)["name"])
-	switch r.Method {
-	case http.MethodGet:
-		agents, err := h.store.ReadAgents()
-		if err != nil {
-			http.Error(w, fmt.Sprintf("read agents: %v", err), http.StatusInternalServerError)
-			return
-		}
-		idx := slices.IndexFunc(agents, func(a fleet.Agent) bool { return a.Name == name })
-		if idx < 0 {
-			http.NotFound(w, r)
-			return
-		}
-		writeJSON(w, http.StatusOK, agentToStoreJSON(agents[idx]))
-
-	case http.MethodPatch:
-		h.handleAgentPatch(w, r, name)
-
-	case http.MethodDelete:
-		cascade := r.URL.Query().Get("cascade") == "true"
-		if err := h.DeleteAgent(name, cascade); err != nil {
-			h.writeErr(w, err, "agent delete or cron reload")
-			return
-		}
-		w.WriteHeader(http.StatusNoContent)
+	agents, err := h.store.ReadAgents()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("read agents: %v", err), http.StatusInternalServerError)
+		return
 	}
+	idx := slices.IndexFunc(agents, func(a fleet.Agent) bool { return a.Name == name })
+	if idx < 0 {
+		http.NotFound(w, r)
+		return
+	}
+	writeJSON(w, http.StatusOK, agentToStoreJSON(agents[idx]))
+}
+
+func (h *Handler) handleAgentPatchByName(w http.ResponseWriter, r *http.Request) {
+	name := fleet.NormalizeAgentName(mux.Vars(r)["name"])
+	h.handleAgentPatch(w, r, name)
+}
+
+func (h *Handler) handleAgentDelete(w http.ResponseWriter, r *http.Request) {
+	name := fleet.NormalizeAgentName(mux.Vars(r)["name"])
+	cascade := r.URL.Query().Get("cascade") == "true"
+	if err := h.DeleteAgent(name, cascade); err != nil {
+		h.writeErr(w, err, "agent delete or cron reload")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (h *Handler) handleAgentPatch(w http.ResponseWriter, r *http.Request, name string) {
@@ -337,60 +345,59 @@ func (p SkillPatch) apply(s *fleet.Skill) {
 
 // ── Skill handlers ────────────────────────────────────────────────────────────────────────────────────
 
-func (h *Handler) handleSkills(w http.ResponseWriter, r *http.Request) {
-	switch r.Method {
-	case http.MethodGet:
-		skills, err := h.store.ReadSkills()
-		if err != nil {
-			http.Error(w, fmt.Sprintf("read skills: %v", err), http.StatusInternalServerError)
-			return
-		}
-		out := make([]storeSkillJSON, 0, len(skills))
-		for name, sk := range skills {
-			out = append(out, storeSkillJSON{Name: name, Prompt: sk.Prompt})
-		}
-		writeJSON(w, http.StatusOK, out)
-
-	case http.MethodPost:
-		var req storeSkillJSON
-		if !decodeBody(w, r, h.maxBodyBytes, &req) {
-			return
-		}
-		name, sk, err := h.UpsertSkill(req.Name, fleet.Skill{Prompt: req.Prompt})
-		if err != nil {
-			h.writeErr(w, err, "skill upsert or cron reload")
-			return
-		}
-		writeJSON(w, http.StatusOK, storeSkillJSON{Name: name, Prompt: sk.Prompt})
+func (h *Handler) handleSkillsList(w http.ResponseWriter, _ *http.Request) {
+	skills, err := h.store.ReadSkills()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("read skills: %v", err), http.StatusInternalServerError)
+		return
 	}
+	out := make([]storeSkillJSON, 0, len(skills))
+	for name, sk := range skills {
+		out = append(out, storeSkillJSON{Name: name, Prompt: sk.Prompt})
+	}
+	writeJSON(w, http.StatusOK, out)
 }
 
-func (h *Handler) handleSkill(w http.ResponseWriter, r *http.Request) {
-	name := fleet.NormalizeSkillName(mux.Vars(r)["name"])
-	switch r.Method {
-	case http.MethodGet:
-		skills, err := h.store.ReadSkills()
-		if err != nil {
-			http.Error(w, fmt.Sprintf("read skills: %v", err), http.StatusInternalServerError)
-			return
-		}
-		sk, ok := skills[name]
-		if !ok {
-			http.NotFound(w, r)
-			return
-		}
-		writeJSON(w, http.StatusOK, storeSkillJSON{Name: name, Prompt: sk.Prompt})
-
-	case http.MethodPatch:
-		h.handleSkillPatch(w, r, name)
-
-	case http.MethodDelete:
-		if err := h.DeleteSkill(name); err != nil {
-			h.writeErr(w, err, "skill delete or cron reload")
-			return
-		}
-		w.WriteHeader(http.StatusNoContent)
+func (h *Handler) handleSkillCreate(w http.ResponseWriter, r *http.Request) {
+	var req storeSkillJSON
+	if !decodeBody(w, r, h.maxBodyBytes, &req) {
+		return
 	}
+	name, sk, err := h.UpsertSkill(req.Name, fleet.Skill{Prompt: req.Prompt})
+	if err != nil {
+		h.writeErr(w, err, "skill upsert or cron reload")
+		return
+	}
+	writeJSON(w, http.StatusOK, storeSkillJSON{Name: name, Prompt: sk.Prompt})
+}
+
+func (h *Handler) handleSkillGet(w http.ResponseWriter, r *http.Request) {
+	name := fleet.NormalizeSkillName(mux.Vars(r)["name"])
+	skills, err := h.store.ReadSkills()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("read skills: %v", err), http.StatusInternalServerError)
+		return
+	}
+	sk, ok := skills[name]
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	writeJSON(w, http.StatusOK, storeSkillJSON{Name: name, Prompt: sk.Prompt})
+}
+
+func (h *Handler) handleSkillPatchByName(w http.ResponseWriter, r *http.Request) {
+	name := fleet.NormalizeSkillName(mux.Vars(r)["name"])
+	h.handleSkillPatch(w, r, name)
+}
+
+func (h *Handler) handleSkillDelete(w http.ResponseWriter, r *http.Request) {
+	name := fleet.NormalizeSkillName(mux.Vars(r)["name"])
+	if err := h.DeleteSkill(name); err != nil {
+		h.writeErr(w, err, "skill delete or cron reload")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (h *Handler) handleSkillPatch(w http.ResponseWriter, r *http.Request, name string) {
@@ -556,32 +563,30 @@ func (j storeBackendJSON) toConfig() fleet.Backend {
 
 // ── Backend handlers ────────────────────────────────────────────────────────────────────────────────────
 
-func (h *Handler) handleBackends(w http.ResponseWriter, r *http.Request) {
-	switch r.Method {
-	case http.MethodGet:
-		all, err := h.store.ReadBackends()
-		if err != nil {
-			http.Error(w, fmt.Sprintf("read backends: %v", err), http.StatusInternalServerError)
-			return
-		}
-		out := make([]storeBackendJSON, 0, len(all))
-		for name, b := range all {
-			out = append(out, backendToStoreJSON(name, b))
-		}
-		writeJSON(w, http.StatusOK, out)
-
-	case http.MethodPost:
-		var req storeBackendJSON
-		if !decodeBody(w, r, h.maxBodyBytes, &req) {
-			return
-		}
-		name, b, err := h.UpsertBackend(req.Name, req.toConfig())
-		if err != nil {
-			h.writeErr(w, err, "backend upsert or cron reload")
-			return
-		}
-		writeJSON(w, http.StatusOK, backendToStoreJSON(name, b))
+func (h *Handler) handleBackendsList(w http.ResponseWriter, _ *http.Request) {
+	all, err := h.store.ReadBackends()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("read backends: %v", err), http.StatusInternalServerError)
+		return
 	}
+	out := make([]storeBackendJSON, 0, len(all))
+	for name, b := range all {
+		out = append(out, backendToStoreJSON(name, b))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (h *Handler) handleBackendCreate(w http.ResponseWriter, r *http.Request) {
+	var req storeBackendJSON
+	if !decodeBody(w, r, h.maxBodyBytes, &req) {
+		return
+	}
+	name, b, err := h.UpsertBackend(req.Name, req.toConfig())
+	if err != nil {
+		h.writeErr(w, err, "backend upsert or cron reload")
+		return
+	}
+	writeJSON(w, http.StatusOK, backendToStoreJSON(name, b))
 }
 
 func (h *Handler) handleBackendsStatus(w http.ResponseWriter, r *http.Request) {

--- a/internal/daemon/fleet/guardrails.go
+++ b/internal/daemon/fleet/guardrails.go
@@ -71,64 +71,63 @@ func (p GuardrailPatch) apply(g *fleet.Guardrail) {
 
 // ── Guardrail handlers ───────────────────────────────────────────────────────
 
-func (h *Handler) handleGuardrails(w http.ResponseWriter, r *http.Request) {
-	switch r.Method {
-	case http.MethodGet:
-		gs, err := h.store.ReadAllGuardrails()
-		if err != nil {
-			http.Error(w, fmt.Sprintf("read guardrails: %v", err), http.StatusInternalServerError)
-			return
-		}
-		out := make([]storeGuardrailJSON, 0, len(gs))
-		for _, g := range gs {
-			out = append(out, guardrailToJSON(g))
-		}
-		writeJSON(w, http.StatusOK, out)
-
-	case http.MethodPost:
-		var req storeGuardrailJSON
-		if !decodeBody(w, r, h.maxBodyBytes, &req) {
-			return
-		}
-		// Operator-supplied rows are never built-in; ignore any client-set
-		// is_builtin / default_content values to keep the migration the
-		// sole source of those flags.
-		g, err := h.UpsertGuardrail(fleet.Guardrail{
-			Name:        req.Name,
-			Description: req.Description,
-			Content:     req.Content,
-			Enabled:     req.Enabled,
-			Position:    req.Position,
-		})
-		if err != nil {
-			h.writeErr(w, err, "guardrail upsert")
-			return
-		}
-		writeJSON(w, http.StatusOK, guardrailToJSON(g))
+func (h *Handler) handleGuardrailsList(w http.ResponseWriter, _ *http.Request) {
+	gs, err := h.store.ReadAllGuardrails()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("read guardrails: %v", err), http.StatusInternalServerError)
+		return
 	}
+	out := make([]storeGuardrailJSON, 0, len(gs))
+	for _, g := range gs {
+		out = append(out, guardrailToJSON(g))
+	}
+	writeJSON(w, http.StatusOK, out)
 }
 
-func (h *Handler) handleGuardrail(w http.ResponseWriter, r *http.Request) {
-	name := fleet.NormalizeGuardrailName(mux.Vars(r)["name"])
-	switch r.Method {
-	case http.MethodGet:
-		g, err := h.store.GetGuardrail(name)
-		if err != nil {
-			h.writeErr(w, err, "guardrail get")
-			return
-		}
-		writeJSON(w, http.StatusOK, guardrailToJSON(g))
-
-	case http.MethodPatch:
-		h.handleGuardrailPatch(w, r, name)
-
-	case http.MethodDelete:
-		if err := h.DeleteGuardrail(name); err != nil {
-			h.writeErr(w, err, "guardrail delete")
-			return
-		}
-		w.WriteHeader(http.StatusNoContent)
+func (h *Handler) handleGuardrailCreate(w http.ResponseWriter, r *http.Request) {
+	var req storeGuardrailJSON
+	if !decodeBody(w, r, h.maxBodyBytes, &req) {
+		return
 	}
+	// Operator-supplied rows are never built-in; ignore any client-set
+	// is_builtin / default_content values to keep the migration the
+	// sole source of those flags.
+	g, err := h.UpsertGuardrail(fleet.Guardrail{
+		Name:        req.Name,
+		Description: req.Description,
+		Content:     req.Content,
+		Enabled:     req.Enabled,
+		Position:    req.Position,
+	})
+	if err != nil {
+		h.writeErr(w, err, "guardrail upsert")
+		return
+	}
+	writeJSON(w, http.StatusOK, guardrailToJSON(g))
+}
+
+func (h *Handler) handleGuardrailGet(w http.ResponseWriter, r *http.Request) {
+	name := fleet.NormalizeGuardrailName(mux.Vars(r)["name"])
+	g, err := h.store.GetGuardrail(name)
+	if err != nil {
+		h.writeErr(w, err, "guardrail get")
+		return
+	}
+	writeJSON(w, http.StatusOK, guardrailToJSON(g))
+}
+
+func (h *Handler) handleGuardrailPatchByName(w http.ResponseWriter, r *http.Request) {
+	name := fleet.NormalizeGuardrailName(mux.Vars(r)["name"])
+	h.handleGuardrailPatch(w, r, name)
+}
+
+func (h *Handler) handleGuardrailDelete(w http.ResponseWriter, r *http.Request) {
+	name := fleet.NormalizeGuardrailName(mux.Vars(r)["name"])
+	if err := h.DeleteGuardrail(name); err != nil {
+		h.writeErr(w, err, "guardrail delete")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (h *Handler) handleGuardrailPatch(w http.ResponseWriter, r *http.Request, name string) {

--- a/internal/daemon/repos/repos.go
+++ b/internal/daemon/repos/repos.go
@@ -47,8 +47,11 @@ func New(st *store.Store, maxBodyBytes int64, logger zerolog.Logger) *Handler {
 // each handler in an http.TimeoutHandler matching the daemon's
 // HTTP write-timeout setting.
 func (h *Handler) RegisterRoutes(r *mux.Router, withTimeout func(http.Handler) http.Handler) {
-	r.Handle("/repos", withTimeout(http.HandlerFunc(h.handleRepos))).Methods(http.MethodGet, http.MethodPost)
-	r.Handle("/repos/{owner}/{repo}", withTimeout(http.HandlerFunc(h.handleRepo))).Methods(http.MethodGet, http.MethodPatch, http.MethodDelete)
+	r.Handle("/repos", withTimeout(http.HandlerFunc(h.handleReposList))).Methods(http.MethodGet)
+	r.Handle("/repos", withTimeout(http.HandlerFunc(h.handleRepoCreate))).Methods(http.MethodPost)
+	r.Handle("/repos/{owner}/{repo}", withTimeout(http.HandlerFunc(h.handleRepoGet))).Methods(http.MethodGet)
+	r.Handle("/repos/{owner}/{repo}", withTimeout(http.HandlerFunc(h.handleRepoPatch))).Methods(http.MethodPatch)
+	r.Handle("/repos/{owner}/{repo}", withTimeout(http.HandlerFunc(h.handleRepoDelete))).Methods(http.MethodDelete)
 	r.Handle("/repos/{owner}/{repo}/bindings", withTimeout(http.HandlerFunc(h.handleCreateBinding))).Methods(http.MethodPost)
 	r.Handle("/repos/{owner}/{repo}/bindings/{id}", withTimeout(http.HandlerFunc(h.handleGetBinding))).Methods(http.MethodGet)
 	r.Handle("/repos/{owner}/{repo}/bindings/{id}", withTimeout(http.HandlerFunc(h.handleUpdateBinding))).Methods(http.MethodPatch)
@@ -124,75 +127,78 @@ type repoRuntimeSettingsJSON struct {
 
 // ── Handlers ──────────────────────────────────────────────────────────────────────────
 
-func (h *Handler) handleRepos(w http.ResponseWriter, r *http.Request) {
-	switch r.Method {
-	case http.MethodGet:
-		repos, err := h.store.ReadRepos()
-		if err != nil {
-			http.Error(w, fmt.Sprintf("read repos: %v", err), http.StatusInternalServerError)
-			return
-		}
-		out := make([]storeRepoJSON, len(repos))
-		for i, r := range repos {
-			out[i] = repoToStoreJSON(r)
-		}
-		writeJSON(w, http.StatusOK, out)
-
-	case http.MethodPost:
-		var req storeRepoJSON
-		if !decodeBody(w, r, h.maxBodyBytes, &req) {
-			return
-		}
-		canonical, err := h.UpsertRepo(req.toConfig())
-		if err != nil {
-			h.writeErr(w, err, "repo upsert or cron reload")
-			return
-		}
-		writeJSON(w, http.StatusOK, repoToStoreJSON(canonical))
+func (h *Handler) handleReposList(w http.ResponseWriter, _ *http.Request) {
+	repos, err := h.store.ReadRepos()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("read repos: %v", err), http.StatusInternalServerError)
+		return
 	}
+	out := make([]storeRepoJSON, len(repos))
+	for i, r := range repos {
+		out[i] = repoToStoreJSON(r)
+	}
+	writeJSON(w, http.StatusOK, out)
 }
 
-func (h *Handler) handleRepo(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
-	repoName := fleet.NormalizeRepoName(vars["owner"]) + "/" + fleet.NormalizeRepoName(vars["repo"])
-	switch r.Method {
-	case http.MethodGet:
-		repos, err := h.store.ReadRepos()
-		if err != nil {
-			http.Error(w, fmt.Sprintf("read repos: %v", err), http.StatusInternalServerError)
-			return
-		}
-		for _, repo := range repos {
-			if repo.Name == repoName {
-				writeJSON(w, http.StatusOK, repoToStoreJSON(repo))
-				return
-			}
-		}
-		http.NotFound(w, r)
-
-	case http.MethodPatch:
-		var req repoRuntimeSettingsJSON
-		if !decodeBody(w, r, h.maxBodyBytes, &req) {
-			return
-		}
-		if req.Enabled == nil {
-			http.Error(w, "at least one field is required", http.StatusBadRequest)
-			return
-		}
-		repo, err := h.PatchRepo(repoName, *req.Enabled)
-		if err != nil {
-			h.writeErr(w, err, "repo patch or cron reload")
-			return
-		}
-		writeJSON(w, http.StatusOK, repoToStoreJSON(repo))
-
-	case http.MethodDelete:
-		if err := h.DeleteRepo(repoName); err != nil {
-			h.writeErr(w, err, "repo delete or cron reload")
-			return
-		}
-		w.WriteHeader(http.StatusNoContent)
+func (h *Handler) handleRepoCreate(w http.ResponseWriter, r *http.Request) {
+	var req storeRepoJSON
+	if !decodeBody(w, r, h.maxBodyBytes, &req) {
+		return
 	}
+	canonical, err := h.UpsertRepo(req.toConfig())
+	if err != nil {
+		h.writeErr(w, err, "repo upsert or cron reload")
+		return
+	}
+	writeJSON(w, http.StatusOK, repoToStoreJSON(canonical))
+}
+
+func repoNameFromRequest(r *http.Request) string {
+	vars := mux.Vars(r)
+	return fleet.NormalizeRepoName(vars["owner"]) + "/" + fleet.NormalizeRepoName(vars["repo"])
+}
+
+func (h *Handler) handleRepoGet(w http.ResponseWriter, r *http.Request) {
+	repoName := repoNameFromRequest(r)
+	repos, err := h.store.ReadRepos()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("read repos: %v", err), http.StatusInternalServerError)
+		return
+	}
+	for _, repo := range repos {
+		if repo.Name == repoName {
+			writeJSON(w, http.StatusOK, repoToStoreJSON(repo))
+			return
+		}
+	}
+	http.NotFound(w, r)
+}
+
+func (h *Handler) handleRepoPatch(w http.ResponseWriter, r *http.Request) {
+	repoName := repoNameFromRequest(r)
+	var req repoRuntimeSettingsJSON
+	if !decodeBody(w, r, h.maxBodyBytes, &req) {
+		return
+	}
+	if req.Enabled == nil {
+		http.Error(w, "at least one field is required", http.StatusBadRequest)
+		return
+	}
+	repo, err := h.PatchRepo(repoName, *req.Enabled)
+	if err != nil {
+		h.writeErr(w, err, "repo patch or cron reload")
+		return
+	}
+	writeJSON(w, http.StatusOK, repoToStoreJSON(repo))
+}
+
+func (h *Handler) handleRepoDelete(w http.ResponseWriter, r *http.Request) {
+	repoName := repoNameFromRequest(r)
+	if err := h.DeleteRepo(repoName); err != nil {
+		h.writeErr(w, err, "repo delete or cron reload")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (h *Handler) handleCreateBinding(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- split multi-method daemon routes into explicit one-method handlers
- remove method-switch dispatcher wrappers from fleet, repo, config, and budget routes
- add a router registration test covering expected daemon routes

## Tests
- go test ./internal/daemon -run TestBuildRouterRegistersExpectedRoutes
- go test ./internal/daemon ./internal/daemon/config ./internal/daemon/fleet ./internal/daemon/repos