### PR TITLE
fix: clean up direct runs after panic

### DIFF
--- a/internal/workflow/engine_dispatch.go
+++ b/internal/workflow/engine_dispatch.go
@@ -46,6 +46,7 @@ func (e *Engine) handleDispatchEvent(ctx context.Context, ev Event) error {
 	// committed the dedup slot before enqueuing the event. Re-claiming would see
 	// the committed entry and self-suppress every dispatched run. The enqueue-side
 	// claim is the authoritative gate; handleDispatchEvent only executes it.
+	agentsRunClaimed := false
 	if ev.Kind == "agents.run" && e.dispatcher != nil {
 		dedupRepo := dedupRepoKey(workspaceID, repo.Name)
 		if !e.dispatcher.dedup.TryClaimForDispatch(targetName, dedupRepo, ev.Number, time.Now()) {
@@ -57,6 +58,7 @@ func (e *Engine) handleDispatchEvent(ctx context.Context, ev Event) error {
 			return nil
 		}
 		e.dispatcher.dedup.MarkWebhookRunInFlight(targetName, dedupRepo, ev.Number)
+		agentsRunClaimed = true
 	}
 
 	// Autonomous (cron-fired) runs use the cron bucket dedup window so a
@@ -64,6 +66,7 @@ func (e *Engine) handleDispatchEvent(ctx context.Context, ev Event) error {
 	// self-suppresses (matches the old scheduler.executeAgentRun behavior).
 	// Rollback on error so the slot is freed for the next tick; finalize on
 	// success so the dedup window is preserved.
+	cronClaimed := false
 	if ev.Kind == "cron" && e.dispatcher != nil {
 		if !e.dispatcher.TryMarkAutonomousRun(workspaceID, targetName, repo.Name, time.Now()) {
 			e.logger.Info().
@@ -73,6 +76,7 @@ func (e *Engine) handleDispatchEvent(ctx context.Context, ev Event) error {
 			e.runsDeduped.Add(1)
 			return nil
 		}
+		cronClaimed = true
 	}
 
 	e.logger.Info().
@@ -83,36 +87,61 @@ func (e *Engine) handleDispatchEvent(ctx context.Context, ev Event) error {
 		Str("kind", ev.Kind).
 		Msg("running dispatched agent")
 
-	runErr := e.runAgent(ctx, ev, agent, cfg)
+	var runErr error
+	runSucceeded := false
+	defer func() {
+		if r := recover(); r != nil {
+			if agentsRunClaimed {
+				dedupRepo := dedupRepoKey(workspaceID, repo.Name)
+				e.dispatcher.dedup.AbandonWebhookRun(targetName, dedupRepo, ev.Number)
+			}
+			if cronClaimed {
+				e.dispatcher.RollbackAutonomousRun(workspaceID, targetName, repo.Name)
+			}
+			if ev.Kind == "cron" && e.lastRunRec != nil {
+				e.lastRunRec.RecordLastRun(workspaceID, targetName, repo.Name, time.Now(), "error")
+			}
+			e.logger.Error().
+				Interface("panic", r).
+				Str("workspace", workspaceID).
+				Str("repo", ev.Repo.FullName).
+				Str("target", targetName).
+				Str("kind", ev.Kind).
+				Int("number", ev.Number).
+				Msg("panic in direct agent run; cleanup completed")
+			panic(r)
+		}
 
-	// Release the on-demand claim taken above for agents.run.
-	if ev.Kind == "agents.run" && e.dispatcher != nil {
-		dedupRepo := dedupRepoKey(workspaceID, repo.Name)
-		if runErr != nil {
-			e.dispatcher.dedup.AbandonWebhookRun(targetName, dedupRepo, ev.Number)
-		} else {
-			e.dispatcher.dedup.FinalizeWebhookRun(targetName, dedupRepo, ev.Number)
+		if agentsRunClaimed {
+			dedupRepo := dedupRepoKey(workspaceID, repo.Name)
+			if runSucceeded {
+				e.dispatcher.dedup.FinalizeWebhookRun(targetName, dedupRepo, ev.Number)
+			} else {
+				e.dispatcher.dedup.AbandonWebhookRun(targetName, dedupRepo, ev.Number)
+			}
 		}
-	}
-	// Release the cron bucket mark taken above for autonomous runs.
-	if ev.Kind == "cron" && e.dispatcher != nil {
-		if runErr != nil {
-			e.dispatcher.RollbackAutonomousRun(workspaceID, targetName, repo.Name)
-		} else {
-			e.dispatcher.FinalizeAutonomousRun(workspaceID, targetName, repo.Name)
+		if cronClaimed {
+			if runSucceeded {
+				e.dispatcher.FinalizeAutonomousRun(workspaceID, targetName, repo.Name)
+			} else {
+				e.dispatcher.RollbackAutonomousRun(workspaceID, targetName, repo.Name)
+			}
 		}
-	}
-	// Notify the autonomous scheduler so its lastRuns map (which drives the
-	// per-binding schedule display in /agents) reflects this run's outcome.
-	// Fired only for autonomous events, webhook/agents.run/dispatch runs
-	// have their own provenance and don't update the cron schedule view.
-	if ev.Kind == "cron" && e.lastRunRec != nil {
-		status := "success"
-		if runErr != nil {
-			status = "error"
+		// Notify the autonomous scheduler so its lastRuns map (which drives the
+		// per-binding schedule display in /agents) reflects this run's outcome.
+		// Fired only for autonomous events, webhook/agents.run/dispatch runs
+		// have their own provenance and don't update the cron schedule view.
+		if ev.Kind == "cron" && e.lastRunRec != nil {
+			status := "success"
+			if !runSucceeded {
+				status = "error"
+			}
+			e.lastRunRec.RecordLastRun(workspaceID, targetName, repo.Name, time.Now(), status)
 		}
-		e.lastRunRec.RecordLastRun(workspaceID, targetName, repo.Name, time.Now(), status)
-	}
+	}()
+
+	runErr = e.runAgent(ctx, ev, agent, cfg)
+	runSucceeded = runErr == nil
 	return runErr
 }
 

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -1106,6 +1106,158 @@ func TestHandleEventAutonomousFiresLastRunRecorder(t *testing.T) {
 	}
 }
 
+func TestHandleDirectRunPanicReleasesClaims(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ev   Event
+	}{
+		{
+			name: "agents.run",
+			ev: Event{
+				Repo:    RepoRef{FullName: "owner/repo", Enabled: true},
+				Kind:    "agents.run",
+				Number:  7,
+				Payload: map[string]any{"target_agent": "arch-reviewer"},
+			},
+		},
+		{
+			name: "cron",
+			ev:   autonomousEvent("owner/repo", "arch-reviewer"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			e, runner := newDirectRunTestEngine(t)
+			rec := &stubLastRunRecorder{}
+			e.WithLastRunRecorder(rec)
+			runner.runFn = func(ai.Request) error {
+				if runner.callCount() == 1 {
+					panic("runner panic")
+				}
+				return nil
+			}
+
+			mustPanic(t, func() {
+				_ = e.HandleEvent(context.Background(), tt.ev)
+			})
+
+			if err := e.HandleEvent(context.Background(), tt.ev); err != nil {
+				t.Fatalf("second HandleEvent() error = %v", err)
+			}
+			if got := runner.callCount(); got != 2 {
+				t.Fatalf("runner calls = %d, want 2; stale claim likely blocked retry", got)
+			}
+			if tt.ev.Kind == "cron" {
+				calls := rec.snapshot()
+				if len(calls) != 2 {
+					t.Fatalf("LastRunRecorder calls = %d, want 2: %+v", len(calls), calls)
+				}
+				if calls[0].status != "error" || calls[1].status != "success" {
+					t.Fatalf("cron statuses = %q, %q; want error, success", calls[0].status, calls[1].status)
+				}
+			}
+		})
+	}
+}
+
+func TestHandleDirectRunErrorReleasesClaims(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ev   Event
+	}{
+		{
+			name: "agents.run",
+			ev: Event{
+				Repo:    RepoRef{FullName: "owner/repo", Enabled: true},
+				Kind:    "agents.run",
+				Number:  8,
+				Payload: map[string]any{"target_agent": "arch-reviewer"},
+			},
+		},
+		{
+			name: "cron",
+			ev:   autonomousEvent("owner/repo", "arch-reviewer"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			e, runner := newDirectRunTestEngine(t)
+			rec := &stubLastRunRecorder{}
+			e.WithLastRunRecorder(rec)
+			runner.runFn = func(ai.Request) error {
+				if runner.callCount() == 1 {
+					return errors.New("runner failed")
+				}
+				return nil
+			}
+
+			if err := e.HandleEvent(context.Background(), tt.ev); err == nil {
+				t.Fatal("first HandleEvent() error = nil, want error")
+			}
+			if err := e.HandleEvent(context.Background(), tt.ev); err != nil {
+				t.Fatalf("second HandleEvent() error = %v", err)
+			}
+			if got := runner.callCount(); got != 2 {
+				t.Fatalf("runner calls = %d, want 2; stale claim likely blocked retry", got)
+			}
+			if tt.ev.Kind == "cron" {
+				calls := rec.snapshot()
+				if len(calls) != 2 {
+					t.Fatalf("LastRunRecorder calls = %d, want 2: %+v", len(calls), calls)
+				}
+				if calls[0].status != "error" || calls[1].status != "success" {
+					t.Fatalf("cron statuses = %q, %q; want error, success", calls[0].status, calls[1].status)
+				}
+			}
+		})
+	}
+}
+
+func newDirectRunTestEngine(t *testing.T) (*Engine, *stubRunner) {
+	t.Helper()
+
+	runner := &stubRunner{}
+	cfg := &config.Config{
+		Daemon: config.DaemonConfig{
+			Processor: config.ProcessorConfig{
+				MaxConcurrentAgents: 4,
+				Dispatch:            testDispatchCfg(),
+			},
+			AIBackends: map[string]fleet.Backend{
+				"claude": {Command: "claude"},
+			},
+		},
+		Agents: []fleet.Agent{
+			{Name: "arch-reviewer", Backend: "claude", Prompt: "Review architecture."},
+		},
+		Repos: []fleet.Repo{
+			{Name: "owner/repo", Enabled: true},
+		},
+	}
+	return newEngineFromCfg(t, cfg, map[string]ai.Runner{"claude": runner}, &fakeQueue{}), runner
+}
+
+func mustPanic(t *testing.T, fn func()) {
+	t.Helper()
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("function did not panic")
+		}
+	}()
+	fn()
+}
+
 // TestHandleEventNonAutonomousSkipsLastRunRecorder verifies that label/event
 // driven runs (webhook path) do not fire the LastRunRecorder hook, only
 // autonomous runs update the cron schedule view.


### PR DESCRIPTION
## Summary

Closes #557.

- Wraps direct `agents.run`, `cron`, and `agent.dispatch` execution finalization in a deferred cleanup path.
- Abandons or rolls back acquired direct-run claims when `runAgent` panics, then re-panics after logging workflow context.
- Preserves existing success/error finalization behavior and records cron last-run status through the same finalizer.
- Adds focused workflow tests proving `agents.run` and `cron` retries are not blocked after panic or normal runner errors.

## Test plan

- `go test ./internal/workflow`
- `git diff --check`