### PR TITLE
refactor(fleet): compare orphan test slices directly

### DIFF
--- a/internal/daemon/fleet/orphans_test.go
+++ b/internal/daemon/fleet/orphans_test.go
@@ -1,7 +1,7 @@
 package fleet
 
 import (
-	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/eloylp/agents/internal/config"
@@ -26,7 +26,7 @@ func TestCanonicalModels(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got := canonicalModels(tc.input)
-			if !reflect.DeepEqual(got, tc.want) {
+			if !slices.Equal(got, tc.want) || (got == nil) != (tc.want == nil) {
 				t.Fatalf("canonicalModels(%v) = %#v, want %#v", tc.input, got, tc.want)
 			}
 		})
@@ -132,7 +132,7 @@ func TestComputeOrphanedAgentsIncludesDisabledRefs(t *testing.T) {
 		t.Fatalf("len(orphans) = %d, want 1", len(orphans))
 	}
 	wantRepos := []string{"owner/active", "owner/halfway", "owner/paused"}
-	if !reflect.DeepEqual(orphans[0].Repos, wantRepos) {
+	if !slices.Equal(orphans[0].Repos, wantRepos) {
 		t.Fatalf("repos = %v, want %v (all references including disabled)", orphans[0].Repos, wantRepos)
 	}
 }


### PR DESCRIPTION
## Summary

- Replace `reflect.DeepEqual` with `slices.Equal` for orphan fleet test slice assertions.
- Preserve the canonical model test's existing nil-vs-empty distinction while using the slice-specific helper.

## Testing

- `go test ./... -race`

Note: a fresh checkout is missing the ignored `internal/ui/dist` directory required by the embed pattern, so I created a local-only placeholder before running the full suite. The placeholder is not committed.