### PR TITLE
refactor(workflow): remove split autonomous dispatch helpers

### DIFF
--- a/internal/workflow/dispatch.go
+++ b/internal/workflow/dispatch.go
@@ -72,7 +72,7 @@ func (c *dispatchCounters) snapshot() DispatchStats {
 // dispatchEntry records a dedup slot in the store.
 // committed indicates whether the slot is backed by a real enqueued event.
 // Pending (committed==false) entries block concurrent duplicate TryClaim calls
-// but are invisible to DispatchAlreadyClaimed until committed.
+// until the enqueue attempt either commits or abandons the claim.
 type dispatchEntry struct {
 	expiresAt time.Time
 	committed bool
@@ -178,8 +178,7 @@ func (s *DispatchDedupStore) SeesPendingOrCommitted(target, repo string, number 
 // proceeding past the dedup gate.
 //
 // A successful TryClaim creates a pending entry that blocks future TryClaim
-// calls but is invisible to DispatchAlreadyClaimed until CommitClaim is
-// called. On enqueue failure call AbandonClaim to release the pending slot.
+// calls until CommitClaim or AbandonClaim resolves the enqueue attempt.
 func (s *DispatchDedupStore) TryClaim(target, repo string, number int, now time.Time) bool {
 	key := dispatchStoreKey(target, repo, number)
 	s.mu.Lock()
@@ -191,8 +190,8 @@ func (s *DispatchDedupStore) TryClaim(target, repo string, number int, now time.
 	return true
 }
 
-// CommitClaim upgrades a pending claim to committed, making it visible to
-// DispatchAlreadyClaimed. Must be called after a successful PushEvent.
+// CommitClaim upgrades a pending claim to committed. Must be called after a
+// successful PushEvent.
 func (s *DispatchDedupStore) CommitClaim(target, repo string, number int) {
 	key := dispatchStoreKey(target, repo, number)
 	s.mu.Lock()
@@ -335,8 +334,7 @@ func (s *DispatchDedupStore) SeenCronRun(agent, repo string, number int, now tim
 // Returns false if a dispatch claim, pending or committed, exists within
 // the TTL window (caller should skip the run; dispatch-first ordering).
 //
-// Unlike the split DispatchAlreadyClaimed → MarkAutonomousRun sequence, this
-// single-lock operation eliminates the TOCTOU window where the cron path
+// This single-lock operation eliminates the TOCTOU window where the cron path
 // could observe no dispatch claim and the dispatch path could observe no cron
 // mark before either had written, allowing both to proceed concurrently.
 //
@@ -564,15 +562,15 @@ func (d *Dispatcher) ProcessDispatches(
 
 		if _, err := d.queue.PushEvent(ctx, dispatchEv); err != nil {
 			// Release the pending claim so future retries are not blocked and
-			// DispatchAlreadyClaimed never sees a phantom committed slot.
+			// the dedup store never keeps a phantom committed slot.
 			d.dedup.AbandonClaim(req.Agent, ev.Repo.FullName, number)
 			logBase.Error().Err(err).Msg("failed to enqueue dispatch event")
 			errs = append(errs, fmt.Errorf("dispatch %q: %w", req.Agent, err))
 			continue
 		}
 
-		// Enqueue succeeded, commit the claim so DispatchAlreadyClaimed returns
-		// true and the autonomous scheduler skips a duplicate run for this target.
+		// Enqueue succeeded, commit the claim so the dedup window suppresses
+		// duplicate dispatches for this target.
 		d.dedup.CommitClaim(req.Agent, ev.Repo.FullName, number)
 
 		// Record the dispatch edge in the interaction graph if an observer is set.
@@ -587,41 +585,14 @@ func (d *Dispatcher) ProcessDispatches(
 	return errors.Join(errs...)
 }
 
-// DispatchAlreadyClaimed returns true if a dispatch has claimed (pending or
-// committed) the (agentName, repo, 0) slot in the dispatch dedup namespace
-// within the current dedup window (dispatch-first ordering). Checking pending
-// claims too ensures that a dispatch which has successfully TryClaim'd but has
-// not yet called CommitClaim (PushEvent still in flight) still blocks a
-// concurrent cron/manual run from starting.
-//
-// This is a read-only check; it does not write to the store. Call
-// MarkAutonomousRun separately, only once the run is confirmed to proceed.
-func (d *Dispatcher) DispatchAlreadyClaimed(agentName, repo string, now time.Time) bool {
-	return d.dedup.SeesPendingOrCommitted(agentName, repo, 0, now)
-}
-
-// MarkAutonomousRun writes a cron-namespace activity mark for (agentName,
-// repo, 0) that persists for the full dedup_window_seconds. It must be
-// called before the run starts (after backend and runner resolution succeed)
-// so that dispatches arriving during the in-flight run are suppressed. If the
-// run fails, call RollbackAutonomousRun to remove the mark so that future
-// dispatches are not spuriously suppressed for the full dedup window.
-//
-// The cron mark lives in a different key namespace from dispatch entries,
-// so repeated cron runs are never blocked by this mark, only dispatches
-// that share the same item context (number=0, the autonomous context) are.
-func (d *Dispatcher) MarkAutonomousRun(agentName, repo string, now time.Time) {
-	d.dedup.MarkCronRun(agentName, repo, 0, now)
-}
-
 // TryMarkAutonomousRun atomically checks whether a dispatch has already
 // claimed the (agentName, repo, 0) slot and, if not, writes a cron-namespace
 // mark. Returns true if the mark was written and the caller may proceed with
 // the run. Returns false if a dispatch claim exists (caller should return
 // ErrDispatchSkipped).
 //
-// This replaces the split DispatchAlreadyClaimed → MarkAutonomousRun sequence
-// with a single-lock operation, closing the TOCTOU race between the two paths.
+// This single-lock operation closes the TOCTOU race between the dispatch and
+// autonomous-run paths.
 //
 // If the run fails before completing, call RollbackAutonomousRun to remove the
 // mark so that future dispatches are not spuriously suppressed.
@@ -630,9 +601,9 @@ func (d *Dispatcher) TryMarkAutonomousRun(agentName, repo string, now time.Time)
 }
 
 // RollbackAutonomousRun removes the cron-namespace mark written by
-// MarkAutonomousRun or TryMarkAutonomousRun. It must be called when a run
-// fails so that the stale mark does not suppress autonomous-context dispatches
-// for the full dedup_window_seconds.
+// TryMarkAutonomousRun. It must be called when a run fails so that the stale
+// mark does not suppress autonomous-context dispatches for the full
+// dedup_window_seconds.
 func (d *Dispatcher) RollbackAutonomousRun(agentName, repo string) {
 	d.dedup.RemoveCronMark(agentName, repo, 0)
 }

--- a/internal/workflow/dispatch_test.go
+++ b/internal/workflow/dispatch_test.go
@@ -611,10 +611,10 @@ func TestDispatcherRetrySucceedsAfterEnqueueFailure(t *testing.T) {
 
 // TestDispatchClaimOnlyVisibleAfterSuccessfulEnqueue is a regression test for
 // the lost-work race: if ProcessDispatches fails to enqueue a dispatch event,
-// DispatchAlreadyClaimed must return false so the autonomous scheduler can
-// still run the target. Previously, SeenOrAdd was called before PushEvent and
-// a failed enqueue followed by a dedup rollback still left a brief window where
-// DispatchAlreadyClaimed could return true, causing both paths to skip.
+// TryMarkAutonomousRun must still return true so the autonomous scheduler can
+// run the target. Previously, SeenOrAdd was called before PushEvent and a failed
+// enqueue followed by a dedup rollback still left a brief window where both
+// paths could skip.
 func TestDispatchClaimOnlyVisibleAfterSuccessfulEnqueue(t *testing.T) {
 	t.Parallel()
 	q := &fakeQueue{err: errors.New("queue full")}
@@ -623,29 +623,28 @@ func TestDispatchClaimOnlyVisibleAfterSuccessfulEnqueue(t *testing.T) {
 	reqs := []ai.DispatchRequest{{Agent: "pr-reviewer", Number: 0, Reason: "check"}}
 	d.ProcessDispatches(context.Background(), originatorAgent("coder"), testEvent("owner/repo", 0), "root-1", 0, "", reqs)
 
-	// The enqueue failed, so the dispatch slot must NOT be claimed.
-	if d.DispatchAlreadyClaimed("pr-reviewer", "owner/repo", time.Now()) {
-		t.Error("DispatchAlreadyClaimed returned true after a failed enqueue: phantom claim left by failed dispatch")
+	// The enqueue failed, so the dispatch slot must NOT be claimed and an
+	// autonomous run for the same slot can still proceed.
+	if !d.TryMarkAutonomousRun("pr-reviewer", "owner/repo", time.Now()) {
+		t.Error("TryMarkAutonomousRun returned false after a failed enqueue: phantom claim left by failed dispatch")
 	}
 }
 
-// TestMarkAutonomousRunSuppressesNearSimultaneousDispatch is a regression
+// TestTryMarkAutonomousRunSuppressesNearSimultaneousDispatch is a regression
 // test for the cron-first dedup ordering: when an autonomous run starts and
-// MarkAutonomousRun writes a cron-namespace mark, dispatches targeting the
+// TryMarkAutonomousRun writes a cron-namespace mark, dispatches targeting the
 // same agent/repo with number=0 (autonomous context) must be suppressed for
 // the full dedup_window_seconds, both while the run is in-flight and after
 // it completes.
-func TestMarkAutonomousRunSuppressesNearSimultaneousDispatch(t *testing.T) {
+func TestTryMarkAutonomousRunSuppressesNearSimultaneousDispatch(t *testing.T) {
 	t.Parallel()
 	q := &fakeQueue{}
 	d := testDispatcher(t, q)
 
 	// Simulate: cron run confirms it will proceed and writes the cron-namespace mark.
-	alreadyClaimed := d.DispatchAlreadyClaimed("coder", "owner/repo", time.Now())
-	if alreadyClaimed {
-		t.Fatal("DispatchAlreadyClaimed: expected false on first call (no prior dispatch)")
+	if !d.TryMarkAutonomousRun("coder", "owner/repo", time.Now()) {
+		t.Fatal("TryMarkAutonomousRun: expected true on first call (no prior dispatch)")
 	}
-	d.MarkAutonomousRun("coder", "owner/repo", time.Now())
 
 	// Dispatches targeting the same agent/repo with number=0 must be suppressed
 	// for the full dedup window (coder dispatching to itself is not allowed, so use
@@ -668,18 +667,20 @@ func TestMarkAutonomousRunSuppressesNearSimultaneousDispatch(t *testing.T) {
 	}
 }
 
-// TestMarkAutonomousRunDoesNotSuppressDispatchForDifferentNumber verifies that
+// TestTryMarkAutonomousRunDoesNotSuppressDispatchForDifferentNumber verifies that
 // a cron mark (number=0, autonomous context) does not suppress dispatches
 // targeting a different item number on the same repo. This guards against the
 // cron mark being too broad and blocking valid event-driven dispatches such as
 // "coder → pr-reviewer for PR #42" just because pr-reviewer had a cron run.
-func TestMarkAutonomousRunDoesNotSuppressDispatchForDifferentNumber(t *testing.T) {
+func TestTryMarkAutonomousRunDoesNotSuppressDispatchForDifferentNumber(t *testing.T) {
 	t.Parallel()
 	q := &fakeQueue{}
 	d := testDispatcher(t, q)
 
 	// Cron run for pr-reviewer marks (pr-reviewer, owner/repo, 0).
-	d.MarkAutonomousRun("coder", "owner/repo", time.Now())
+	if !d.TryMarkAutonomousRun("coder", "owner/repo", time.Now()) {
+		t.Fatal("TryMarkAutonomousRun: expected cron mark to be written")
+	}
 
 	// A dispatch targeting coder for PR #42 (number=42) must still be enqueued
 	//, it is a different item context from the autonomous cron run (number=0).
@@ -712,10 +713,9 @@ func TestPostRunDispatchSuppressedWithinDedupWindow(t *testing.T) {
 
 	// Autonomous run confirms it will proceed and writes the cron mark.
 	now := time.Now()
-	if d.DispatchAlreadyClaimed("coder", "owner/repo", now) {
-		t.Fatal("DispatchAlreadyClaimed: expected false on first call (no prior dispatch)")
+	if !d.TryMarkAutonomousRun("coder", "owner/repo", now) {
+		t.Fatal("TryMarkAutonomousRun: expected true on first call (no prior dispatch)")
 	}
-	d.MarkAutonomousRun("coder", "owner/repo", now)
 
 	// Dispatch arriving after the run, still within the TTL window, must be suppressed.
 	originator := agents["pr-reviewer"]
@@ -800,8 +800,12 @@ func TestRemoveCronMarkWithOverlappingRunsRefcount(t *testing.T) {
 
 	now := time.Now()
 	// Simulate two overlapping autonomous runs for the same (agent, repo).
-	d.MarkAutonomousRun("coder", "owner/repo", now)
-	d.MarkAutonomousRun("coder", "owner/repo", now)
+	if !d.TryMarkAutonomousRun("coder", "owner/repo", now) {
+		t.Fatal("first TryMarkAutonomousRun: expected cron mark to be written")
+	}
+	if !d.TryMarkAutonomousRun("coder", "owner/repo", now) {
+		t.Fatal("second TryMarkAutonomousRun: expected cron mark to be written")
+	}
 
 	// First run fails: rolls back. The second run is still in flight, so
 	// dispatches must still be suppressed.
@@ -851,7 +855,9 @@ func TestLongRunningCronMarkBlocksDispatchPastTTL(t *testing.T) {
 
 	// Autonomous run starts; writes cron mark.
 	start := time.Now()
-	d.MarkAutonomousRun("coder", "owner/repo", start)
+	if !d.TryMarkAutonomousRun("coder", "owner/repo", start) {
+		t.Fatal("TryMarkAutonomousRun: expected cron mark to be written")
+	}
 
 	// Simulate the sweeper running after the TTL has elapsed but before the
 	// run completes. The cron mark's refcount is still 1, so it must NOT be


### PR DESCRIPTION
## Summary

- Remove the superseded `Dispatcher.DispatchAlreadyClaimed` and `Dispatcher.MarkAutonomousRun` methods.
- Keep autonomous dispatch dedup callers on the atomic `TryMarkAutonomousRun` API.
- Update workflow dispatch tests and comments to exercise the atomic path directly.

Closes #427

## Testing

- `cd internal/ui && npm ci --offline && npm run build`
- `go vet ./...`
- `go test ./... -race -count=1`