### PR TITLE
Add multi-user auth and GHCR image publishing

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -9,11 +9,6 @@ GITHUB_TOKEN=
 # Optional daemon runtime overrides. These values match the current built-in
 # defaults. Empty values are ignored, so YAML/SQLite startup config values can
 # still remain authoritative when you do not want an env override.
-#
-# Optional legacy bearer-token auth for bootstrap/compatibility. Prefer the
-# dashboard first-user flow and DB-backed API tokens after setup. Generate with:
-#   printf '%s' 'your-token' | shasum -a 256 | awk '{print $1}'
-AGENTS_AUTH_BEARER_TOKEN_HASH=
 
 AGENTS_LOG_LEVEL=info
 AGENTS_LOG_FORMAT=text

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,52 @@
+name: Docker
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*.*.*"]
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,prefix=dev-,format=short,enable=${{ github.ref == 'refs/heads/main' }}
+            type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{raw}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Key numbers:
 
 ```bash
 go test ./... -race    # run all tests
-docker compose build   # build the image (multi-stage Dockerfile handles go build)
+docker compose pull    # pull the published image
 docker compose up -d   # run the daemon
 ```
 
@@ -122,7 +122,8 @@ When making common classes of changes, update all of these at once:
 
 ## Operational notes
 
-- **`.env` is auto-loaded on startup** (`godotenv.Load()`). Required runtime secret: `GITHUB_WEBHOOK_SECRET`. Optional `AGENTS_AUTH_BEARER_TOKEN_HASH` provides legacy bootstrap/compatibility bearer auth; the normal daemon auth model is DB-backed users, browser sessions, and named API tokens. Daemon runtime settings can be overridden at startup with `AGENTS_*` env vars for log, HTTP, processor, and dispatch fields; see `docs/configuration.md` for the full mapping. Empty env vars are ignored, and changes still require a process/container restart.
+- **`.env` is auto-loaded on startup** (`godotenv.Load()`). Required runtime secret: `GITHUB_WEBHOOK_SECRET`. Daemon auth is DB-backed users, browser sessions, and named API tokens. Daemon runtime settings can be overridden at startup with `AGENTS_*` env vars for log, HTTP, processor, and dispatch fields; see `docs/configuration.md` for the full mapping. Empty env vars are ignored, and changes still require a process/container restart.
+- **Published Docker images live at `ghcr.io/eloylp/agents`.** The default compose file pulls `latest`, and `latest` must remain release-only. Pushes to `main` publish explicit `dev-<short_sha>` images for maintainer testing; version tags publish `latest`, `X.Y.Z`, `vX.Y.Z`, and `X.Y`. Do not document local image builds as the default user setup path.
 - **Config is loaded from SQLite at startup.** Seed an empty SQLite store via `POST /import` or the `agents-setup` script; YAML is import/export only, not a runtime input. Manage subsequent changes via the CRUD API or the web dashboard. Prompt and skill content is stored in the database; changes via the API or UI take effect on the next agent run without a restart.
 - **Backend discovery lifecycle.** Startup auto-discovery runs only when the backends table is empty. Manual refresh is explicit via `POST /backends/discover`; `GET /backends/status` is diagnostics-only.
 - **Runtime toolchain.** The Docker image includes `git`, authenticated `gh`, Go, Rust/Cargo, Node/npm, and TypeScript so agents can establish a safe local checkout/test loop when MCP alone is insufficient. `agents-setup` authenticates `gh` with `GITHUB_TOKEN`; `/backends/status` reports tool health.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Removed the legacy `AGENTS_AUTH_BEARER_TOKEN_HASH` auth model. Daemon auth is
+  now only DB-backed browser sessions and named API bearer tokens.
+
+### Changed
+
+- Moved dashboard auth management into a dedicated Config -> Authentication tab
+  with user creation and current-user API token management.
+- Publish Docker images to GitHub Container Registry on `main` and version tags,
+  with release-only `latest` tags and explicit `dev-<short_sha>` tags for main.
+  The default Compose file pulls `ghcr.io/eloylp/agents:latest`.
+
 ## [0.2.0] - 2026-05-05
 
 ### Added
 
-- Minimal bearer-token auth for sensitive daemon surfaces. Set
-  `AGENTS_AUTH_BEARER_TOKEN_HASH` to protect REST write/read APIs, MCP tools,
-  runners, traces, prompts, and live streams while keeping `/status`,
-  `/webhooks/github`, `/v1/*`, and the UI shell reachable.
+- DB-backed daemon auth for sensitive surfaces: browser sessions for the
+  dashboard and named bearer tokens for REST/MCP clients, while keeping
+  `/status`, `/webhooks/github`, `/v1/*`, and the UI shell reachable.
 - Dashboard token prompt and local token management so browser users can
   authenticate against protected API and SSE endpoints without query-string
   secrets.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,11 +54,11 @@ On-demand runs go through the running daemon: `POST /run` (HTTP) or the `trigger
 ## Docker
 
 ```bash
