### PR TITLE
refactor: use slices.Clone for config exports

### DIFF
--- a/internal/daemon/config/config.go
+++ b/internal/daemon/config/config.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/gorilla/mux"
@@ -434,8 +435,8 @@ func (p exportYAML) toConfig() *config.Config {
 		Prompts:    p.Prompts,
 		Skills:     p.Skills,
 		Guardrails: p.Guardrails,
-		Agents:     append([]fleet.Agent{}, p.Agents...),
-		Repos:      append([]fleet.Repo{}, p.Repos...),
+		Agents:     slices.Clone(p.Agents),
+		Repos:      slices.Clone(p.Repos),
 	}
 	for _, w := range p.Workspaces {
 		workspaceID := workspaceYAMLID(w)
@@ -462,7 +463,7 @@ func (p exportYAML) toConfig() *config.Config {
 }
 
 func (p exportYAML) flattenTokenBudgets() []store.TokenBudget {
-	budgets := append([]store.TokenBudget{}, p.TokenBudgets...)
+	budgets := slices.Clone(p.TokenBudgets)
 	for _, w := range p.Workspaces {
 		workspaceID := workspaceYAMLID(w)
 		for _, b := range w.TokenBudgets {


### PR DESCRIPTION
## Summary

- Replaces manual `append([]T{}, src...)` clones in config export/import helpers with `slices.Clone`.
- Keeps the existing shallow-copy behavior unchanged.

## Test plan

- `go test ./internal/daemon/config -race`
- `go test ./... -race`
- `git diff --check`