### PR TITLE
refactor(backends): clone base environment with slices

### DIFF
--- a/internal/backends/discovery.go
+++ b/internal/backends/discovery.go
@@ -592,8 +592,7 @@ func mergeEnv(base []string, override map[string]string) []string {
 	if len(override) == 0 {
 		return base
 	}
-	out := make([]string, 0, len(base)+len(override))
-	out = append(out, base...)
+	out := slices.Grow(slices.Clone(base), len(override))
 	for k, v := range override {
 		out = append(out, k+"="+v)
 	}


### PR DESCRIPTION
## Summary

- Replace the manual base environment slice copy in `mergeEnv` with `slices.Clone` plus `slices.Grow`.
- Keep the empty-override fast path and appended override behavior unchanged.

## Testing

- `go test ./internal/backends -race`
- `go test ./... -race` after creating the local ignored `internal/ui/dist/index.html` embed placeholder required in a fresh checkout
- `git diff --check`