### PR TITLE
Fix v0.2.0 quickstart build command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   method instead of dispatching inside handler bodies.
 - UI documentation screenshots and auth guidance were refreshed for the
   current dashboard.
+- Quickstart install and upgrade commands now force a local image rebuild so
+  the checked-out release tag is what actually runs.
 
 ### Fixed
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
       - HOME=/home/agents
       - GITHUB_TOKEN=${GITHUB_TOKEN}
     volumes:
-      # SQLite database (daemon config + fleet + agent memory).
+      # SQLite database (fleet config + agent memory + observability).
       - agents-data:/var/lib/agents
       # Claude Code / Codex auth + MCP config. Populate once via
       # `docker compose run --rm --entrypoint claude agents login`

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,7 +15,7 @@ cp .env.sample .env
 sed -i.bak "s/^GITHUB_WEBHOOK_SECRET=.*/GITHUB_WEBHOOK_SECRET=$(openssl rand -hex 32)/" .env && rm .env.bak
 # Edit GITHUB_TOKEN in .env before continuing.
 # Optional before exposing the daemon: set AGENTS_AUTH_BEARER_TOKEN_HASH.
-docker compose up -d
+docker compose up -d --build
 ```
 
 The shipped [`docker-compose.yaml`](../docker-compose.yaml) is the source of truth for what gets mounted and exposed. Two named volumes back the runtime: `agents-data` (SQLite store) and `agents-home` (Claude / Codex auth + MCP config). The daemon boots against an empty database with built-in defaults, no YAML seed is required.
@@ -59,9 +59,9 @@ docker compose restart agents
 
 # Upgrade to a newer tagged release. Pick the latest tag from
 # https://github.com/eloylp/agents/tags and substitute below.
-git fetch origin --tags && git checkout v0.2.0 && docker compose build && docker compose up -d
+git fetch origin --tags && git checkout v0.2.0 && docker compose up -d --build
 # Or track main directly (latest fixes, less stable than tagged releases):
-# git checkout main && git pull && docker compose build && docker compose up -d
+# git checkout main && git pull && docker compose up -d --build
 
 # Re-run backend discovery (after rotating auth or adding a CLI).
 curl -X POST http://localhost:8080/backends/discover


### PR DESCRIPTION
## Summary
- use `docker compose up -d --build` in quickstart install and upgrade commands
- document the fix in the v0.2.0 changelog
- update the compose volume comment now that daemon config is env-only

## Tests
- git diff --check

Found while validating the v0.2.0 quickstart on ts-vortex: plain `docker compose up -d` reused an older local `agents-agents:latest` image instead of rebuilding the checked-out tag.
