### PR TITLE
refactor: use sorted values for workflow repos

### DIFF
--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -1025,6 +1025,5 @@ func allowedReposForAgent(workspaceID string, agent fleet.Agent, repos []fleet.R
 		}
 		allowed = append(allowed, repo.Name)
 	}
-	slices.Sort(allowed)
-	return slices.Compact(allowed)
+	return slices.Compact(slices.Sorted(slices.Values(allowed)))
 }


### PR DESCRIPTION
## Summary

- Replaces the manual sort-then-compact sequence in `allowedReposForAgent` with `slices.Sorted(slices.Values(...))` before compaction.
- Keeps the existing allowed-repository ordering and duplicate removal behavior unchanged.

## Test plan

- `go test ./internal/workflow -race -v`
- `for pkg in $(go list ./...); do printf '== %s\n' "$pkg"; go test -race "$pkg" || exit 1; done`
- `git diff --check`