### PR TITLE
refactor(backends): stream model fallback lines

### DIFF
--- a/internal/backends/discovery.go
+++ b/internal/backends/discovery.go
@@ -504,9 +504,8 @@ func parseModels(raw string) []string {
 	}
 
 	// Plain-text fallback: one model per line, skip headers and decorators.
-	lines := strings.Split(raw, "\n")
-	names := make([]string, 0, len(lines))
-	for _, line := range lines {
+	var names []string
+	for line := range strings.SplitSeq(raw, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" || strings.HasPrefix(line, "|") || strings.HasPrefix(line, "*") || strings.HasPrefix(line, "#") {
 			continue


### PR DESCRIPTION
## Summary

- Replace the plain-text model fallback's `strings.Split` allocation with `strings.SplitSeq`.
- Keep the existing per-line filtering and deduped model output unchanged.

## Testing

- `go test ./internal/backends -race`
- `go test ./... -race` after creating the local ignored `internal/ui/dist/index.html` embed placeholder required in a fresh checkout
- `git diff --check`