### PR TITLE
refactor: use typed graph sort functions

### DIFF
--- a/internal/daemon/observe/observe.go
+++ b/internal/daemon/observe/observe.go
@@ -11,12 +11,13 @@ package observe
 
 import (
 	"bytes"
+	"cmp"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"path/filepath"
-	"sort"
+	"slices"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -415,7 +416,9 @@ func (h *Handler) HandleGraph(w http.ResponseWriter, r *http.Request) {
 	for id := range seen {
 		nodes = append(nodes, graphNode{ID: id, Status: nodeStatus(id)})
 	}
-	sort.Slice(nodes, func(i, j int) bool { return nodes[i].ID < nodes[j].ID })
+	slices.SortFunc(nodes, func(a, b graphNode) int {
+		return cmp.Compare(a.ID, b.ID)
+	})
 
 	edgeByKey := make(map[string]graphEdge, len(edges)+len(configuredEdges))
 	for key, e := range configuredEdges {
@@ -445,11 +448,11 @@ func (h *Handler) HandleGraph(w http.ResponseWriter, r *http.Request) {
 		}
 		wireEdges = append(wireEdges, e)
 	}
-	sort.Slice(wireEdges, func(i, j int) bool {
-		if wireEdges[i].From == wireEdges[j].From {
-			return wireEdges[i].To < wireEdges[j].To
+	slices.SortFunc(wireEdges, func(a, b graphEdge) int {
+		if n := cmp.Compare(a.From, b.From); n != 0 {
+			return n
 		}
-		return wireEdges[i].From < wireEdges[j].From
+		return cmp.Compare(a.To, b.To)
 	})
 
 	w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## Summary

- Replaces index-based `sort.Slice` comparators in the observability graph handler with typed `slices.SortFunc` comparators.
- Keeps node sorting by ID and edge sorting by from/to unchanged while avoiding repeated slice indexing inside the comparators.

## Test plan

- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY go test ./internal/daemon/observe`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.