-docker compose build
+docker compose pull
 docker compose up -d
 ```
 
-Multi-stage build on `node:22-alpine` so the image includes Claude Code, Codex, git, GitHub CLI, Go, Rust/Cargo, Node/npm, TypeScript, and the daemon. Runs as non-root `agents` user. Default CMD is `--db /var/lib/agents/agents.db`. Compose mounts:
+The default compose file pulls the published `ghcr.io/eloylp/agents:latest` image. `latest` is release-only; main-branch builds are explicit `dev-<short_sha>` tags. The image is built from the multi-stage Dockerfile and includes Claude Code, Codex, git, GitHub CLI, Go, Rust/Cargo, Node/npm, TypeScript, and the daemon. Runs as non-root `agents` user. Default CMD is `--db /var/lib/agents/agents.db`. Compose mounts:
 - `agents-data` named volume → `/var/lib/agents` (SQLite database persistence)
 - `agents-home` named volume → `/home/agents` (Claude / Codex auth, MCP config, and gh auth; populated by `docker compose exec -it agents agents-setup` once during setup, no host bind-mount of `~/.claude.json` etc.). GitHub access should flow through MCP first; authenticated gh is kept as fallback for complex workflows that need a local checkout/test/PR loop.
 
@@ -68,7 +68,6 @@ YAML config is import/export only, not a runtime input. To seed an empty fleet, 
 
 - `GITHUB_WEBHOOK_SECRET`, HMAC shared secret for the webhook receiver.
 - `GITHUB_TOKEN`, Personal Access Token used by the GitHub MCP server inside the container, by the `gh` CLI fallback, and forwarded into AI backend subprocesses through the env allowlist (`internal/ai/cmdrunner.go`). Required by `scripts/setup.sh` (hard-fails if unset). `repo` scope minimum; add `workflow` if agents touch CI. Codex resolves it at runtime; Claude stores it in `~/.claude.json`; `gh auth login --with-token` runs during setup so agents have a working CLI fallback when GitHub MCP tools fail to register. All credentials live on the `agents-home` volume.
-- `AGENTS_AUTH_BEARER_TOKEN_HASH`, optional SHA-256 hex hash of a legacy daemon bearer token. When set, first-user bootstrap requires that token and sensitive API/MCP routes still accept it during migration. The normal auth model is DB-backed users, `HttpOnly` browser sessions, and named API tokens created from the dashboard.
 - Daemon runtime settings can be overridden at startup with `AGENTS_*` env vars for log, HTTP, processor, and dispatch fields. See `docs/configuration.md` for the full mapping. Empty env vars are ignored, and changes still require a process/container restart.
 
 ## Architecture Notes
@@ -130,6 +129,6 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full flow, label semantics, and
 ## Security Notes
 
 - Webhook authenticity is enforced with HMAC SHA-256 signature verification.
-- Sensitive API and MCP endpoints require daemon auth after first-user setup. Browser users receive DB-backed opaque session tokens in `HttpOnly` cookies; MCP/API clients use named DB-backed bearer tokens; `AGENTS_AUTH_BEARER_TOKEN_HASH` remains as bootstrap/compatibility auth.
+- Sensitive API and MCP endpoints require daemon auth after first-user setup. Browser users receive DB-backed opaque session tokens in `HttpOnly` cookies; MCP/API clients use named DB-backed bearer tokens.
 - Prompts are never logged in plaintext; only the length is recorded.
 - The daemon delegates GitHub operations to the configured AI backend; agents prefer MCP tools and may use authenticated gh only as the documented fallback.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The daemon dispatches each agent via an AI CLI ([Claude Code](https://docs.anthr
 
 ## Get started
 
-See [`docs/quickstart.md`](docs/quickstart.md) to get the daemon running on a repo in a few minutes, `docker compose up -d` is the recommended path. For five import-ready fleet scenarios (solo coder, coder + reviewer, autonomous fleet, local LLM, multi-repo) see [`config_examples/`](config_examples/).
+See [`docs/quickstart.md`](docs/quickstart.md) to get the daemon running on a repo in a few minutes from the published `ghcr.io/eloylp/agents` image. For five import-ready fleet scenarios (solo coder, coder + reviewer, autonomous fleet, local LLM, multi-repo) see [`config_examples/`](config_examples/).
 
 ## Features
 
@@ -26,7 +26,7 @@ See [`docs/quickstart.md`](docs/quickstart.md) to get the daemon running on a re
 - **Observable**: See the full event chain in realtime from the [UI](docs/ui.md), from events to runners to traces that will facilitate your prompt tunning journey.
 - **[Self-hosted](docs/quickstart.md)**: your code and prompts stay on your infrastructure. No SaaS dependency.
 - **[Security recommendations](docs/security.md)**: ships built-in guardrails prepended to every agent prompt for indirect prompt-injection resistance, public-action discretion, daemon-only memory scope, and GitHub repository tool usage (MCP first, gh fallback).
-- **Daemon auth**: create the first local user in the dashboard, use an `HttpOnly` browser session for UI access, and create revocable named bearer tokens for MCP/API clients. Existing `AGENTS_AUTH_BEARER_TOKEN_HASH` deployments still work as bootstrap/compatibility auth.
+- **Daemon auth**: create the first local user in the dashboard, use an `HttpOnly` browser session for UI access, and create revocable named bearer tokens for MCP/API clients.
 - **Multi-backend**: pick Claude, Codex, or a custom backend per agent. Different agents in the same fleet can use different providers.
 - **Discovery and diagnostics**: the daemon detects backends and tools, validates CLI health, and persists discovery snapshots.
 - **[Local-model support](docs/local-models.md)**: run any agent through `llama.cpp`, Ollama, vLLM, or any OpenAI-compatible endpoint. The daemon ships a built-in Anthropic-to-OpenAI translation proxy so the existing `claude` CLI works unchanged against your own LLM (experimental).

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   agents:
-    build: .
+    image: ghcr.io/eloylp/agents:latest
     ports:
       - "8080:8080"
     environment:

--- a/docs/api.md
+++ b/docs/api.md
@@ -12,6 +12,21 @@ Sensitive endpoints require daemon auth. Browser clients use the `agents_session
 | `POST` | `/webhooks/github` | GitHub webhook receiver (`X-Hub-Signature-256` HMAC verified) |
 | `POST` | `/run` | On-demand agent trigger |
 
+## Auth endpoints
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/auth/status` | Public auth state: whether first-user bootstrap is required and whether the caller is authenticated |
+| `POST` | `/auth/bootstrap` | Create the first user on an empty database and set an `agents_session` cookie |
+| `POST` | `/auth/login` | Exchange username/password for an `agents_session` cookie |
+| `POST` | `/auth/logout` | Revoke the current browser session and clear the session cookie |
+| `GET` | `/auth/me` | Current authenticated user |
+| `GET` | `/auth/users` | List dashboard users |
+| `POST` | `/auth/users` | Create an additional dashboard user with `{"username":"...","password":"..."}` |
+| `GET` | `/auth/tokens` | List the current user's API tokens |
+| `POST` | `/auth/tokens` | Create a named API token. The plaintext token is returned once |
+| `DELETE` | `/auth/tokens/{id}` | Revoke one of the current user's API tokens |
+
 The `/run` body is `{"agent": "<name>", "repo": "owner/repo"}`. It returns `202 Accepted` immediately with an `event_id`; the agent runs asynchronously.
 
 ## Observability endpoints

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,7 +26,6 @@ See [`.env.sample`](../.env.sample) for a copy-pasteable list with current defau
 
 | Env var | Runtime setting |
 |---|---|
-| `AGENTS_AUTH_BEARER_TOKEN_HASH` | optional SHA-256 hex hash for legacy bootstrap/compatibility bearer auth |
 | `AGENTS_LOG_LEVEL` | log level |
 | `AGENTS_LOG_FORMAT` | log format |
 | `AGENTS_HTTP_LISTEN_ADDR` | HTTP listen address |

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -23,7 +23,7 @@ export AGENTS_MCP_TOKEN='agents_...'
 codex mcp add agents-fleet --url https://agents.example.com/mcp --bearer-token-env-var AGENTS_MCP_TOKEN
 ```
 
-Create `AGENTS_MCP_TOKEN` from the dashboard at Config -> Tokens. Plaintext tokens are shown only once and can be revoked from the same page. Legacy deployments that still set `AGENTS_AUTH_BEARER_TOKEN_HASH` may use the matching bearer token during migration, but named DB-backed API tokens are the recommended MCP credential.
+Create `AGENTS_MCP_TOKEN` from the dashboard at Config -> Authentication. Plaintext tokens are shown only once and can be revoked from the same page.
 
 The same pattern works for Cursor, Cline, and any other MCP-compatible client; consult their docs for the exact config syntax.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,20 +7,20 @@ The daemon dispatches AI CLIs (`claude`, `codex`) with sandbox-bypass flags so a
 ## Bring up the daemon
 
 ```bash
-git clone --branch v0.2.0 https://github.com/eloylp/agents
-cd agents
+mkdir agents && cd agents
+curl -fsSLO https://raw.githubusercontent.com/eloylp/agents/main/docker-compose.yaml
+curl -fsSLO https://raw.githubusercontent.com/eloylp/agents/main/.env.sample
 # .env holds runtime secrets (loaded automatically by compose).
 # Webhook secret: random per install. PAT: from https://github.com/settings/tokens with repo scope.
 cp .env.sample .env
 sed -i.bak "s/^GITHUB_WEBHOOK_SECRET=.*/GITHUB_WEBHOOK_SECRET=$(openssl rand -hex 32)/" .env && rm .env.bak
 # Edit GITHUB_TOKEN in .env before continuing.
-# Optional before migration/exposure: set legacy AGENTS_AUTH_BEARER_TOKEN_HASH.
-docker compose up -d --build
+docker compose up -d
 ```
 
 The shipped [`docker-compose.yaml`](../docker-compose.yaml) is the source of truth for what gets mounted and exposed. Two named volumes back the runtime: `agents-data` (SQLite store) and `agents-home` (Claude / Codex auth, MCP config, and `gh` auth). The image includes the AI CLIs plus `git`, `gh`, Go, Rust/Cargo, Node/npm, and TypeScript so agents can run local checkout/test loops when MCP alone is not enough. The daemon boots against an empty database with built-in defaults, no YAML seed is required.
 
