### PR TITLE
refactor(backends): stream first line scan

### DIFF
--- a/internal/backends/discovery.go
+++ b/internal/backends/discovery.go
@@ -561,7 +561,7 @@ func resolveCommand(defaultName, preferred string) (string, bool) {
 
 func firstNonEmptyLine(values ...string) string {
 	for _, v := range values {
-		for _, line := range strings.Split(strings.TrimSpace(v), "\n") {
+		for line := range strings.SplitSeq(strings.TrimSpace(v), "\n") {
 			line = strings.TrimSpace(line)
 			if line != "" {
 				return line


### PR DESCRIPTION
## Summary

- Use `strings.SplitSeq` when scanning command output for the first non-empty line.
- Avoid allocating a temporary line slice in backend discovery diagnostics.

## Testing

- `go test ./... -race`

Note: a fresh checkout is missing the ignored `internal/ui/dist` directory required by the embed pattern, so I created a local-only placeholder before running the full suite. The placeholder is not committed.