### PR TITLE
refactor(daemontest): inline backend picker

### DIFF
--- a/internal/daemon/daemontest/daemontest.go
+++ b/internal/daemon/daemontest/daemontest.go
@@ -92,9 +92,9 @@ func MinimalCfg(mutator func(*config.Config)) *config.Config {
 				EventQueueBuffer:    16,
 				MaxConcurrentAgents: 1,
 				Dispatch: config.DispatchConfig{
-					MaxDepth:           2,
-					MaxFanout:          2,
-					DedupWindowSeconds: 60,
+					MaxDepth:            2,
+					MaxFanout:           2,
+					DedupWindowSeconds:  60,
 				},
 			},
 			AIBackends: map[string]fleet.Backend{

--- a/internal/daemon/daemontest/daemontest.go
+++ b/internal/daemon/daemontest/daemontest.go
@@ -48,7 +48,12 @@ func New(t *testing.T, cfg *config.Config) *daemon.Daemon {
 		cfg.Daemon.AIBackends = backends
 	}
 	if len(agents) == 0 {
-		agents = []fleet.Agent{{Name: "coder", Backend: pickAnyBackend(backends), Prompt: "code", Description: "Writes code"}}
+		backend := "claude"
+		for name := range backends {
+			backend = name
+			break
+		}
+		agents = []fleet.Agent{{Name: "coder", Backend: backend, Prompt: "code", Description: "Writes code"}}
 		cfg.Agents = agents
 	}
 	for i := range agents {
@@ -66,13 +71,6 @@ func New(t *testing.T, cfg *config.Config) *daemon.Daemon {
 		t.Fatalf("daemon.New: %v", err)
 	}
 	return d
-}
-
-func pickAnyBackend(backends map[string]fleet.Backend) string {
-	for name := range backends {
-		return name
-	}
-	return "claude"
 }
 
 // MinimalCfg returns a *config.Config with the daemon-level fields the


### PR DESCRIPTION
## Summary

- Inline the one-call `pickAnyBackend` helper into `daemontest.New`.
- Keep the existing fallback to `claude` when no backend name is found.

## Testing

- `npm ci --offline` (internal/ui)
- `npm run build` (internal/ui)
- `go test ./... -race`