### PR TITLE
refactor(webhook): drive delivery eviction test deterministically

### DIFF
--- a/internal/webhook/delivery_store.go
+++ b/internal/webhook/delivery_store.go
@@ -30,11 +30,15 @@ func (s *DeliveryStore) Run(ctx context.Context) error {
 	}
 	ticker := time.NewTicker(s.ttl / 4)
 	defer ticker.Stop()
+	return s.run(ctx, ticker.C)
+}
+
+func (s *DeliveryStore) run(ctx context.Context, ticks <-chan time.Time) error {
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
-		case now := <-ticker.C:
+		case now := <-ticks:
 			s.evict(now)
 		}
 	}

--- a/internal/webhook/delivery_store_test.go
+++ b/internal/webhook/delivery_store_test.go
@@ -122,6 +122,7 @@ func TestDeliveryStore_BackgroundEviction(t *testing.T) {
 	}
 
 	ticks <- now.Add(ttl + time.Millisecond)
+	ticks <- now.Add(ttl + time.Millisecond)
 
 	s.mu.Lock()
 	count := len(s.deliveries)

--- a/internal/webhook/delivery_store_test.go
+++ b/internal/webhook/delivery_store_test.go
@@ -102,8 +102,16 @@ func TestDeliveryStore_BackgroundEviction(t *testing.T) {
 	s := NewDeliveryStore(ttl)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go func() { _ = s.Run(ctx) }()
+	ticks := make(chan time.Time)
+	done := make(chan struct{})
+	go func() {
+		_ = s.run(ctx, ticks)
+		close(done)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
 
 	now := time.Now()
 	s.SeenOrAdd("abc", now)
@@ -113,9 +121,7 @@ func TestDeliveryStore_BackgroundEviction(t *testing.T) {
 		t.Fatal("expected entry to be seen immediately after insertion")
 	}
 
-	// Wait longer than one eviction interval (ttl/4) plus one TTL so the entry expires
-	// and the background ticker has had a chance to evict it.
-	time.Sleep(ttl + ttl/4 + 20*time.Millisecond)
+	ticks <- now.Add(ttl + time.Millisecond)
 
 	s.mu.Lock()
 	count := len(s.deliveries)


### PR DESCRIPTION
## Summary

- Extract the delivery-store eviction select loop behind `Run` so tests can drive ticks directly.
- Replace the background eviction test's wall-clock sleep with an injected tick and cleanup-managed goroutine shutdown.

## Testing

- `go test ./internal/webhook -race`
- `go test ./... -race`
- `git diff --check`