### PR TITLE
fix: fail runner runs on backend timeout

### DIFF
--- a/internal/ai/cmdrunner.go
+++ b/internal/ai/cmdrunner.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -98,6 +99,23 @@ func (r *CommandRunner) runCommand(ctx context.Context, logger zerolog.Logger, r
 
 	env := buildCommandEnv(req, r.env)
 	stdoutCap, stderr, cmdErr := r.runContainerCommand(cmdCtx, args, stdin, env, req.OnLine)
+	if cmdErr != nil {
+		switch {
+		case errors.Is(cmdCtx.Err(), context.DeadlineExceeded):
+			cmdErr = CommandInterruptedError{
+				Backend: r.backendName,
+				Kind:    "timeout",
+				Timeout: r.timeout,
+				Err:     cmdErr,
+			}
+		case errors.Is(cmdCtx.Err(), context.Canceled):
+			cmdErr = CommandInterruptedError{
+				Backend: r.backendName,
+				Kind:    "canceled",
+				Err:     cmdErr,
+			}
+		}
+	}
 	return r.parseCommandResponse(logger, stdoutCap, stderr, cmdErr)
 }
 
@@ -237,6 +255,11 @@ func (r *CommandRunner) parseCommandResponse(logger zerolog.Logger, stdoutCap li
 		return Response{}, fmt.Errorf("parse %s response: empty response (no fields populated)", r.backendName)
 	}
 	if cmdErr != nil {
+		var interrupted CommandInterruptedError
+		if errors.As(cmdErr, &interrupted) {
+			logger.Error().Err(cmdErr).Str("stderr", truncateString(stderr, 2000)).Msgf("%s command interrupted after valid partial output", r.backendName)
+			return response, cmdErr
+		}
 		logger.Warn().Err(cmdErr).Str("stderr", truncateString(stderr, 2000)).Msgf("%s command exited non-zero but produced valid output", r.backendName)
 	}
 	logger.Info().

--- a/internal/ai/cmdrunner.go
+++ b/internal/ai/cmdrunner.go
@@ -104,14 +104,14 @@ func (r *CommandRunner) runCommand(ctx context.Context, logger zerolog.Logger, r
 		case errors.Is(cmdCtx.Err(), context.DeadlineExceeded):
 			cmdErr = CommandInterruptedError{
 				Backend: r.backendName,
-				Kind:    "timeout",
+				Kind:    CommandInterruptedTimeout,
 				Timeout: r.timeout,
 				Err:     cmdErr,
 			}
 		case errors.Is(cmdCtx.Err(), context.Canceled):
 			cmdErr = CommandInterruptedError{
 				Backend: r.backendName,
-				Kind:    "canceled",
+				Kind:    CommandInterruptedCanceled,
 				Err:     cmdErr,
 			}
 		}