-> **First-run note.** The compose file builds the image locally on first invocation, multi-stage build (UI + Go binary), expect ~3-5 minutes depending on the host. `docker compose logs -f agents` shows progress.
+> **First-run note.** The compose file pulls `ghcr.io/eloylp/agents:latest`, which is only updated from version tags. Main-branch builds are published separately as `ghcr.io/eloylp/agents:dev-<short_sha>` so users do not accidentally pull development images.
 
 Verify the daemon is healthy:
 
@@ -47,7 +47,7 @@ Once it finishes, the daemon has working backends and tools. **Fleet configurati
 
 ## Production essentials
 
-Before exposing the daemon publicly, open the dashboard and create the first local user, then create named API tokens for MCP/REST clients from Config -> Tokens. Existing operators may set `AGENTS_AUTH_BEARER_TOKEN_HASH` as bootstrap/compatibility auth during migration. Configure your reverse proxy for TLS/routing: see [security.md → Daemon auth](security.md#daemon-auth) and [Reverse-proxy routing](security.md#reverse-proxy-routing).
+Before exposing the daemon publicly, open the dashboard and create the first local user, then create named API tokens for MCP/REST clients from Config -> Authentication. Configure your reverse proxy for TLS/routing: see [security.md → Daemon auth](security.md#daemon-auth) and [Reverse-proxy routing](security.md#reverse-proxy-routing).
 
 ## Day-2 operations
 
@@ -58,11 +58,18 @@ docker compose logs -f agents
 # Graceful restart (in-flight runs are allowed to finish).
 docker compose restart agents
 
-# Upgrade to a newer tagged release. Pick the latest tag from
-# https://github.com/eloylp/agents/tags and substitute below.
-git fetch origin --tags && git checkout v0.2.0 && docker compose up -d --build
-# Or track main directly (latest fixes, less stable than tagged releases):
-# git checkout main && git pull && docker compose up -d --build
+# Upgrade to the latest published image.
+docker compose pull agents && docker compose up -d agents
+
+# To pin a tagged release, edit docker-compose.yaml to use either:
+# image: ghcr.io/eloylp/agents:0.2.0
+# or:
+# image: ghcr.io/eloylp/agents:v0.2.0
+# then run:
+# docker compose pull agents && docker compose up -d agents
+
+# To test an unreleased main-branch build, explicitly use:
+# image: ghcr.io/eloylp/agents:dev-<short_sha>
 
 # Re-run backend discovery (after rotating auth or adding a CLI).
 curl -X POST http://localhost:8080/backends/discover

--- a/docs/security.md
+++ b/docs/security.md
@@ -5,54 +5,25 @@ This page describes the daemon's threat model and the recommendations shipped ag
 ## Defaults the project ships
 
 - **Webhook HMAC verification** on every `POST /webhooks/github` request.
-- **DB-backed daemon auth for sensitive routes.** The dashboard creates the first local user, browser sessions use opaque DB-backed tokens in an `HttpOnly` cookie, and MCP/API clients use named revocable bearer tokens created from Config -> Tokens. Existing `AGENTS_AUTH_BEARER_TOKEN_HASH` deployments still work as bootstrap and compatibility auth.
+- **DB-backed daemon auth for sensitive routes.** The dashboard creates the first local user, browser sessions use opaque DB-backed tokens in an `HttpOnly` cookie, and MCP/API clients use named revocable bearer tokens created from Config -> Authentication.
 - **The daemon itself is read-only against GitHub.** GitHub operations happen inside the AI backend subprocess. Agents are instructed to prefer GitHub MCP tools; an authenticated `gh` CLI is present as a fallback for complex local checkout, test, and PR flows. The daemon still has no GitHub write SDK in `cmd/agents`.
 - **Per-event audit trail.** Every run records the composed prompt, every tool call with input/output summaries, and the response. Reachable from the dashboard for forensic review.
 - **Default built-in guardrails seeded into the database.** Policy blocks prepended to every agent's composed prompt at render time. `security` recommends ignoring instructions found in untrusted text, refusing secret reads/exfiltration, refusing out-of-tree filesystem access, refusing arbitrary network egress, and halting on probable injection. `memory-scope` tells agents to use only daemon-provided `Existing memory:` for the current `(agent, repo)` pair, ignore CLI-native/session/global memory, and stay bound to the repository named in the runtime context. `mcp-tool-usage` tells agents to use MCP first and authenticated `gh` only as fallback for complex local checkout/test/PR loops. **Operators can edit, disable, or replace built-ins** via `/ui/config` → Guardrails. Inspect live text at `GET /guardrails/{name}`. Like every prompt-level control, sufficiently determined indirect-injection attacks (role-play, encoded payloads, multi-turn manipulation) can defeat them.
 
 ## Daemon auth <a id="daemon-auth"></a>
 
-On a fresh database, open the dashboard and create the first user. The daemon stores a password hash and issues an opaque session token in an `HttpOnly` cookie. After at least one user exists, sensitive REST, MCP, `/run`, traces, runners, config, guardrails, repos, skills, agents, memory, graph, and event routes require one of:
+On a fresh database, open the dashboard and create the first user. Authenticated users can create additional dashboard users from Config -> Authentication. The daemon stores password hashes and issues opaque session tokens in `HttpOnly` cookies. After at least one user exists, sensitive REST, MCP, `/run`, traces, runners, config, guardrails, repos, skills, agents, memory, graph, and event routes require one of:
 
 1. A valid browser session cookie.
 2. A valid DB-backed API token sent as `Authorization: Bearer <token>`.
-3. The legacy `AGENTS_AUTH_BEARER_TOKEN_HASH` bearer token, when configured.
 
-Create MCP/API tokens from Config -> Tokens. Plaintext API tokens are returned only once at creation; the database stores only token hashes plus metadata such as name, prefix, creation time, last-used time, expiry, and revocation time.
+Create MCP/API tokens from Config -> Authentication. Plaintext API tokens are returned only once at creation; the database stores only token hashes plus metadata such as name, prefix, creation time, last-used time, expiry, and revocation time.
 
 `GITHUB_TOKEN` is unrelated to daemon auth. It remains the GitHub credential used by MCP, the `gh` fallback, and AI backend subprocesses. `GITHUB_WEBHOOK_SECRET` is also separate and remains the HMAC secret for `/webhooks/github`.
 
-## Legacy bearer-token auth <a id="bearer-token-auth"></a>
-
-Set the token hash at daemon startup:
-
-```bash
-# macOS
-printf '%s' 'your-token' | shasum -a 256 | awk '{print $1}'
-
-# Linux
-printf '%s' 'your-token' | sha256sum | awk '{print $1}'
-```
-
-Then put the resulting 64-character hex string in `.env`:
-
-```env
-AGENTS_AUTH_BEARER_TOKEN_HASH=...
-```
-
-Do not hash a string with a trailing newline. If `AGENTS_AUTH_BEARER_TOKEN_HASH` is empty or unset, legacy bearer compatibility is disabled.
-
-Authenticated clients send:
-
-```http
-Authorization: Bearer your-token
-```
-
-If no local users exist and `AGENTS_AUTH_BEARER_TOKEN_HASH` is set, first-user bootstrap requires this legacy bearer token. After bootstrap, prefer named DB-backed API tokens and remove the env hash when migration is complete.
-
 ## Reverse-proxy routing <a id="reverse-proxy-routing"></a>
 
-Use your reverse proxy for TLS and routing. With `AGENTS_AUTH_BEARER_TOKEN_HASH` set, the proxy no longer needs to provide basic auth for API/MCP access.
+Use your reverse proxy for TLS and routing. The proxy does not need to provide basic auth for API/MCP access; daemon auth protects sensitive routes itself.
 
 | Router | Paths | Auth | Purpose |
 |---|---|---|---|

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -97,7 +97,7 @@ Current fleet config snapshot. Includes YAML import/export for shareable fleet s
 
 ## Authentication
 
-The dashboard supports first-user setup, username/password login, logout, and named API token management in Config -> Tokens. Browser sessions use an opaque DB-backed token in an `HttpOnly` cookie. MCP and REST clients use API tokens created in the dashboard and sent as `Authorization: Bearer <token>`.
+The dashboard supports first-user setup, username/password login, logout, additional user creation, and named API token management in Config -> Authentication. Browser sessions use an opaque DB-backed token in an `HttpOnly` cookie. MCP and REST clients use API tokens created in the dashboard and sent as `Authorization: Bearer <token>`.
 
 Use your reverse proxy for TLS/routing, not as the primary API auth layer. See [security.md → Daemon auth](security.md#daemon-auth) and [Reverse-proxy routing](security.md#reverse-proxy-routing).
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,17 +45,9 @@ type Config struct {
 type DaemonConfig struct {
 	Log        LogConfig                `yaml:"log"`
 	HTTP       HTTPConfig               `yaml:"http"`
-	Auth       AuthConfig               `yaml:"-"`
 	Processor  ProcessorConfig          `yaml:"processor"`
 	AIBackends map[string]fleet.Backend `yaml:"-"`
 	Proxy      ProxyConfig              `yaml:"proxy"`
-}
-
-// AuthConfig controls daemon-level access to sensitive HTTP surfaces. The UI
-// shell stays public so browsers can render the token prompt; API/MCP routes
-// are protected when BearerTokenHash is set.
-type AuthConfig struct {
-	BearerTokenHash string `yaml:"-"`
 }
 
 // ProxyConfig controls the built-in Anthropic↔OpenAI translation proxy.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,8 +1,6 @@
 package config
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -77,8 +75,6 @@ func TestLoadAppliesDaemonEnvOverrides(t *testing.T) {
 	t.Setenv("LLM_KEY", "key-abc")
 	t.Setenv("AGENTS_LOG_LEVEL", "debug")
 	t.Setenv("AGENTS_LOG_FORMAT", "json")
-	hash := sha256.Sum256([]byte("secret-token"))
-	t.Setenv("AGENTS_AUTH_BEARER_TOKEN_HASH", hex.EncodeToString(hash[:]))
 	t.Setenv("AGENTS_HTTP_LISTEN_ADDR", "127.0.0.1:9090")
 	t.Setenv("AGENTS_HTTP_STATUS_PATH", "/healthz")
 	t.Setenv("AGENTS_HTTP_WEBHOOK_PATH", "/hooks/github")
@@ -108,9 +104,6 @@ func TestLoadAppliesDaemonEnvOverrides(t *testing.T) {
 
 	if cfg.Daemon.Log.Level != "debug" || cfg.Daemon.Log.Format != "json" {
 		t.Fatalf("log overrides = %+v, want debug/json", cfg.Daemon.Log)
-	}
-	if cfg.Daemon.Auth.BearerTokenHash != hex.EncodeToString(hash[:]) {
-		t.Fatalf("auth bearer token hash = %q, want env override", cfg.Daemon.Auth.BearerTokenHash)
 	}
 	if got := cfg.Daemon.HTTP.ListenAddr; got != "127.0.0.1:9090" {
 		t.Fatalf("listen addr = %q, want env override", got)
@@ -170,19 +163,6 @@ func TestLoadRejectsInvalidDaemonPathEnvOverride(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "AGENTS_HTTP_STATUS_PATH") {
 		t.Fatalf("error = %q, want env var name", err)
-	}
-}
-
-func TestLoadRejectsInvalidAuthBearerTokenHashEnv(t *testing.T) {
-	t.Setenv("AGENTS_AUTH_BEARER_TOKEN_HASH", "not-hex")
-	path := writeConfig(t, minimalYAML(""))
-
-	_, err := Load(path)
-	if err == nil {
-		t.Fatal("Load got nil error, want invalid auth hash error")
-	}
-	if !strings.Contains(err.Error(), "auth bearer token hash") {
-		t.Fatalf("error = %q, want auth hash context", err)
 	}
 }
 

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -109,9 +109,6 @@ func (c *Config) normalize() {
 	// Log.
 	c.Daemon.Log.Level = strings.ToLower(strings.TrimSpace(c.Daemon.Log.Level))
 	c.Daemon.Log.Format = strings.ToLower(strings.TrimSpace(c.Daemon.Log.Format))
-
-	// Auth.
-	c.Daemon.Auth.BearerTokenHash = strings.ToLower(strings.TrimSpace(c.Daemon.Auth.BearerTokenHash))
 }
 
 // setDefault writes def into *dst if *dst is empty (after trimming).

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -11,8 +11,6 @@ const (
 	envLogLevel  = "AGENTS_LOG_LEVEL"
 	envLogFormat = "AGENTS_LOG_FORMAT"
 
-	envAuthBearerTokenHash = "AGENTS_AUTH_BEARER_TOKEN_HASH"
-
 	envHTTPListenAddr             = "AGENTS_HTTP_LISTEN_ADDR"
 	envHTTPStatusPath             = "AGENTS_HTTP_STATUS_PATH"
 	envHTTPWebhookPath            = "AGENTS_HTTP_WEBHOOK_PATH"
@@ -44,8 +42,6 @@ const (
 func (c *Config) applyEnvOverrides() error {
 	applyStringEnv(envLogLevel, &c.Daemon.Log.Level)
 	applyStringEnv(envLogFormat, &c.Daemon.Log.Format)
-
-	applyStringEnv(envAuthBearerTokenHash, &c.Daemon.Auth.BearerTokenHash)
 
 	applyStringEnv(envHTTPListenAddr, &c.Daemon.HTTP.ListenAddr)
 	if err := applyPathEnv(envHTTPStatusPath, &c.Daemon.HTTP.StatusPath); err != nil {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"maps"
@@ -53,9 +52,6 @@ func (c *Config) validate() error {
 	if err := c.validateLogConfig(); err != nil {
 		return err
 	}
-	if err := c.validateAuthConfig(); err != nil {
-		return err
-	}
 	if err := c.validateBackends(); err != nil {
 		return err
 	}
@@ -72,20 +68,6 @@ func (c *Config) validate() error {
 		return err
 	}
 	return c.validateRepos()
-}
-
-func (c *Config) validateAuthConfig() error {
-	hash := c.Daemon.Auth.BearerTokenHash
-	if hash == "" {
-		return nil
-	}
-	if len(hash) != 64 {
-		return fmt.Errorf("config: auth bearer token hash must be 64 hex characters, got %d", len(hash))
-	}
-	if _, err := hex.DecodeString(hash); err != nil {
-		return fmt.Errorf("config: auth bearer token hash must be valid hex: %w", err)
-	}
-	return nil
 }
 
 func (c *Config) validateProxy() error {

--- a/internal/daemon/auth.go
+++ b/internal/daemon/auth.go
@@ -2,9 +2,6 @@ package daemon
 
 import (
 	"context"
-	"crypto/sha256"
-	"crypto/subtle"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"net"
@@ -29,10 +26,14 @@ type authStatusResponse struct {
 	BootstrapRequired bool        `json:"bootstrap_required"`
 	Authenticated     bool        `json:"authenticated"`
 	User              *store.User `json:"user,omitempty"`
-	LegacyEnabled     bool        `json:"legacy_enabled"`
 }
 
 type authCredentialsRequest struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+type createUserRequest struct {
 	Username string `json:"username"`
 	Password string `json:"password"`
 }
@@ -53,19 +54,14 @@ func (d *Daemon) registerAuthRoutes(router *mux.Router, withTimeout func(http.Ha
 	router.Handle("/auth/login", withTimeout(http.HandlerFunc(d.handleAuthLogin))).Methods(http.MethodPost)
 	router.Handle("/auth/logout", withTimeout(http.HandlerFunc(d.handleAuthLogout))).Methods(http.MethodPost)
 	router.Handle("/auth/me", withTimeout(http.HandlerFunc(d.handleAuthMe))).Methods(http.MethodGet)
+	router.Handle("/auth/users", withTimeout(http.HandlerFunc(d.handleAuthUsersList))).Methods(http.MethodGet)
+	router.Handle("/auth/users", withTimeout(http.HandlerFunc(d.handleAuthUsersCreate))).Methods(http.MethodPost)
 	router.Handle("/auth/tokens", withTimeout(http.HandlerFunc(d.handleAuthTokensList))).Methods(http.MethodGet)
 	router.Handle("/auth/tokens", withTimeout(http.HandlerFunc(d.handleAuthTokensCreate))).Methods(http.MethodPost)
 	router.Handle("/auth/tokens/{id}", withTimeout(http.HandlerFunc(d.handleAuthTokenRevoke))).Methods(http.MethodDelete)
 }
 
 func (d *Daemon) withBearerAuth(next http.Handler) http.Handler {
-	legacyHash := strings.TrimSpace(d.daemonCfg.Auth.BearerTokenHash)
-	var legacyExpected []byte
-	if legacyHash != "" {
-		if decoded, err := hex.DecodeString(legacyHash); err == nil && len(decoded) == sha256.Size {
-			legacyExpected = decoded
-		}
-	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if d.isPublicRoute(r) {
 			next.ServeHTTP(w, r)
@@ -74,10 +70,6 @@ func (d *Daemon) withBearerAuth(next http.Handler) http.Handler {
 		identity, ok := d.authenticateRequest(r)
 		if ok {
 			next.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), authContextKey{}, identity)))
-			return
-		}
-		if legacyExpected != nil && validBearerToken(legacyExpected, r.Header.Get("Authorization")) {
-			next.ServeHTTP(w, r)
 			return
 		}
 		w.Header().Set("WWW-Authenticate", `Bearer realm="agents"`)
@@ -145,7 +137,6 @@ func (d *Daemon) handleAuthStatus(w http.ResponseWriter, r *http.Request) {
 	}
 	resp := authStatusResponse{
 		BootstrapRequired: count == 0,
-		LegacyEnabled:     strings.TrimSpace(d.daemonCfg.Auth.BearerTokenHash) != "",
 	}
 	if identity, ok := d.currentIdentity(r); ok {
 		resp.Authenticated = true
@@ -164,15 +155,6 @@ func (d *Daemon) handleAuthBootstrap(w http.ResponseWriter, r *http.Request) {
 	if count != 0 {
 		http.Error(w, "bootstrap closed", http.StatusConflict)
 		return
-	}
-	legacyHash := strings.TrimSpace(d.daemonCfg.Auth.BearerTokenHash)
-	if legacyHash != "" {
-		expected, err := hex.DecodeString(legacyHash)
-		if err != nil || len(expected) != sha256.Size || !validBearerToken(expected, r.Header.Get("Authorization")) {
-			w.Header().Set("WWW-Authenticate", `Bearer realm="agents"`)
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
-			return
-		}
 	}
 	var req authCredentialsRequest
 	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, d.daemonCfg.HTTP.MaxBodyBytes)).Decode(&req); err != nil {
@@ -234,6 +216,47 @@ func (d *Daemon) handleAuthMe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, identity.User, http.StatusOK)
+}
+
+func (d *Daemon) handleAuthUsersList(w http.ResponseWriter, r *http.Request) {
+	if _, ok := d.currentIdentity(r); !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	users, err := d.store.ListUsers(r.Context())
+	if err != nil {
+		d.logger.Error().Err(err).Msg("auth users: list")
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, users, http.StatusOK)
+}
+
+func (d *Daemon) handleAuthUsersCreate(w http.ResponseWriter, r *http.Request) {
+	if _, ok := d.currentIdentity(r); !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	var req createUserRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, d.daemonCfg.HTTP.MaxBodyBytes)).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	user, err := d.store.CreateUser(r.Context(), req.Username, req.Password)
+	if errors.Is(err, store.ErrAuthInvalid) {
+		http.Error(w, "invalid user request", http.StatusBadRequest)
+		return
+	}
+	if errors.Is(err, store.ErrAuthConflict) {
+		http.Error(w, "user already exists", http.StatusConflict)
+		return
+	}
+	if err != nil {
+		d.logger.Error().Err(err).Msg("auth users: create")
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, user, http.StatusCreated)
 }
 
 func (d *Daemon) handleAuthTokensList(w http.ResponseWriter, r *http.Request) {
@@ -327,17 +350,4 @@ func writeJSON(w http.ResponseWriter, v any, status int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(v)
-}
-
-func validBearerToken(expected []byte, header string) bool {
-	scheme, token, ok := strings.Cut(strings.TrimSpace(header), " ")
-	if !ok || !strings.EqualFold(scheme, "Bearer") {
-		return false
-	}
-	token = strings.TrimSpace(token)
-	if token == "" {
-		return false
-	}
-	sum := sha256.Sum256([]byte(token))
-	return subtle.ConstantTimeCompare(sum[:], expected) == 1
 }

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -834,13 +834,10 @@ func TestBuildHandlerPublicRoutesStayOpen(t *testing.T) {
 	}
 }
 
-func TestBuildHandlerBearerAuthProtectsSensitiveRoutes(t *testing.T) {
+func TestBuildHandlerAuthProtectsSensitiveRoutes(t *testing.T) {
 	t.Parallel()
 
-	sum := sha256.Sum256([]byte("secret-token"))
-	srv, _ := newTestServer(t, testCfg(func(c *config.Config) {
-		c.Daemon.Auth.BearerTokenHash = hex.EncodeToString(sum[:])
-	}))
+	srv, _ := newTestServer(t, testCfg(nil))
 	ts := httptest.NewServer(srv.AuthHandler())
 	t.Cleanup(ts.Close)
 
@@ -848,24 +845,18 @@ func TestBuildHandlerBearerAuthProtectsSensitiveRoutes(t *testing.T) {
 		name       string
 		method     string
 		path       string
-		authHeader string
 		wantStatus int
 	}{
 		{name: "status stays public", method: http.MethodGet, path: "/status", wantStatus: http.StatusOK},
 		{name: "ui shell stays public", method: http.MethodGet, path: "/ui/", wantStatus: http.StatusOK},
-		{name: "api requires bearer", method: http.MethodGet, path: "/config", wantStatus: http.StatusUnauthorized},
-		{name: "api rejects wrong bearer", method: http.MethodGet, path: "/config", authHeader: "Bearer wrong", wantStatus: http.StatusUnauthorized},
-		{name: "api accepts bearer", method: http.MethodGet, path: "/config", authHeader: "Bearer secret-token", wantStatus: http.StatusOK},
-		{name: "mcp requires bearer", method: http.MethodPost, path: "/mcp", wantStatus: http.StatusUnauthorized},
+		{name: "api requires auth", method: http.MethodGet, path: "/config", wantStatus: http.StatusUnauthorized},
+		{name: "mcp requires auth", method: http.MethodPost, path: "/mcp", wantStatus: http.StatusUnauthorized},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			req, _ := http.NewRequest(tc.method, ts.URL+tc.path, nil)
-			if tc.authHeader != "" {
-				req.Header.Set("Authorization", tc.authHeader)
-			}
 			resp, err := http.DefaultClient.Do(req)
 			if err != nil {
 				t.Fatalf("request failed: %v", err)
@@ -881,9 +872,7 @@ func TestBuildHandlerBearerAuthProtectsSensitiveRoutes(t *testing.T) {
 func TestBuildHandlerProxyRoutesAreLocalOnlyWithoutAuth(t *testing.T) {
 	t.Parallel()
 
-	sum := sha256.Sum256([]byte("secret-token"))
 	srv, _ := newTestServer(t, testCfg(func(c *config.Config) {
-		c.Daemon.Auth.BearerTokenHash = hex.EncodeToString(sum[:])
 		c.Daemon.Proxy = config.ProxyConfig{
 			Enabled: true,
 			Path:    "/v1/messages",
@@ -898,12 +887,10 @@ func TestBuildHandlerProxyRoutesAreLocalOnlyWithoutAuth(t *testing.T) {
 	tests := []struct {
 		name       string
 		remoteAddr string
-		authHeader string
 		wantStatus int
 	}{
 		{name: "remote proxy call requires auth", remoteAddr: "203.0.113.10:4444", wantStatus: http.StatusUnauthorized},
 		{name: "loopback proxy call reaches proxy", remoteAddr: "127.0.0.1:4444", wantStatus: http.StatusBadRequest},
-		{name: "remote proxy call with auth reaches proxy", remoteAddr: "203.0.113.10:4444", authHeader: "Bearer secret-token", wantStatus: http.StatusBadRequest},
 	}
 
 	for _, tc := range tests {
@@ -911,9 +898,6 @@ func TestBuildHandlerProxyRoutesAreLocalOnlyWithoutAuth(t *testing.T) {
 			t.Parallel()
 			req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{}`))
 			req.RemoteAddr = tc.remoteAddr
-			if tc.authHeader != "" {
-				req.Header.Set("Authorization", tc.authHeader)
-			}
 			rr := httptest.NewRecorder()
 			srv.AuthHandler().ServeHTTP(rr, req)
 			if rr.Code != tc.wantStatus {
@@ -978,6 +962,29 @@ func TestBuildHandlerDBAuthBootstrapLoginAndAPIToken(t *testing.T) {
 	resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("session /config got %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/auth/users", nil)
+	req.AddCookie(sessionCookie)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("list users request failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("list users got %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/auth/users", bytes.NewReader([]byte(`{"username":"operator","password":"correct horse battery staple"}`)))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(sessionCookie)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("create user request failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create user got %d, want %d", resp.StatusCode, http.StatusCreated)
 	}
 
 	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/auth/tokens", bytes.NewReader([]byte(`{"name":"Codex MCP"}`)))

--- a/internal/store/auth.go
+++ b/internal/store/auth.go
@@ -18,6 +18,7 @@ import (
 var (
 	ErrAuthNotFound    = errors.New("auth: not found")
 	ErrAuthInvalid     = errors.New("auth: invalid credentials")
+	ErrAuthConflict    = errors.New("auth: conflict")
 	ErrBootstrapClosed = errors.New("auth: bootstrap closed")
 )
 
@@ -68,6 +69,67 @@ func (s *Store) UserCount(ctx context.Context) (int, error) {
 		return 0, fmt.Errorf("auth: count users: %w", err)
 	}
 	return count, nil
+}
+
+func (s *Store) ListUsers(ctx context.Context) ([]User, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id,username,created_at,updated_at,last_login_at,disabled_at
+		FROM users ORDER BY username ASC, id ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("auth: list users: %w", err)
+	}
+	defer rows.Close()
+	var out []User
+	for rows.Next() {
+		user, err := scanUser(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, user)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("auth: list users rows: %w", err)
+	}
+	return out, nil
+}
+
+func (s *Store) CreateUser(ctx context.Context, username, password string) (User, error) {
+	username = strings.TrimSpace(username)
+	if username == "" || password == "" {
+		return User{}, ErrAuthInvalid
+	}
+	hash, err := hashPassword(password)
+	if err != nil {
+		return User{}, err
+	}
+	res, err := s.db.ExecContext(ctx, `
+		INSERT INTO users(username,password_hash,created_at,updated_at)
+		VALUES(?,?,datetime('now'),datetime('now'))`, username, hash)
+	if err != nil {
+		if isUniqueConstraintError(err) {
+			return User{}, ErrAuthConflict
+		}
+		return User{}, fmt.Errorf("auth: create user: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return User{}, fmt.Errorf("auth: user id: %w", err)
+	}
+	return s.GetUser(ctx, id)
+}
+
+func (s *Store) GetUser(ctx context.Context, id int64) (User, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id,username,created_at,updated_at,last_login_at,disabled_at
+		FROM users WHERE id=?`, id)
+	user, err := scanUser(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return User{}, ErrAuthNotFound
+	}
+	if err != nil {
+		return User{}, err
+	}
+	return user, nil
 }
 
 func (s *Store) BootstrapUser(ctx context.Context, username, password string, sessionTTL time.Duration) (CreatedAuthToken, error) {
@@ -217,6 +279,11 @@ func (s *Store) RevokeAuthToken(ctx context.Context, userID, tokenID int64) erro
 		return ErrAuthNotFound
 	}
 	return nil
+}
+
+func isUniqueConstraintError(err error) bool {
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "unique constraint") || strings.Contains(msg, "constraint failed")
 }
 
 func (s *Store) RevokeAuthTokenByHash(ctx context.Context, token string) error {
@@ -375,6 +442,19 @@ func randomBytes(n int) ([]byte, error) {
 
 type tokenScanner interface {
 	Scan(dest ...any) error
+}
+
+func scanUser(row tokenScanner) (User, error) {
+	var user User
+	var created, updated, lastLogin, disabled sql.NullString
+	if err := row.Scan(&user.ID, &user.Username, &created, &updated, &lastLogin, &disabled); err != nil {
+		return User{}, err
+	}
+	user.CreatedAt = parseDBTime(created)
+	user.UpdatedAt = parseDBTime(updated)
+	user.LastLoginAt = parseDBTimePtr(lastLogin)
+	user.DisabledAt = parseDBTimePtr(disabled)
+	return user, nil
 }
 
 func scanAuthToken(row tokenScanner) (AuthToken, error) {

--- a/internal/store/auth_test.go
+++ b/internal/store/auth_test.go
@@ -25,6 +25,23 @@ func TestAuthBootstrapLoginAndAPITokenLifecycle(t *testing.T) {
 	if _, err := st.BootstrapUser(ctx, "other", "password", 0); !errors.Is(err, store.ErrBootstrapClosed) {
 		t.Fatalf("second BootstrapUser() error = %v, want %v", err, store.ErrBootstrapClosed)
 	}
+	other, err := st.CreateUser(ctx, "other", "password")
+	if err != nil {
+		t.Fatalf("CreateUser() error = %v", err)
+	}
+	if other.Username != "other" {
+		t.Fatalf("CreateUser() username = %q, want other", other.Username)
+	}
+	if _, err := st.CreateUser(ctx, "other", "password"); !errors.Is(err, store.ErrAuthConflict) {
+		t.Fatalf("CreateUser(duplicate) error = %v, want %v", err, store.ErrAuthConflict)
+	}
+	users, err := st.ListUsers(ctx)
+	if err != nil {
+		t.Fatalf("ListUsers() error = %v", err)
+	}
+	if len(users) != 2 {
+		t.Fatalf("ListUsers() len = %d, want 2", len(users))
+	}
 
 	if _, err := st.Login(ctx, "admin", "wrong", 0); !errors.Is(err, store.ErrAuthInvalid) {
 		t.Fatalf("Login(wrong password) error = %v, want %v", err, store.ErrAuthInvalid)

--- a/internal/ui/src/app/config/page.tsx
+++ b/internal/ui/src/app/config/page.tsx
@@ -214,7 +214,7 @@ export default function ConfigPage() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
   const [raw, setRaw] = useState(false)
-  const [tab, setTab] = useState<'inspector' | 'backends' | 'guardrails' | 'import-export' | 'tokens'>('inspector')
+  const [tab, setTab] = useState<'inspector' | 'authentication' | 'backends' | 'guardrails' | 'import-export' | 'tokens'>('inspector')
 
   const [backends, setBackends] = useState<Backend[]>([])
   const [tools, setTools] = useState<ToolStatus[]>([])
@@ -695,6 +695,7 @@ export default function ConfigPage() {
 
       <div style={{ display: 'flex', gap: '0', marginBottom: '0', borderBottom: '1px solid var(--border)' }}>
         <button style={tabStyle('inspector')} onClick={() => setTab('inspector')}>Inspector</button>
+        <button style={tabStyle('authentication')} onClick={() => setTab('authentication')}>Authentication</button>
         <button style={tabStyle('backends')} onClick={() => setTab('backends')}>Backends and tools</button>
         <button style={tabStyle('guardrails')} onClick={() => setTab('guardrails')}>Guardrails</button>
         <button style={tabStyle('import-export')} onClick={() => setTab('import-export')}>Import / Export</button>
@@ -703,8 +704,6 @@ export default function ConfigPage() {
 
       {tab === 'inspector' && (
         <Card style={{ borderTopLeftRadius: 0 }}>
-          <AuthTokenSettings />
-          <hr style={{ border: 0, borderTop: '1px solid var(--border-subtle)', margin: '1rem 0' }} />
           {loading && <p style={{ color: 'var(--text-muted)' }}>Loading…</p>}
           {error && <p style={{ color: 'var(--text-danger)' }}>Error: {error}. (Is the API key set? Check Authorization header.)</p>}
           {config && (
@@ -720,6 +719,12 @@ export default function ConfigPage() {
               )}
             </pre>
           )}
+        </Card>
+      )}
+
+      {tab === 'authentication' && (
+        <Card style={{ borderTopLeftRadius: 0 }}>
+          <AuthTokenSettings />
         </Card>
       )}
 

--- a/internal/ui/src/lib/auth.tsx
+++ b/internal/ui/src/lib/auth.tsx
@@ -8,7 +8,6 @@ type AuthStatus = {
   bootstrap_required: boolean
   authenticated: boolean
   user?: { username: string }
-  legacy_enabled: boolean
 }
 
 type AuthToken = {
@@ -20,6 +19,15 @@ type AuthToken = {
   expires_at?: string
   last_used_at?: string
   revoked_at?: string
+}
+
+type AuthUser = {
+  id: number
+  username: string
+  created_at: string
+  updated_at: string
+  last_login_at?: string
+  disabled_at?: string
 }
 
 let fetchPatched = false
@@ -153,16 +161,25 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
 export function AuthTokenSettings() {
   const [status, setStatus] = useState<AuthStatus | null>(null)
+  const [users, setUsers] = useState<AuthUser[]>([])
   const [tokens, setTokens] = useState<AuthToken[]>([])
   const [name, setName] = useState('Codex MCP')
   const [created, setCreated] = useState('')
+  const [newUsername, setNewUsername] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [userError, setUserError] = useState('')
+  const [tokenError, setTokenError] = useState('')
 
   const refresh = async () => {
     const next = await loadAuthStatus()
     setStatus(next)
     if (!next?.authenticated) return
-    const res = await fetch('/auth/tokens', { cache: 'no-store' })
-    if (res.ok) setTokens(await res.json() as AuthToken[])
+    const [usersRes, tokensRes] = await Promise.all([
+      fetch('/auth/users', { cache: 'no-store' }),
+      fetch('/auth/tokens', { cache: 'no-store' }),
+    ])
+    if (usersRes.ok) setUsers(await usersRes.json() as AuthUser[])
+    if (tokensRes.ok) setTokens(await tokensRes.json() as AuthToken[])
   }
 
   useEffect(() => {
@@ -171,14 +188,35 @@ export function AuthTokenSettings() {
 
   const create = async () => {
     setCreated('')
+    setTokenError('')
     const res = await fetch('/auth/tokens', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name }),
     })
-    if (!res.ok) return
+    if (!res.ok) {
+      setTokenError('Could not create API token.')
+      return
+    }
     const data = await res.json() as AuthToken & { token: string }
     setCreated(data.token)
+    await refresh()
+  }
+
+  const createUser = async () => {
+    setUserError('')
+    const res = await fetch('/auth/users', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: newUsername, password: newPassword }),
+    })
+    if (!res.ok) {
+      const text = await res.text()
+      setUserError(text.trim() || 'Could not create user.')
+      return
+    }
+    setNewUsername('')
+    setNewPassword('')
     await refresh()
   }
 
@@ -203,30 +241,115 @@ export function AuthTokenSettings() {
       </div>
       {status?.authenticated && (
         <>
-          <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
-            <input value={name} onChange={e => setName(e.target.value)} style={{ ...inputStyle, maxWidth: '260px' }} />
-            <button type="button" onClick={create} style={primaryButtonStyle}>Create API token</button>
-          </div>
-          {created && (
-            <code style={{ display: 'block', padding: '0.75rem', border: '1px solid var(--border)', borderRadius: '6px', overflowWrap: 'anywhere', color: 'var(--text-heading)' }}>
-              {created}
-            </code>
-          )}
-          <div style={{ display: 'grid', gap: '0.5rem' }}>
-            {tokens.map(token => (
-              <div key={token.id} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '1rem', border: '1px solid var(--border-subtle)', borderRadius: '6px', padding: '0.65rem' }}>
-                <div>
-                  <strong style={{ color: 'var(--text-heading)', fontSize: '0.82rem' }}>{token.name}</strong>
-                  <p style={{ color: 'var(--text-muted)', fontSize: '0.74rem' }}>{token.kind} · {token.prefix} · {token.revoked_at ? 'revoked' : 'active'}</p>
+          <section style={sectionStyle}>
+            <div>
+              <h4 style={sectionTitleStyle}>Users</h4>
+              <p style={sectionHelpStyle}>Create additional dashboard users. Every user can manage daemon configuration and create their own API tokens.</p>
+            </div>
+            <div style={{ display: 'grid', gap: '0.5rem' }}>
+              {users.map(user => (
+                <div key={user.id} style={rowStyle}>
+                  <div>
+                    <strong style={{ color: 'var(--text-heading)', fontSize: '0.82rem' }}>{user.username}</strong>
+                    <p style={{ color: 'var(--text-muted)', fontSize: '0.74rem' }}>
+                      created {formatDate(user.created_at)}
+                      {user.last_login_at ? ` · last login ${formatDate(user.last_login_at)}` : ''}
+                      {user.disabled_at ? ' · disabled' : ''}
+                    </p>
+                  </div>
+                  {status.user?.username === user.username && <span style={pillStyle}>current</span>}
                 </div>
-                {!token.revoked_at && <button type="button" onClick={() => revoke(token.id)} style={secondaryButtonStyle}>Revoke</button>}
-              </div>
-            ))}
-          </div>
+              ))}
+            </div>
+            <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+              <input value={newUsername} onChange={e => setNewUsername(e.target.value)} placeholder="Username" style={{ ...inputStyle, maxWidth: '220px' }} />
+              <input type="password" value={newPassword} onChange={e => setNewPassword(e.target.value)} placeholder="Password" style={{ ...inputStyle, maxWidth: '260px' }} />
+              <button type="button" onClick={createUser} style={primaryButtonStyle}>Create user</button>
+            </div>
+            {userError && <p style={{ color: 'var(--text-danger)', fontSize: '0.78rem' }}>{userError}</p>}
+          </section>
+
+          <section style={sectionStyle}>
+            <div>
+              <h4 style={sectionTitleStyle}>API tokens</h4>
+              <p style={sectionHelpStyle}>Create revocable bearer tokens for MCP and REST clients. Plaintext tokens are shown only once.</p>
+            </div>
+            <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+              <input value={name} onChange={e => setName(e.target.value)} style={{ ...inputStyle, maxWidth: '260px' }} />
+              <button type="button" onClick={create} style={primaryButtonStyle}>Create API token</button>
+            </div>
+            {tokenError && <p style={{ color: 'var(--text-danger)', fontSize: '0.78rem' }}>{tokenError}</p>}
+            {created && (
+              <code style={{ display: 'block', padding: '0.75rem', border: '1px solid var(--border)', borderRadius: '6px', overflowWrap: 'anywhere', color: 'var(--text-heading)' }}>
+                {created}
+              </code>
+            )}
+            <div style={{ display: 'grid', gap: '0.5rem' }}>
+              {tokens.map(token => (
+                <div key={token.id} style={rowStyle}>
+                  <div>
+                    <strong style={{ color: 'var(--text-heading)', fontSize: '0.82rem' }}>{token.name}</strong>
+                    <p style={{ color: 'var(--text-muted)', fontSize: '0.74rem' }}>{token.kind} · {token.prefix} · {token.revoked_at ? 'revoked' : 'active'}</p>
+                  </div>
+                  {!token.revoked_at && <button type="button" onClick={() => revoke(token.id)} style={secondaryButtonStyle}>Revoke</button>}
+                </div>
+              ))}
+            </div>
+          </section>
         </>
       )}
     </div>
   )
+}
+
+function formatDate(value: string) {
+  if (!value) return 'unknown'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleString()
+}
+
+const sectionStyle: React.CSSProperties = {
+  display: 'grid',
+  gap: '0.75rem',
+  padding: '0.85rem',
+  border: '1px solid var(--border-subtle)',
+  borderRadius: '8px',
+  background: 'var(--bg)',
+}
+
+const sectionTitleStyle: React.CSSProperties = {
+  fontSize: '0.9rem',
+  fontWeight: 700,
+  color: 'var(--text-heading)',
+  margin: 0,
+}
+
+const sectionHelpStyle: React.CSSProperties = {
+  color: 'var(--text-muted)',
+  fontSize: '0.76rem',
+  marginTop: '0.25rem',
+}
+
+const rowStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: '1rem',
+  border: '1px solid var(--border-subtle)',
+  borderRadius: '6px',
+  padding: '0.65rem',
+  background: 'var(--bg-card)',
+}
+
+const pillStyle: React.CSSProperties = {
+  fontSize: '0.68rem',
+  textTransform: 'uppercase',
+  letterSpacing: '0.04em',
+  border: '1px solid var(--border)',
+  borderRadius: '999px',
+  color: 'var(--text-muted)',
+  padding: '0.15rem 0.45rem',
 }
 
 const overlayStyle: React.CSSProperties = {


### PR DESCRIPTION
## Summary
- remove the legacy bearer-hash auth model and rely on DB-backed sessions/API tokens
- add authenticated user listing/creation plus a dedicated Config -> Authentication tab
- publish Docker images to GHCR on main/tag pushes and make Compose pull the release image by default

## Validation
- go test ./... -race
- npm test
- npm run build
- docker compose config --quiet
- workflow YAML parse check