### PR TITLE
refactor: use bytes.Lines for SSE workspace scan

### DIFF
--- a/internal/daemon/observe/observe.go
+++ b/internal/daemon/observe/observe.go
@@ -613,7 +613,7 @@ func ServeSSEWithIntervalFiltered(w http.ResponseWriter, r *http.Request, hub SS
 }
 
 func workspaceFromSSEMessage(msg []byte) string {
-	for _, line := range bytes.Split(msg, []byte("\n")) {
+	for line := range bytes.Lines(msg) {
 		line = bytes.TrimSpace(line)
 		if !bytes.HasPrefix(line, []byte("data:")) {
 			continue


### PR DESCRIPTION
## Summary

- Replaces manual newline splitting in the SSE workspace filter with `bytes.Lines`.
- Keeps the existing trim and `data:` parsing behavior unchanged.

## Test plan

- `go test ./internal/daemon/observe -race`
- `go test ./... -race`