### PR TITLE
refactor(fleet): use Cut for repo name parsing

### DIFF
--- a/internal/fleet/repo.go
+++ b/internal/fleet/repo.go
@@ -28,8 +28,8 @@ func ValidateRepoName(name string) error {
 	if strings.ContainsAny(trimmed, " \t\r\n") {
 		return fmt.Errorf("repo name %q contains whitespace; expected owner/repo", trimmed)
 	}
-	parts := strings.Split(trimmed, "/")
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+	owner, repo, ok := strings.Cut(trimmed, "/")
+	if !ok || owner == "" || repo == "" || strings.Contains(repo, "/") {
 		return fmt.Errorf("repo name %q must be in owner/repo form", trimmed)
 	}
 	return nil


### PR DESCRIPTION
## Summary

- Use `strings.Cut` when splitting repo names into owner and repo parts.
- Preserve the existing validation behavior for empty names, whitespace, missing parts, and extra slashes.

## Testing

- Not run locally because this run is constrained to GitHub MCP repository access and no local checkout path is available for executing `go test -race ./internal/fleet`.
