### PR TITLE
refactor(screenshotseed): remove unused disabled flag

### DIFF
--- a/cmd/screenshotseed/main.go
+++ b/cmd/screenshotseed/main.go
@@ -102,8 +102,6 @@ func run() error {
 // with mixed binding shapes (labels + cron).
 func buildFixtureConfig() *config.Config {
 	enabled := true
-	disabled := false
-	_ = disabled
 
 	cfg := &config.Config{
 		Daemon: config.DaemonConfig{


### PR DESCRIPTION
## Summary

- Remove the unused `disabled` local and blank assignment from the screenshot seed fixture builder.
- Keep the fixture configuration behavior unchanged.

## Testing

- `go test ./... -race`
- `git diff --check`