### PR TITLE
refactor: use slices contains in runtime tests

### DIFF
--- a/internal/runtime/backend_setup_test.go
+++ b/internal/runtime/backend_setup_test.go
@@ -13,7 +13,7 @@ func TestWrapBackendCommandMaterializesClaudeMCP(t *testing.T) {
 	if !slices.Contains(command, "--mcp-config") || !slices.Contains(command, RunnerClaudeMCPPath) {
 		t.Fatalf("command = %v, want claude --mcp-config %s", command, RunnerClaudeMCPPath)
 	}
-	if !envContains(env, "GH_TOKEN=gh-token") {
+	if !slices.Contains(env, "GH_TOKEN=gh-token") {
 		t.Fatalf("env = %v, want GH_TOKEN fallback", env)
 	}
 	if !strings.Contains(command[2], RunnerClaudeMCPPath) || !strings.Contains(command[2], claudeProjectMCPConfig) {
@@ -25,22 +25,13 @@ func TestWrapBackendCommandMaterializesCodexAuthAndSchema(t *testing.T) {
 	t.Parallel()
 
 	command, env := WrapBackendCommand("codex", []string{"codex", "exec"}, []string{"CODEX_AUTH_JSON_BASE64=e30=", "OPENAI_API_KEY=sk-test"}, BackendSetupOptions{ResponseSchema: `{"type":"object"}`})
-	if !envContains(env, ResponseSchemaEnv+`={"type":"object"}`) {
+	if !slices.Contains(env, ResponseSchemaEnv+`={"type":"object"}`) {
 		t.Fatalf("env = %v, want response schema env", env)
 	}
-	if !envContains(env, "AGENTS_BACKEND_COMMAND=codex") {
+	if !slices.Contains(env, "AGENTS_BACKEND_COMMAND=codex") {
 		t.Fatalf("env = %v, want backend command env", env)
 	}
 	if !strings.Contains(command[2], RunnerResponseSchema) || !strings.Contains(command[2], "CODEX_AUTH_JSON_BASE64") || !strings.Contains(command[2], "$codex_cmd\" login --with-api-key") {
 		t.Fatalf("setup script = %q, want codex schema and auth materialization", command[2])
 	}
-}
-
-func envContains(env []string, want string) bool {
-	for _, entry := range env {
-		if entry == want {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
## Summary

- Replaces the runtime backend setup test's local env membership helper with `slices.Contains`.
- Removes the now-unused loop helper while keeping the same assertions.

## Test plan

- `go test ./internal/runtime`
- `git diff --check`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY go test ./...`

Note: an initial unsanitized `go test ./...` run failed in `internal/backends` because the local shell exported credential variables into an environment-sensitive fixture. Rerunning with those variables unset passed.