### PR TITLE
Fix authenticated dashboard SSE streams

### DIFF
--- a/internal/ui/src/app/events/page.tsx
+++ b/internal/ui/src/app/events/page.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import Card from '@/components/Card'
 import RepoFilter, { useRepoFilter } from '@/components/RepoFilter'
+import { openAuthenticatedSSE } from '@/lib/sse'
 
 interface Event {
   at: string
@@ -139,18 +140,19 @@ export default function EventsPage() {
   useEffect(() => { load() }, [timeRange]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
-    const es = new EventSource('/events/stream')
-    setStreaming(true)
-    es.onmessage = (e) => {
-      try {
-        const ev: Event = JSON.parse(e.data)
-        setEvents(prev => [ev, ...prev.slice(0, 499)])
-        setNewIds(prev => { const s = new Set(prev); s.add(ev.id); return s })
-        setTimeout(() => setNewIds(prev => { const s = new Set(prev); s.delete(ev.id); return s }), 2000)
-      } catch { /* ignore */ }
-    }
-    es.onerror = () => setStreaming(false)
-    return () => es.close()
+    const stream = openAuthenticatedSSE('/events/stream', {
+      onOpen: () => setStreaming(true),
+      onMessage: data => {
+        try {
+          const ev: Event = JSON.parse(data)
+          setEvents(prev => [ev, ...prev.slice(0, 499)])
+          setNewIds(prev => { const s = new Set(prev); s.add(ev.id); return s })
+          setTimeout(() => setNewIds(prev => { const s = new Set(prev); s.delete(ev.id); return s }), 2000)
+        } catch { /* ignore */ }
+      },
+      onError: () => setStreaming(false),
+    })
+    return () => stream.close()
   }, [])
 
   const filtered = events.filter(e =>

--- a/internal/ui/src/app/memory/page.tsx
+++ b/internal/ui/src/app/memory/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useState, useEffect, useRef } from 'react'
 import Card from '@/components/Card'
+import { openAuthenticatedSSE } from '@/lib/sse'
 
 interface Agent {
   name: string
@@ -30,18 +31,19 @@ export default function MemoryPage() {
 
   // Watch memory stream for change notifications
   useEffect(() => {
-    const es = new EventSource('/memory/stream')
-    setStreaming(true)
-    es.onmessage = (e) => {
-      try {
-        const msg: { agent: string; repo: string } = JSON.parse(e.data)
-        if (selected && msg.agent === selected.agent && msg.repo === selected.repoKey) {
-          loadFile(selected.agent, selected.repoKey)
-        }
-      } catch { /* ignore */ }
-    }
-    es.onerror = () => setStreaming(false)
-    return () => es.close()
+    const stream = openAuthenticatedSSE('/memory/stream', {
+      onOpen: () => setStreaming(true),
+      onMessage: data => {
+        try {
+          const msg: { agent: string; repo: string } = JSON.parse(data)
+          if (selected && msg.agent === selected.agent && msg.repo === selected.repoKey) {
+            loadFile(selected.agent, selected.repoKey)
+          }
+        } catch { /* ignore */ }
+      },
+      onError: () => setStreaming(false),
+    })
+    return () => stream.close()
   }, [selected]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const loadFile = (agent: string, repoKey: string) => {

--- a/internal/ui/src/app/runners/page.tsx
+++ b/internal/ui/src/app/runners/page.tsx
@@ -7,6 +7,7 @@ import Modal from '@/components/Modal'
 import RepoFilter from '@/components/RepoFilter'
 import { StreamCard, TranscriptFilter, allStreamCardKinds, parseStreamLine, type StreamCardEntry, type StreamCardKind } from '@/components/StreamCard'
 import { fmtDuration } from '@/lib/format'
+import { openAuthenticatedSSE } from '@/lib/sse'
 
 interface RunnerRow {
   id: number
@@ -90,21 +91,15 @@ function LiveStreamModal({ span, onClose }: { span: { id: string; agent: string;
   const visibleEntries = entries.filter(e => visibleKinds.has(e.kind))
 
   useEffect(() => {
-    const es = new EventSource(`/traces/${encodeURIComponent(span.id)}/stream`)
-    es.onopen = () => setStatus('live')
-    es.onmessage = (e) => {
-      setEntries(prev => [...prev, parseStreamLine(e.data)])
-    }
-    es.addEventListener('end', () => {
-      setStatus('ended')
-      es.close()
+    const stream = openAuthenticatedSSE(`/traces/${encodeURIComponent(span.id)}/stream`, {
+      onOpen: () => setStatus('live'),
+      onMessage: data => setEntries(prev => [...prev, parseStreamLine(data)]),
+      onEvent: event => {
+        if (event === 'end') setStatus('ended')
+      },
+      onError: () => setStatus('error'),
     })
-    es.onerror = () => {
-      // EventSource auto-retries on transient failures; only surface the
-      // error state when the connection genuinely fails to establish.
-      if (es.readyState === EventSource.CLOSED) setStatus('error')
-    }
-    return () => es.close()
+    return () => stream.close()
   }, [span.id])
 
   useEffect(() => {

--- a/internal/ui/src/app/traces/page.tsx
+++ b/internal/ui/src/app/traces/page.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link'
 import RepoFilter, { useRepoFilter } from '@/components/RepoFilter'
 import { StreamCard, TranscriptFilter, allStreamCardKinds, stepToCardEntries, type PersistedStep, type StreamCardKind } from '@/components/StreamCard'
 import { fmtDuration } from '@/lib/format'
+import { openAuthenticatedSSE } from '@/lib/sse'
 
 type TraceStep = PersistedStep
 
@@ -388,16 +389,17 @@ function TracesContent() {
 
   useEffect(() => {
     load()
-    const es = new EventSource('/traces/stream')
-    setStreaming(true)
-    es.onmessage = (e) => {
-      try {
-        const sp: Span = JSON.parse(e.data)
-        setSpans(prev => [...prev.slice(-199), sp])
-      } catch { /* ignore */ }
-    }
-    es.onerror = () => setStreaming(false)
-    return () => es.close()
+    const stream = openAuthenticatedSSE('/traces/stream', {
+      onOpen: () => setStreaming(true),
+      onMessage: data => {
+        try {
+          const sp: Span = JSON.parse(data)
+          setSpans(prev => [...prev.slice(-199), sp])
+        } catch { /* ignore */ }
+      },
+      onError: () => setStreaming(false),
+    })
+    return () => stream.close()
   }, [])
 
   const handleSelect = (id: string) => {

--- a/internal/ui/src/lib/sse.test.ts
+++ b/internal/ui/src/lib/sse.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest'
+import { dispatchSSEBlockForTest } from './sse'
+
+describe('dispatchSSEBlockForTest', () => {
+  it('dispatches message data blocks', () => {
+    const onMessage = vi.fn()
+
+    dispatchSSEBlockForTest('data: {"ok":true}', { onMessage })
+
+    expect(onMessage).toHaveBeenCalledWith('{"ok":true}')
+  })
+
+  it('dispatches named events separately from normal messages', () => {
+    const onMessage = vi.fn()
+    const onEvent = vi.fn()
+
+    dispatchSSEBlockForTest('event: end\ndata: done', { onMessage, onEvent })
+
+    expect(onMessage).not.toHaveBeenCalled()
+    expect(onEvent).toHaveBeenCalledWith('end', 'done')
+  })
+
+  it('joins multiline data payloads', () => {
+    const onMessage = vi.fn()
+
+    dispatchSSEBlockForTest('data: first\ndata: second', { onMessage })
+
+    expect(onMessage).toHaveBeenCalledWith('first\nsecond')
+  })
+})

--- a/internal/ui/src/lib/sse.ts
+++ b/internal/ui/src/lib/sse.ts
@@ -1,0 +1,84 @@
+'use client'
+
+import { getStoredBearerToken } from '@/lib/auth'
+
+interface AuthenticatedSSEHandlers {
+  onOpen?: () => void
+  onMessage?: (data: string) => void
+  onEvent?: (event: string, data: string) => void
+  onError?: (error: Error) => void
+}
+
+interface AuthenticatedSSEConnection {
+  close: () => void
+}
+
+export function openAuthenticatedSSE(url: string, handlers: AuthenticatedSSEHandlers): AuthenticatedSSEConnection {
+  const controller = new AbortController()
+  const headers = new Headers({ Accept: 'text/event-stream' })
+  const token = getStoredBearerToken()
+  if (token) headers.set('Authorization', `Bearer ${token}`)
+
+  void readSSE(url, headers, controller.signal, handlers)
+  return { close: () => controller.abort() }
+}
+
+async function readSSE(
+  url: string,
+  headers: Headers,
+  signal: AbortSignal,
+  handlers: AuthenticatedSSEHandlers,
+) {
+  try {
+    const res = await fetch(url, { headers, cache: 'no-store', signal })
+    if (!res.ok) throw new Error(`SSE ${url} returned HTTP ${res.status}`)
+    if (!res.body) throw new Error(`SSE ${url} did not provide a response body`)
+
+    handlers.onOpen?.()
+
+    const reader = res.body.getReader()
+    const decoder = new TextDecoder()
+    let buffer = ''
+
+    while (true) {
+      const { value, done } = await reader.read()
+      if (done) break
+      buffer += decoder.decode(value, { stream: true })
+      const parts = buffer.split(/\r?\n\r?\n/)
+      buffer = parts.pop() ?? ''
+      for (const part of parts) dispatchSSEBlock(part, handlers)
+    }
+    if (buffer.trim() !== '') dispatchSSEBlock(buffer, handlers)
+  } catch (error) {
+    if (signal.aborted) return
+    handlers.onError?.(error instanceof Error ? error : new Error(String(error)))
+  }
+}
+
+export function dispatchSSEBlockForTest(block: string, handlers: AuthenticatedSSEHandlers) {
+  dispatchSSEBlock(block, handlers)
+}
+
+function dispatchSSEBlock(block: string, handlers: AuthenticatedSSEHandlers) {
+  let event = 'message'
+  const data: string[] = []
+
+  for (const line of block.split(/\r?\n/)) {
+    if (line === '' || line.startsWith(':')) continue
+    if (line.startsWith('event:')) {
+      event = line.slice('event:'.length).trim()
+      continue
+    }
+    if (line.startsWith('data:')) {
+      const value = line.slice('data:'.length)
+      data.push(value.startsWith(' ') ? value.slice(1) : value)
+    }
+  }
+
+  const payload = data.join('\n')
+  if (event === 'message') {
+    if (payload !== '') handlers.onMessage?.(payload)
+    return
+  }
+  handlers.onEvent?.(event, payload)
+}


### PR DESCRIPTION
## Summary\n- replace native EventSource with a fetch-based authenticated SSE helper\n- keep bearer token in the Authorization header, never query params\n- update all dashboard SSE consumers:\n  - /events/stream\n  - /traces/stream\n  - /traces/{span_id}/stream\n  - /memory/stream\n- add parser coverage for normal messages, named events, and multiline data\n\n## Why\nNative EventSource cannot send Authorization headers, so protected SSE endpoints returned 401 after bearer auth landed.\n\n## Tests\n- cd internal/ui && npm test\n- cd internal/ui && npm run build\n