### PR TITLE
Prepare v0.2.0 release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -45,7 +45,7 @@ body:
     attributes:
       label: Daemon version or commit SHA
       description: Output of `agents --version` if a release, or the commit you built from.
-      placeholder: "v0.1.0 / 32b6a59"
+      placeholder: "v0.2.0 / <commit-sha>"
     validations:
       required: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-05-05
+
+### Added
+
+- Minimal bearer-token auth for sensitive daemon surfaces. Set
+  `AGENTS_AUTH_BEARER_TOKEN_HASH` to protect REST write/read APIs, MCP tools,
+  runners, traces, prompts, and live streams while keeping `/status`,
+  `/webhooks/github`, `/v1/*`, and the UI shell reachable.
+- Dashboard token prompt and local token management so browser users can
+  authenticate against protected API and SSE endpoints without query-string
+  secrets.
+- Codex-compatible MCP access with bearer auth, enabling both Claude Code and
+  Codex users to manage the fleet through the same `/mcp` endpoint.
+- Token budgets and leaderboard across REST, MCP, and the dashboard:
+  global/backend/agent caps, daily/weekly/monthly UTC windows, alert
+  thresholds, per-scope CRUD, and per-agent average total tokens per run.
+- Built-in `discretion` and `memory-scope` guardrails. `discretion` reduces
+  noisy public GitHub actions, while `memory-scope` instructs agents to ignore
+  CLI-native, global, or session memory and use only the daemon-rendered memory
+  for the current `(agent, repo)` pair.
+- Daemon runtime environment overrides for log, HTTP, processor, dispatch, and
+  proxy settings, documented in `.env.sample` and `docs/configuration.md`.
+
+### Changed
+
+- Daemon runtime configuration is no longer part of the persisted fleet
+  config, `/config`, `/export`, `/import`, REST CRUD, or MCP config surfaces.
+  Fleet strategy remains database-backed and import/exportable; process
+  settings are startup-only environment variables.
+- Authenticated live streams now use fetch-based SSE clients so runners,
+  traces, events, and memory streams can send `Authorization: Bearer ...`
+  headers instead of leaking tokens through URL query parameters.
+- Token budget scope selection in the dashboard uses backend/agent dropdowns
+  instead of requiring operators to type stored names manually.
+- Trace cards in the dashboard are easier to open, and the transcript filter
+  remains sticky inside scroll containers.
+- `/runners` adds a per-repo filter, improving queue and trace triage on
+  multi-repo fleets.
+- Daemon route registration was refactored to register handlers per HTTP
+  method instead of dispatching inside handler bodies.
+- UI documentation screenshots and auth guidance were refreshed for the
+  current dashboard.
+
+### Fixed
+
+- Propagated `GITHUB_TOKEN` into AI subprocesses so GitHub MCP tooling keeps
+  working after the environment variable rename from `GITHUB_PAT_TOKEN`.
+- Normalized daemon SSE event handling to keep live transcript/ring-buffer
+  rendering consistent across Claude and Codex backend output parsers.
+- Corrected token leaderboard average wording so average total tokens per run
+  is not confused with the separate input/output/cache columns.
+
 ## [0.1.0] - 2026-05-03
 
 First public release. The daemon is a self-hosted orchestrator that dispatches
@@ -141,5 +193,6 @@ calls, or runtime inter-agent dispatch. Everything below ships in this release.
   are expected as issues, with the autonomous fleet implementing
   `ai ready`-labelled work. See [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
-[Unreleased]: https://github.com/eloylp/agents/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/eloylp/agents/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/eloylp/agents/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/eloylp/agents/releases/tag/v0.1.0

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,7 +7,7 @@ The daemon dispatches AI CLIs (`claude`, `codex`) with sandbox-bypass flags so a
 ## Bring up the daemon
 
 ```bash
-git clone --branch v0.1.0 https://github.com/eloylp/agents
+git clone --branch v0.2.0 https://github.com/eloylp/agents
 cd agents
 # .env holds runtime secrets (loaded automatically by compose).
 # Webhook secret: random per install. PAT: from https://github.com/settings/tokens with repo scope.
@@ -57,9 +57,9 @@ docker compose logs -f agents
 # Graceful restart (in-flight runs are allowed to finish).
 docker compose restart agents
 
-# Upgrade to a newer tagged release. Pick the latest from
-# https://github.com/eloylp/agents/releases and substitute below.
-git fetch origin --tags && git checkout v0.1.0 && docker compose build && docker compose up -d
+# Upgrade to a newer tagged release. Pick the latest tag from
+# https://github.com/eloylp/agents/tags and substitute below.
+git fetch origin --tags && git checkout v0.2.0 && docker compose build && docker compose up -d
 # Or track main directly (latest fixes, less stable than tagged releases):
 # git checkout main && git pull && docker compose build && docker compose up -d
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -45,7 +45,7 @@ import (
 // Version is advertised to MCP clients during the initialize handshake.
 // It tracks the wire contract (tool names, shapes), bump it whenever a
 // tool's input or output schema changes in a non-backwards-compatible way.
-const Version = "0.1.0"
+const Version = "0.2.0"
 
 // Deps bundles the dependencies the MCP tools call into. internal/daemon
 // constructs each component once and hands the same references to the

--- a/internal/ui/package-lock.json
+++ b/internal/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agents-ui",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agents-ui",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@types/dagre": "^0.7.54",
         "@uiw/react-md-editor": "^4.1.0",

--- a/internal/ui/package.json
+++ b/internal/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-ui",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- add v0.2.0 changelog notes based on the v0.1.0..HEAD diff
- update quickstart commands to use v0.2.0 tags
- bump MCP/UI version references to 0.2.0

## Tests
- git diff --check
- npm test
- npm run build
- GOCACHE=/tmp/go-build-agents go test ./... -race