### PR TITLE
refactor(repos): use IndexFunc for repo lookup

### DIFF
--- a/internal/daemon/repos/repos.go
+++ b/internal/daemon/repos/repos.go
@@ -169,11 +169,11 @@ func (h *Handler) handleRepoGet(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("read repos: %v", err), http.StatusInternalServerError)
 		return
 	}
-	for _, repo := range repos {
-		if repo.Name == repoName && fleet.NormalizeWorkspaceID(repo.WorkspaceID) == workspaceID {
-			writeJSON(w, http.StatusOK, repoToStoreJSON(repo))
-			return
-		}
+	if idx := slices.IndexFunc(repos, func(repo fleet.Repo) bool {
+		return repo.Name == repoName && fleet.NormalizeWorkspaceID(repo.WorkspaceID) == workspaceID
+	}); idx >= 0 {
+		writeJSON(w, http.StatusOK, repoToStoreJSON(repos[idx]))
+		return
 	}
 	http.NotFound(w, r)
 }


### PR DESCRIPTION
## Summary

- Replace the manual repo search in `handleRepoGet` with `slices.IndexFunc`, matching the lookup style already used by `PatchRepo`.
- Keep the existing 200/404 behavior unchanged.

## Testing

- `go test ./... -race`

Note: this fresh checkout was missing the ignored `internal/ui/dist` directory required by the embed pattern, so I created a local-only placeholder before rerunning the full suite. The placeholder is not committed.