### PR TITLE
refactor(daemon): use ContainsFunc for agent lookup

### DIFF
--- a/internal/daemon/crud_test.go
+++ b/internal/daemon/crud_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -147,14 +148,9 @@ func TestStoreCRUDAgentCreateAndGet(t *testing.T) {
 	if err := json.NewDecoder(rr.Body).Decode(&agents); err != nil {
 		t.Fatalf("decode list: %v", err)
 	}
-	var found bool
-	for _, a := range agents {
-		if a["name"] == "coder" {
-			found = true
-			break
-		}
-	}
-	if !found {
+	if !slices.ContainsFunc(agents, func(a map[string]any) bool {
+		return a["name"] == "coder"
+	}) {
 		t.Errorf("coder not found in agent list: %v", agents)
 	}
 


### PR DESCRIPTION
## Summary

- Replace the manual found flag in the CRUD agent list test with `slices.ContainsFunc`.
- Keep the existing assertion and failure message behavior unchanged.

## Testing

- `go test ./... -race`

Note: this fresh checkout was missing the ignored `internal/ui/dist` directory required by the embed pattern, so I created a local-only ignored placeholder before rerunning the full suite. The placeholder is not committed.