### PR TITLE
refactor(mcp): cut SSE data prefix once

### DIFF
--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -108,8 +108,8 @@ func extractJSONRPC(t *testing.T, rec *httptest.ResponseRecorder) []byte {
 	if bytes.HasPrefix(body, []byte("data:")) {
 		// Minimal SSE extraction: find the first "data:" line payload.
 		for _, line := range bytes.Split(body, []byte("\n")) {
-			if bytes.HasPrefix(line, []byte("data:")) {
-				return bytes.TrimSpace(bytes.TrimPrefix(line, []byte("data:")))
+			if payload, ok := bytes.CutPrefix(line, []byte("data:")); ok {
+				return bytes.TrimSpace(payload)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- Use `bytes.CutPrefix` when extracting SSE `data:` payloads in the MCP server test helper.
- Avoid checking and trimming the same prefix separately while preserving the existing fallback behavior.

## Testing

- `go test ./... -race`