### PR TITLE
refactor: use slices concat for runner command

### DIFF
--- a/internal/ai/cmdrunner.go
+++ b/internal/ai/cmdrunner.go
@@ -115,7 +115,7 @@ func (r *CommandRunner) runContainerCommand(ctx context.Context, args []string, 
 		setup.ResponseSchema = ResponseSchemaString()
 	}
 
-	command := append([]string{r.command}, args...)
+	command := slices.Concat([]string{r.command}, args)
 	command, env = runtimeexec.WrapBackendCommand(r.backendName, command, env, setup)
 	spec := r.containerSpec
 	spec.Image = r.containerImage


### PR DESCRIPTION
## Summary

- Replaces the manual runner command prepend in `CommandRunner` with `slices.Concat`.
- Keeps the command order passed into backend setup unchanged while using the existing stdlib slices import.

## Test plan

- `go test ./internal/ai`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY go test ./...`
- `git diff --check`