### PR TITLE
fix: persist explicit admin role

### DIFF
--- a/internal/store/auth.go
+++ b/internal/store/auth.go
@@ -74,7 +74,7 @@ func (s *Store) UserCount(ctx context.Context) (int, error) {
 
 func (s *Store) ListUsers(ctx context.Context) ([]User, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id,username,created_at,updated_at,last_login_at,disabled_at,id=(SELECT MIN(id) FROM users)
+		SELECT id,username,created_at,updated_at,last_login_at,disabled_at,is_admin
 		FROM users ORDER BY username ASC, id ASC`)
 	if err != nil {
 		return nil, fmt.Errorf("auth: list users: %w", err)
@@ -121,7 +121,7 @@ func (s *Store) CreateUser(ctx context.Context, username, password string) (User
 
 func (s *Store) GetUser(ctx context.Context, id int64) (User, error) {
 	row := s.db.QueryRowContext(ctx, `
-		SELECT id,username,created_at,updated_at,last_login_at,disabled_at,id=(SELECT MIN(id) FROM users)
+		SELECT id,username,created_at,updated_at,last_login_at,disabled_at,is_admin
 		FROM users WHERE id=?`, id)
 	user, err := scanUser(row)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -143,12 +143,20 @@ func (s *Store) DeleteUser(ctx context.Context, id int64) error {
 	}
 	defer tx.Rollback()
 
-	var adminID int64
-	if err := tx.QueryRowContext(ctx, "SELECT COALESCE(MIN(id), 0) FROM users").Scan(&adminID); err != nil {
-		return fmt.Errorf("auth: admin lookup: %w", err)
+	var isAdmin int
+	if err := tx.QueryRowContext(ctx, "SELECT is_admin FROM users WHERE id=?", id).Scan(&isAdmin); errors.Is(err, sql.ErrNoRows) {
+		return ErrAuthNotFound
+	} else if err != nil {
+		return fmt.Errorf("auth: lookup delete user: %w", err)
 	}
-	if adminID == id {
-		return ErrAuthForbidden
+	if isAdmin != 0 {
+		var adminCount int
+		if err := tx.QueryRowContext(ctx, "SELECT COUNT(*) FROM users WHERE is_admin != 0 AND disabled_at IS NULL").Scan(&adminCount); err != nil {
+			return fmt.Errorf("auth: count admins: %w", err)
+		}
+		if adminCount <= 1 {
+			return ErrAuthForbidden
+		}
 	}
 	res, err := tx.ExecContext(ctx, "DELETE FROM users WHERE id=?", id)
 	if err != nil {
@@ -190,8 +198,8 @@ func (s *Store) BootstrapUser(ctx context.Context, username, password string, se
 		return CreatedAuthToken{}, err
 	}
 	res, err := tx.ExecContext(ctx, `
-		INSERT INTO users(username,password_hash,created_at,updated_at)
-		VALUES(?,?,datetime('now'),datetime('now'))`, username, hash)
+		INSERT INTO users(username,password_hash,is_admin,created_at,updated_at)
+		VALUES(?,?,1,datetime('now'),datetime('now'))`, username, hash)
 	if err != nil {
 		return CreatedAuthToken{}, fmt.Errorf("auth: create user: %w", err)
 	}
@@ -348,7 +356,7 @@ func (s *Store) AuthenticateToken(ctx context.Context, token, kind string) (Auth
 	hash := hashToken(token)
 	row := s.db.QueryRowContext(ctx, `
 		SELECT
-			u.id,u.username,u.created_at,u.updated_at,u.last_login_at,u.disabled_at,u.id=(SELECT MIN(id) FROM users),
+			u.id,u.username,u.created_at,u.updated_at,u.last_login_at,u.disabled_at,u.is_admin,
 			t.id,t.user_id,t.kind,t.name,t.prefix,t.created_at,t.expires_at,t.last_used_at,t.revoked_at
 		FROM auth_tokens t
 		JOIN users u ON u.id = t.user_id

--- a/internal/store/auth_test.go
+++ b/internal/store/auth_test.go
@@ -86,6 +86,9 @@ func TestAuthBootstrapLoginAndAPITokenLifecycle(t *testing.T) {
 	if identity.User.Username != "admin" {
 		t.Fatalf("authenticated username = %q, want admin", identity.User.Username)
 	}
+	if !identity.User.IsAdmin {
+		t.Fatal("AuthenticateToken(session) user is not marked admin")
+	}
 
 	api, err := st.CreateAPIToken(ctx, identity.User.ID, "Codex MCP", nil)
 	if err != nil {
@@ -115,6 +118,95 @@ func TestAuthBootstrapLoginAndAPITokenLifecycle(t *testing.T) {
 	}
 	if _, err := st.AuthenticateToken(ctx, api.Token, store.AuthTokenKindAPI); !errors.Is(err, store.ErrAuthInvalid) {
 		t.Fatalf("AuthenticateToken(revoked api) error = %v, want %v", err, store.ErrAuthInvalid)
+	}
+}
+
+func TestAuthAdminStatusComesFromDatabase(t *testing.T) {
+	t.Parallel()
+
+	db := openTestDB(t)
+	st := store.New(db)
+	ctx := context.Background()
+
+	created, err := st.BootstrapUser(ctx, "bootstrap", "correct horse battery staple", 0)
+	if err != nil {
+		t.Fatalf("BootstrapUser() error = %v", err)
+	}
+	other, err := st.CreateUser(ctx, "operator", "correct horse battery staple")
+	if err != nil {
+		t.Fatalf("CreateUser() error = %v", err)
+	}
+	if _, err := db.Exec("UPDATE users SET is_admin = CASE WHEN id = ? THEN 1 ELSE 0 END", other.ID); err != nil {
+		t.Fatalf("update admin flags: %v", err)
+	}
+
+	users, err := st.ListUsers(ctx)
+	if err != nil {
+		t.Fatalf("ListUsers() error = %v", err)
+	}
+	for _, user := range users {
+		switch user.ID {
+		case created.UserID:
+			if user.IsAdmin {
+				t.Fatalf("bootstrap user IsAdmin = true after DB flag cleared")
+			}
+		case other.ID:
+			if !user.IsAdmin {
+				t.Fatalf("operator IsAdmin = false after DB flag set")
+			}
+		}
+	}
+	got, err := st.GetUser(ctx, other.ID)
+	if err != nil {
+		t.Fatalf("GetUser(operator) error = %v", err)
+	}
+	if !got.IsAdmin {
+		t.Fatal("GetUser(operator) IsAdmin = false, want true")
+	}
+	session, err := st.Login(ctx, "operator", "correct horse battery staple", 0)
+	if err != nil {
+		t.Fatalf("Login(operator) error = %v", err)
+	}
+	identity, err := st.AuthenticateToken(ctx, session.Token, store.AuthTokenKindSession)
+	if err != nil {
+		t.Fatalf("AuthenticateToken(operator) error = %v", err)
+	}
+	if !identity.User.IsAdmin {
+		t.Fatal("AuthenticateToken(operator) IsAdmin = false, want true")
+	}
+}
+
+func TestAuthDeleteAdminAllowsAnotherAdmin(t *testing.T) {
+	t.Parallel()
+
+	db := openTestDB(t)
+	st := store.New(db)
+	ctx := context.Background()
+
+	created, err := st.BootstrapUser(ctx, "admin", "correct horse battery staple", 0)
+	if err != nil {
+		t.Fatalf("BootstrapUser() error = %v", err)
+	}
+	other, err := st.CreateUser(ctx, "second-admin", "correct horse battery staple")
+	if err != nil {
+		t.Fatalf("CreateUser() error = %v", err)
+	}
+	if _, err := db.Exec("UPDATE users SET is_admin = 1 WHERE id = ?", other.ID); err != nil {
+		t.Fatalf("promote second admin: %v", err)
+	}
+
+	if err := st.DeleteUser(ctx, created.UserID); err != nil {
+		t.Fatalf("DeleteUser(first admin) error = %v", err)
+	}
+	users, err := st.ListUsers(ctx)
+	if err != nil {
+		t.Fatalf("ListUsers() error = %v", err)
+	}
+	if len(users) != 1 || users[0].ID != other.ID || !users[0].IsAdmin {
+		t.Fatalf("remaining users = %+v, want only second admin", users)
+	}
+	if err := st.DeleteUser(ctx, other.ID); !errors.Is(err, store.ErrAuthForbidden) {
+		t.Fatalf("DeleteUser(last admin) error = %v, want %v", err, store.ErrAuthForbidden)
 	}
 }
 

--- a/internal/store/migrations/029_auth_admin_role.sql
+++ b/internal/store/migrations/029_auth_admin_role.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS users (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    username      TEXT NOT NULL UNIQUE,
+    password_hash TEXT NOT NULL,
+    created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at    TEXT NOT NULL DEFAULT (datetime('now')),
+    last_login_at TEXT,
+    disabled_at   TEXT
+);
+
+ALTER TABLE users ADD COLUMN is_admin INTEGER NOT NULL DEFAULT 0;
+
+UPDATE users
+SET is_admin = 1
+WHERE id = (SELECT MIN(id) FROM users)
+  AND NOT EXISTS (SELECT 1 FROM users WHERE is_admin != 0);

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -525,6 +525,96 @@ func TestWorkspacePromptMigrationBackfillsExistingAgents(t *testing.T) {
 	}
 }
 
+func TestAuthAdminMigrationBackfillsFirstExistingUser(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "agents.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open raw db: %v", err)
+	}
+	if _, err := db.Exec(`
+		CREATE TABLE schema_migrations (name TEXT PRIMARY KEY, applied_at TEXT NOT NULL DEFAULT (datetime('now')));
+		CREATE TABLE users (
+			id            INTEGER PRIMARY KEY AUTOINCREMENT,
+			username      TEXT NOT NULL UNIQUE,
+			password_hash TEXT NOT NULL,
+			created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+			updated_at    TEXT NOT NULL DEFAULT (datetime('now')),
+			last_login_at TEXT,
+			disabled_at   TEXT
+		);
+		CREATE TABLE auth_tokens (
+			id           INTEGER PRIMARY KEY AUTOINCREMENT,
+			user_id      INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			kind         TEXT NOT NULL CHECK (kind IN ('session', 'api')),
+			name         TEXT NOT NULL,
+			token_hash   TEXT NOT NULL UNIQUE,
+			prefix       TEXT NOT NULL,
+			created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+			expires_at   TEXT,
+			last_used_at TEXT,
+			revoked_at   TEXT,
+			scopes       TEXT
+		);
+		INSERT INTO users(username, password_hash) VALUES ('first', 'hash'), ('second', 'hash');
+	`); err != nil {
+		t.Fatalf("seed pre-029 auth schema: %v", err)
+	}
+	for _, name := range []string{
+		"001_init.sql",
+		"002_observability_and_memory.sql",
+		"003_memory_cascade.sql",
+		"004_drop_unused_tables.sql",
+		"005_trace_steps.sql",
+		"006_backend_metadata_and_agent_model.sql",
+		"007_agent_allow_memory.sql",
+		"008_event_queue.sql",
+		"009_traces_prompt_tokens.sql",
+		"010_guardrails.sql",
+		"011_trace_steps_kind.sql",
+		"012_mcp_tool_usage_guardrail.sql",
+		"013_discretion_guardrail.sql",
+		"014_token_budgets.sql",
+		"015_remove_daemon_config.sql",
+		"016_memory_scope_guardrail.sql",
+		"017_repository_tool_fallback_guardrail.sql",
+		"018_security_guardrail_gh_fallback.sql",
+		"019_auth.sql",
+		"020_agent_ids_and_graph_layouts.sql",
+		"021_workspaces_prompts.sql",
+		"022_workspace_memory.sql",
+		"023_workspace_graph_layouts.sql",
+		"024_workspace_observe_budgets.sql",
+		"025_workspace_entity_identity.sql",
+		"026_scoped_prompts.sql",
+		"027_scoped_skills_guardrails.sql",
+		"028_runtime_settings.sql",
+	} {
+		if _, err := db.Exec("INSERT INTO schema_migrations(name) VALUES(?)", name); err != nil {
+			t.Fatalf("mark migration %s applied: %v", name, err)
+		}
+	}
+	db.Close()
+
+	db, err = store.Open(path)
+	if err != nil {
+		t.Fatalf("Open after pre-029 seed: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	var firstAdmin, secondAdmin int
+	if err := db.QueryRow("SELECT is_admin FROM users WHERE username='first'").Scan(&firstAdmin); err != nil {
+		t.Fatalf("first is_admin: %v", err)
+	}
+	if err := db.QueryRow("SELECT is_admin FROM users WHERE username='second'").Scan(&secondAdmin); err != nil {
+		t.Fatalf("second is_admin: %v", err)
+	}
+	if firstAdmin != 1 || secondAdmin != 0 {
+		t.Fatalf("admin flags first=%d second=%d, want first=1 second=0", firstAdmin, secondAdmin)
+	}
+}
+
 // TestImportLoad verifies the full round-trip: Import writes a config into the
 // database, Load reads it back, and the resulting *config.Config matches the
 // original on all fields that are persisted.


### PR DESCRIPTION
## Summary

Closes #539.

- Adds a `users.is_admin` migration and backfills the current first user as admin for existing installs.
- Persists the bootstrap user as admin and reads admin status from the database in user and token auth paths.
- Protects the last enabled admin from deletion while allowing admin deletion when another admin remains.
- Adds store and migration coverage for DB-backed admin status, bootstrap/admin auth identity, and last-admin behavior.

## Test plan

- `go test ./internal/store ./internal/daemon`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test -race ./internal/store ./internal/daemon`
- `git diff --check`

Note: an initial unsanitized `go test ./...` hit the existing backend discovery environment-sensitive failure in this runner; rerunning with backend credential variables unset passed.