### PR TITLE
fix: switch password hashing to bcrypt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/mark3labs/mcp-go v0.49.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/rs/zerolog v1.34.0
+	golang.org/x/crypto v0.51.0
 	golang.org/x/sync v0.20.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.49.1
@@ -44,7 +45,7 @@ require (
 	go.opentelemetry.io/otel v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
+	golang.org/x/sys v0.44.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	modernc.org/libc v1.72.0 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,8 @@ go.opentelemetry.io/otel/metric v1.43.0 h1:d7638QeInOnuwOONPp4JAOGfbCEpYb+K6DVWv
 go.opentelemetry.io/otel/metric v1.43.0/go.mod h1:RDnPtIxvqlgO8GRW18W6Z/4P462ldprJtfxHxyKd2PY=
 go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09nk+3A=
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
+golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
+golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
 golang.org/x/mod v0.33.0 h1:tHFzIWbBifEmbwtGz65eaWyGiGZatSrT9prnU8DbVL8=
 golang.org/x/mod v0.33.0/go.mod h1:swjeQEj+6r7fODbD2cqrnje9PnziFuw4bmLbBZFrQ5w=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
@@ -105,6 +107,8 @@ golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
 golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
+golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/tools v0.42.0 h1:uNgphsn75Tdz5Ji2q36v/nsFSfR/9BRFvqhGBaJGd5k=
 golang.org/x/tools v0.42.0/go.mod h1:Ma6lCIwGZvHK6XtgbswSoWroEkhugApmsXyrUmBhfr0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/store/auth.go
+++ b/internal/store/auth.go
@@ -62,8 +62,6 @@ const (
 	AuthTokenKindAPI     = "api"
 
 	randomTokenBytes = 32
-
-	legacyPBKDF2PasswordPrefix = "pbkdf2-sha256$"
 )
 
 func (s *Store) UserCount(ctx context.Context) (int, error) {

--- a/internal/store/auth.go
+++ b/internal/store/auth.go
@@ -61,9 +61,7 @@ const (
 	AuthTokenKindSession = "session"
 	AuthTokenKindAPI     = "api"
 
-	passwordHashIterations = 210000
-	passwordHashBytes      = 32
-	randomTokenBytes       = 32
+	randomTokenBytes = 32
 
 	legacyPBKDF2PasswordPrefix = "pbkdf2-sha256$"
 )
@@ -378,11 +376,16 @@ func (s *Store) AuthenticateToken(ctx context.Context, token, kind string) (Auth
 }
 
 func hashPassword(password string) (string, error) {
-	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	hash, err := bcrypt.GenerateFromPassword(bcryptPasswordInput(password), bcrypt.DefaultCost)
 	if err != nil {
 		return "", err
 	}
 	return string(hash), nil
+}
+
+func bcryptPasswordInput(password string) []byte {
+	sum := sha256.Sum256([]byte(password))
+	return sum[:]
 }
 
 func pbkdf2SHA256WithIter(password string, salt []byte, iter, keyLen int) ([]byte, error) {
@@ -391,10 +394,7 @@ func pbkdf2SHA256WithIter(password string, salt []byte, iter, keyLen int) ([]byt
 
 func verifyPassword(password, encoded string) (verified bool, needsRehash bool) {
 	if strings.HasPrefix(encoded, "$2a$") || strings.HasPrefix(encoded, "$2b$") || strings.HasPrefix(encoded, "$2y$") {
-		return bcrypt.CompareHashAndPassword([]byte(encoded), []byte(password)) == nil, false
-	}
-	if !strings.HasPrefix(encoded, legacyPBKDF2PasswordPrefix) {
-		return false, false
+		return bcrypt.CompareHashAndPassword([]byte(encoded), bcryptPasswordInput(password)) == nil, false
 	}
 	algorithm, rest, ok := strings.Cut(encoded, "$")
 	if !ok || algorithm != "pbkdf2-sha256" {

--- a/internal/store/auth.go
+++ b/internal/store/auth.go
@@ -13,6 +13,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"golang.org/x/crypto/bcrypt"
 )
 
 var (
@@ -61,8 +63,9 @@ const (
 
 	passwordHashIterations = 210000
 	passwordHashBytes      = 32
-	passwordSaltBytes      = 16
 	randomTokenBytes       = 32
+
+	legacyPBKDF2PasswordPrefix = "pbkdf2-sha256$"
 )
 
 func (s *Store) UserCount(ctx context.Context) (int, error) {
@@ -233,11 +236,22 @@ func (s *Store) Login(ctx context.Context, username, password string, sessionTTL
 	if err != nil {
 		return CreatedAuthToken{}, fmt.Errorf("auth: lookup user: %w", err)
 	}
-	if disabled.Valid || !verifyPassword(password, stored) {
+	verified, needsRehash := verifyPassword(password, stored)
+	if disabled.Valid || !verified {
 		return CreatedAuthToken{}, ErrAuthInvalid
 	}
-	if _, err := tx.ExecContext(ctx, "UPDATE users SET last_login_at=datetime('now'), updated_at=datetime('now') WHERE id=?", userID); err != nil {
-		return CreatedAuthToken{}, fmt.Errorf("auth: update login: %w", err)
+	if needsRehash {
+		hash, err := hashPassword(password)
+		if err != nil {
+			return CreatedAuthToken{}, err
+		}
+		if _, err := tx.ExecContext(ctx, "UPDATE users SET password_hash=?, last_login_at=datetime('now'), updated_at=datetime('now') WHERE id=?", hash, userID); err != nil {
+			return CreatedAuthToken{}, fmt.Errorf("auth: update login: %w", err)
+		}
+	} else {
+		if _, err := tx.ExecContext(ctx, "UPDATE users SET last_login_at=datetime('now'), updated_at=datetime('now') WHERE id=?", userID); err != nil {
+			return CreatedAuthToken{}, fmt.Errorf("auth: update login: %w", err)
+		}
 	}
 	created, err := createTokenTx(ctx, tx, userID, AuthTokenKindSession, "Web session", sessionTTL)
 	if err != nil {
@@ -364,51 +378,53 @@ func (s *Store) AuthenticateToken(ctx context.Context, token, kind string) (Auth
 }
 
 func hashPassword(password string) (string, error) {
-	salt, err := randomBytes(passwordSaltBytes)
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if err != nil {
 		return "", err
 	}
-	key, err := pbkdf2SHA256WithIter(password, salt, passwordHashIterations, passwordHashBytes)
-	if err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("pbkdf2-sha256$%d$%s$%s", passwordHashIterations, base64.RawStdEncoding.EncodeToString(salt), base64.RawStdEncoding.EncodeToString(key)), nil
+	return string(hash), nil
 }
 
 func pbkdf2SHA256WithIter(password string, salt []byte, iter, keyLen int) ([]byte, error) {
 	return pbkdf2.Key(sha256.New, password, salt, iter, keyLen)
 }
 
-func verifyPassword(password, encoded string) bool {
+func verifyPassword(password, encoded string) (verified bool, needsRehash bool) {
+	if strings.HasPrefix(encoded, "$2a$") || strings.HasPrefix(encoded, "$2b$") || strings.HasPrefix(encoded, "$2y$") {
+		return bcrypt.CompareHashAndPassword([]byte(encoded), []byte(password)) == nil, false
+	}
+	if !strings.HasPrefix(encoded, legacyPBKDF2PasswordPrefix) {
+		return false, false
+	}
 	algorithm, rest, ok := strings.Cut(encoded, "$")
 	if !ok || algorithm != "pbkdf2-sha256" {
-		return false
+		return false, false
 	}
 	iterRaw, rest, ok := strings.Cut(rest, "$")
 	if !ok {
-		return false
+		return false, false
 	}
 	saltRaw, keyRaw, ok := strings.Cut(rest, "$")
 	if !ok || strings.Contains(keyRaw, "$") {
-		return false
+		return false, false
 	}
 	var iter int
 	if _, err := fmt.Sscanf(iterRaw, "%d", &iter); err != nil || iter <= 0 {
-		return false
+		return false, false
 	}
 	salt, err := base64.RawStdEncoding.DecodeString(saltRaw)
 	if err != nil {
-		return false
+		return false, false
 	}
 	want, err := base64.RawStdEncoding.DecodeString(keyRaw)
 	if err != nil {
-		return false
+		return false, false
 	}
 	got, err := pbkdf2SHA256WithIter(password, salt, iter, len(want))
 	if err != nil {
-		return false
+		return false, false
 	}
-	return subtle.ConstantTimeCompare(got, want) == 1
+	return subtle.ConstantTimeCompare(got, want) == 1, true
 }
 
 func createTokenTx(ctx context.Context, tx *sql.Tx, userID int64, kind, name string, ttl time.Duration) (CreatedAuthToken, error) {

--- a/internal/store/auth_test.go
+++ b/internal/store/auth_test.go
@@ -137,7 +137,7 @@ func TestAuthNewUsersStoreBcryptHashes(t *testing.T) {
 	if _, err := bcrypt.Cost([]byte(hash)); err != nil {
 		t.Fatalf("bcrypt.Cost() error = %v", err)
 	}
-	if err := bcrypt.CompareHashAndPassword([]byte(hash), []byte("correct horse battery staple")); err != nil {
+	if err := bcrypt.CompareHashAndPassword([]byte(hash), bcryptPasswordInput("correct horse battery staple")); err != nil {
 		t.Fatalf("bcrypt password verification error = %v", err)
 	}
 
@@ -146,6 +146,28 @@ func TestAuthNewUsersStoreBcryptHashes(t *testing.T) {
 	}
 	if got := passwordHashForUser(t, db, user.ID); got != hash {
 		t.Fatalf("password hash changed after bcrypt login: got %q, want %q", got, hash)
+	}
+}
+
+func TestAuthLongPasswordsStoreAndLoginWithBcrypt(t *testing.T) {
+	t.Parallel()
+
+	db := openTestDB(t)
+	st := store.New(db)
+	ctx := context.Background()
+	password := strings.Repeat("long-password-", 8)
+
+	user, err := st.CreateUser(ctx, "long-bcrypt-user", password)
+	if err != nil {
+		t.Fatalf("CreateUser() error = %v", err)
+	}
+
+	hash := passwordHashForUser(t, db, user.ID)
+	if err := bcrypt.CompareHashAndPassword([]byte(hash), bcryptPasswordInput(password)); err != nil {
+		t.Fatalf("bcrypt password verification error = %v", err)
+	}
+	if _, err := st.Login(ctx, "long-bcrypt-user", password, 0); err != nil {
+		t.Fatalf("Login() error = %v", err)
 	}
 }
 
@@ -170,8 +192,34 @@ func TestAuthLegacyPBKDF2LoginUpgradesToBcrypt(t *testing.T) {
 	if strings.HasPrefix(upgraded, "pbkdf2-sha256$") {
 		t.Fatalf("password hash still has legacy prefix: %q", upgraded)
 	}
-	if err := bcrypt.CompareHashAndPassword([]byte(upgraded), []byte(password)); err != nil {
+	if err := bcrypt.CompareHashAndPassword([]byte(upgraded), bcryptPasswordInput(password)); err != nil {
 		t.Fatalf("upgraded bcrypt verification error = %v", err)
+	}
+}
+
+func TestAuthLongLegacyPBKDF2LoginUpgradesToBcrypt(t *testing.T) {
+	t.Parallel()
+
+	db := openTestDB(t)
+	st := store.New(db)
+	ctx := context.Background()
+	password := strings.Repeat("legacy-long-password-", 5)
+	legacyHash := legacyPBKDF2Hash(t, password)
+	userID := insertUserWithPasswordHash(t, db, "legacy-long-user", legacyHash)
+
+	if _, err := st.Login(ctx, "legacy-long-user", password, 0); err != nil {
+		t.Fatalf("Login() error = %v", err)
+	}
+
+	upgraded := passwordHashForUser(t, db, userID)
+	if upgraded == legacyHash {
+		t.Fatal("password hash was not upgraded")
+	}
+	if err := bcrypt.CompareHashAndPassword([]byte(upgraded), bcryptPasswordInput(password)); err != nil {
+		t.Fatalf("upgraded bcrypt verification error = %v", err)
+	}
+	if _, err := st.Login(ctx, "legacy-long-user", password, 0); err != nil {
+		t.Fatalf("second Login() error = %v", err)
 	}
 }
 
@@ -212,6 +260,11 @@ func legacyPBKDF2Hash(t *testing.T, password string) string {
 		base64.RawStdEncoding.EncodeToString(salt),
 		base64.RawStdEncoding.EncodeToString(key),
 	)
+}
+
+func bcryptPasswordInput(password string) []byte {
+	sum := sha256.Sum256([]byte(password))
+	return sum[:]
 }
 
 func insertUserWithPasswordHash(t *testing.T, db *sql.DB, username, hash string) int64 {

--- a/internal/store/auth_test.go
+++ b/internal/store/auth_test.go
@@ -2,10 +2,17 @@ package store_test
 
 import (
 	"context"
+	"crypto/pbkdf2"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/base64"
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/eloylp/agents/internal/store"
+	"golang.org/x/crypto/bcrypt"
 )
 
 func TestAuthBootstrapLoginAndAPITokenLifecycle(t *testing.T) {
@@ -109,4 +116,128 @@ func TestAuthBootstrapLoginAndAPITokenLifecycle(t *testing.T) {
 	if _, err := st.AuthenticateToken(ctx, api.Token, store.AuthTokenKindAPI); !errors.Is(err, store.ErrAuthInvalid) {
 		t.Fatalf("AuthenticateToken(revoked api) error = %v, want %v", err, store.ErrAuthInvalid)
 	}
+}
+
+func TestAuthNewUsersStoreBcryptHashes(t *testing.T) {
+	t.Parallel()
+
+	db := openTestDB(t)
+	st := store.New(db)
+	ctx := context.Background()
+
+	user, err := st.CreateUser(ctx, "bcrypt-user", "correct horse battery staple")
+	if err != nil {
+		t.Fatalf("CreateUser() error = %v", err)
+	}
+
+	hash := passwordHashForUser(t, db, user.ID)
+	if !strings.HasPrefix(hash, "$2") {
+		t.Fatalf("password hash prefix = %q, want bcrypt", hash)
+	}
+	if _, err := bcrypt.Cost([]byte(hash)); err != nil {
+		t.Fatalf("bcrypt.Cost() error = %v", err)
+	}
+	if err := bcrypt.CompareHashAndPassword([]byte(hash), []byte("correct horse battery staple")); err != nil {
+		t.Fatalf("bcrypt password verification error = %v", err)
+	}
+
+	if _, err := st.Login(ctx, "bcrypt-user", "correct horse battery staple", 0); err != nil {
+		t.Fatalf("Login() error = %v", err)
+	}
+	if got := passwordHashForUser(t, db, user.ID); got != hash {
+		t.Fatalf("password hash changed after bcrypt login: got %q, want %q", got, hash)
+	}
+}
+
+func TestAuthLegacyPBKDF2LoginUpgradesToBcrypt(t *testing.T) {
+	t.Parallel()
+
+	db := openTestDB(t)
+	st := store.New(db)
+	ctx := context.Background()
+	const password = "legacy password"
+	legacyHash := legacyPBKDF2Hash(t, password)
+	userID := insertUserWithPasswordHash(t, db, "legacy-user", legacyHash)
+
+	if _, err := st.Login(ctx, "legacy-user", password, 0); err != nil {
+		t.Fatalf("Login() error = %v", err)
+	}
+
+	upgraded := passwordHashForUser(t, db, userID)
+	if upgraded == legacyHash {
+		t.Fatal("password hash was not upgraded")
+	}
+	if strings.HasPrefix(upgraded, "pbkdf2-sha256$") {
+		t.Fatalf("password hash still has legacy prefix: %q", upgraded)
+	}
+	if err := bcrypt.CompareHashAndPassword([]byte(upgraded), []byte(password)); err != nil {
+		t.Fatalf("upgraded bcrypt verification error = %v", err)
+	}
+}
+
+func TestAuthInvalidAndUnknownPasswordHashesFailClosed(t *testing.T) {
+	t.Parallel()
+
+	db := openTestDB(t)
+	st := store.New(db)
+	ctx := context.Background()
+	legacyHash := legacyPBKDF2Hash(t, "correct password")
+	legacyID := insertUserWithPasswordHash(t, db, "legacy-invalid", legacyHash)
+	unknownID := insertUserWithPasswordHash(t, db, "unknown-format", "sha1$not-supported")
+
+	if _, err := st.Login(ctx, "legacy-invalid", "wrong password", 0); !errors.Is(err, store.ErrAuthInvalid) {
+		t.Fatalf("Login(wrong legacy password) error = %v, want %v", err, store.ErrAuthInvalid)
+	}
+	if got := passwordHashForUser(t, db, legacyID); got != legacyHash {
+		t.Fatalf("legacy hash changed after failed login: got %q, want %q", got, legacyHash)
+	}
+	if _, err := st.Login(ctx, "unknown-format", "correct password", 0); !errors.Is(err, store.ErrAuthInvalid) {
+		t.Fatalf("Login(unknown hash) error = %v, want %v", err, store.ErrAuthInvalid)
+	}
+	if got := passwordHashForUser(t, db, unknownID); got != "sha1$not-supported" {
+		t.Fatalf("unknown hash changed after failed login: got %q", got)
+	}
+}
+
+func legacyPBKDF2Hash(t *testing.T, password string) string {
+	t.Helper()
+
+	salt := []byte("fixed-test-salt!")
+	key, err := pbkdf2.Key(sha256.New, password, salt, 210000, 32)
+	if err != nil {
+		t.Fatalf("pbkdf2.Key() error = %v", err)
+	}
+	return fmt.Sprintf(
+		"pbkdf2-sha256$210000$%s$%s",
+		base64.RawStdEncoding.EncodeToString(salt),
+		base64.RawStdEncoding.EncodeToString(key),
+	)
+}
+
+func insertUserWithPasswordHash(t *testing.T, db *sql.DB, username, hash string) int64 {
+	t.Helper()
+
+	res, err := db.Exec(
+		"INSERT INTO users(username,password_hash,created_at,updated_at) VALUES(?,?,datetime('now'),datetime('now'))",
+		username,
+		hash,
+	)
+	if err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("LastInsertId() error = %v", err)
+	}
+	return id
+}
+
+func passwordHashForUser(t *testing.T, db *sql.DB, userID int64) string {
+	t.Helper()
+
+	var hash string
+	if err := db.QueryRow("SELECT password_hash FROM users WHERE id=?", userID).Scan(&hash); err != nil {
+		t.Fatalf("query password hash: %v", err)
+	}
+	return hash
 }


### PR DESCRIPTION
## Summary

Closes #538.

- Stores newly created daemon user passwords as bcrypt hashes using `bcrypt.DefaultCost`.
- Keeps legacy `pbkdf2-sha256$...` password verification for existing installs.
- Opportunistically upgrades a successful legacy PBKDF2 login to bcrypt inside the login transaction.
- Fails closed for unsupported password hash formats.

## Test plan

- `go test ./internal/store ./internal/daemon`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `go test -race ./internal/store ./internal/daemon`
- `git diff --check`