### PR TITLE
refactor(workflow): use maps.DeleteFunc for dispatch eviction

### DIFF
--- a/internal/workflow/dispatch.go
+++ b/internal/workflow/dispatch.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -122,16 +123,14 @@ func (s *DispatchDedupStore) Run(ctx context.Context) error {
 func (s *DispatchDedupStore) evict(now time.Time) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	for key, entry := range s.entries {
+	maps.DeleteFunc(s.entries, func(key string, entry dispatchEntry) bool {
 		// Do not evict entries whose run is still in flight: the refcount
 		// tracks active callers that called MarkCronRun/MarkWebhookRunInFlight
 		// but have not yet called the corresponding finalize/abandon method.
 		// Evicting such an entry would allow TryClaimForDispatch to proceed
 		// even though the run is still executing.
-		if now.After(entry.expiresAt) && s.cronRefCounts[key] == 0 && s.webhookRefCounts[key] == 0 {
-			delete(s.entries, key)
-		}
-	}
+		return now.After(entry.expiresAt) && s.cronRefCounts[key] == 0 && s.webhookRefCounts[key] == 0
+	})
 }
 
 // dispatchStoreKey builds the map key for a dispatch-namespace entry.


### PR DESCRIPTION
## Summary

- Replace the manual dispatch dedupe eviction delete loop with `maps.DeleteFunc`.
- Keep the existing in-flight refcount guard and TTL behavior unchanged.

## Testing

- `go test ./internal/workflow -race`
- `go test ./... -race` after creating the local ignored `internal/ui/dist/index.html` embed placeholder required in a fresh checkout
- `git diff --check`