### PR TITLE
refactor(observe): trim SSE test payload as bytes

### DIFF
--- a/internal/observe/observe_test.go
+++ b/internal/observe/observe_test.go
@@ -1,6 +1,7 @@
 package observe_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"maps"
@@ -249,8 +250,8 @@ func TestWatchMemoryDirNoOpOnEmptyDir(t *testing.T) {
 // extractSSEData strips the "data: " prefix and trailing newlines added by
 // sseData so the payload can be unmarshalled as JSON.
 func extractSSEData(raw []byte) []byte {
-	s, _ := strings.CutPrefix(string(raw), "data: ")
-	return []byte(strings.TrimRight(s, "\n"))
+	payload, _ := bytes.CutPrefix(raw, []byte("data: "))
+	return bytes.TrimRight(payload, "\n")
 }
 
 func TestExtractSSEData(t *testing.T) {


### PR DESCRIPTION
## Summary

- Use byte-slice helpers in the observe SSE test helper instead of converting the payload through string trimming.
- Preserve the existing SSE payload extraction behavior.

## Testing

- `go test ./... -race`

Note: this fresh checkout was missing the ignored `internal/ui/dist` directory required by the embed pattern, so I created a local-only ignored placeholder before rerunning the full suite. The placeholder is not committed.