### PR TITLE
refactor(ai): iterate codex jsonl with bytes lines

### DIFF
--- a/internal/ai/cmdrunner.go
+++ b/internal/ai/cmdrunner.go
@@ -579,7 +579,7 @@ func extractCodexAgentMessageJSON(all []byte) ([]byte, bool) {
 	}
 	var lastText string
 	var found bool
-	for _, line := range bytes.Split(all, []byte("\n")) {
+	for line := range bytes.Lines(all) {
 		line = bytes.TrimSpace(line)
 		if len(line) == 0 || line[0] != '{' {
 			continue


### PR DESCRIPTION
## Summary

- Use `bytes.Lines` when walking Codex JSONL output for the last agent message.
- Avoid allocating the temporary slice produced by `bytes.Split`.

## Testing

- `go test ./... -race`

Note: a fresh checkout is missing the ignored `internal/ui/dist` directory required by the embed pattern, so I created a local-only placeholder before running the full suite. The placeholder is not committed.