### PR TITLE
refactor(observe): seed graph test dispatches synchronously

### DIFF
--- a/internal/daemon/observe/observe_test.go
+++ b/internal/daemon/observe/observe_test.go
@@ -493,12 +493,15 @@ func TestHandleTraceNotFound(t *testing.T) {
 
 func TestHandleGraphReturnsEdges(t *testing.T) {
 	t.Parallel()
-	obs := newTestEvents(t)
-	h := newHandlerOnStore(t, obs)
-
-	obs.RecordDispatch("coder", "reviewer", "owner/repo", 10, "needs review")
-	obs.RecordDispatch("coder", "reviewer", "owner/repo", 11, "follow-up")
-	time.Sleep(50 * time.Millisecond)
+	fx := newFixture(t, nil)
+	h := New(fx.events, fx.store, nil, nil, nil, zerolog.Nop())
+	if _, err := fx.db.Exec(
+		`INSERT INTO dispatch_history (from_agent, to_agent, repo, number, reason) VALUES (?,?,?,?,?), (?,?,?,?,?)`,
+		"coder", "reviewer", "owner/repo", 10, "needs review",
+		"coder", "reviewer", "owner/repo", 11, "follow-up",
+	); err != nil {
+		t.Fatalf("seed dispatches: %v", err)
+	}
 
 	req := httptest.NewRequest(http.MethodGet, "/graph", nil)
 	rec := httptest.NewRecorder()


### PR DESCRIPTION
## Summary

- Seed `TestHandleGraphReturnsEdges` dispatch history synchronously through SQLite.
- Remove the sleep that waited for asynchronous `RecordDispatch` persistence before reading the graph.

## Testing

- `go test ./... -race -count=1`

Note: this fresh checkout was missing the ignored `internal/ui/dist` directory required by the embed pattern, so I created a local-only placeholder before running the full suite. The placeholder is not committed.