### PR TITLE
refactor: simplify canonical model sorting

### DIFF
--- a/internal/daemon/fleet/orphans.go
+++ b/internal/daemon/fleet/orphans.go
@@ -126,15 +126,14 @@ func workspaceAgentKey(workspaceID, agentName string) string {
 }
 
 func canonicalModels(models []string) []string {
-	out := make([]string, 0, len(models))
+	seen := make(map[string]struct{}, len(models))
 	for _, m := range models {
 		if m = strings.TrimSpace(m); m != "" {
-			out = append(out, m)
+			seen[m] = struct{}{}
 		}
 	}
-	if len(out) == 0 {
+	if len(seen) == 0 {
 		return nil
 	}
-	slices.Sort(out)
-	return slices.Compact(out)
+	return slices.Sorted(maps.Keys(seen))
 }


### PR DESCRIPTION
## Summary

- Replaces manual append, sort, and compact plumbing in `canonicalModels` with a set plus `slices.Sorted(maps.Keys(...))`.
- Preserves the existing trimming, deduplication, sorted output, and nil-on-empty behavior.

## Test plan

- `go test ./internal/daemon/fleet -race`
- `go test ./... -race`
- `git diff --check`