### PR TITLE
refactor: simplify runtime command slices

### DIFF
--- a/internal/runtime/backend_setup.go
+++ b/internal/runtime/backend_setup.go
@@ -65,7 +65,7 @@ func WrapBackendCommand(backendName string, command []string, env []string, opts
 		return command, env
 	}
 	if strings.HasPrefix(backendName, "claude") && getEnv(env, "GITHUB_TOKEN") != "" && !slices.Contains(command[1:], "--mcp-config") {
-		command = append(command[:1], append([]string{"--mcp-config", RunnerClaudeMCPPath}, command[1:]...)...)
+		command = slices.Insert(command, 1, "--mcp-config", RunnerClaudeMCPPath)
 	}
 	return shellEntrypoint(command, BackendSetupScript(backendName, opts)), env
 }
@@ -76,7 +76,7 @@ cmd=$1
 shift
 exec "$cmd" "$@"
 `, "agents-runner"}
-	return append(out, command...)
+	return slices.Concat(out, command)
 }
 
 const baseContainerSetup = `


### PR DESCRIPTION
## Summary

- Replaces the manual nested append used to inject Claude MCP args with `slices.Insert`.
- Uses `slices.Concat` when building the shell entrypoint command prefix plus backend command.
- Keeps runtime command ordering and environment behavior unchanged.

## Test plan

- `go test ./internal/runtime`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.