### PR TITLE
refactor(mcp): iterate server test SSE lines lazily

### DIFF
--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -107,7 +107,7 @@ func extractJSONRPC(t *testing.T, rec *httptest.ResponseRecorder) []byte {
 	body := rec.Body.Bytes()
 	if bytes.HasPrefix(body, []byte("data:")) {
 		// Minimal SSE extraction: find the first "data:" line payload.
-		for _, line := range bytes.Split(body, []byte("\n")) {
+		for line := range bytes.Lines(body) {
 			if payload, ok := bytes.CutPrefix(line, []byte("data:")); ok {
 				return bytes.TrimSpace(payload)
 			}


### PR DESCRIPTION
## Summary

- Use `bytes.Lines` when scanning MCP server test SSE responses for the first `data:` frame.
- Avoid allocating the temporary slice produced by `bytes.Split` while preserving the helper behavior.

## Testing

- `go test ./... -race`

Note: this fresh checkout was missing the ignored `internal/ui/dist` directory required by the embed pattern, so I created a local-only placeholder before rerunning the full suite. The placeholder is not committed.