### PR TITLE
Publish amd64 Docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,8 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: docker/setup-qemu-action@v3
-
       - uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
@@ -44,7 +42,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- publish Docker images for linux/amd64 only
- remove QEMU setup from the Docker workflow

## Context
The Docker publish for 2e052a5 failed in the linux/arm64 Next.js build under QEMU with SIGILL. ts-lonestar is x86_64, and our deployment target is amd64.

## Tests
- workflow-only change