### PR TITLE
refactor(mcp): use ContainsFunc in binding persistence test

### DIFF
--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -2036,14 +2037,9 @@ func TestToolCreateBindingForwardsAndReturnsID(t *testing.T) {
 	if !ok {
 		t.Fatal("owner/one missing")
 	}
-	found := false
-	for _, b := range r.Use {
-		if b.Agent == "coder" && len(b.Labels) == 1 && b.Labels[0] == "ai:fix" {
-			found = true
-			break
-		}
-	}
-	if !found {
+	if !slices.ContainsFunc(r.Use, func(b fleet.Binding) bool {
+		return b.Agent == "coder" && len(b.Labels) == 1 && b.Labels[0] == "ai:fix"
+	}) {
 		t.Errorf("new ai:fix binding not persisted on owner/one: %+v", r.Use)
 	}
 }


### PR DESCRIPTION
## Summary

- Replace the manual found-flag scan in `TestToolCreateBindingForwardsAndReturnsID` with `slices.ContainsFunc`.
- Keep the persisted binding assertion behavior unchanged while using the slice helper directly.

## Testing

- `go test ./... -race`

Note: this fresh checkout was missing the ignored `internal/ui/dist` directory required by the embed pattern, so I created a local-only placeholder before running the full suite. The placeholder is not committed.