### PR TITLE
refactor(observe): use slices.Contains for agent dedupe

### DIFF
--- a/internal/daemon/observe/observe.go
+++ b/internal/daemon/observe/observe.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"net/http"
 	"path/filepath"
+	"slices"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -155,16 +156,14 @@ func agentsForEvent(s *obstore.Store, eventID string) []string {
 	if len(spans) == 0 {
 		return nil
 	}
-	seen := make(map[string]struct{}, len(spans))
 	out := make([]string, 0, len(spans))
 	for _, sp := range spans {
 		if sp.Agent == "" {
 			continue
 		}
-		if _, ok := seen[sp.Agent]; ok {
+		if slices.Contains(out, sp.Agent) {
 			continue
 		}
-		seen[sp.Agent] = struct{}{}
 		out = append(out, sp.Agent)
 	}
 	return out


### PR DESCRIPTION
## Summary

- Replace the local `seen` map in `agentsForEvent` with `slices.Contains` over the result slice.
- Preserve existing empty-agent filtering, de-duplication, and trace insertion order.

## Testing

- `go test ./... -race`

Note: this fresh checkout was missing the ignored `internal/ui/dist` directory required by the embed pattern, so I created a local-only ignored placeholder before rerunning the full suite. The placeholder is not committed.