### PR TITLE
Fix root login redirect and square corners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   login modal.
 - Added a dedicated public root login/bootstrap page that redirects
   authenticated browser sessions into `/ui/`.
+- Root login now confirms the browser session before redirecting and uses
+  square-corner controls.
+- Moved sign out to the top-right dashboard navigation.
 - Publish Docker images to GitHub Container Registry on `main` and version tags,
   with release-only `latest` tags and explicit `dev-<short_sha>` tags for main.
   The default Compose file pulls `ghcr.io/eloylp/agents:latest`.

--- a/internal/daemon/auth.go
+++ b/internal/daemon/auth.go
@@ -437,7 +437,7 @@ const rootLoginHTML = `<!doctype html>
       position: relative;
       width: min(430px, 100%);
       border: 1px solid rgba(255,255,255,0.55);
-      border-radius: 20px;
+      border-radius: 0;
       background: rgba(255,255,255,0.88);
       backdrop-filter: blur(18px);
       padding: 22px;
@@ -476,7 +476,7 @@ const rootLoginHTML = `<!doctype html>
       margin-top: 0.35rem;
       padding: 0.65rem 0.75rem;
       border: 1px solid #bfdbfe;
-      border-radius: 6px;
+      border-radius: 0;
       background: #f8fafc;
       color: #1e293b;
       font: inherit;
