### PR TITLE
refactor(fleet): trust workspace normalization

### DIFF
--- a/internal/fleet/prompt.go
+++ b/internal/fleet/prompt.go
@@ -29,7 +29,7 @@ func CatalogScopePath(workspaceID, repo string) string {
 	if workspaceID == "" {
 		workspaceID = DefaultWorkspaceID
 	}
-	workspaceID = strings.ToLower(NormalizeWorkspaceID(workspaceID))
+	workspaceID = NormalizeWorkspaceID(workspaceID)
 	if repo == "" {
 		return workspaceID
 	}
@@ -49,7 +49,7 @@ func ParseCatalogScopePath(scope string) (workspaceID, repo string, explicit boo
 		return "", "", true
 	}
 	workspaceID, repo, found := strings.Cut(lower, "/")
-	workspaceID = strings.ToLower(NormalizeWorkspaceID(workspaceID))
+	workspaceID = NormalizeWorkspaceID(workspaceID)
 	if !found {
 		return workspaceID, "", true
 	}


### PR DESCRIPTION
## Summary

- Remove redundant `strings.ToLower` calls around `NormalizeWorkspaceID` in catalog scope helpers.
- Keep catalog scope path and parse behavior unchanged while relying on the shared workspace normalizer.

## Testing

- `go test ./internal/fleet -race`
- `go test ./... -race`
- `git diff --check`