### PR TITLE
fix: make MCP observability workspace-aware

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -187,7 +187,10 @@ func registerTools(srv *server.MCPServer, deps Deps) {
 	if deps.Observe != nil {
 		srv.AddTool(
 			mcpgo.NewTool("list_events",
-				mcpgo.WithDescription("List recent events (GitHub webhook deliveries, cron firings, on-demand runs, dispatches). Ordered oldest→newest, capped at 500."),
+				mcpgo.WithDescription("List recent events (GitHub webhook deliveries, cron firings, on-demand runs, dispatches) for one workspace. Ordered oldest→newest, capped at 500. Omitted workspace defaults to default."),
+				mcpgo.WithString("workspace",
+					mcpgo.Description("Optional workspace id or display name. Defaults to default."),
+				),
 				mcpgo.WithString("since",
 					mcpgo.Description("Optional RFC3339 timestamp; return only events strictly after this time."),
 				),
@@ -196,13 +199,19 @@ func registerTools(srv *server.MCPServer, deps Deps) {
 		)
 		srv.AddTool(
 			mcpgo.NewTool("list_traces",
-				mcpgo.WithDescription("List recent agent run spans. Ordered newest→oldest, capped at 200. Each span records backend, repo, status, duration, and summary."),
+				mcpgo.WithDescription("List recent agent run spans for one workspace. Ordered newest→oldest, capped at 200. Each span records backend, repo, status, duration, and summary. Omitted workspace defaults to default."),
+				mcpgo.WithString("workspace",
+					mcpgo.Description("Optional workspace id or display name. Defaults to default."),
+				),
 			),
 			toolListTraces(deps),
 		)
 		srv.AddTool(
 			mcpgo.NewTool("get_trace",
 				mcpgo.WithDescription("Fetch every span in a single trace by root event ID. Returns the full dispatch chain rooted at the originating event."),
+				mcpgo.WithString("workspace",
+					mcpgo.Description("Optional workspace id or display name. Defaults to default."),
+				),
 				mcpgo.WithString("root_event_id",
 					mcpgo.Required(),
 					mcpgo.Description("Root event ID of the trace (e.g. from list_events or list_traces)."),
@@ -232,7 +241,10 @@ func registerTools(srv *server.MCPServer, deps Deps) {
 		)
 		srv.AddTool(
 			mcpgo.NewTool("get_graph",
-				mcpgo.WithDescription("Return the agent interaction graph: every configured agent as a node plus observed inter-agent dispatch edges with counts and individual dispatch records."),
+				mcpgo.WithDescription("Return one workspace's agent interaction graph: configured agents as nodes plus observed and configured inter-agent dispatch edges. Omitted workspace defaults to default."),
+				mcpgo.WithString("workspace",
+					mcpgo.Description("Optional workspace id or display name. Defaults to default."),
+				),
 			),
 			toolGetGraph(deps),
 		)

--- a/internal/mcp/tools_observe.go
+++ b/internal/mcp/tools_observe.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"cmp"
 	"context"
 	"maps"
 	"slices"
@@ -48,7 +49,8 @@ func toolListEvents(deps Deps) server.ToolHandlerFunc {
 				since = t
 			}
 		}
-		return jsonResult(nilSafe(deps.Observe.ListEvents(since)))
+		workspace, _ := trimmedStringOptional(req, "workspace")
+		return jsonResult(nilSafe(deps.Observe.ListEventsForWorkspace(workspace, since)))
 	}
 }
 
@@ -56,8 +58,9 @@ func toolListEvents(deps Deps) server.ToolHandlerFunc {
 // shape already matches GET /traces so clients can parse both surfaces with
 // the same decoder.
 func toolListTraces(deps Deps) server.ToolHandlerFunc {
-	return func(_ context.Context, _ mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
-		return jsonResult(nilSafe(deps.Observe.ListTraces()))
+	return func(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		workspace, _ := trimmedStringOptional(req, "workspace")
+		return jsonResult(nilSafe(deps.Observe.ListTracesForWorkspace(workspace)))
 	}
 }
 
@@ -70,7 +73,8 @@ func toolGetTrace(deps Deps) server.ToolHandlerFunc {
 		if !ok {
 			return mcpgo.NewToolResultError("root_event_id is required"), nil
 		}
-		spans := deps.Observe.TracesByRootEventID(id)
+		workspace, _ := trimmedStringOptional(req, "workspace")
+		spans := deps.Observe.TracesByRootEventIDForWorkspace(workspace, id)
 		if len(spans) == 0 {
 			return mcpgo.NewToolResultErrorf("trace %q not found", id), nil
 		}
@@ -120,8 +124,10 @@ func toolGetTracePrompt(deps Deps) server.ToolHandlerFunc {
 // edge endpoints not in the current config (e.g. agents removed after they
 // dispatched) are added so the graph stays self-consistent.
 func toolGetGraph(deps Deps) server.ToolHandlerFunc {
-	return func(_ context.Context, _ mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
-		edges := deps.Observe.ListEdges()
+	return func(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		workspace, _ := trimmedStringOptional(req, "workspace")
+		workspaceID := fleet.NormalizeWorkspaceID(workspace)
+		edges := deps.Observe.ListEdgesForWorkspace(workspaceID)
 
 		agents, err := deps.Store.ReadAgents()
 		if err != nil {
@@ -129,8 +135,29 @@ func toolGetGraph(deps Deps) server.ToolHandlerFunc {
 		}
 
 		seen := make(map[string]struct{})
+		agentNames := make(map[string]struct{})
+		configuredEdges := make(map[string]mcpGraphEdge)
 		for _, a := range agents {
+			if fleet.NormalizeWorkspaceID(a.WorkspaceID) != workspaceID {
+				continue
+			}
 			seen[a.Name] = struct{}{}
+			agentNames[a.Name] = struct{}{}
+		}
+		for _, a := range agents {
+			if fleet.NormalizeWorkspaceID(a.WorkspaceID) != workspaceID {
+				continue
+			}
+			for _, target := range a.CanDispatch {
+				if _, ok := agentNames[target]; !ok {
+					continue
+				}
+				configuredEdges[mcpGraphEdgeKey(a.Name, target)] = mcpGraphEdge{
+					From:       a.Name,
+					To:         target,
+					Dispatches: []mcpGraphDispatch{},
+				}
+			}
 		}
 		for _, e := range edges {
 			seen[e.From] = struct{}{}
@@ -142,7 +169,10 @@ func toolGetGraph(deps Deps) server.ToolHandlerFunc {
 			nodes = append(nodes, mcpGraphNode{ID: name})
 		}
 
-		wireEdges := make([]mcpGraphEdge, 0, len(edges))
+		edgeByKey := make(map[string]mcpGraphEdge, len(edges)+len(configuredEdges))
+		for key, e := range configuredEdges {
+			edgeByKey[key] = e
+		}
 		for _, e := range edges {
 			recs := make([]mcpGraphDispatch, 0, len(e.Dispatches))
 			for _, d := range e.Dispatches {
@@ -153,19 +183,36 @@ func toolGetGraph(deps Deps) server.ToolHandlerFunc {
 					Reason: d.Reason,
 				})
 			}
-			wireEdges = append(wireEdges, mcpGraphEdge{
+			edgeByKey[mcpGraphEdgeKey(e.From, e.To)] = mcpGraphEdge{
 				From:       e.From,
 				To:         e.To,
 				Count:      e.Count,
 				Dispatches: recs,
-			})
+			}
 		}
+		wireEdges := make([]mcpGraphEdge, 0, len(edgeByKey))
+		for _, e := range edgeByKey {
+			if e.Dispatches == nil {
+				e.Dispatches = []mcpGraphDispatch{}
+			}
+			wireEdges = append(wireEdges, e)
+		}
+		slices.SortFunc(wireEdges, func(a, b mcpGraphEdge) int {
+			if byFrom := cmp.Compare(a.From, b.From); byFrom != 0 {
+				return byFrom
+			}
+			return cmp.Compare(a.To, b.To)
+		})
 
 		return jsonResult(map[string]any{
 			"nodes": nodes,
 			"edges": wireEdges,
 		})
 	}
+}
+
+func mcpGraphEdgeKey(from, to string) string {
+	return from + "\x00" + to
 }
 
 // toolGetDispatches returns the current dispatch counters.

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -837,9 +837,10 @@ func TestToolTriggerAgentMissingArgs(t *testing.T) {
 func seedEvent(t *testing.T, db *sql.DB, ev observe.TimestampedEvent) {
 	t.Helper()
 	payload, _ := json.Marshal(ev.Payload)
+	workspaceID := fleet.NormalizeWorkspaceID(ev.WorkspaceID)
 	if _, err := db.Exec(
-		`INSERT INTO events (id, at, repo, kind, number, actor, payload) VALUES (?, ?, ?, ?, ?, ?, ?)`,
-		ev.ID, ev.At, ev.Repo, ev.Kind, ev.Number, ev.Actor, string(payload),
+		`INSERT INTO events (id, workspace_id, at, repo, kind, number, actor, payload) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		ev.ID, workspaceID, ev.At, ev.Repo, ev.Kind, ev.Number, ev.Actor, string(payload),
 	); err != nil {
 		t.Fatalf("seed event: %v", err)
 	}
@@ -849,13 +850,21 @@ func seedEvent(t *testing.T, db *sql.DB, ev observe.TimestampedEvent) {
 // Same async-vs-sync rationale as seedEvent.
 func seedSpan(t *testing.T, db *sql.DB, sp observe.Span) {
 	t.Helper()
+	workspaceID := fleet.NormalizeWorkspaceID(sp.WorkspaceID)
 	if _, err := db.Exec(
-		`INSERT INTO traces (span_id, root_event_id, parent_span_id, agent, backend, repo, number, event_kind, invoked_by, dispatch_depth, queue_wait_ms, artifacts_count, summary, started_at, finished_at, duration_ms, status, error) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
-		sp.SpanID, sp.RootEventID, sp.ParentSpanID, sp.Agent, sp.Backend, sp.Repo, sp.Number,
+		`INSERT INTO traces (span_id, workspace_id, root_event_id, parent_span_id, agent, backend, repo, number, event_kind, invoked_by, dispatch_depth, queue_wait_ms, artifacts_count, summary, started_at, finished_at, duration_ms, status, error) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		sp.SpanID, workspaceID, sp.RootEventID, sp.ParentSpanID, sp.Agent, sp.Backend, sp.Repo, sp.Number,
 		sp.EventKind, sp.InvokedBy, sp.DispatchDepth, sp.QueueWaitMs, sp.ArtifactsCount, sp.Summary,
 		sp.StartedAt, sp.FinishedAt, sp.DurationMs, sp.Status, sp.ErrorMsg,
 	); err != nil {
 		t.Fatalf("seed span: %v", err)
+	}
+}
+
+func seedWorkspace(t *testing.T, deps Deps, id string) {
+	t.Helper()
+	if _, err := deps.Store.UpsertWorkspace(fleet.Workspace{ID: id, Name: id}); err != nil {
+		t.Fatalf("upsert workspace %s: %v", id, err)
 	}
 }
 
@@ -908,6 +917,28 @@ func TestToolListEventsSinceFilter(t *testing.T) {
 	}
 }
 
+func TestToolListEventsFiltersWorkspace(t *testing.T) {
+	t.Parallel()
+	deps := testFixture(t)
+	seedWorkspace(t, deps, "team-a")
+	seedWorkspace(t, deps, "team-b")
+	seedEvent(t, deps.Store.DB(), observe.TimestampedEvent{ID: "default-event", At: time.Date(2026, 4, 20, 9, 0, 0, 0, time.UTC), Kind: "agents.run", Repo: "owner/one"})
+	seedEvent(t, deps.Store.DB(), observe.TimestampedEvent{ID: "team-a-event", WorkspaceID: "team-a", At: time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC), Kind: "agents.run", Repo: "owner/team-a"})
+	seedEvent(t, deps.Store.DB(), observe.TimestampedEvent{ID: "team-b-event", WorkspaceID: "team-b", At: time.Date(2026, 4, 20, 11, 0, 0, 0, time.UTC), Kind: "agents.run", Repo: "owner/team-b"})
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"workspace": "team-a"}
+	res, err := toolListEvents(deps)(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var got []map[string]any
+	decodeText(t, res, &got)
+	if len(got) != 1 || got[0]["id"] != "team-a-event" {
+		t.Fatalf("workspace filter expected only team-a event, got %+v", got)
+	}
+}
+
 func TestToolListEventsNilSlice(t *testing.T) {
 	t.Parallel()
 	deps := testFixture(t)
@@ -942,6 +973,29 @@ func TestToolListTraces(t *testing.T) {
 	}
 }
 
+func TestToolListTracesFiltersWorkspace(t *testing.T) {
+	t.Parallel()
+	deps := testFixture(t)
+	seedWorkspace(t, deps, "team-a")
+	seedWorkspace(t, deps, "team-b")
+	now := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+	seedSpan(t, deps.Store.DB(), observe.Span{SpanID: "default-span", Agent: "coder", Status: "success", StartedAt: now, FinishedAt: now.Add(time.Second)})
+	seedSpan(t, deps.Store.DB(), observe.Span{SpanID: "team-a-span", WorkspaceID: "team-a", Agent: "coder", Status: "success", StartedAt: now.Add(time.Minute), FinishedAt: now.Add(time.Minute + time.Second)})
+	seedSpan(t, deps.Store.DB(), observe.Span{SpanID: "team-b-span", WorkspaceID: "team-b", Agent: "coder", Status: "success", StartedAt: now.Add(2 * time.Minute), FinishedAt: now.Add(2*time.Minute + time.Second)})
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"workspace": "team-a"}
+	res, err := toolListTraces(deps)(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var got []map[string]any
+	decodeText(t, res, &got)
+	if len(got) != 1 || got[0]["span_id"] != "team-a-span" {
+		t.Fatalf("workspace filter expected only team-a span, got %+v", got)
+	}
+}
+
 func TestToolGetTrace(t *testing.T) {
 	t.Parallel()
 	deps := testFixture(t)
@@ -967,6 +1021,36 @@ func TestToolGetTrace(t *testing.T) {
 	}
 	if !res.IsError {
 		t.Fatalf("expected IsError for missing trace, got %+v", res)
+	}
+}
+
+func TestToolGetTraceFiltersWorkspace(t *testing.T) {
+	t.Parallel()
+	deps := testFixture(t)
+	seedWorkspace(t, deps, "team-a")
+	seedWorkspace(t, deps, "team-b")
+	now := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+	seedSpan(t, deps.Store.DB(), observe.Span{SpanID: "team-a-span", WorkspaceID: "team-a", RootEventID: "root-1", Agent: "coder", StartedAt: now, FinishedAt: now.Add(time.Second)})
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"workspace": "team-a", "root_event_id": "root-1"}
+	res, err := toolGetTrace(deps)(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var got []map[string]any
+	decodeText(t, res, &got)
+	if len(got) != 1 || got[0]["span_id"] != "team-a-span" {
+		t.Fatalf("unexpected trace payload: %+v", got)
+	}
+
+	req.Params.Arguments = map[string]any{"workspace": "team-b", "root_event_id": "root-1"}
+	res, err = toolGetTrace(deps)(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected IsError for trace in wrong workspace, got %+v", res)
 	}
 }
 
@@ -1120,6 +1204,87 @@ func TestToolGetGraphSeedsNodesFromFleetAndEdges(t *testing.T) {
 	dispatches, ok := edge["dispatches"].([]any)
 	if !ok || len(dispatches) != 1 {
 		t.Fatalf("expected 1 dispatch record, got %+v", edge["dispatches"])
+	}
+}
+
+func TestToolGetGraphFiltersWorkspace(t *testing.T) {
+	t.Parallel()
+	deps := testFixture(t)
+	if _, err := deps.Store.UpsertWorkspace(fleet.Workspace{ID: "team-a", Name: "Team A"}); err != nil {
+		t.Fatalf("upsert workspace: %v", err)
+	}
+	if err := deps.Store.UpsertAgent(fleet.Agent{
+		WorkspaceID:   "team-a",
+		Name:          "team-reviewer",
+		Backend:       "claude",
+		Prompt:        "review",
+		Description:   "reviews team code",
+		AllowDispatch: true,
+		CanDispatch:   []string{},
+		AllowMemory:   nil,
+		Skills:        []string{},
+	}); err != nil {
+		t.Fatalf("upsert team reviewer: %v", err)
+	}
+	if err := deps.Store.UpsertAgent(fleet.Agent{
+		WorkspaceID:   "team-a",
+		Name:          "team-coder",
+		Backend:       "claude",
+		Prompt:        "code",
+		Description:   "writes team code",
+		AllowDispatch: true,
+		CanDispatch:   []string{"team-reviewer"},
+		AllowMemory:   nil,
+		Skills:        []string{},
+	}); err != nil {
+		t.Fatalf("upsert team coder: %v", err)
+	}
+	if _, err := deps.Store.DB().Exec(
+		`INSERT INTO dispatch_history (workspace_id, from_agent, to_agent, repo, number, reason) VALUES (?,?,?,?,?,?)`,
+		"team-a", "team-coder", "team-ghost", "owner/team", 7, "followup",
+	); err != nil {
+		t.Fatalf("seed team dispatch: %v", err)
+	}
+	if _, err := deps.Store.DB().Exec(
+		`INSERT INTO dispatch_history (workspace_id, from_agent, to_agent, repo, number, reason) VALUES (?,?,?,?,?,?)`,
+		fleet.DefaultWorkspaceID, "coder", "ghost", "owner/one", 8, "default followup",
+	); err != nil {
+		t.Fatalf("seed default dispatch: %v", err)
+	}
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"workspace": "team-a"}
+	res, err := toolGetGraph(deps)(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var got struct {
+		Nodes []map[string]any `json:"nodes"`
+		Edges []map[string]any `json:"edges"`
+	}
+	decodeText(t, res, &got)
+	for _, want := range []string{"team-coder", "team-reviewer", "team-ghost"} {
+		if !slices.ContainsFunc(got.Nodes, func(n map[string]any) bool { return n["id"] == want }) {
+			t.Errorf("missing node %q in %+v", want, got.Nodes)
+		}
+	}
+	for _, notWant := range []string{"coder", "reviewer", "ghost"} {
+		if slices.ContainsFunc(got.Nodes, func(n map[string]any) bool { return n["id"] == notWant }) {
+			t.Errorf("unexpected node %q in %+v", notWant, got.Nodes)
+		}
+	}
+	if !slices.ContainsFunc(got.Edges, func(e map[string]any) bool {
+		return e["from"] == "team-coder" && e["to"] == "team-reviewer"
+	}) {
+		t.Fatalf("expected configured team edge in %+v", got.Edges)
+	}
+	if !slices.ContainsFunc(got.Edges, func(e map[string]any) bool {
+		return e["from"] == "team-coder" && e["to"] == "team-ghost" && e["count"].(float64) == 1
+	}) {
+		t.Fatalf("expected observed team edge in %+v", got.Edges)
+	}
+	if slices.ContainsFunc(got.Edges, func(e map[string]any) bool { return e["from"] == "coder" || e["to"] == "ghost" }) {
+		t.Fatalf("default workspace edge leaked into team graph: %+v", got.Edges)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #545.

- Adds optional `workspace` arguments to MCP `list_events`, `list_traces`, `get_trace`, and `get_graph`.
- Routes those tools through the same workspace-aware observe store methods used by REST.
- Filters MCP graph configured nodes/edges to the selected workspace while preserving observed dispatch endpoints for that workspace.
- Adds focused MCP tests for workspace-filtered events, traces, trace lookup, and graph output.

## Test plan

- `go test ./internal/mcp`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `git diff --check`