### PR TITLE
refactor(proxy): use maps.Copy for extra body

### DIFF
--- a/internal/anthropic_proxy/handler.go
+++ b/internal/anthropic_proxy/handler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"time"
 
@@ -258,9 +259,7 @@ func (h *Handler) marshalWithExtraBody(req ChatRequest) ([]byte, error) {
 	if err := json.Unmarshal(b, &m); err != nil {
 		return nil, err
 	}
-	for k, v := range h.upstream.ExtraBody {
-		m[k] = v
-	}
+	maps.Copy(m, h.upstream.ExtraBody)
 	return json.Marshal(m)
 }
 


### PR DESCRIPTION
## Summary

- Replace the manual `ExtraBody` map copy loop with `maps.Copy` in the Anthropic proxy request marshalling path.
- Keep the existing extra-body merge behavior unchanged.

## Testing

- `go test ./internal/anthropic_proxy -race`
- `go test ./... -race`
- `git diff --check`