### PR TITLE
refactor(store): use IndexFunc in binding test

### DIFF
--- a/internal/store/crud_test.go
+++ b/internal/store/crud_test.go
@@ -1386,16 +1386,11 @@ func TestReadBindingExposesIDViaLoadRepos(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadRepos: %v", err)
 	}
-	var r *fleet.Repo
-	for i := range repos {
-		if repos[i].Name == "owner/repo" {
-			r = &repos[i]
-			break
-		}
-	}
-	if r == nil {
+	idx := slices.IndexFunc(repos, func(r fleet.Repo) bool { return r.Name == "owner/repo" })
+	if idx == -1 {
 		t.Fatalf("repo not found")
 	}
+	r := &repos[idx]
 	// First binding was seeded by seedRepoWithAgent; the two additions we
 	// expect as id1/id2 below it.
 	seen := map[int64]bool{}


### PR DESCRIPTION
## Summary

- Replace the hand-written repo lookup loop in `TestReadBindingExposesIDViaLoadRepos` with `slices.IndexFunc`.
- Keep the test behavior unchanged while using the slice helper already imported in the file.

## Testing

- `go test ./... -race`

Note: this fresh checkout was missing the ignored `internal/ui/dist` directory required by the embed pattern, so I created a local-only placeholder before running the full suite. The placeholder is not committed.