### PR TITLE
Fix runner MCP diagnostics

### DIFF
--- a/internal/ai/cmdrunner.go
+++ b/internal/ai/cmdrunner.go
@@ -31,16 +31,8 @@ type CommandRunner struct {
 type runtimeexecSpec = runtimeexec.ContainerSpec
 
 const (
-	containerRunDir            = runtimeexec.RunnerTempMount
-	containerWorkspaceDir      = "/workspace"
-	containerResponseSchema    = containerRunDir + "/response-schema.json"
-	containerHomeDir           = containerRunDir + "/home"
-	containerXDGConfigDir      = containerRunDir + "/config"
-	containerXDGCacheDir       = containerRunDir + "/cache"
-	containerXDGDataDir        = containerRunDir + "/data"
-	containerCodexHomeDir      = containerRunDir + "/codex"
-	containerClaudeMCPPath     = containerRunDir + "/claude-mcp.json"
-	containerResponseSchemaEnv = "AGENTS_RESPONSE_SCHEMA"
+	containerWorkspaceDir   = runtimeexec.RunnerWorkspaceDir
+	containerResponseSchema = runtimeexec.RunnerResponseSchema
 )
 
 func newCommandRunner(backendName string, command string, env map[string]string, timeoutSeconds int, maxPromptChars int, logger zerolog.Logger) *CommandRunner {
@@ -113,28 +105,18 @@ func (r *CommandRunner) runContainerCommand(ctx context.Context, args []string, 
 	writer := &captureWriter{onLine: onLine}
 	var stderr bytes.Buffer
 
+	setup := runtimeexec.BackendSetupOptions{}
 	if r.isCodexBackend() {
 		var schemaErr error
 		args, schemaErr = rewriteContainerResponseSchemaArg(args)
 		if schemaErr != nil {
 			return lineCapture{}, "", schemaErr
 		}
-		env = setEnvValues(env, containerResponseSchemaEnv, ResponseSchemaString())
+		setup.ResponseSchema = ResponseSchemaString()
 	}
 
-	env = setEnvValues(env,
-		"HOME", containerHomeDir,
-		"TMPDIR", containerRunDir,
-		"XDG_CONFIG_HOME", containerXDGConfigDir,
-		"XDG_CACHE_HOME", containerXDGCacheDir,
-		"XDG_DATA_HOME", containerXDGDataDir,
-		"CODEX_HOME", containerCodexHomeDir,
-	)
-	if getEnv(env, "GITHUB_TOKEN") != "" && getEnv(env, "GH_TOKEN") == "" {
-		env = append(env, "GH_TOKEN="+getEnv(env, "GITHUB_TOKEN"))
-	}
 	command := append([]string{r.command}, args...)
-	command = r.containerEntrypoint(command, env)
+	command, env = runtimeexec.WrapBackendCommand(r.backendName, command, env, setup)
 	spec := r.containerSpec
 	spec.Image = r.containerImage
 	spec.Command = command
@@ -158,68 +140,6 @@ func (r *CommandRunner) runContainerCommand(ctx context.Context, args []string, 
 	return writer.capture, stderr.String(), nil
 }
 
-func (r *CommandRunner) containerEntrypoint(command []string, env []string) []string {
-	if len(command) == 0 {
-		return command
-	}
-	switch {
-	case r.isClaudeBackend() && getEnv(env, "GITHUB_TOKEN") != "" && !hasArg(command[1:], "--mcp-config"):
-		command = append(command[:1], append([]string{"--mcp-config", containerClaudeMCPPath}, command[1:]...)...)
-		return shellEntrypoint(command, baseContainerSetup+claudeContainerSetup)
-	case r.isCodexBackend():
-		return shellEntrypoint(command, baseContainerSetup+codexContainerSetup)
-	default:
-		return shellEntrypoint(command, baseContainerSetup)
-	}
-}
-
-func shellEntrypoint(command []string, setup string) []string {
-	out := []string{"/bin/sh", "-lc", setup + `
-cmd=$1
-shift
-exec "$cmd" "$@"
-`, "agents-runner"}
-	return append(out, command...)
-}
-
-const baseContainerSetup = `
-set -eu
-mkdir -p "$HOME" "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME" "$XDG_DATA_HOME" "$CODEX_HOME"
-`
-
-const claudeContainerSetup = `
-if [ -n "${GITHUB_TOKEN:-}" ]; then
-  printf '{"mcpServers":{"github":{"type":"http","url":"https://api.githubcopilot.com/mcp/","headers":{"Authorization":"Bearer %s"}}}}\n' "$GITHUB_TOKEN" > /tmp/agents-run/claude-mcp.json
-fi
-`
-
-const codexContainerSetup = `
-if [ -n "${AGENTS_RESPONSE_SCHEMA:-}" ]; then
-  printf '%s' "$AGENTS_RESPONSE_SCHEMA" > /tmp/agents-run/response-schema.json
-fi
-if [ -n "${GITHUB_TOKEN:-}" ]; then
-  cat > "$CODEX_HOME/config.toml" <<'TOML'
-[mcp_servers.github]
-url = "https://api.githubcopilot.com/mcp/"
-bearer_token_env_var = "GITHUB_TOKEN"
-TOML
-fi
-if [ -n "${OPENAI_API_KEY:-}" ]; then
-  printf '%s' "$OPENAI_API_KEY" | "$1" login --with-api-key >/dev/null || echo "codex login failed" >&2
-elif [ -n "${CODEX_ACCESS_TOKEN:-}" ]; then
-  printf '%s' "$CODEX_ACCESS_TOKEN" | "$1" login --with-access-token >/dev/null || echo "codex login failed" >&2
-fi
-`
-
-func hasArg(args []string, arg string) bool {
-	for _, a := range args {
-		if a == arg {
-			return true
-		}
-	}
-	return false
-}
-
 func rewriteContainerResponseSchemaArg(args []string) ([]string, error) {
 	if !slices.Contains(args, "--output-schema") {
 		return args, nil
@@ -232,31 +152,6 @@ func rewriteContainerResponseSchemaArg(args []string) ([]string, error) {
 		}
 	}
 	return nil, fmt.Errorf("codex output schema flag missing path")
-}
-
-func setEnvValues(env []string, kvs ...string) []string {
-	if len(kvs)%2 != 0 {
-		panic("setEnvValues requires key/value pairs")
-	}
-	keys := make(map[string]string, len(kvs)/2)
-	for i := 0; i < len(kvs); i += 2 {
-		keys[kvs[i]] = kvs[i+1]
-	}
-	out := env[:0]
-	for _, entry := range env {
-		key, _, found := strings.Cut(entry, "=")
-		if !found {
-			continue
-		}
-		if _, replace := keys[key]; replace {
-			continue
-		}
-		out = append(out, entry)
-	}
-	for i := 0; i < len(kvs); i += 2 {
-		out = append(out, kvs[i]+"="+kvs[i+1])
-	}
-	return out
 }
 
 func (r *CommandRunner) parseCommandResponse(logger zerolog.Logger, stdoutCap lineCapture, stderr string, cmdErr error) (Response, error) {
@@ -817,14 +712,4 @@ func allowCommandEnvKey(key string) bool {
 	default:
 		return strings.HasPrefix(key, "LC_")
 	}
-}
-
-func getEnv(env []string, key string) string {
-	prefix := key + "="
-	for i := len(env) - 1; i >= 0; i-- {
-		if strings.HasPrefix(env[i], prefix) {
-			return strings.TrimPrefix(env[i], prefix)
-		}
-	}
-	return ""
 }

--- a/internal/backends/discovery.go
+++ b/internal/backends/discovery.go
@@ -23,9 +23,9 @@ const (
 	CodexName       = "codex"
 	ClaudeLocalName = "claude_local"
 
-	diagnosticHome       = runtimeexec.RunnerTempMount + "/home"
-	diagnosticConfigHome = runtimeexec.RunnerTempMount + "/config"
-	diagnosticCodexHome  = runtimeexec.RunnerTempMount + "/codex"
+	diagnosticHome       = runtimeexec.RunnerHomeDir
+	diagnosticConfigHome = runtimeexec.RunnerXDGConfigDir
+	diagnosticCodexHome  = runtimeexec.RunnerCodexHomeDir
 )
 
 var (
@@ -253,7 +253,7 @@ func diagnoseVersionedToolInRuntime(ctx context.Context, runner runtimeexec.Runn
 		status.Detail = command + " binary not found in runner image"
 		return status
 	}
-	stdout, stderr, err := runToolCommandInRuntime(ctx, runner, settings, path, args, nil)
+	stdout, stderr, err := runToolCommandInRuntime(ctx, runner, settings, "", path, args, nil)
 	status.Version = firstNonEmptyLine(stdout, stderr)
 	status.Healthy = err == nil
 	if err != nil {
@@ -278,10 +278,10 @@ func diagnoseGitHubCLIInRuntime(ctx context.Context, runner runtimeexec.Runner, 
 		return status
 	}
 
-	versionOut, versionErr, versionRunErr := runToolCommandInRuntime(ctx, runner, settings, path, []string{"--version"}, nil)
+	versionOut, versionErr, versionRunErr := runToolCommandInRuntime(ctx, runner, settings, "", path, []string{"--version"}, nil)
 	status.Version = firstNonEmptyLine(versionOut, versionErr)
 
-	authOut, authErr, authRunErr := runToolCommandInRuntime(ctx, runner, settings, path, []string{"auth", "status", "--hostname", "github.com"}, nil)
+	authOut, authErr, authRunErr := runToolCommandInRuntime(ctx, runner, settings, "", path, []string{"auth", "status", "--hostname", "github.com"}, nil)
 	authDetail := firstNonEmptyLine(authOut, authErr)
 	if authDetail == "" {
 		authDetail = firstNonEmptyLine(authRunErrString(authRunErr))
@@ -329,14 +329,14 @@ func diagnoseBackendInRuntime(ctx context.Context, runner runtimeexec.Runner, se
 		env["ANTHROPIC_BASE_URL"] = localURL
 	}
 
-	versionOut, versionErr, versionRunErr := runToolCommandInRuntime(ctx, runner, settings, path, []string{"--version"}, env)
+	versionOut, versionErr, versionRunErr := runToolCommandInRuntime(ctx, runner, settings, backendName, path, []string{"--version"}, env)
 	versionOK := versionRunErr == nil
 	status.Version = firstNonEmptyLine(versionOut, versionErr)
 
 	models, modelsDetail := discoverModelsInRuntime(ctx, runner, settings, commandName, path, env)
 	status.Models = models
 
-	mcpDetail := checkGitHubMCPInRuntime(ctx, runner, settings, path, env)
+	mcpDetail := checkGitHubMCPInRuntime(ctx, runner, settings, backendName, path, env)
 	status.Healthy = versionOK
 
 	details := make([]string, 0, 3)
@@ -366,7 +366,7 @@ func discoverModelsInRuntime(ctx context.Context, runner runtimeexec.Runner, set
 	}
 	failures := make([]string, 0, len(commands))
 	for _, args := range commands {
-		stdout, stderr, err := runToolCommandInRuntime(ctx, runner, settings, command, args, env)
+		stdout, stderr, err := runToolCommandInRuntime(ctx, runner, settings, backendName, command, args, env)
 		if err != nil {
 			detail := firstNonEmptyLine(stderr, stdout, err.Error())
 			if detail == "" {
@@ -388,8 +388,8 @@ func discoverModelsInRuntime(ctx context.Context, runner runtimeexec.Runner, set
 	return nil, "models discovery failed: " + failures[0]
 }
 
-func checkGitHubMCPInRuntime(ctx context.Context, runner runtimeexec.Runner, settings fleet.RuntimeSettings, command string, env map[string]string) string {
-	stdout, stderr, err := runToolCommandInRuntime(ctx, runner, settings, command, []string{"mcp", "list"}, env)
+func checkGitHubMCPInRuntime(ctx context.Context, runner runtimeexec.Runner, settings fleet.RuntimeSettings, backendName string, command string, env map[string]string) string {
+	stdout, stderr, err := runToolCommandInRuntime(ctx, runner, settings, backendName, command, []string{"mcp", "list"}, env)
 	if err != nil {
 		detail := firstNonEmptyLine(stderr, stdout)
 		if detail == "" {
@@ -625,7 +625,7 @@ func commandPathInRuntime(ctx context.Context, runner runtimeexec.Runner, settin
 	if command == "" {
 		return "", false
 	}
-	stdout, _, err := runShellInRuntime(ctx, runner, settings, "command -v "+shellQuote(command), nil)
+	stdout, _, err := runShellInRuntime(ctx, runner, settings, "", "", "command -v "+shellQuote(command), nil)
 	if err != nil {
 		return "", false
 	}
@@ -648,11 +648,11 @@ func firstNonEmptyLine(values ...string) string {
 	return ""
 }
 
-func runToolCommandInRuntime(ctx context.Context, runner runtimeexec.Runner, settings fleet.RuntimeSettings, command string, args []string, env map[string]string) (string, string, error) {
-	return runShellInRuntime(ctx, runner, settings, "exec "+shellJoin(command, args), env)
+func runToolCommandInRuntime(ctx context.Context, runner runtimeexec.Runner, settings fleet.RuntimeSettings, backendName string, command string, args []string, env map[string]string) (string, string, error) {
+	return runShellInRuntime(ctx, runner, settings, backendName, command, "exec "+shellJoin(command, args), env)
 }
 
-func runShellInRuntime(ctx context.Context, runner runtimeexec.Runner, settings fleet.RuntimeSettings, script string, env map[string]string) (string, string, error) {
+func runShellInRuntime(ctx context.Context, runner runtimeexec.Runner, settings fleet.RuntimeSettings, backendName string, backendCommand string, script string, env map[string]string) (string, string, error) {
 	runCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
 
@@ -660,11 +660,15 @@ func runShellInRuntime(ctx context.Context, runner runtimeexec.Runner, settings 
 	var stderr bytes.Buffer
 	policy := settings.Constraints
 	policy.TimeoutSeconds = 0
+	diagnosticEnv := diagnosticEnv(env)
+	setupOptions := runtimeexec.BackendSetupOptions{BackendCommand: backendCommand}
+	diagnosticEnv = runtimeexec.PrepareBackendEnv(diagnosticEnv, setupOptions)
+	setup := runtimeexec.BackendSetupScript(backendName, setupOptions)
 	status, err := runner.Run(runCtx, runtimeexec.ContainerSpec{
 		Image:      settings.RunnerImage,
-		Command:    []string{"/bin/sh", "-lc", "mkdir -p " + shellQuote(diagnosticHome) + " " + shellQuote(diagnosticConfigHome) + " " + shellQuote(diagnosticCodexHome) + " && " + script},
-		WorkingDir: "/workspace",
-		Env:        diagnosticEnv(env),
+		Command:    []string{"/bin/sh", "-lc", setup + script},
+		WorkingDir: runtimeexec.RunnerWorkspaceDir,
+		Env:        diagnosticEnv,
 		Stdout:     &stdout,
 		Stderr:     &stderr,
 		Policy:     policy,

--- a/internal/backends/discovery_test.go
+++ b/internal/backends/discovery_test.go
@@ -166,6 +166,28 @@ func TestDiagnoseGitHubCLIInRuntimeUsesRunnerContainer(t *testing.T) {
 	}
 }
 
+func TestCheckGitHubMCPInRuntimeUsesBackendSetup(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "test-token")
+
+	var got runtimeexec.ContainerSpec
+	runner := fakeRuntimeRunner{run: func(spec runtimeexec.ContainerSpec) (int, string, string, error) {
+		got = spec
+		script := strings.Join(spec.Command, " ")
+		if !strings.Contains(script, "/workspace/.mcp.json") {
+			t.Fatalf("runner command = %v, want shared claude MCP setup", spec.Command)
+		}
+		return 0, `github: https://api.githubcopilot.com/mcp (HTTP) - ✓ Connected`, "", nil
+	}}
+
+	detail := checkGitHubMCPInRuntime(context.Background(), runner, fleet.RuntimeSettings{RunnerImage: "runner:test"}, "claude", "claude", nil)
+	if detail != "github MCP: connected" {
+		t.Fatalf("detail = %q, want connected", detail)
+	}
+	if !envContains(got.Env, "GH_TOKEN=test-token") {
+		t.Fatalf("Env missing GH_TOKEN fallback: %v", got.Env)
+	}
+}
+
 type fakeRuntimeRunner struct {
 	run func(runtimeexec.ContainerSpec) (code int, stdout string, stderr string, err error)
 }

--- a/internal/runtime/backend_setup.go
+++ b/internal/runtime/backend_setup.go
@@ -1,0 +1,152 @@
+package runtime
+
+import "strings"
+
+const (
+	RunnerWorkspaceDir     = "/workspace"
+	RunnerTempMount        = "/tmp/agents-run"
+	RunnerHomeDir          = RunnerTempMount + "/home"
+	RunnerXDGConfigDir     = RunnerTempMount + "/config"
+	RunnerXDGCacheDir      = RunnerTempMount + "/cache"
+	RunnerXDGDataDir       = RunnerTempMount + "/data"
+	RunnerCodexHomeDir     = RunnerTempMount + "/codex"
+	RunnerClaudeMCPPath    = RunnerTempMount + "/claude-mcp.json"
+	RunnerResponseSchema   = RunnerTempMount + "/response-schema.json"
+	ResponseSchemaEnv      = "AGENTS_RESPONSE_SCHEMA"
+	claudeProjectMCPConfig = RunnerWorkspaceDir + "/.mcp.json"
+)
+
+type BackendSetupOptions struct {
+	ResponseSchema string
+	BackendCommand string
+}
+
+func PrepareBackendEnv(env []string, opts BackendSetupOptions) []string {
+	out := setEnvValues(env,
+		"HOME", RunnerHomeDir,
+		"TMPDIR", RunnerTempMount,
+		"XDG_CONFIG_HOME", RunnerXDGConfigDir,
+		"XDG_CACHE_HOME", RunnerXDGCacheDir,
+		"XDG_DATA_HOME", RunnerXDGDataDir,
+		"CODEX_HOME", RunnerCodexHomeDir,
+	)
+	if opts.ResponseSchema != "" {
+		out = setEnvValues(out, ResponseSchemaEnv, opts.ResponseSchema)
+	}
+	if opts.BackendCommand != "" {
+		out = setEnvValues(out, "AGENTS_BACKEND_COMMAND", opts.BackendCommand)
+	}
+	if getEnv(out, "GITHUB_TOKEN") != "" && getEnv(out, "GH_TOKEN") == "" {
+		out = append(out, "GH_TOKEN="+getEnv(out, "GITHUB_TOKEN"))
+	}
+	return out
+}
+
+func BackendSetupScript(backendName string, opts BackendSetupOptions) string {
+	script := baseContainerSetup
+	switch {
+	case strings.HasPrefix(backendName, "claude"):
+		script += claudeContainerSetup
+	case strings.HasPrefix(backendName, "codex"):
+		script += codexContainerSetup
+	}
+	return script
+}
+
+func WrapBackendCommand(backendName string, command []string, env []string, opts BackendSetupOptions) ([]string, []string) {
+	if len(command) > 0 && opts.BackendCommand == "" {
+		opts.BackendCommand = command[0]
+	}
+	env = PrepareBackendEnv(env, opts)
+	if len(command) == 0 {
+		return command, env
+	}
+	if strings.HasPrefix(backendName, "claude") && getEnv(env, "GITHUB_TOKEN") != "" && !hasArg(command[1:], "--mcp-config") {
+		command = append(command[:1], append([]string{"--mcp-config", RunnerClaudeMCPPath}, command[1:]...)...)
+	}
+	return shellEntrypoint(command, BackendSetupScript(backendName, opts)), env
+}
+
+func shellEntrypoint(command []string, setup string) []string {
+	out := []string{"/bin/sh", "-lc", setup + `
+cmd=$1
+shift
+exec "$cmd" "$@"
+`, "agents-runner"}
+	return append(out, command...)
+}
+
+const baseContainerSetup = `
+set -eu
+mkdir -p "$HOME" "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME" "$XDG_DATA_HOME" "$CODEX_HOME" "` + RunnerWorkspaceDir + `"
+`
+
+const claudeContainerSetup = `
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+  printf '{"mcpServers":{"github":{"type":"http","url":"https://api.githubcopilot.com/mcp/","headers":{"Authorization":"Bearer %s"}}}}\n' "$GITHUB_TOKEN" > ` + RunnerClaudeMCPPath + `
+  cp ` + RunnerClaudeMCPPath + ` ` + claudeProjectMCPConfig + `
+fi
+`
+
+const codexContainerSetup = `
+if [ -n "${AGENTS_RESPONSE_SCHEMA:-}" ]; then
+  printf '%s' "$AGENTS_RESPONSE_SCHEMA" > ` + RunnerResponseSchema + `
+fi
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+  cat > "$CODEX_HOME/config.toml" <<'TOML'
+[mcp_servers.github]
+url = "https://api.githubcopilot.com/mcp/"
+bearer_token_env_var = "GITHUB_TOKEN"
+TOML
+fi
+codex_cmd="${AGENTS_BACKEND_COMMAND:-codex}"
+if [ -n "${OPENAI_API_KEY:-}" ]; then
+  printf '%s' "$OPENAI_API_KEY" | "$codex_cmd" login --with-api-key >/dev/null || echo "codex login failed" >&2
+elif [ -n "${CODEX_ACCESS_TOKEN:-}" ]; then
+  printf '%s' "$CODEX_ACCESS_TOKEN" | "$codex_cmd" login --with-access-token >/dev/null || echo "codex login failed" >&2
+fi
+`
+
+func hasArg(args []string, arg string) bool {
+	for _, a := range args {
+		if a == arg {
+			return true
+		}
+	}
+	return false
+}
+
+func setEnvValues(env []string, kvs ...string) []string {
+	if len(kvs)%2 != 0 {
+		panic("setEnvValues requires key/value pairs")
+	}
+	keys := make(map[string]string, len(kvs)/2)
+	for i := 0; i < len(kvs); i += 2 {
+		keys[kvs[i]] = kvs[i+1]
+	}
+	out := env[:0]
+	for _, entry := range env {
+		key, _, found := strings.Cut(entry, "=")
+		if !found {
+			continue
+		}
+		if _, replace := keys[key]; replace {
+			continue
+		}
+		out = append(out, entry)
+	}
+	for i := 0; i < len(kvs); i += 2 {
+		out = append(out, kvs[i]+"="+kvs[i+1])
+	}
+	return out
+}
+
+func getEnv(env []string, key string) string {
+	prefix := key + "="
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			return strings.TrimPrefix(entry, prefix)
+		}
+	}
+	return ""
+}

--- a/internal/runtime/backend_setup_test.go
+++ b/internal/runtime/backend_setup_test.go
@@ -1,0 +1,46 @@
+package runtime
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestWrapBackendCommandMaterializesClaudeMCP(t *testing.T) {
+	t.Parallel()
+
+	command, env := WrapBackendCommand("claude", []string{"claude", "-p"}, []string{"GITHUB_TOKEN=gh-token"}, BackendSetupOptions{})
+	if !slices.Contains(command, "--mcp-config") || !slices.Contains(command, RunnerClaudeMCPPath) {
+		t.Fatalf("command = %v, want claude --mcp-config %s", command, RunnerClaudeMCPPath)
+	}
+	if !envContains(env, "GH_TOKEN=gh-token") {
+		t.Fatalf("env = %v, want GH_TOKEN fallback", env)
+	}
+	if !strings.Contains(command[2], RunnerClaudeMCPPath) || !strings.Contains(command[2], claudeProjectMCPConfig) {
+		t.Fatalf("setup script = %q, want claude MCP config materialization", command[2])
+	}
+}
+
+func TestWrapBackendCommandMaterializesCodexAuthAndSchema(t *testing.T) {
+	t.Parallel()
+
+	command, env := WrapBackendCommand("codex", []string{"codex", "exec"}, []string{"OPENAI_API_KEY=sk-test"}, BackendSetupOptions{ResponseSchema: `{"type":"object"}`})
+	if !envContains(env, ResponseSchemaEnv+`={"type":"object"}`) {
+		t.Fatalf("env = %v, want response schema env", env)
+	}
+	if !envContains(env, "AGENTS_BACKEND_COMMAND=codex") {
+		t.Fatalf("env = %v, want backend command env", env)
+	}
+	if !strings.Contains(command[2], RunnerResponseSchema) || !strings.Contains(command[2], "$codex_cmd\" login --with-api-key") {
+		t.Fatalf("setup script = %q, want codex schema and login materialization", command[2])
+	}
+}
+
+func envContains(env []string, want string) bool {
+	for _, entry := range env {
+		if entry == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -10,8 +10,6 @@ import (
 	"github.com/eloylp/agents/internal/fleet"
 )
 
-const RunnerTempMount = "/tmp/agents-run"
-
 type ContainerSpec struct {
 	Image      string
 	Command    []string


### PR DESCRIPTION
## Summary
- extract runner backend setup/materialization into internal/runtime
- reuse the same setup for real agent runs and backend diagnostics
- materialize ephemeral GitHub MCP config for Claude/Codex diagnostics so /backends/status reflects runner-ready state

## Tests
- GOCACHE=/tmp/go-build-agents go test ./...