@@ -252,6 +252,9 @@ func (r *CommandRunner) parseCommandResponse(logger zerolog.Logger, stdoutCap li
 	response.Usage = extractUsage(stdoutCap.all.Bytes())
 	if response.Summary == "" && len(response.Artifacts) == 0 && len(response.Dispatch) == 0 {
 		logger.Error().Str("raw_stdout", truncateString(rawOut, 4000)).Msgf("%s response is empty (no summary, artifacts, or dispatch)", r.backendName)
+		if cmdErr != nil {
+			return Response{}, fmt.Errorf("%s command failed: %w", r.backendName, cmdErr)
+		}
 		return Response{}, fmt.Errorf("parse %s response: empty response (no fields populated)", r.backendName)
 	}
 	if cmdErr != nil {

--- a/internal/ai/cmdrunner_test.go
+++ b/internal/ai/cmdrunner_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"slices"
 	"strings"
 	"testing"
@@ -38,6 +39,26 @@ func (f *silentContainerRunner) EnsureImage(context.Context, string) error { ret
 func (f *silentContainerRunner) Run(_ context.Context, spec runtimeexec.ContainerSpec) (runtimeexec.ExitStatus, error) {
 	f.spec = spec
 	return runtimeexec.ExitStatus{}, nil
+}
+
+type timeoutContainerRunner struct {
+	spec        runtimeexec.ContainerSpec
+	writeJSON   bool
+	writeSignal chan struct{}
+}
+
+func (f *timeoutContainerRunner) EnsureImage(context.Context, string) error { return nil }
+
+func (f *timeoutContainerRunner) Run(ctx context.Context, spec runtimeexec.ContainerSpec) (runtimeexec.ExitStatus, error) {
+	f.spec = spec
+	if f.writeJSON && spec.Stdout != nil {
+		_, _ = spec.Stdout.Write([]byte(`{"summary":"partial checkpoint","artifacts":[],"memory":"","dispatch":[]}` + "\n"))
+	}
+	if f.writeSignal != nil {
+		close(f.writeSignal)
+	}
+	<-ctx.Done()
+	return runtimeexec.ExitStatus{}, ctx.Err()
 }
 
 func TestBuildCommandEnvDaemonNumber(t *testing.T) {
@@ -435,6 +456,31 @@ func TestCommandRunnerEmptyStdoutIsError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "empty response") {
 		t.Errorf("expected 'empty response' in error, got: %v", err)
+	}
+}
+
+func TestCommandRunnerTimeoutWithPartialOutputReturnsErrorAndResponse(t *testing.T) {
+	t.Parallel()
+	fake := &timeoutContainerRunner{writeJSON: true, writeSignal: make(chan struct{})}
+	r := NewContainerCommandRunner(
+		"codex", "codex", nil,
+		1, 4000, fake, "ghcr.io/example/runner:test",
+		runtimeexec.ContainerSpec{},
+		zerolog.Nop(),
+	)
+	got, err := r.Run(context.Background(), Request{Workflow: "wf", Repo: "owner/repo"})
+	if err == nil {
+		t.Fatal("Run error = nil, want timeout error")
+	}
+	var interrupted CommandInterruptedError
+	if !errors.As(err, &interrupted) {
+		t.Fatalf("Run error = %T %v, want CommandInterruptedError", err, err)
+	}
+	if interrupted.Kind != "timeout" {
+		t.Fatalf("interruption kind = %q, want timeout", interrupted.Kind)
+	}
+	if got.Summary != "partial checkpoint" {
+		t.Fatalf("summary = %q, want partial checkpoint", got.Summary)
 	}
 }
 

--- a/internal/ai/cmdrunner_test.go
+++ b/internal/ai/cmdrunner_test.go
@@ -42,9 +42,9 @@ func (f *silentContainerRunner) Run(_ context.Context, spec runtimeexec.Containe
 }
 
 type timeoutContainerRunner struct {
-	spec        runtimeexec.ContainerSpec
-	writeJSON   bool
-	writeSignal chan struct{}
+	spec      runtimeexec.ContainerSpec
+	writeJSON bool
+	stdout    string
 }
 
 func (f *timeoutContainerRunner) EnsureImage(context.Context, string) error { return nil }
@@ -52,10 +52,11 @@ func (f *timeoutContainerRunner) EnsureImage(context.Context, string) error { re
 func (f *timeoutContainerRunner) Run(ctx context.Context, spec runtimeexec.ContainerSpec) (runtimeexec.ExitStatus, error) {
 	f.spec = spec
 	if f.writeJSON && spec.Stdout != nil {
-		_, _ = spec.Stdout.Write([]byte(`{"summary":"partial checkpoint","artifacts":[],"memory":"","dispatch":[]}` + "\n"))
-	}
-	if f.writeSignal != nil {
-		close(f.writeSignal)
+		stdout := f.stdout
+		if stdout == "" {
+			stdout = `{"summary":"partial checkpoint","artifacts":[],"memory":"","dispatch":[]}`
+		}
+		_, _ = spec.Stdout.Write([]byte(stdout + "\n"))
 	}
 	<-ctx.Done()
 	return runtimeexec.ExitStatus{}, ctx.Err()
@@ -461,7 +462,7 @@ func TestCommandRunnerEmptyStdoutIsError(t *testing.T) {
 
 func TestCommandRunnerTimeoutWithPartialOutputReturnsErrorAndResponse(t *testing.T) {
 	t.Parallel()
-	fake := &timeoutContainerRunner{writeJSON: true, writeSignal: make(chan struct{})}
+	fake := &timeoutContainerRunner{writeJSON: true}
 	r := NewContainerCommandRunner(
 		"codex", "codex", nil,
 		1, 4000, fake, "ghcr.io/example/runner:test",
@@ -476,11 +477,42 @@ func TestCommandRunnerTimeoutWithPartialOutputReturnsErrorAndResponse(t *testing
 	if !errors.As(err, &interrupted) {
 		t.Fatalf("Run error = %T %v, want CommandInterruptedError", err, err)
 	}
-	if interrupted.Kind != "timeout" {
+	if interrupted.Kind != CommandInterruptedTimeout {
 		t.Fatalf("interruption kind = %q, want timeout", interrupted.Kind)
 	}
 	if got.Summary != "partial checkpoint" {
 		t.Fatalf("summary = %q, want partial checkpoint", got.Summary)
+	}
+}
+
+func TestCommandRunnerTimeoutWithEmptyPartialOutputPreservesTimeoutError(t *testing.T) {
+	t.Parallel()
+	fake := &timeoutContainerRunner{
+		writeJSON: true,
+		stdout:    `{"summary":"","artifacts":[],"memory":"","dispatch":[]}`,
+	}
+	r := NewContainerCommandRunner(
+		"codex", "codex", nil,
+		1, 4000, fake, "ghcr.io/example/runner:test",
+		runtimeexec.ContainerSpec{},
+		zerolog.Nop(),
+	)
+	got, err := r.Run(context.Background(), Request{Workflow: "wf", Repo: "owner/repo"})
+	if err == nil {
+		t.Fatal("Run error = nil, want timeout error")
+	}
+	var interrupted CommandInterruptedError
+	if !errors.As(err, &interrupted) {
+		t.Fatalf("Run error = %T %v, want CommandInterruptedError", err, err)
+	}
+	if interrupted.Kind != CommandInterruptedTimeout {
+		t.Fatalf("interruption kind = %q, want timeout", interrupted.Kind)
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("Run error = %q, want timeout detail", err.Error())
+	}
+	if got.Summary != "" {
+		t.Fatalf("summary = %q, want empty response", got.Summary)
 	}
 }
 

--- a/internal/ai/types.go
+++ b/internal/ai/types.go
@@ -10,23 +10,30 @@ type Runner interface {
 	Run(ctx context.Context, req Request) (Response, error)
 }
 
+type CommandInterruptionKind string
+
+const (
+	CommandInterruptedTimeout  CommandInterruptionKind = "timeout"
+	CommandInterruptedCanceled CommandInterruptionKind = "canceled"
+)
+
 // CommandInterruptedError marks backend command cancellation/timeout as a hard
 // run failure even when the CLI emitted a parseable partial response first.
 type CommandInterruptedError struct {
 	Backend string
-	Kind    string
+	Kind    CommandInterruptionKind
 	Timeout time.Duration
 	Err     error
 }
 
 func (e CommandInterruptedError) Error() string {
 	switch e.Kind {
-	case "timeout":
+	case CommandInterruptedTimeout:
 		if e.Timeout > 0 {
 			return fmt.Sprintf("%s command timed out after %s", e.Backend, e.Timeout)
 		}
 		return fmt.Sprintf("%s command timed out", e.Backend)
-	case "canceled":
+	case CommandInterruptedCanceled:
 		return fmt.Sprintf("%s command canceled", e.Backend)
 	default:
 		return fmt.Sprintf("%s command interrupted", e.Backend)

--- a/internal/ai/types.go
+++ b/internal/ai/types.go
@@ -1,9 +1,40 @@
 package ai
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"time"
+)
 
 type Runner interface {
 	Run(ctx context.Context, req Request) (Response, error)
+}
+
+// CommandInterruptedError marks backend command cancellation/timeout as a hard
+// run failure even when the CLI emitted a parseable partial response first.
+type CommandInterruptedError struct {
+	Backend string
+	Kind    string
+	Timeout time.Duration
+	Err     error
+}
+
+func (e CommandInterruptedError) Error() string {
+	switch e.Kind {
+	case "timeout":
+		if e.Timeout > 0 {
+			return fmt.Sprintf("%s command timed out after %s", e.Backend, e.Timeout)
+		}
+		return fmt.Sprintf("%s command timed out", e.Backend)
+	case "canceled":
+		return fmt.Sprintf("%s command canceled", e.Backend)
+	default:
+		return fmt.Sprintf("%s command interrupted", e.Backend)
+	}
+}
+
+func (e CommandInterruptedError) Unwrap() error {
+	return e.Err
 }
 
 // RenderedPrompt is the result of RenderAgentPrompt: stable system-level

--- a/internal/daemon/runners/runners.go
+++ b/internal/daemon/runners/runners.go
@@ -96,6 +96,7 @@ type RunnerRow struct {
 	SpanID           string `json:"span_id,omitempty"`
 	RunDuration      int64  `json:"run_duration_ms,omitempty"`
 	Summary          string `json:"summary,omitempty"`
+	Error            string `json:"error,omitempty"`
 	PromptSize       int64  `json:"prompt_size,omitempty"`
 	InputTokens      int64  `json:"input_tokens,omitempty"`
 	OutputTokens     int64  `json:"output_tokens,omitempty"`
@@ -214,6 +215,7 @@ func (h *Handler) expand(ev store.RunnerRecord) []RunnerRow {
 		row.SpanID = sp.SpanID
 		row.RunDuration = sp.DurationMs
 		row.Summary = sp.Summary
+		row.Error = sp.ErrorMsg
 		row.Status = sp.Status // "success" | "error"
 		row.PromptSize = sp.PromptSize
 		row.InputTokens = sp.InputTokens

--- a/internal/daemon/runners/runners_test.go
+++ b/internal/daemon/runners/runners_test.go
@@ -107,7 +107,7 @@ func TestList_CompletedEventFannedOutToTwoAgentsShowsTwoRows(t *testing.T) {
 		Agent: "reviewer", Backend: "claude", Repo: "a/r", EventKind: "issues.labeled",
 		Number: 7, Summary: "reviewer failed",
 		StartedAt: now, FinishedAt: now.Add(2 * time.Second),
-		Status: "error",
+		Status: "error", ErrorMsg: "claude command timed out after 10m0s",
 	})
 	// RecordSpan persists asynchronously into SQLite; poll until both
 	// rows are visible before asking the handler to JOIN.
@@ -143,6 +143,9 @@ func TestList_CompletedEventFannedOutToTwoAgentsShowsTwoRows(t *testing.T) {
 	}
 	if agents["reviewer"].Status != "error" {
 		t.Errorf("reviewer status = %q, want error", agents["reviewer"].Status)
+	}
+	if agents["reviewer"].Error != "claude command timed out after 10m0s" {
+		t.Errorf("reviewer error = %q, want timeout detail", agents["reviewer"].Error)
 	}
 	if agents["coder"].RunDuration != 1000 {
 		t.Errorf("coder duration = %d, want 1000", agents["coder"].RunDuration)

--- a/internal/mcp/tools_runners_test.go
+++ b/internal/mcp/tools_runners_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"testing"
+	"time"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 
@@ -37,6 +38,56 @@ func TestToolListRunnersReturnsRows(t *testing.T) {
 	// agent empty, status=enqueued.
 	if len(got.Runners) != 2 || got.Runners[0].ID != id2 || got.Runners[1].ID != id1 {
 		t.Fatalf("runners = %+v, want newest-first [%d %d]", got.Runners, id2, id1)
+	}
+}
+
+func TestToolListRunnersIncludesTraceError(t *testing.T) {
+	t.Parallel()
+	deps := testFixture(t)
+	id, _ := deps.Channels.PushEvent(context.Background(), workflow.Event{
+		ID: "ev-timeout", Kind: "issues.labeled", Number: 3, Repo: workflow.RepoRef{FullName: "owner/one"},
+	})
+	<-deps.Channels.EventChan()
+	_ = deps.Store.MarkEventStarted(id)
+	now := time.Now()
+	deps.Observe.RecordSpan(workflow.SpanInput{
+		SpanID: "sp-timeout", RootEventID: "ev-timeout",
+		Agent: "coder", Backend: "codex", Repo: "owner/one", EventKind: "issues.labeled",
+		Number: 3, Summary: "partial checkpoint",
+		StartedAt: now, FinishedAt: now.Add(time.Second),
+		Status: "error", ErrorMsg: "codex command timed out after 10m0s",
+	})
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(deps.Observe.TracesByRootEventID("ev-timeout")) >= 1 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	_ = deps.Store.MarkEventCompleted(id)
+
+	req := mcpgo.CallToolRequest{}
+	res, err := toolListRunners(deps)(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("tool error: %s", textOf(t, res))
+	}
+	var got daemonrunners.ListResponse
+	decodeText(t, res, &got)
+	if len(got.Runners) == 0 {
+		t.Fatal("no runners returned")
+	}
+	row := got.Runners[0]
+	if row.Status != "error" {
+		t.Fatalf("status = %q, want error", row.Status)
+	}
+	if row.Summary != "partial checkpoint" {
+		t.Fatalf("summary = %q, want partial checkpoint", row.Summary)
+	}
+	if row.Error != "codex command timed out after 10m0s" {
+		t.Fatalf("error = %q, want timeout detail", row.Error)
 	}
 }
 

--- a/internal/ui/src/app/runners/page.tsx
+++ b/internal/ui/src/app/runners/page.tsx
@@ -8,6 +8,7 @@ import RepoFilter from '@/components/RepoFilter'
 import WorkspaceSelect from '@/components/WorkspaceSelect'
 import { StreamCard, TranscriptFilter, allStreamCardKinds, stepToCardEntries, type PersistedStep, type StreamCardEntry, type StreamCardKind } from '@/components/StreamCard'
 import { fmtDuration } from '@/lib/format'
+import { newRunnerTimeoutTracker, observeRunnerTimeouts } from '@/lib/runner-timeouts'
 import { openAuthenticatedSSE } from '@/lib/sse'
 import { useSelectedWorkspace, withWorkspace } from '@/lib/workspace'
 
@@ -241,7 +242,7 @@ function RunnersInner() {
   const [highlightUntil, setHighlightUntil] = useState<number | null>(null)
   const [streamSpan, setStreamSpan] = useState<{ id: string; agent: string; repo: string; kind: string } | null>(null)
   const [timeoutToast, setTimeoutToast] = useState<RunnerRow | null>(null)
-  const seenTimeouts = useRef<Set<string>>(new Set())
+  const timeoutTracker = useRef(newRunnerTimeoutTracker())
 
   const load = async () => {
     try {
@@ -250,16 +251,8 @@ function RunnersInner() {
       if (!res.ok) throw new Error(`status ${res.status}`)
       const data: ListResponse = await res.json()
       const nextRows = data.runners ?? []
-      const newTimeout = nextRows.find(r => {
-        const key = r.span_id || `${r.id}:${r.agent || ''}`
-        const isTimeout = r.status === 'error' && /timed out|timeout/i.test(r.error || '')
-        return isTimeout && !seenTimeouts.current.has(key)
-      })
-      if (newTimeout) {
-        const key = newTimeout.span_id || `${newTimeout.id}:${newTimeout.agent || ''}`
-        seenTimeouts.current.add(key)
-        setTimeoutToast(newTimeout)
-      }
+      const newTimeout = observeRunnerTimeouts(nextRows, timeoutTracker.current)
+      if (newTimeout) setTimeoutToast(newTimeout)
       setRows(nextRows)
       setError(null)
     } catch (e) {
@@ -270,6 +263,7 @@ function RunnersInner() {
   }
 
   useEffect(() => {
+    timeoutTracker.current = newRunnerTimeoutTracker()
     load()
     const id = window.setInterval(load, POLL_MS)
     return () => window.clearInterval(id)

--- a/internal/ui/src/app/runners/page.tsx
+++ b/internal/ui/src/app/runners/page.tsx
@@ -28,6 +28,7 @@ interface RunnerRow {
   span_id?: string
   run_duration_ms?: number
   summary?: string
+  error?: string
   prompt_size?: number
   input_tokens?: number
   output_tokens?: number
@@ -239,6 +240,8 @@ function RunnersInner() {
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
   const [highlightUntil, setHighlightUntil] = useState<number | null>(null)
   const [streamSpan, setStreamSpan] = useState<{ id: string; agent: string; repo: string; kind: string } | null>(null)
+  const [timeoutToast, setTimeoutToast] = useState<RunnerRow | null>(null)
+  const seenTimeouts = useRef<Set<string>>(new Set())
 
   const load = async () => {
     try {
@@ -246,7 +249,18 @@ function RunnersInner() {
       const res = await fetch(url, { cache: 'no-store' })
       if (!res.ok) throw new Error(`status ${res.status}`)
       const data: ListResponse = await res.json()
-      setRows(data.runners ?? [])
+      const nextRows = data.runners ?? []
+      const newTimeout = nextRows.find(r => {
+        const key = r.span_id || `${r.id}:${r.agent || ''}`
+        const isTimeout = r.status === 'error' && /timed out|timeout/i.test(r.error || '')
+        return isTimeout && !seenTimeouts.current.has(key)
+      })
+      if (newTimeout) {
+        const key = newTimeout.span_id || `${newTimeout.id}:${newTimeout.agent || ''}`
+        seenTimeouts.current.add(key)
+        setTimeoutToast(newTimeout)
+      }
+      setRows(nextRows)
       setError(null)
     } catch (e) {
       setError((e as Error).message)
@@ -386,6 +400,19 @@ function RunnersInner() {
       {error && (
         <Card style={{ marginBottom: '1rem', borderColor: 'var(--border-danger)' }}>
           <span style={{ color: 'var(--text-danger)', fontSize: '0.85rem' }}>Error loading runners: {error}</span>
+        </Card>
+      )}
+      {timeoutToast && (
+        <Card style={{ marginBottom: '1rem', borderColor: 'var(--border-danger)' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem', alignItems: 'center' }}>
+            <span style={{ color: 'var(--text-danger)', fontSize: '0.85rem' }}>
+              Runner timed out: {timeoutToast.agent || timeoutToast.target_agent || 'agent'} · {timeoutToast.repo || '-'} · {timeoutToast.error}
+            </span>
+            <button
+              onClick={() => setTimeoutToast(null)}
+              style={{ background: 'var(--bg-input)', border: '1px solid var(--border)', color: 'var(--text)', padding: '4px 10px', borderRadius: '4px', cursor: 'pointer', fontSize: '0.8rem' }}
+            >Dismiss</button>
+          </div>
         </Card>
       )}
 
@@ -548,6 +575,10 @@ function RunnersInner() {
                       {r.summary && (<>
                         <span style={{ color: 'var(--text-faint)' }}>Summary</span>
                         <span style={{ color: 'var(--text)' }}>{r.summary}</span>
+                      </>)}
+                      {r.error && (<>
+                        <span style={{ color: 'var(--text-faint)' }}>Error</span>
+                        <span style={{ color: 'var(--text-danger)' }}>{r.error}</span>
                       </>)}
                       {(r.input_tokens || r.output_tokens || r.cache_read_tokens || r.cache_write_tokens) ? (<>
                         <span style={{ color: 'var(--text-faint)' }}>Tokens</span>

--- a/internal/ui/src/lib/runner-timeouts.test.ts
+++ b/internal/ui/src/lib/runner-timeouts.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { newRunnerTimeoutTracker, observeRunnerTimeouts, type RunnerTimeoutRow } from './runner-timeouts'
+
+function row(id: number, error: string, span_id?: string): RunnerTimeoutRow {
+  return {
+    id,
+    span_id,
+    status: 'error',
+    error,
+    agent: 'coder',
+  }
+}
+
+describe('observeRunnerTimeouts', () => {
+  it('primes historical timeout rows on initial load without returning a toast row', () => {
+    const tracker = newRunnerTimeoutTracker()
+    const got = observeRunnerTimeouts([
+      row(1, 'codex command timed out after 10m0s', 'span-1'),
+      row(2, 'codex command timeout', 'span-2'),
+    ], tracker)
+
+    expect(got).toBeNull()
+    expect(tracker.initialized).toBe(true)
+    expect(tracker.seen.has('span-1')).toBe(true)
+    expect(tracker.seen.has('span-2')).toBe(true)
+  })
+
+  it('returns the first newly observed timeout after initial load and dedupes later polls', () => {
+    const tracker = newRunnerTimeoutTracker()
+    observeRunnerTimeouts([row(1, 'codex command timed out after 10m0s', 'span-1')], tracker)
+
+    const first = observeRunnerTimeouts([
+      row(1, 'codex command timed out after 10m0s', 'span-1'),
+      row(2, 'codex command timed out after 10m0s', 'span-2'),
+    ], tracker)
+    expect(first?.span_id).toBe('span-2')
+
+    const second = observeRunnerTimeouts([
+      row(1, 'codex command timed out after 10m0s', 'span-1'),
+      row(2, 'codex command timed out after 10m0s', 'span-2'),
+    ], tracker)
+    expect(second).toBeNull()
+  })
+
+  it('marks all timeout rows in a poll as seen while returning only one toast candidate', () => {
+    const tracker = newRunnerTimeoutTracker()
+    observeRunnerTimeouts([], tracker)
+
+    const got = observeRunnerTimeouts([
+      row(1, 'codex command timed out after 10m0s', 'span-1'),
+      row(2, 'codex command timeout', 'span-2'),
+    ], tracker)
+
+    expect(got?.span_id).toBe('span-1')
+    expect(observeRunnerTimeouts([
+      row(1, 'codex command timed out after 10m0s', 'span-1'),
+      row(2, 'codex command timeout', 'span-2'),
+    ], tracker)).toBeNull()
+  })
+})

--- a/internal/ui/src/lib/runner-timeouts.ts
+++ b/internal/ui/src/lib/runner-timeouts.ts
@@ -1,0 +1,37 @@
+export interface RunnerTimeoutRow {
+  id: number
+  status: string
+  error?: string
+  agent?: string
+  span_id?: string
+}
+
+export interface RunnerTimeoutTracker {
+  initialized: boolean
+  seen: Set<string>
+}
+
+export function newRunnerTimeoutTracker(): RunnerTimeoutTracker {
+  return { initialized: false, seen: new Set() }
+}
+
+function runnerTimeoutKey(row: RunnerTimeoutRow): string {
+  return row.span_id || `${row.id}:${row.agent || ''}`
+}
+
+function isRunnerTimeout(row: RunnerTimeoutRow): boolean {
+  return row.status === 'error' && /timed out|timeout/i.test(row.error || '')
+}
+
+export function observeRunnerTimeouts<T extends RunnerTimeoutRow>(rows: T[], tracker: RunnerTimeoutTracker): T | null {
+  const timeoutRows = rows.filter(isRunnerTimeout)
+  if (!tracker.initialized) {
+    for (const row of timeoutRows) tracker.seen.add(runnerTimeoutKey(row))
+    tracker.initialized = true
+    return null
+  }
+
+  const newlyObserved = timeoutRows.find(row => !tracker.seen.has(runnerTimeoutKey(row))) ?? null
+  for (const row of timeoutRows) tracker.seen.add(runnerTimeoutKey(row))
+  return newlyObserved
+}

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -17,6 +17,7 @@ import (
 type stubRunner struct {
 	mu     sync.Mutex
 	calls  []ai.Request
+	run    func(ai.Request) (ai.Response, error)
 	runFn  func(ai.Request) error
 	respFn func(ai.Request) ai.Response
 }
@@ -24,8 +25,12 @@ type stubRunner struct {
 func (s *stubRunner) Run(_ context.Context, req ai.Request) (ai.Response, error) {
 	s.mu.Lock()
 	s.calls = append(s.calls, req)
+	run := s.run
 	respFn := s.respFn
 	s.mu.Unlock()
+	if run != nil {
+		return run(req)
+	}
 	if s.runFn != nil {
 		if err := s.runFn(req); err != nil {
 			return ai.Response{}, err
@@ -1140,5 +1145,33 @@ func TestHandleEventAutonomousReportsErrorStatus(t *testing.T) {
 	calls := rec.snapshot()
 	if len(calls) != 1 || calls[0].status != "error" {
 		t.Fatalf("expected one error-status record, got %+v", calls)
+	}
+}
+
+func TestHandleEventRunnerErrorRecordsPartialSummaryAsError(t *testing.T) {
+	t.Parallel()
+	e, runner := newTestEngine(t, nil)
+	rec := &traceRecorderStub{}
+	e.WithTraceRecorder(rec)
+	runner.run = func(ai.Request) (ai.Response, error) {
+		return ai.Response{Summary: "partial checkpoint"}, errors.New("codex command timed out after 1s")
+	}
+
+	err := e.HandleEvent(context.Background(), labelEvent("issues.labeled", "owner/repo", "ai:review:arch-reviewer", 1))
+	if err == nil {
+		t.Fatal("HandleEvent error = nil, want runner error")
+	}
+	span, ok := rec.last()
+	if !ok {
+		t.Fatal("no trace span recorded")
+	}
+	if span.Status != "error" {
+		t.Fatalf("span status = %q, want error", span.Status)
+	}
+	if span.Summary != "partial checkpoint" {
+		t.Fatalf("span summary = %q, want partial checkpoint", span.Summary)
+	}
+	if !strings.Contains(span.ErrorMsg, "timed out") {
+		t.Fatalf("span error = %q, want timeout detail", span.ErrorMsg)
 	}
 }

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -1154,7 +1154,12 @@ func TestHandleEventRunnerErrorRecordsPartialSummaryAsError(t *testing.T) {
 	rec := &traceRecorderStub{}
 	e.WithTraceRecorder(rec)
 	runner.run = func(ai.Request) (ai.Response, error) {
-		return ai.Response{Summary: "partial checkpoint"}, errors.New("codex command timed out after 1s")
+		return ai.Response{Summary: "partial checkpoint"}, ai.CommandInterruptedError{
+			Backend: "codex",
+			Kind:    ai.CommandInterruptedTimeout,
+			Timeout: time.Second,
+			Err:     context.DeadlineExceeded,
+		}
 	}
 
 	err := e.HandleEvent(context.Background(), labelEvent("issues.labeled", "owner/repo", "ai:review:arch-reviewer", 1))


### PR DESCRIPTION
## Summary

Closes #549.

- Treats backend command timeout/cancel as a hard interrupted run even when the CLI emitted parseable partial JSON first.
- Preserves the parsed partial summary as trace diagnostic context while recording span status as `error` with timeout detail.
- Surfaces trace error metadata through runner REST/MCP rows and renders timeout failures clearly in the Runners UI with a one-time timeout notification.

## Test plan

- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY go test ./internal/ai ./internal/workflow ./internal/daemon ./internal/mcp`
- `cd internal/ui && npm test`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY go test ./...`
- `git diff --check`

Note: `npm ci` emitted the repository's existing Next.js audit/deprecation warnings; tests passed after dependencies were installed locally.