### PR TITLE
refactor(daemon): use Cut for memory reader test keys

### DIFF
--- a/internal/daemon/observe/observe_test.go
+++ b/internal/daemon/observe/observe_test.go
@@ -164,12 +164,7 @@ func seedMemoryReader(t *testing.T, db *sql.DB, content map[string]string, mtime
 	seenAgent := map[string]bool{}
 	seenRepo := map[string]bool{}
 	for key, body := range content {
-		parts := strings.SplitN(key, "\x00", 2)
-		agent := parts[0]
-		repo := ""
-		if len(parts) == 2 {
-			repo = parts[1]
-		}
+		agent, repo, _ := strings.Cut(key, "\x00")
 		agent = ai.NormalizeToken(agent)
 		repo = ai.NormalizeToken(repo)
 		if !seenAgent[agent] {


### PR DESCRIPTION
## Summary

- Replace manual `SplitN` handling for memory reader test keys with `strings.Cut`.
- Preserve the existing no-separator behavior where the repo portion defaults to empty.

## Testing

- `cd internal/ui && npm ci --offline && npm run build`
- `go test ./... -race`