### PR TITLE
docs: add internal/runtime to package code maps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ internal/
   anthropic_proxy/              # built-in Anthropic Messages ↔ OpenAI Chat Completions translation
   observe/                      # observability store: events, traces, dispatch graph, SSE hubs
   scheduler/                    # cron scheduler + agent memory (SQLite-backed)
+  runtime/                      # Runner interface + ContainerSpec/ExitStatus types, Docker implementation, per-backend container setup
   backends/                     # backend discovery: CLI probing, GitHub MCP health checks, tool diagnostics, orphan detection
   store/                        # SQLite-backed config + event_queue store: Open, Import, Load, CRUD, *store.Store facade
   workflow/                     # event routing engine, durable event queue (persist-on-push + replay), processor, dispatcher

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ internal/
   anthropic_proxy/          # Built-in Anthropic↔OpenAI Chat Completions translation proxy
   observe/                  # Observability store: events, traces, dispatch graph, SSE hubs
   scheduler/                # Cron scheduler + agent memory (SQLite-backed)
+  runtime/                  # Runner interface + ContainerSpec/ExitStatus types, Docker implementation, per-backend container setup (env, scripts, paths)
   backends/                 # Backend discovery: CLI probing, GitHub MCP health checks, tool diagnostics, orphan detection
   store/                    # SQLite-backed config + event_queue store: Open, Import, Load, CRUD; *store.Store facade hides the *sql.DB
   workflow/                 # Event routing engine, durable event queue (persist-on-push + replay), processor, dispatcher

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,6 +31,7 @@ internal/
 ├─ workflow/                    Engine, Processor, Dispatcher, DataChannels, dispatch dedup
 ├─ scheduler/                   cron registration + event producer
 ├─ ai/                          prompt composition, CLI runner (stdin in, JSON out)
+├─ runtime/                     execution-plane abstraction: Runner interface, ContainerSpec/ExitStatus types, Docker implementation, per-backend container setup
 ├─ backends/                    backend discovery (CLI probing, MCP health, tool diagnostics, model catalog)
 ├─ anthropic_proxy/             Anthropic↔OpenAI translation proxy
 ├─ observe/                     events/traces/spans/steps/memory persistence + SSE hubs


### PR DESCRIPTION
## Summary

PR #513 ("Split daemon and runner runtime settings", merged 2026-05-14) introduced `internal/runtime/` as the execution-plane abstraction layer. The package owns the `Runner` interface, `ContainerSpec`/`ExitStatus` types, the Docker implementation, and per-backend container setup (env preparation, setup scripts, filesystem paths inside runner containers). `docs/architecture.md` mentions it in prose but all three directory maps were not updated.

- `CLAUDE.md` — add `runtime/` to the `## Directory Structure` block (after `scheduler/`, before `backends/`)
- `AGENTS.md` — add `runtime/` to the `## Code map (current)` block (after `scheduler/`, before `backends/`)
- `docs/architecture.md` — add `├─ runtime/` to the layer-cake tree (after `ai/`, before `backends/`, matching the tier description already present in the prose)

## Test plan

- Read the diff and confirm each entry is in the right position relative to neighbours
- No code changes; no tests required