### PR TITLE
refactor(ai): use errors.Is for EOF check

### DIFF
--- a/internal/ai/cmdrunner.go
+++ b/internal/ai/cmdrunner.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -121,7 +122,7 @@ func (r *CommandRunner) runCommand(ctx context.Context, logger zerolog.Logger, r
 			}
 		}
 		if err != nil {
-			if err != io.EOF {
+			if !errors.Is(err, io.EOF) {
 				logger.Warn().Err(err).Msgf("read %s stdout", r.backendName)
 			}
 			break


### PR DESCRIPTION
## Summary

- Use `errors.Is` when suppressing expected `io.EOF` stdout read termination in the command runner.
- Preserve the existing warning behavior for non-EOF stdout read errors.

## Testing

- `go test ./... -race`

Note: this fresh checkout was missing the ignored `internal/ui/dist` directory required by the embed pattern, so I created a local-only placeholder before rerunning the full suite. The placeholder is not committed.