### PR TITLE
fix: preserve replayed dispatch depth

### DIFF
--- a/internal/workflow/engine_dispatch.go
+++ b/internal/workflow/engine_dispatch.go
@@ -2,7 +2,10 @@ package workflow
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"math"
+	"strconv"
 	"time"
 )
 
@@ -122,7 +125,7 @@ func (e *Engine) handleDispatchEvent(ctx context.Context, ev Event) error {
 func extractDispatchContext(ev Event) (rootEventID string, depth int) {
 	if ev.Kind == "agent.dispatch" {
 		rootEventID, _ = ev.Payload["root_event_id"].(string)
-		if d, ok := ev.Payload["dispatch_depth"].(int); ok {
+		if d, ok := parseDispatchDepth(ev.Payload["dispatch_depth"]); ok {
 			depth = d
 		}
 		return rootEventID, depth
@@ -132,4 +135,39 @@ func extractDispatchContext(ev Event) (rootEventID string, depth int) {
 		return ev.ID, 0
 	}
 	return GenEventID(), 0
+}
+
+func parseDispatchDepth(value any) (int, bool) {
+	switch d := value.(type) {
+	case int:
+		return d, true
+	case int64:
+		return intFromInt64(d)
+	case float64:
+		if math.Trunc(d) != d || d < float64(math.MinInt) || d > float64(math.MaxInt) {
+			return 0, false
+		}
+		return int(d), true
+	case json.Number:
+		parsed, err := d.Int64()
+		if err != nil {
+			return 0, false
+		}
+		return intFromInt64(parsed)
+	case string:
+		parsed, err := strconv.ParseInt(d, 10, 0)
+		if err != nil {
+			return 0, false
+		}
+		return int(parsed), true
+	default:
+		return 0, false
+	}
+}
+
+func intFromInt64(value int64) (int, bool) {
+	if value < int64(math.MinInt) || value > int64(math.MaxInt) {
+		return 0, false
+	}
+	return int(value), true
 }

--- a/internal/workflow/engine_dispatch.go
+++ b/internal/workflow/engine_dispatch.go
@@ -9,12 +9,21 @@ import (
 	"time"
 )
 
-// handleDispatchEvent fires the target agent named in ev.Payload["target_agent"]
+type agentDispatchPayload struct {
+	TargetAgent   string
+	Reason        string
+	RootEventID   string
+	DispatchDepth int
+	InvokedBy     string
+	ParentSpanID  string
+}
+
+// handleDispatchEvent fires the target agent named in the event payload
 // directly, bypassing normal binding lookup.
 func (e *Engine) handleDispatchEvent(ctx context.Context, ev Event) error {
-	targetName, _ := ev.Payload["target_agent"].(string)
-	if targetName == "" {
-		return fmt.Errorf("agent.dispatch event missing target_agent in payload")
+	targetName, err := eventTargetAgent(ev)
+	if err != nil {
+		return err
 	}
 	workspaceID := eventWorkspaceID(ev)
 
@@ -119,25 +128,108 @@ func (e *Engine) handleDispatchEvent(ctx context.Context, ev Event) error {
 	return runErr
 }
 
+func eventTargetAgent(ev Event) (string, error) {
+	if ev.Kind == "agent.dispatch" {
+		payload, err := decodeAgentDispatchPayload(ev)
+		if err != nil {
+			return "", err
+		}
+		return payload.TargetAgent, nil
+	}
+	targetName, _ := ev.Payload["target_agent"].(string)
+	if targetName == "" {
+		return "", fmt.Errorf("%s event missing target_agent in payload", ev.Kind)
+	}
+	return targetName, nil
+}
+
 // extractDispatchContext extracts root event ID and dispatch depth from ev.
 // For non-dispatch events, it generates a new root event ID using ev.ID if
 // set, or a fresh random ID.
-func extractDispatchContext(ev Event) (rootEventID string, depth int) {
+func extractDispatchContext(ev Event) (rootEventID string, depth int, err error) {
 	if ev.Kind == "agent.dispatch" {
-		rootEventID, _ = ev.Payload["root_event_id"].(string)
-		if d, ok := parseDispatchDepth(ev.Payload["dispatch_depth"]); ok {
-			depth = d
+		payload, err := decodeAgentDispatchPayload(ev)
+		if err != nil {
+			return "", 0, err
 		}
-		return rootEventID, depth
+		return payload.RootEventID, payload.DispatchDepth, nil
 	}
 	// Regular event: use event ID as root, depth 0.
 	if ev.ID != "" {
-		return ev.ID, 0
+		return ev.ID, 0, nil
 	}
-	return GenEventID(), 0
+	return GenEventID(), 0, nil
 }
 
-func parseDispatchDepth(value any) (int, bool) {
+func decodeAgentDispatchPayload(ev Event) (agentDispatchPayload, error) {
+	if ev.Kind != "agent.dispatch" {
+		return agentDispatchPayload{}, fmt.Errorf("decode agent.dispatch payload from %q event", ev.Kind)
+	}
+	targetAgent, err := payloadString(ev.Payload, "target_agent", true)
+	if err != nil {
+		return agentDispatchPayload{}, err
+	}
+	reason, err := payloadString(ev.Payload, "reason", false)
+	if err != nil {
+		return agentDispatchPayload{}, err
+	}
+	rootEventID, err := payloadString(ev.Payload, "root_event_id", false)
+	if err != nil {
+		return agentDispatchPayload{}, err
+	}
+	invokedBy, err := payloadString(ev.Payload, "invoked_by", false)
+	if err != nil {
+		return agentDispatchPayload{}, err
+	}
+	parentSpanID, err := payloadString(ev.Payload, "parent_span_id", false)
+	if err != nil {
+		return agentDispatchPayload{}, err
+	}
+	dispatchDepth, err := payloadInt(ev.Payload, "dispatch_depth")
+	if err != nil {
+		return agentDispatchPayload{}, err
+	}
+	return agentDispatchPayload{
+		TargetAgent:   targetAgent,
+		Reason:        reason,
+		RootEventID:   rootEventID,
+		DispatchDepth: dispatchDepth,
+		InvokedBy:     invokedBy,
+		ParentSpanID:  parentSpanID,
+	}, nil
+}
+
+func payloadString(payload map[string]any, key string, required bool) (string, error) {
+	value, ok := payload[key]
+	if !ok || value == nil {
+		if required {
+			return "", fmt.Errorf("agent.dispatch event missing %s in payload", key)
+		}
+		return "", nil
+	}
+	s, ok := value.(string)
+	if !ok {
+		return "", fmt.Errorf("agent.dispatch event payload %s must be string, got %T", key, value)
+	}
+	if required && s == "" {
+		return "", fmt.Errorf("agent.dispatch event missing %s in payload", key)
+	}
+	return s, nil
+}
+
+func payloadInt(payload map[string]any, key string) (int, error) {
+	value, ok := payload[key]
+	if !ok || value == nil {
+		return 0, nil
+	}
+	parsed, ok := parsePayloadInt(value)
+	if !ok {
+		return 0, fmt.Errorf("agent.dispatch event payload %s must be an integer, got %T", key, value)
+	}
+	return parsed, nil
+}
+
+func parsePayloadInt(value any) (int, bool) {
 	switch d := value.(type) {
 	case int:
 		return d, true

--- a/internal/workflow/engine_run.go
+++ b/internal/workflow/engine_run.go
@@ -36,14 +36,21 @@ func (e *Engine) runAgent(ctx context.Context, ev Event, agent fleet.Agent, cfg 
 		)
 	}
 
-	rootEventID, dispatchDepth := extractDispatchContext(ev)
+	rootEventID, dispatchDepth, err := extractDispatchContext(ev)
+	if err != nil {
+		return err
+	}
 
 	// Build dispatch context fields for dispatched agents.
 	var invokedBy, reason, parentSpanID string
 	if ev.Kind == "agent.dispatch" {
-		invokedBy, _ = ev.Payload["invoked_by"].(string)
-		reason, _ = ev.Payload["reason"].(string)
-		parentSpanID, _ = ev.Payload["parent_span_id"].(string)
+		payload, err := decodeAgentDispatchPayload(ev)
+		if err != nil {
+			return err
+		}
+		invokedBy = payload.InvokedBy
+		reason = payload.Reason
+		parentSpanID = payload.ParentSpanID
 	}
 
 	// Serialise the read/run/write sequence for this (agent, repo) pair to

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -55,10 +55,12 @@ func TestExtractDispatchContextPreservesDispatchDepth(t *testing.T) {
 		name      string
 		payload   map[string]any
 		wantDepth int
+		wantErr   bool
 	}{
 		{
 			name: "in-memory int depth",
 			payload: map[string]any{
+				"target_agent":   "pr-reviewer",
 				"root_event_id":  "root-123",
 				"dispatch_depth": 2,
 			},
@@ -67,6 +69,7 @@ func TestExtractDispatchContextPreservesDispatchDepth(t *testing.T) {
 		{
 			name: "json replay float64 depth",
 			payload: map[string]any{
+				"target_agent":   "pr-reviewer",
 				"root_event_id":  "root-123",
 				"dispatch_depth": float64(2),
 			},
@@ -75,17 +78,19 @@ func TestExtractDispatchContextPreservesDispatchDepth(t *testing.T) {
 		{
 			name: "missing depth falls back to zero",
 			payload: map[string]any{
+				"target_agent":  "pr-reviewer",
 				"root_event_id": "root-123",
 			},
 			wantDepth: 0,
 		},
 		{
-			name: "malformed depth falls back to zero",
+			name: "malformed depth is rejected",
 			payload: map[string]any{
+				"target_agent":   "pr-reviewer",
 				"root_event_id":  "root-123",
 				"dispatch_depth": 2.5,
 			},
-			wantDepth: 0,
+			wantErr: true,
 		},
 	}
 
@@ -93,10 +98,19 @@ func TestExtractDispatchContextPreservesDispatchDepth(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			rootEventID, depth := extractDispatchContext(Event{
+			rootEventID, depth, err := extractDispatchContext(Event{
 				Kind:    "agent.dispatch",
 				Payload: tt.payload,
 			})
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("extractDispatchContext error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("extractDispatchContext: %v", err)
+			}
 			if rootEventID != "root-123" {
 				t.Fatalf("rootEventID = %q, want %q", rootEventID, "root-123")
 			}
@@ -454,6 +468,76 @@ func TestEngineDispatchEventPayloadPropagatedToPrompt(t *testing.T) {
 		if !strings.Contains(capturedUser, want) {
 			t.Errorf("User missing %q\nfull User:\n%s", want, capturedUser)
 		}
+	}
+}
+
+func TestEngineDispatchEventReplayDepthPropagatedToPrompt(t *testing.T) {
+	t.Parallel()
+	var capturedUser string
+	runner := &stubRunner{
+		runFn: func(req ai.Request) error {
+			capturedUser = req.User
+			return nil
+		},
+	}
+	cfg := &config.Config{
+		Daemon: config.DaemonConfig{
+			Processor: config.ProcessorConfig{
+				MaxConcurrentAgents: 4,
+				Dispatch:            config.DispatchConfig{MaxDepth: 3, MaxFanout: 4, DedupWindowSeconds: 300},
+			},
+			AIBackends: map[string]fleet.Backend{"claude": {Command: "claude"}},
+		},
+		Skills: map[string]fleet.Skill{},
+		Agents: []fleet.Agent{
+			{Name: "pr-reviewer", Backend: "claude", Prompt: "Review code.", AllowDispatch: true},
+		},
+		Repos: []fleet.Repo{{Name: "owner/repo", Enabled: true}},
+	}
+	e := newEngineFromCfg(t, cfg, map[string]ai.Runner{"claude": runner}, nil)
+
+	ev := Event{
+		ID:     "dispatch-1",
+		Repo:   RepoRef{FullName: "owner/repo", Enabled: true},
+		Kind:   "agent.dispatch",
+		Number: 7,
+		Actor:  "coder",
+		Payload: map[string]any{
+			"target_agent":   "pr-reviewer",
+			"reason":         "please review",
+			"root_event_id":  "root-abc",
+			"dispatch_depth": float64(2),
+			"invoked_by":     "coder",
+		},
+	}
+
+	if err := e.HandleEvent(context.Background(), ev); err != nil {
+		t.Fatalf("HandleEvent: %v", err)
+	}
+	if !strings.Contains(capturedUser, "Dispatch depth: 2") {
+		t.Fatalf("User missing replayed dispatch depth\nfull User:\n%s", capturedUser)
+	}
+}
+
+func TestEngineDispatchEventRejectsMalformedReplayDepth(t *testing.T) {
+	t.Parallel()
+	e, runner := newTestEngine(t, nil)
+
+	err := e.HandleEvent(context.Background(), Event{
+		ID:    "dispatch-1",
+		Repo:  RepoRef{FullName: "owner/repo", Enabled: true},
+		Kind:  "agent.dispatch",
+		Actor: "coder",
+		Payload: map[string]any{
+			"target_agent":   "pr-reviewer",
+			"dispatch_depth": float64(2.5),
+		},
+	})
+	if err == nil {
+		t.Fatal("HandleEvent error = nil, want malformed dispatch_depth error")
+	}
+	if got := runner.callCount(); got != 0 {
+		t.Fatalf("runner calls = %d, want 0", got)
 	}
 }
 

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -48,6 +48,65 @@ func (s *stubRunner) callCount() int {
 	return len(s.calls)
 }
 
+func TestExtractDispatchContextPreservesDispatchDepth(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		payload   map[string]any
+		wantDepth int
+	}{
+		{
+			name: "in-memory int depth",
+			payload: map[string]any{
+				"root_event_id":  "root-123",
+				"dispatch_depth": 2,
+			},
+			wantDepth: 2,
+		},
+		{
+			name: "json replay float64 depth",
+			payload: map[string]any{
+				"root_event_id":  "root-123",
+				"dispatch_depth": float64(2),
+			},
+			wantDepth: 2,
+		},
+		{
+			name: "missing depth falls back to zero",
+			payload: map[string]any{
+				"root_event_id": "root-123",
+			},
+			wantDepth: 0,
+		},
+		{
+			name: "malformed depth falls back to zero",
+			payload: map[string]any{
+				"root_event_id":  "root-123",
+				"dispatch_depth": 2.5,
+			},
+			wantDepth: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rootEventID, depth := extractDispatchContext(Event{
+				Kind:    "agent.dispatch",
+				Payload: tt.payload,
+			})
+			if rootEventID != "root-123" {
+				t.Fatalf("rootEventID = %q, want %q", rootEventID, "root-123")
+			}
+			if depth != tt.wantDepth {
+				t.Fatalf("depth = %d, want %d", depth, tt.wantDepth)
+			}
+		})
+	}
+}
+
 func (s *stubRunner) lastSystem() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
## Summary

Closes #543.

- Decodes daemon-owned `agent.dispatch` payloads through a package-local typed helper instead of scattering `map[string]any` reads through workflow execution.
- Preserves replayed JSON integer dispatch depth values by decoding `float64(2)` into the typed `int` dispatch context.
- Rejects malformed dispatch payload fields, including non-integer replayed `dispatch_depth`, before running the target agent.
- Adds focused workflow tests for in-memory depth, replayed depth, missing compatible depth, malformed depth rejection, and prompt propagation.

## Test plan

- `go test ./internal/workflow`
- `go test -race ./internal/workflow`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY go test ./...`
- `git diff --check`

Note: an unsanitized `go test ./...` run fails in `internal/backends` when credential environment variables are present in the runner; the sanitized full-suite command above passes.