### PR TITLE
refactor: use sorted backend status keys

### DIFF
--- a/internal/backends/discovery.go
+++ b/internal/backends/discovery.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"regexp"
 	"slices"
@@ -746,19 +747,14 @@ func diagnosticEnv(override map[string]string) []string {
 }
 
 func unavailableBackendStatuses(existing map[string]fleet.Backend, detail string) []BackendStatus {
-	names := make([]string, 0, len(existing)+len(builtinBackendNames))
 	seen := make(map[string]struct{}, len(existing)+len(builtinBackendNames))
 	for _, name := range builtinBackendNames {
-		names = append(names, name)
 		seen[name] = struct{}{}
 	}
 	for name := range existing {
-		if _, ok := seen[name]; ok {
-			continue
-		}
-		names = append(names, name)
+		seen[name] = struct{}{}
 	}
-	slices.Sort(names)
+	names := slices.Sorted(maps.Keys(seen))
 	out := make([]BackendStatus, 0, len(names))
 	for _, name := range names {
 		cfg := existing[name]


### PR DESCRIPTION
## Summary

- Replaces manual backend-name collection and sorting in unavailable runtime diagnostics with `slices.Sorted(maps.Keys(...))`.
- Keeps the same built-in plus configured backend set and deterministic ordering.

## Test plan

- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY go test ./internal/backends`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.