@@ -486,7 +486,7 @@ const rootLoginHTML = `<!doctype html>
       margin-top: 1rem;
       padding: 0.7rem 0.9rem;
       border: 1px solid #1d4ed8;
-      border-radius: 6px;
+      border-radius: 0;
       background: #2563eb;
       color: #fff;
       font: inherit;
@@ -496,7 +496,7 @@ const rootLoginHTML = `<!doctype html>
     button:disabled { cursor: wait; opacity: 0.72; }
     .status {
       border: 1px solid rgba(37,99,235,0.22);
-      border-radius: 12px;
+      border-radius: 0;
       background: rgba(239,246,255,0.72);
       color: #1e3a5f;
       padding: 0.8rem;
@@ -517,7 +517,7 @@ const rootLoginHTML = `<!doctype html>
     <p id="copy">Checking your browser session.</p>
     <div id="loading" class="status">Checking session...</div>
     <form id="form" hidden>
-      <label>Username<input id="username" name="username" autocomplete="username" value="admin" autofocus></label>
+      <label>Username<input id="username" name="username" autocomplete="username" autofocus></label>
       <label>Password<input id="password" name="password" type="password" autocomplete="current-password"></label>
       <p id="error" class="error" hidden></p>
       <button id="submit" type="submit">Sign in</button>
@@ -532,12 +532,21 @@ const rootLoginHTML = `<!doctype html>
     const error = document.getElementById('error');
     let bootstrapRequired = false;
 
+    function openDashboard() {
+      try {
+        window.top.location.assign('/ui/');
+      } catch {
+        window.location.assign('/ui/');
+      }
+      setTimeout(() => window.location.replace('/ui/'), 75);
+    }
+
     async function refresh() {
       const res = await fetch('/auth/status', { cache: 'no-store', credentials: 'same-origin' });
       if (!res.ok) throw new Error('Could not check auth status.');
       const status = await res.json();
       if (status.authenticated) {
-        window.location.replace('/ui/');
+        openDashboard();
         return;
       }
       bootstrapRequired = Boolean(status.bootstrap_required);
@@ -564,13 +573,23 @@ const rootLoginHTML = `<!doctype html>
           password: document.getElementById('password').value,
         }),
       });
-      button.disabled = false;
       if (!res.ok) {
+        button.disabled = false;
         error.textContent = bootstrapRequired ? 'Bootstrap failed.' : 'Login failed.';
         error.hidden = false;
         return;
       }
-      window.location.replace('/ui/');
+      button.textContent = 'Opening dashboard...';
+      const statusRes = await fetch('/auth/status', { cache: 'no-store', credentials: 'same-origin' });
+      const status = statusRes.ok ? await statusRes.json() : null;
+      if (!status || !status.authenticated) {
+        button.disabled = false;
+        button.textContent = bootstrapRequired ? 'Create admin user' : 'Sign in';
+        error.textContent = 'Signed in, but the browser session was not confirmed. Reload and try again.';
+        error.hidden = false;
+        return;
+      }
+      openDashboard();
     });
 
     refresh().catch((err) => {

--- a/internal/ui/src/components/NavBar.tsx
+++ b/internal/ui/src/components/NavBar.tsx
@@ -27,6 +27,11 @@ export default function NavBar() {
   const [orphanCount, setOrphanCount] = useState(0)
   const [budgetAlertCount, setBudgetAlertCount] = useState(0)
 
+  const signOut = async () => {
+    await fetch('/auth/logout', { method: 'POST', credentials: 'same-origin' })
+    window.location.replace('/')
+  }
+
   useEffect(() => {
     let cancelled = false
     const load = async () => {
@@ -123,7 +128,7 @@ export default function NavBar() {
             marginLeft: 'auto',
             background: 'none',
             border: '1px solid var(--border)',
-            borderRadius: '6px',
+            borderRadius: 0,
             padding: '4px 10px',
             cursor: 'pointer',
             fontSize: '0.78rem',
@@ -131,6 +136,21 @@ export default function NavBar() {
           }}
         >
           {theme === 'light' ? 'Dark' : 'Light'}
+        </button>
+        <button
+          onClick={signOut}
+          style={{
+            marginLeft: '0.5rem',
+            background: 'var(--bg-card)',
+            border: '1px solid var(--border)',
+            borderRadius: 0,
+            padding: '4px 10px',
+            cursor: 'pointer',
+            fontSize: '0.78rem',
+            color: 'var(--text-muted)',
+          }}
+        >
+          Sign out
         </button>
       </nav>
       {orphanCount > 0 && (

--- a/internal/ui/src/lib/auth.tsx
+++ b/internal/ui/src/lib/auth.tsx
@@ -190,10 +190,6 @@ export function AuthTokenSettings() {
             {status?.authenticated ? `Signed in as ${status.user?.username || 'user'}.` : 'No active browser session.'}
           </p>
         </div>
-        <div style={{ display: 'flex', gap: '0.5rem' }}>
-          {!status?.authenticated && <button type="button" onClick={requestBearerTokenModal} style={secondaryButtonStyle}>Sign in</button>}
-          {status?.authenticated && <button type="button" onClick={async () => { await fetch('/auth/logout', { method: 'POST' }); window.location.reload() }} style={secondaryButtonStyle}>Sign out</button>}
-        </div>
       </div>
       {status?.authenticated && (
         <>
@@ -360,7 +356,7 @@ const authCardStyle: React.CSSProperties = {
   position: 'relative',
   width: 'min(430px, 100%)',
   border: '1px solid rgba(255,255,255,0.55)',
-  borderRadius: '20px',
+  borderRadius: 0,
   background: 'rgba(255,255,255,0.88)',
   backdropFilter: 'blur(18px)',
   padding: '1.35rem',
@@ -393,7 +389,7 @@ const authCopyStyle: React.CSSProperties = {
 
 const authLoadingStyle: React.CSSProperties = {
   border: '1px solid rgba(37,99,235,0.22)',
-  borderRadius: '12px',
+  borderRadius: 0,
   background: 'rgba(239,246,255,0.72)',
   color: '#1e3a5f',
   padding: '0.8rem',


### PR DESCRIPTION
## Summary
- confirm the browser session after root login/bootstrap before navigating to /ui/
- force top-level navigation to /ui/ after successful login
- remove rounded corners from the root login card, controls, and SPA auth fallback

## Tests
- GOCACHE=/tmp/go-build-agents go test ./internal/daemon
- GOCACHE=/tmp/go-build-agents go test ./... -race
- npm test (internal/ui)
- npm run build (internal/ui)