### PR TITLE
refactor(backends): stream MCP status lines

### DIFF
--- a/internal/backends/discovery.go
+++ b/internal/backends/discovery.go
@@ -402,8 +402,8 @@ func checkGitHubMCP(ctx context.Context, command string, env map[string]string) 
 }
 
 func parseGitHubMCPStatus(output string) (hasGitHub bool, connected bool) {
-	for _, line := range strings.Split(strings.ToLower(output), "\n") {
-		line = strings.TrimSpace(line)
+	for line := range strings.SplitSeq(output, "\n") {
+		line = strings.ToLower(strings.TrimSpace(line))
 		if line == "" || !strings.Contains(line, "github") {
 			continue
 		}


### PR DESCRIPTION
## Summary

- Iterate MCP status output with `strings.SplitSeq` instead of splitting a lowercased copy of the whole string.
- Keep each line normalized before the existing GitHub connection checks.

## Testing

- `go test ./... -race`

Note: this fresh checkout was missing the ignored `internal/ui/dist` directory required by the embed pattern, so I created a local-only placeholder before rerunning the full suite. The placeholder is not committed.