### PR TITLE
refactor(ai): iterate Claude test lines lazily

### DIFF
--- a/internal/ai/cmdrunner_test.go
+++ b/internal/ai/cmdrunner_test.go
@@ -636,7 +636,8 @@ func TestParseClaudeSteps(t *testing.T) {
 	// time, simulating lineCapture.addLine but with a controllable clock.
 	toTimedLines := func(data []byte, base time.Time, step time.Duration) []timedLine {
 		var tls []timedLine
-		for _, raw := range bytes.Split(bytes.TrimRight(data, "\n"), []byte("\n")) {
+		for raw := range bytes.Lines(data) {
+			raw = bytes.TrimSuffix(raw, []byte("\n"))
 			if len(raw) == 0 {
 				continue
 			}


### PR DESCRIPTION
## Summary

- Use `bytes.Lines` in the Claude step parser test helper instead of splitting the whole JSONL buffer.
- Trim the line ending before re-adding the captured newline so the simulated `lineCapture.addLine` shape stays unchanged.

## Testing

- `go test ./... -race`

Note: this fresh checkout was missing the ignored `internal/ui/dist` directory required by the embed pattern, so I created a local-only placeholder before running the full suite. The placeholder is not committed.