### PR TITLE
refactor(mcp): use slices.Contains for tool name checks

### DIFF
--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
 )
 
@@ -58,9 +59,9 @@ func TestHandlerInitializeAndListTools(t *testing.T) {
 	if err := json.Unmarshal(body, &resp); err != nil {
 		t.Fatalf("unmarshal tools/list body %q: %v", body, err)
 	}
-	got := make(map[string]bool, len(resp.Result.Tools))
+	got := make([]string, 0, len(resp.Result.Tools))
 	for _, tl := range resp.Result.Tools {
-		got[tl.Name] = true
+		got = append(got, tl.Name)
 	}
 	want := []string{
 		"list_agents",
@@ -75,7 +76,7 @@ func TestHandlerInitializeAndListTools(t *testing.T) {
 		"trigger_agent",
 	}
 	for _, name := range want {
-		if !got[name] {
+		if !slices.Contains(got, name) {
 			t.Errorf("tools/list missing tool %q (got %+v)", name, got)
 		}
 	}


### PR DESCRIPTION
## Summary

- Collect MCP tool names into a slice in the server test.
- Use `slices.Contains` for the expected-name checks instead of building a temporary membership map.

## Testing

- `go test ./... -race`

Note: this fresh checkout was missing the ignored `internal/ui/dist` directory required by the embed pattern, so I created a local-only ignored placeholder before rerunning the full suite. The placeholder is not committed.