### PR TITLE
refactor(observe): use struct set for graph errors

### DIFF
--- a/internal/daemon/observe/observe.go
+++ b/internal/daemon/observe/observe.go
@@ -360,11 +360,11 @@ func (h *Handler) HandleGraph(w http.ResponseWriter, r *http.Request) {
 
 	// Build a map of the last cron error status for each agent so idle
 	// agents that last exited with an error are flagged in the response.
-	lastErrorByAgent := make(map[string]bool)
+	lastErrorByAgent := make(map[string]struct{})
 	if h.sched != nil {
 		for _, as := range h.sched.AgentStatuses() {
 			if fleet.NormalizeWorkspaceID(as.WorkspaceID) == workspaceID && as.LastStatus == "error" {
-				lastErrorByAgent[as.Name] = true
+				lastErrorByAgent[as.Name] = struct{}{}
 			}
 		}
 	}
@@ -373,7 +373,7 @@ func (h *Handler) HandleGraph(w http.ResponseWriter, r *http.Request) {
 		if h.events != nil && h.events.IsRunning(name) {
 			return "running"
 		}
-		if lastErrorByAgent[name] {
+		if _, ok := lastErrorByAgent[name]; ok {
 			return "error"
 		}
 		return ""


### PR DESCRIPTION
## Summary

- Represent the graph handler's last-error agent membership as `map[string]struct{}`.
- Preserve the existing running/error/idle status selection behavior.

## Testing

- `go test ./... -race`

Note: this fresh checkout was missing the ignored `internal/ui/dist` directory required by the embed pattern, so I created a local-only ignored placeholder before rerunning the full suite. The placeholder is not committed.