### PR TITLE
refactor(mcp): use ContainsFunc for graph node checks

### DIFF
--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -866,12 +866,10 @@ func TestToolGetGraphSeedsNodesFromFleetAndEdges(t *testing.T) {
 	if len(got.Nodes) != 3 {
 		t.Fatalf("expected 3 nodes, got %+v", got.Nodes)
 	}
-	ids := map[string]bool{}
-	for _, n := range got.Nodes {
-		ids[n["id"].(string)] = true
-	}
 	for _, want := range []string{"coder", "reviewer", "ghost"} {
-		if !ids[want] {
+		if !slices.ContainsFunc(got.Nodes, func(n map[string]any) bool {
+			return n["id"] == want
+		}) {
 			t.Errorf("missing node %q in %+v", want, got.Nodes)
 		}
 	}


### PR DESCRIPTION
## Summary

- Replace the one-off node ID map in the MCP graph test with `slices.ContainsFunc` over the decoded node slice.
- Keep the existing expected-node assertions unchanged.

## Testing

- `go test ./... -race`