### PR TITLE
ui: hide skipped events from runners

### DIFF
--- a/internal/ui/src/app/graph/page.tsx
+++ b/internal/ui/src/app/graph/page.tsx
@@ -478,6 +478,7 @@ export default function GraphPage() {
       if (!res.ok) throw new Error(`runners ${res.status}`)
       const data = await res.json() as { runners?: RunnerRow[] }
       const rows = (data.runners ?? [])
+        .filter(r => r.status !== 'skipped')
         .filter(r => r.agent === agentName || r.target_agent === agentName)
         .slice(0, 8)
       setAgentRuns(rows)

--- a/internal/ui/src/app/runners/page.tsx
+++ b/internal/ui/src/app/runners/page.tsx
@@ -67,6 +67,10 @@ const statusStyle: Record<string, { bg: string; text: string; border: string }> 
 const POLL_MS = 2000
 const HIGHLIGHT_MS = 4000
 
+function isRunnerExecution(row: RunnerRow) {
+  return row.status !== 'skipped'
+}
+
 function fmtTime(s?: string) {
   if (!s) return '-'
   return new Date(s).toLocaleTimeString()
@@ -228,7 +232,6 @@ function RunnersInner() {
   }
 
   const [rows, setRows] = useState<RunnerRow[]>([])
-  const [total, setTotal] = useState(0)
   const [status, setStatus] = useState<'' | 'enqueued' | 'running' | 'completed'>('')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -244,7 +247,6 @@ function RunnersInner() {
       if (!res.ok) throw new Error(`status ${res.status}`)
       const data: ListResponse = await res.json()
       setRows(data.runners ?? [])
-      setTotal(data.total)
       setError(null)
     } catch (e) {
       setError((e as Error).message)
@@ -279,7 +281,7 @@ function RunnersInner() {
   }, [focusEvent, rows.length, highlighted])
 
   const filtered = useMemo(() => {
-    let result = rows
+    let result = rows.filter(isRunnerExecution)
     if (focusEvent) result = result.filter(r => r.event_id === focusEvent)
     if (repoParam) result = result.filter(r => r.repo === repoParam)
     return result
@@ -353,7 +355,7 @@ function RunnersInner() {
             {focusEvent ? (
               <>Showing event <code style={{ color: 'var(--accent)' }}>{focusEvent}</code> · {filtered.length} row{filtered.length !== 1 ? 's' : ''}</>
             ) : (
-              <>{total} event{total !== 1 ? 's' : ''} matching filter · {filtered.length} runner row{filtered.length !== 1 ? 's' : ''} · enqueued {counts.enqueued ?? 0} · running {counts.running ?? 0} · success {counts.success ?? 0} · error {counts.error ?? 0} · skipped {counts.skipped ?? 0}</>
+              <>{filtered.length} runner execution{filtered.length !== 1 ? 's' : ''} · enqueued {counts.enqueued ?? 0} · running {counts.running ?? 0} · success {counts.success ?? 0} · error {counts.error ?? 0} · skipped/no-op events live in Events</>
             )}
           </p>
         </div>
@@ -410,7 +412,11 @@ function RunnersInner() {
         </div>
 
         {loading && filtered.length === 0 && <p style={{ color: 'var(--text-muted)', padding: '0.5rem 0' }}>Loading...</p>}
-        {!loading && filtered.length === 0 && <p style={{ color: 'var(--text-muted)', padding: '0.5rem 0' }}>No runners.</p>}
+        {!loading && filtered.length === 0 && (
+          <p style={{ color: 'var(--text-muted)', padding: '0.5rem 0' }}>
+            {focusEvent ? 'No runner execution for this event. It may have been skipped; Events keeps the full audit log.' : 'No runner executions.'}
+          </p>
+        )}
 
         <div style={{ maxHeight: '600px', overflowY: 'auto' }}>
           {filtered.map((r, idx) => {


### PR DESCRIPTION
## Summary
- hide skipped/no-op events from the Runners page by default
- keep the Events page as the full audit log for skipped events
- hide skipped rows from the graph agent activity panel

## Tests
- npm run build