### PR TITLE
refactor(store): reuse row scanner interface

### DIFF
--- a/internal/store/runners.go
+++ b/internal/store/runners.go
@@ -215,13 +215,7 @@ func runnerStatusFilter(status RunnerStatus) (string, []any) {
 	return "", nil
 }
 
-// scanner is satisfied by both *sql.Row and *sql.Rows so scanRunnerRow
-// can serve GetRunner and ListRunners from one helper.
-type scanner interface {
-	Scan(dest ...any) error
-}
-
-func scanRunnerRow(s scanner) (RunnerRecord, error) {
+func scanRunnerRow(s rowScanner) (RunnerRecord, error) {
 	var (
 		id              int64
 		blob            string


### PR DESCRIPTION
## Summary

- Remove the duplicate runner-specific scanner interface.
- Reuse the package-local rowScanner contract for scanRunnerRow, matching the other store row scan helpers.

## Testing

- `go test ./... -race`

Note: this fresh checkout was missing the ignored `internal/ui/dist` directory required by the embed pattern, so I created a local-only ignored placeholder before rerunning the full suite. The placeholder is not committed.