### PR TITLE
refactor(observe): use Cut for memory path parsing

### DIFF
--- a/internal/observe/watch.go
+++ b/internal/observe/watch.go
@@ -89,10 +89,10 @@ func WatchMemoryDir(ctx context.Context, dir string, interval time.Duration, hub
 // such as "agentname/owner_repo.md".
 func buildMemoryChangeEvent(rel string) MemoryChangeEvent {
 	ev := MemoryChangeEvent{Path: rel}
-	parts := strings.SplitN(rel, string(filepath.Separator), 2)
-	if len(parts) == 2 {
-		ev.Agent = parts[0]
-		ev.Repo = strings.TrimSuffix(parts[1], ".md")
+	agent, repoPath, ok := strings.Cut(rel, string(filepath.Separator))
+	if ok {
+		ev.Agent = agent
+		ev.Repo = strings.TrimSuffix(repoPath, ".md")
 	}
 	return ev
 }


### PR DESCRIPTION
## Summary

- Replace the two-part `strings.SplitN` memory path parsing with `strings.Cut`.
- Preserve the existing behavior for paths without a separator and `.md` repo suffix trimming.

## Testing

- `go test ./... -race`