### PR TITLE
fix: make graph dispatch wiring always editable

### DIFF
--- a/docs/dispatch.md
+++ b/docs/dispatch.md
@@ -86,7 +86,7 @@ agents:
 
 ## UI wiring editor
 
-The **Graph** page in the web dashboard (`/ui/`) has an "Edit wiring" toggle and a right-side Agent editor. When active:
+The **Graph** page in the web dashboard (`/ui/`) keeps dispatch wiring editable directly on the canvas:
 
 - **Add a connection**: drag from any agent node to another. The dashboard writes the source agent's `can_dispatch` list and enables `allow_dispatch` on the target through the normal agent save surface.
 - **Remove a connection**: click an existing edge to open it in the Agent editor, then remove the wiring. The daemon removes the target from the source agent's `can_dispatch` list; the target's `allow_dispatch` flag is left alone, since other agents may still dispatch to it.

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -29,7 +29,7 @@ Primary workflow designer showing agents as draggable graph nodes and dispatch p
 
 The right-side **Agent editor** is the graph's main editing surface. Click an agent to inspect or edit its definition, run it against bound repos, review recent runner rows / trace links, manage repo triggers, and add or remove dispatch wiring. Operators can create agents without leaving the designer.
 
-Toggle "Edit wiring" to add dispatch connections by drag-and-drop. Click an edge to inspect runtime dispatch history or remove the wiring from the Agent editor. Dispatch changes write back to the source agent's `can_dispatch` list and the target's `allow_dispatch` flag.
+Dispatch wiring is always editable: drag from one agent to another to add a connection, or click an edge to inspect runtime dispatch history and remove the wiring from the Agent editor. Dispatch changes write back to the source agent's `can_dispatch` list and the target's `allow_dispatch` flag.
 
 ![Agent interaction graph](img/graph.png)
 

--- a/internal/ui/src/app/graph/page.tsx
+++ b/internal/ui/src/app/graph/page.tsx
@@ -948,39 +948,6 @@ export default function GraphPage() {
               )}
 
               <div>
