### PR TITLE
refactor(fleet): reuse orphan agent key

### DIFF
--- a/internal/daemon/fleet/orphans.go
+++ b/internal/daemon/fleet/orphans.go
@@ -78,10 +78,11 @@ func computeOrphanedAgents(cfg *config.Config) []OrphanedAgent {
 	for _, repo := range cfg.Repos {
 		workspaceID := fleet.NormalizeWorkspaceID(repo.WorkspaceID)
 		for _, binding := range repo.Use {
-			set := reposByAgent[workspaceAgentKey(workspaceID, binding.Agent)]
+			key := workspaceAgentKey(workspaceID, binding.Agent)
+			set := reposByAgent[key]
 			if set == nil {
 				set = make(map[string]struct{})
-				reposByAgent[workspaceAgentKey(workspaceID, binding.Agent)] = set
+				reposByAgent[key] = set
 			}
 			set[repo.Name] = struct{}{}
 		}


### PR DESCRIPTION
## Summary

- Store the workspace-agent map key once while indexing repos for orphaned agents.
- Keep the orphan detection and repo grouping behavior unchanged.

## Testing

- `go test ./internal/daemon/fleet -race`
- `go test ./... -race`
- `git diff --check`