### PR TITLE
refactor: use sorted map keys for backend dedupe

### DIFF
--- a/internal/backends/discovery.go
+++ b/internal/backends/discovery.go
@@ -595,20 +595,14 @@ func dedupeSorted(in []string) []string {
 		return nil
 	}
 	seen := make(map[string]struct{}, len(in))
-	out := make([]string, 0, len(in))
 	for _, s := range in {
 		s = strings.TrimSpace(s)
 		if s == "" {
 			continue
 		}
-		if _, ok := seen[s]; ok {
-			continue
-		}
 		seen[s] = struct{}{}
-		out = append(out, s)
 	}
-	slices.Sort(out)
-	return out
+	return slices.Sorted(maps.Keys(seen))
 }
 
 func resolveCommandInRuntime(ctx context.Context, runner runtimeexec.Runner, settings fleet.RuntimeSettings, defaultName, preferred string) (string, bool) {


### PR DESCRIPTION
## Summary

- Replaces the manual append-and-sort step in backend model deduping with `slices.Sorted(maps.Keys(...))`.
- Keeps the same trim, empty-filter, dedupe, and sorted output behavior while removing the duplicate check and output slice bookkeeping.

## Test plan

- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./internal/backends`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.