### PR TITLE
refactor: use sorted map keys for workspace imports

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -484,8 +484,7 @@ func importReferencedWorkspaces(tx *sql.Tx, agents []fleet.Agent, repos []fleet.
 		}
 		seen[id] = struct{}{}
 	}
-	ids := slices.Collect(maps.Keys(seen))
-	slices.Sort(ids)
+	ids := slices.Sorted(maps.Keys(seen))
 	for _, id := range ids {
 		if err := validateEntityID(id); err != nil {
 			return fmt.Errorf("store import: workspace %q: %w", id, err)


### PR DESCRIPTION
## Summary

- Replaces collect-then-sort of imported workspace IDs with `slices.Sorted(maps.Keys(...))`.
- Keeps workspace import ordering deterministic with less plumbing.

## Test plan

- `go test ./internal/store -race`
- `go test ./... -race`
- `git diff --check`