-                <div style={{ fontSize: '0.75rem', fontWeight: 600, color: 'var(--accent)', textTransform: 'uppercase', marginBottom: '0.5rem' }}>Latest runs and traces</div>
-                {agentActivityLoading && <p style={{ color: 'var(--text-muted)', fontSize: '0.8rem' }}>Loading recent runs...</p>}
-                {!agentActivityLoading && agentRuns.length === 0 && (
-                  <p style={{ color: 'var(--text-muted)', fontSize: '0.8rem' }}>No recent runs for this agent.</p>
-                )}
-                {!agentActivityLoading && agentRuns.length > 0 && (
-                  <div style={{ display: 'grid', gap: '0.5rem' }}>
-                    {agentRuns.map(run => (
-                      <div key={`${run.id}:${run.span_id ?? ''}`} style={{ background: 'var(--bg)', border: '1px solid var(--border-subtle)', borderRadius: '6px', padding: '10px', display: 'grid', gap: '4px' }}>
-                        <div style={{ display: 'flex', justifyContent: 'space-between', gap: '0.75rem', alignItems: 'center' }}>
-                          <div style={{ color: 'var(--text)', fontWeight: 600, fontSize: '0.8rem' }}>
-                            {run.repo || '-'} {run.number > 0 ? `#${run.number}` : ''}
-                          </div>
-                          <span style={{ color: run.status === 'error' ? 'var(--text-danger)' : run.status === 'success' ? 'var(--success)' : 'var(--accent)', fontSize: '0.72rem', fontWeight: 700 }}>
-                            {run.status}
-                          </span>
-                        </div>
-                        <div style={{ color: 'var(--text-muted)', fontSize: '0.75rem' }}>
-                          {run.kind || '-'} · {fmtTime(run.started_at ?? run.completed_at)} · {fmtDuration(run.run_duration_ms)}
-                        </div>
-                        {run.summary && <div style={{ color: 'var(--text-faint)', fontSize: '0.75rem', fontStyle: 'italic' }}>{run.summary}</div>}
-                        {run.event_id && (
-                          <Link href={`/traces/?id=${encodeURIComponent(run.event_id)}`} style={{ color: 'var(--accent)', fontSize: '0.75rem', textDecoration: 'none' }}>
-                            Open trace →
-                          </Link>
-                        )}
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </div>
-
-              <div>
                 <div style={{ fontSize: '0.75rem', fontWeight: 600, color: 'var(--accent)', textTransform: 'uppercase', marginBottom: '0.5rem' }}>Repo triggers</div>
                 {selectedNodeBindings.length === 0 ? (
                   <p style={{ color: 'var(--text-muted)', fontSize: '0.8rem' }}>No repo triggers are bound to this agent.</p>
@@ -1150,6 +1117,39 @@ export default function GraphPage() {
                 )}
                 {wiringError && (
                   <p style={{ color: 'var(--text-danger)', fontSize: '0.8rem', marginTop: '0.5rem' }}>{wiringError}</p>
+                )}
+              </div>
+
+              <div>
+                <div style={{ fontSize: '0.75rem', fontWeight: 600, color: 'var(--accent)', textTransform: 'uppercase', marginBottom: '0.5rem' }}>Latest runs and traces</div>
+                {agentActivityLoading && <p style={{ color: 'var(--text-muted)', fontSize: '0.8rem' }}>Loading recent runs...</p>}
+                {!agentActivityLoading && agentRuns.length === 0 && (
+                  <p style={{ color: 'var(--text-muted)', fontSize: '0.8rem' }}>No recent runs for this agent.</p>
+                )}
+                {!agentActivityLoading && agentRuns.length > 0 && (
+                  <div style={{ display: 'grid', gap: '0.5rem' }}>
+                    {agentRuns.map(run => (
+                      <div key={`${run.id}:${run.span_id ?? ''}`} style={{ background: 'var(--bg)', border: '1px solid var(--border-subtle)', borderRadius: '6px', padding: '10px', display: 'grid', gap: '4px' }}>
+                        <div style={{ display: 'flex', justifyContent: 'space-between', gap: '0.75rem', alignItems: 'center' }}>
+                          <div style={{ color: 'var(--text)', fontWeight: 600, fontSize: '0.8rem' }}>
+                            {run.repo || '-'} {run.number > 0 ? `#${run.number}` : ''}
+                          </div>
+                          <span style={{ color: run.status === 'error' ? 'var(--text-danger)' : run.status === 'success' ? 'var(--success)' : 'var(--accent)', fontSize: '0.72rem', fontWeight: 700 }}>
+                            {run.status}
+                          </span>
+                        </div>
+                        <div style={{ color: 'var(--text-muted)', fontSize: '0.75rem' }}>
+                          {run.kind || '-'} · {fmtTime(run.started_at ?? run.completed_at)} · {fmtDuration(run.run_duration_ms)}
+                        </div>
+                        {run.summary && <div style={{ color: 'var(--text-faint)', fontSize: '0.75rem', fontStyle: 'italic' }}>{run.summary}</div>}
+                        {run.event_id && (
+                          <Link href={`/traces/?id=${encodeURIComponent(run.event_id)}`} style={{ color: 'var(--accent)', fontSize: '0.75rem', textDecoration: 'none' }}>
+                            Open trace →
+                          </Link>
+                        )}
+                      </div>
+                    ))}
+                  </div>
                 )}
               </div>
             </div>

--- a/internal/ui/src/app/graph/page.tsx
+++ b/internal/ui/src/app/graph/page.tsx
@@ -231,7 +231,6 @@ export default function GraphPage() {
   const [addTargetName, setAddTargetName] = useState('')
   const [loading, setLoading] = useState(true)
   const [repoFilter, setRepoFilter] = useRepoFilter()
-  const [editMode, setEditMode] = useState(false)
   const [wiringError, setWiringError] = useState('')
   const [wiringBusy, setWiringBusy] = useState(false)
   const [backendOptions, setBackendOptions] = useState<BackendOption[]>([])
@@ -463,16 +462,13 @@ export default function GraphPage() {
   }, [])
 
   const onNodeClick = useCallback((_: React.MouseEvent, node: Node) => {
-    // In edit mode, clicks on nodes initiate drag-connect via React Flow handles;
-    // suppress the details modal so the focus stays on wiring.
-    if (editMode) return
     const agent = agents.find(a => (a.id || a.name) === node.id)
     if (agent) {
       setSelectedNodeName(agent.name)
       setSelectedEdge(null)
       setPanelMode('details')
     }
-  }, [agents, editMode])
+  }, [agents])
 
   const onNodeDragStop = useCallback((_: React.MouseEvent, node: Node) => {
     const nodeID = node.id
@@ -803,18 +799,6 @@ export default function GraphPage() {
           <button onClick={openCreateAgent} style={{ background: 'var(--btn-primary-bg)', border: '1px solid var(--btn-primary-border)', color: '#fff', padding: '6px 12px', borderRadius: '6px', cursor: 'pointer', fontSize: '0.875rem', fontWeight: 600 }}>
             + Create agent
           </button>
-          <button
-            onClick={() => { setEditMode(m => !m); setWiringError(''); setSelectedEdge(null); setSelectedNodeName(null); setPanelMode(null); }}
-            style={{
-              background: editMode ? 'var(--btn-primary-bg)' : 'var(--bg-card)',
-              border: `1px solid ${editMode ? 'var(--btn-primary-border)' : 'var(--border)'}`,
-              color: editMode ? '#fff' : 'var(--accent)',
-              padding: '6px 12px', borderRadius: '6px', cursor: 'pointer', fontSize: '0.875rem', fontWeight: 500,
-            }}
-            aria-pressed={editMode}
-          >
-            {editMode ? 'Editing wiring' : 'Edit wiring'}
-          </button>
           <button onClick={load} style={{ background: 'var(--bg-card)', border: '1px solid var(--border)', color: 'var(--accent)', padding: '6px 12px', borderRadius: '6px', cursor: 'pointer', fontSize: '0.875rem', fontWeight: 500 }}>
             Refresh
           </button>
@@ -824,11 +808,10 @@ export default function GraphPage() {
         </div>
       </div>
 
-      {editMode && (
+      {(wiringBusy || wiringError) && (
         <div style={{ marginBottom: '1rem', padding: '8px 12px', background: 'var(--accent-bg)', border: '1px solid var(--btn-primary-border)', borderRadius: '6px', fontSize: '0.8rem', color: 'var(--text)' }}>
-          Drag from one agent to another to wire a dispatch edge. Click an edge to remove it.
-          {wiringBusy && <span style={{ marginLeft: '0.5rem', color: 'var(--text-muted)' }}>Saving…</span>}
-          {wiringError && <span style={{ marginLeft: '0.5rem', color: 'var(--text-danger)' }}>{wiringError}</span>}
+          {wiringBusy && <span style={{ color: 'var(--text-muted)' }}>Saving dispatch wiring...</span>}
+          {wiringError && <span style={{ color: 'var(--text-danger)' }}>{wiringError}</span>}
         </div>
       )}
 
@@ -1208,7 +1191,7 @@ export default function GraphPage() {
                 fitView
                 proOptions={{ hideAttribution: true }}
                 nodesDraggable={true}
-                nodesConnectable={editMode}
+                nodesConnectable={true}
                 elementsSelectable={true}
                 edgesFocusable={true}
                 minZoom={0.3}


### PR DESCRIPTION
## Summary
- Remove the graph Edit wiring mode toggle.
- Keep dispatch handles always enabled so users can connect agents directly.
- Keep edge click/removal in the Agent editor and update docs to match.
- Move the Agent editor's latest runs/traces section to the bottom so configuration controls stay first.

## Test plan
- `npm test` in `internal/ui`
- `npm run build` in `internal/ui`
- `go test ./... -race`
