### PR TITLE
fix: preserve omitted runtime settings

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -136,7 +136,7 @@ Duplicate webhook deliveries are suppressed via `X-GitHub-Delivery` with a TTL c
 | Method | Path | Description |
 |---|---|---|
 | `GET` | `/runtime` | Read global runner image and container constraints. |
-| `PUT/PATCH` | `/runtime` | Replace global runner image and constraints. Secret values are not accepted here. |
+| `PUT/PATCH` | `/runtime` | `PUT` replaces global runner image and constraints; `PATCH` updates only supplied fields and preserves omitted settings. Secret values are not accepted here. |
 | `PUT/PATCH` | `/workspaces/{workspace}/runtime` | Set or clear the selected workspace's runner image override. |
 
 Runtime settings are also included in `/config`, `/export`, and `/import`. Credentials are daemon environment variables and are never returned by these routes.

--- a/docs/api.md
+++ b/docs/api.md
@@ -140,6 +140,7 @@ Duplicate webhook deliveries are suppressed via `X-GitHub-Delivery` with a TTL c
 | `PUT/PATCH` | `/workspaces/{workspace}/runtime` | Set or clear the selected workspace's runner image override. |
 
 Runtime settings are also included in `/config`, `/export`, and `/import`. Credentials are daemon environment variables and are never returned by these routes.
+For global `/runtime`, empty string clears string constraints such as `cpus`, `memory`, and `network_mode`; empty `runner_image` resets to the built-in default because the field cannot be unset.
 
 ## AI runner contract
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -96,6 +96,7 @@ runtime:
 Runtime settings are fleet state because operators may need to switch runner images or constraints without rebuilding the daemon. They are stored in SQLite, returned by `/config`, included in import/export, and editable through Config -> Runtime, REST, and MCP. They are not startup env overrides; use the database-backed surfaces for runner image and container policy changes.
 
 The global runner image applies to every run unless a workspace sets `runner_image`. Constraints are passed to Docker where supported: CPU, memory, PID limit, timeout, and network mode. Advanced egress filtering is not part of the v1 runtime settings.
+When patching global runtime settings through REST or MCP, omitted fields are preserved. Empty string clears string constraints such as `cpus`, `memory`, and `network_mode`; empty `runner_image` resets to the built-in default because the global image cannot be unset.
 
 ## `backends`
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -116,7 +116,7 @@ These tools mirror the `/runners` REST surface; see [api.md](api.md#runners-mana
 |---|---|
 | `get_config` | Current fleet config snapshot. |
 | `get_runtime` | Read global runner image and container constraints. |
-| `update_runtime` | Replace global runner image and basic constraints. Secret values are not accepted. |
+| `update_runtime` | Patch global runner image and basic constraints, preserving omitted settings. Secret values are not accepted. |
 | `update_workspace_runtime` | Set or clear one workspace's runner image override. |
 | `export_config` | Fleet config as YAML (round-trippable via `import_config`). |
 | `import_config` | Import YAML config. `mode=replace` prunes missing entries. |

--- a/internal/daemon/config/config.go
+++ b/internal/daemon/config/config.go
@@ -77,6 +77,22 @@ func (h *Handler) HandleRuntime(w http.ResponseWriter, _ *http.Request) {
 // HandleUpdateRuntime serves PUT/PATCH /runtime. Secret values are not part of
 // this shape; credentials are injected from daemon environment at run time.
 func (h *Handler) HandleUpdateRuntime(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodPatch {
+		var patch store.RuntimeSettingsPatch
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, h.daemonCfg.HTTP.MaxBodyBytes)).Decode(&patch); err != nil {
+			http.Error(w, fmt.Sprintf("parse runtime settings patch: %v", err), http.StatusBadRequest)
+			return
+		}
+		updated, err := h.store.PatchRuntimeSettings(patch)
+		if err != nil {
+			http.Error(w, err.Error(), storeErrStatus(err))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(updated)
+		return
+	}
+
 	var settings fleet.RuntimeSettings
 	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, h.daemonCfg.HTTP.MaxBodyBytes)).Decode(&settings); err != nil {
 		http.Error(w, fmt.Sprintf("parse runtime settings: %v", err), http.StatusBadRequest)

--- a/internal/daemon/crud_test.go
+++ b/internal/daemon/crud_test.go
@@ -1058,6 +1058,90 @@ func TestStoreCRUDBackendPatchRuntimeSettingsValidation(t *testing.T) {
 	}
 }
 
+func TestStoreCRUDRuntimePatchPreservesOmittedFields(t *testing.T) {
+	t.Parallel()
+	s := openCRUDTestServer(t)
+
+	if rr := doCRUDRequest(t, s, http.MethodPut, "/runtime", map[string]any{
+		"runner_image": "ghcr.io/example/custom-runner:v1",
+		"constraints": map[string]any{
+			"cpus":            "2",
+			"memory":          "4g",
+			"pids_limit":      256,
+			"timeout_seconds": 900,
+			"network_mode":    "bridge",
+		},
+	}); rr.Code != http.StatusOK {
+		t.Fatalf("PUT /runtime: got %d, %s", rr.Code, rr.Body.String())
+	}
+
+	rr := doCRUDRequest(t, s, http.MethodPatch, "/runtime", map[string]any{
+		"constraints": map[string]any{
+			"cpus":            "",
+			"timeout_seconds": 1200,
+		},
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("PATCH /runtime: got %d, %s", rr.Code, rr.Body.String())
+	}
+	var out fleet.RuntimeSettings
+	if err := json.NewDecoder(rr.Body).Decode(&out); err != nil {
+		t.Fatalf("decode patch response: %v", err)
+	}
+	if out.RunnerImage != "ghcr.io/example/custom-runner:v1" {
+		t.Fatalf("runner_image = %q, want custom image", out.RunnerImage)
+	}
+	if out.Constraints.CPUs != "" {
+		t.Fatalf("cpus = %q, want cleared", out.Constraints.CPUs)
+	}
+	if out.Constraints.Memory != "4g" || out.Constraints.NetworkMode != "bridge" {
+		t.Fatalf("constraints not preserved: %+v", out.Constraints)
+	}
+	if out.Constraints.PidsLimit != 256 || out.Constraints.TimeoutSeconds != 1200 {
+		t.Fatalf("numeric constraints = %+v, want pids 256 timeout 1200", out.Constraints)
+	}
+}
+
+func TestStoreCRUDRuntimePutRemainsFullReplacement(t *testing.T) {
+	t.Parallel()
+	s := openCRUDTestServer(t)
+
+	if rr := doCRUDRequest(t, s, http.MethodPut, "/runtime", map[string]any{
+		"runner_image": "ghcr.io/example/custom-runner:v1",
+		"constraints": map[string]any{
+			"cpus":            "2",
+			"memory":          "4g",
+			"pids_limit":      256,
+			"timeout_seconds": 900,
+			"network_mode":    "bridge",
+		},
+	}); rr.Code != http.StatusOK {
+		t.Fatalf("initial PUT /runtime: got %d, %s", rr.Code, rr.Body.String())
+	}
+
+	rr := doCRUDRequest(t, s, http.MethodPut, "/runtime", map[string]any{
+		"constraints": map[string]any{
+			"timeout_seconds": 1200,
+		},
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("replacement PUT /runtime: got %d, %s", rr.Code, rr.Body.String())
+	}
+	var out fleet.RuntimeSettings
+	if err := json.NewDecoder(rr.Body).Decode(&out); err != nil {
+		t.Fatalf("decode put response: %v", err)
+	}
+	if out.RunnerImage != fleet.DefaultRunnerImage {
+		t.Fatalf("runner_image = %q, want default %q", out.RunnerImage, fleet.DefaultRunnerImage)
+	}
+	if out.Constraints.CPUs != "" || out.Constraints.Memory != "" || out.Constraints.NetworkMode != "" {
+		t.Fatalf("string constraints preserved during replacement: %+v", out.Constraints)
+	}
+	if out.Constraints.PidsLimit != 0 || out.Constraints.TimeoutSeconds != 1200 {
+		t.Fatalf("numeric constraints = %+v, want pids 0 timeout 1200", out.Constraints)
+	}
+}
+
 func TestBackendsLocalCreateNamedAndDelete(t *testing.T) {
 	t.Parallel()
 	s := openCRUDTestServer(t)

--- a/internal/daemon/crud_test.go
+++ b/internal/daemon/crud_test.go
@@ -1076,8 +1076,10 @@ func TestStoreCRUDRuntimePatchPreservesOmittedFields(t *testing.T) {
 	}
 
 	rr := doCRUDRequest(t, s, http.MethodPatch, "/runtime", map[string]any{
+		"runner_image": "",
 		"constraints": map[string]any{
 			"cpus":            "",
+			"pids_limit":      0,
 			"timeout_seconds": 1200,
 		},
 	})
@@ -1088,8 +1090,8 @@ func TestStoreCRUDRuntimePatchPreservesOmittedFields(t *testing.T) {
 	if err := json.NewDecoder(rr.Body).Decode(&out); err != nil {
 		t.Fatalf("decode patch response: %v", err)
 	}
-	if out.RunnerImage != "ghcr.io/example/custom-runner:v1" {
-		t.Fatalf("runner_image = %q, want custom image", out.RunnerImage)
+	if out.RunnerImage != fleet.DefaultRunnerImage {
+		t.Fatalf("runner_image = %q, want default %q", out.RunnerImage, fleet.DefaultRunnerImage)
 	}
 	if out.Constraints.CPUs != "" {
 		t.Fatalf("cpus = %q, want cleared", out.Constraints.CPUs)
@@ -1097,8 +1099,8 @@ func TestStoreCRUDRuntimePatchPreservesOmittedFields(t *testing.T) {
 	if out.Constraints.Memory != "4g" || out.Constraints.NetworkMode != "bridge" {
 		t.Fatalf("constraints not preserved: %+v", out.Constraints)
 	}
-	if out.Constraints.PidsLimit != 256 || out.Constraints.TimeoutSeconds != 1200 {
-		t.Fatalf("numeric constraints = %+v, want pids 256 timeout 1200", out.Constraints)
+	if out.Constraints.PidsLimit != 0 || out.Constraints.TimeoutSeconds != 1200 {
+		t.Fatalf("numeric constraints = %+v, want pids 0 timeout 1200", out.Constraints)
 	}
 }
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -310,7 +310,7 @@ func registerTools(srv *server.MCPServer, deps Deps) {
 		)
 		srv.AddTool(
 			mcpgo.NewTool("update_runtime",
-				mcpgo.WithDescription("Update global runner runtime settings. Credentials are not accepted here; runner auth comes from daemon environment at execution time."),
+				mcpgo.WithDescription("Patch global runner runtime settings. Omitted fields are preserved. Credentials are not accepted here; runner auth comes from daemon environment at execution time."),
 				mcpgo.WithString("runner_image", mcpgo.Description("Default runner image for agent runs, for example ghcr.io/eloylp/agents-runner:latest.")),
 				mcpgo.WithString("cpus", mcpgo.Description("Optional Docker CPU quota expression, such as 2 or 0.5.")),
 				mcpgo.WithString("memory", mcpgo.Description("Optional memory limit, such as 2g or 512m.")),

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -311,7 +311,7 @@ func registerTools(srv *server.MCPServer, deps Deps) {
 		srv.AddTool(
 			mcpgo.NewTool("update_runtime",
 				mcpgo.WithDescription("Patch global runner runtime settings. Omitted fields are preserved. Credentials are not accepted here; runner auth comes from daemon environment at execution time."),
-				mcpgo.WithString("runner_image", mcpgo.Description("Default runner image for agent runs, for example ghcr.io/eloylp/agents-runner:latest.")),
+				mcpgo.WithString("runner_image", mcpgo.Description("Default runner image for agent runs, for example ghcr.io/eloylp/agents-runner:latest. Empty resets to the built-in default; it does not clear the field.")),
 				mcpgo.WithString("cpus", mcpgo.Description("Optional Docker CPU quota expression, such as 2 or 0.5.")),
 				mcpgo.WithString("memory", mcpgo.Description("Optional memory limit, such as 2g or 512m.")),
 				mcpgo.WithNumber("pids_limit", mcpgo.Description("Optional process limit for runner containers.")),

--- a/internal/mcp/tools_config.go
+++ b/internal/mcp/tools_config.go
@@ -2,8 +2,13 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
 
-	"github.com/eloylp/agents/internal/fleet"
+	"github.com/eloylp/agents/internal/store"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -35,11 +40,11 @@ func toolGetRuntime(deps Deps) server.ToolHandlerFunc {
 
 func toolUpdateRuntime(deps Deps) server.ToolHandlerFunc {
 	return func(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
-		settings, err := runtimeSettingsFromRequest(req)
+		patch, err := runtimeSettingsPatchFromRequest(req)
 		if err != nil {
 			return mcpgo.NewToolResultError(err.Error()), nil
 		}
-		updated, err := deps.Store.WriteRuntimeSettings(settings)
+		updated, err := deps.Store.PatchRuntimeSettings(patch)
 		if err != nil {
 			return mcpgo.NewToolResultErrorFromErr("update runtime settings", err), nil
 		}
@@ -62,28 +67,67 @@ func toolUpdateWorkspaceRuntime(deps Deps) server.ToolHandlerFunc {
 	}
 }
 
-func runtimeSettingsFromRequest(req mcpgo.CallToolRequest) (fleet.RuntimeSettings, error) {
-	current := fleet.RuntimeSettings{}
+func runtimeSettingsPatchFromRequest(req mcpgo.CallToolRequest) (store.RuntimeSettingsPatch, error) {
+	var patch store.RuntimeSettingsPatch
 	if image, ok := trimmedStringOptional(req, "runner_image"); ok {
-		current.RunnerImage = image
+		patch.RunnerImage = &image
 	}
 	if cpus, ok := trimmedStringOptional(req, "cpus"); ok {
-		current.Constraints.CPUs = cpus
+		patch.Constraints.CPUs = &cpus
 	}
 	if memory, ok := trimmedStringOptional(req, "memory"); ok {
-		current.Constraints.Memory = memory
+		patch.Constraints.Memory = &memory
 	}
 	if network, ok := trimmedStringOptional(req, "network_mode"); ok {
-		current.Constraints.NetworkMode = network
+		patch.Constraints.NetworkMode = &network
 	}
-	if pids := req.GetInt("pids_limit", 0); pids > 0 {
-		current.Constraints.PidsLimit = int64(pids)
+	if pids, ok, err := optionalIntArg(req, "pids_limit"); err != nil {
+		return store.RuntimeSettingsPatch{}, err
+	} else if ok {
+		pids64 := int64(pids)
+		patch.Constraints.PidsLimit = &pids64
 	}
-	if timeout := req.GetInt("timeout_seconds", 0); timeout > 0 {
-		current.Constraints.TimeoutSeconds = timeout
+	if timeout, ok, err := optionalIntArg(req, "timeout_seconds"); err != nil {
+		return store.RuntimeSettingsPatch{}, err
+	} else if ok {
+		patch.Constraints.TimeoutSeconds = &timeout
 	}
-	fleet.NormalizeRuntimeSettings(&current)
-	return current, nil
+	return patch, nil
+}
+
+func optionalIntArg(req mcpgo.CallToolRequest, key string) (int, bool, error) {
+	raw, ok := req.GetArguments()[key]
+	if !ok || raw == nil {
+		return 0, false, nil
+	}
+	switch v := raw.(type) {
+	case int:
+		return v, true, nil
+	case int64:
+		if v < int64(math.MinInt) || v > int64(math.MaxInt) {
+			return 0, false, fmt.Errorf("%s is outside int range", key)
+		}
+		return int(v), true, nil
+	case float64:
+		if math.Trunc(v) != v || v < float64(math.MinInt) || v > float64(math.MaxInt) {
+			return 0, false, fmt.Errorf("%s must be an integer", key)
+		}
+		return int(v), true, nil
+	case json.Number:
+		i, err := strconv.ParseInt(v.String(), 10, 0)
+		if err != nil {
+			return 0, false, fmt.Errorf("%s must be an integer", key)
+		}
+		return int(i), true, nil
+	case string:
+		i, err := strconv.Atoi(strings.TrimSpace(v))
+		if err != nil {
+			return 0, false, fmt.Errorf("%s must be an integer", key)
+		}
+		return i, true, nil
+	default:
+		return 0, false, fmt.Errorf("%s must be an integer", key)
+	}
 }
 
 // toolExportConfig returns the CRUD-mutable sections of the fleet config as a

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -3042,6 +3042,7 @@ func TestToolUpdateRuntimePreservesOmittedFields(t *testing.T) {
 	req := mcpgo.CallToolRequest{}
 	req.Params.Arguments = map[string]any{
 		"timeout_seconds": float64(1200),
+		"pids_limit":      float64(0),
 	}
 	res, err := toolUpdateRuntime(deps)(context.Background(), req)
 	if err != nil || res.IsError {
@@ -3057,8 +3058,36 @@ func TestToolUpdateRuntimePreservesOmittedFields(t *testing.T) {
 	if got.Constraints.CPUs != "2" || got.Constraints.Memory != "4g" || got.Constraints.NetworkMode != "bridge" {
 		t.Fatalf("constraints not preserved: %+v", got.Constraints)
 	}
-	if got.Constraints.PidsLimit != 256 || got.Constraints.TimeoutSeconds != 1200 {
-		t.Fatalf("numeric constraints = %+v, want pids 256 timeout 1200", got.Constraints)
+	if got.Constraints.PidsLimit != 0 || got.Constraints.TimeoutSeconds != 1200 {
+		t.Fatalf("numeric constraints = %+v, want pids 0 timeout 1200", got.Constraints)
+	}
+}
+
+func TestToolUpdateRuntimeEmptyRunnerImageResetsDefault(t *testing.T) {
+	t.Parallel()
+	deps := testFixture(t)
+
+	_, err := deps.Store.WriteRuntimeSettings(fleet.RuntimeSettings{
+		RunnerImage: "ghcr.io/example/custom-runner:v1",
+	})
+	if err != nil {
+		t.Fatalf("WriteRuntimeSettings: %v", err)
+	}
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"runner_image": "",
+	}
+	res, err := toolUpdateRuntime(deps)(context.Background(), req)
+	if err != nil || res.IsError {
+		t.Fatalf("update_runtime failed: err=%v body=%s", err, textOf(t, res))
+	}
+	got, err := deps.Store.ReadRuntimeSettings()
+	if err != nil {
+		t.Fatalf("ReadRuntimeSettings: %v", err)
+	}
+	if got.RunnerImage != fleet.DefaultRunnerImage {
+		t.Fatalf("runner_image = %q, want default %q", got.RunnerImage, fleet.DefaultRunnerImage)
 	}
 }
 

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -3020,3 +3020,80 @@ func TestToolUpdateBackendEmptyPatchRejected(t *testing.T) {
 		t.Fatal("expected tool error for empty patch")
 	}
 }
+
+func TestToolUpdateRuntimePreservesOmittedFields(t *testing.T) {
+	t.Parallel()
+	deps := testFixture(t)
+
+	_, err := deps.Store.WriteRuntimeSettings(fleet.RuntimeSettings{
+		RunnerImage: "ghcr.io/example/custom-runner:v1",
+		Constraints: fleet.RuntimeConstraints{
+			CPUs:           "2",
+			Memory:         "4g",
+			PidsLimit:      256,
+			TimeoutSeconds: 900,
+			NetworkMode:    "bridge",
+		},
+	})
+	if err != nil {
+		t.Fatalf("WriteRuntimeSettings: %v", err)
+	}
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"timeout_seconds": float64(1200),
+	}
+	res, err := toolUpdateRuntime(deps)(context.Background(), req)
+	if err != nil || res.IsError {
+		t.Fatalf("update_runtime failed: err=%v body=%s", err, textOf(t, res))
+	}
+	got, err := deps.Store.ReadRuntimeSettings()
+	if err != nil {
+		t.Fatalf("ReadRuntimeSettings: %v", err)
+	}
+	if got.RunnerImage != "ghcr.io/example/custom-runner:v1" {
+		t.Fatalf("runner_image = %q, want custom image", got.RunnerImage)
+	}
+	if got.Constraints.CPUs != "2" || got.Constraints.Memory != "4g" || got.Constraints.NetworkMode != "bridge" {
+		t.Fatalf("constraints not preserved: %+v", got.Constraints)
+	}
+	if got.Constraints.PidsLimit != 256 || got.Constraints.TimeoutSeconds != 1200 {
+		t.Fatalf("numeric constraints = %+v, want pids 256 timeout 1200", got.Constraints)
+	}
+}
+
+func TestToolUpdateRuntimeClearsStringConstraint(t *testing.T) {
+	t.Parallel()
+	deps := testFixture(t)
+
+	_, err := deps.Store.WriteRuntimeSettings(fleet.RuntimeSettings{
+		RunnerImage: "ghcr.io/example/custom-runner:v1",
+		Constraints: fleet.RuntimeConstraints{
+			CPUs:        "2",
+			Memory:      "4g",
+			NetworkMode: "bridge",
+		},
+	})
+	if err != nil {
+		t.Fatalf("WriteRuntimeSettings: %v", err)
+	}
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"cpus": "",
+	}
+	res, err := toolUpdateRuntime(deps)(context.Background(), req)
+	if err != nil || res.IsError {
+		t.Fatalf("update_runtime failed: err=%v body=%s", err, textOf(t, res))
+	}
+	got, err := deps.Store.ReadRuntimeSettings()
+	if err != nil {
+		t.Fatalf("ReadRuntimeSettings: %v", err)
+	}
+	if got.Constraints.CPUs != "" {
+		t.Fatalf("cpus = %q, want cleared", got.Constraints.CPUs)
+	}
+	if got.RunnerImage != "ghcr.io/example/custom-runner:v1" || got.Constraints.Memory != "4g" || got.Constraints.NetworkMode != "bridge" {
+		t.Fatalf("omitted fields not preserved: %+v", got)
+	}
+}

--- a/internal/store/facade.go
+++ b/internal/store/facade.go
@@ -75,9 +75,11 @@ func (s *Store) ReadRuntimeSettings() (fleet.RuntimeSettings, error) {
 func (s *Store) WriteRuntimeSettings(settings fleet.RuntimeSettings) (fleet.RuntimeSettings, error) {
 	return WriteRuntimeSettings(s.db, settings)
 }
+
 func (s *Store) PatchRuntimeSettings(patch RuntimeSettingsPatch) (fleet.RuntimeSettings, error) {
 	return PatchRuntimeSettings(s.db, patch)
 }
+
 func (s *Store) ReadWorkspace(workspace string) (fleet.Workspace, error) {
 	return ReadWorkspace(s.db, workspace)
 }

--- a/internal/store/facade.go
+++ b/internal/store/facade.go
@@ -75,6 +75,9 @@ func (s *Store) ReadRuntimeSettings() (fleet.RuntimeSettings, error) {
 func (s *Store) WriteRuntimeSettings(settings fleet.RuntimeSettings) (fleet.RuntimeSettings, error) {
 	return WriteRuntimeSettings(s.db, settings)
 }
+func (s *Store) PatchRuntimeSettings(patch RuntimeSettingsPatch) (fleet.RuntimeSettings, error) {
+	return PatchRuntimeSettings(s.db, patch)
+}
 func (s *Store) ReadWorkspace(workspace string) (fleet.Workspace, error) {
 	return ReadWorkspace(s.db, workspace)
 }

--- a/internal/store/runtime_settings.go
+++ b/internal/store/runtime_settings.go
@@ -12,6 +12,19 @@ import (
 
 const runtimeConfigKey = "runtime"
 
+type RuntimeSettingsPatch struct {
+	RunnerImage *string                 `json:"runner_image,omitempty"`
+	Constraints RuntimeConstraintsPatch `json:"constraints,omitempty"`
+}
+
+type RuntimeConstraintsPatch struct {
+	CPUs           *string `json:"cpus,omitempty"`
+	Memory         *string `json:"memory,omitempty"`
+	PidsLimit      *int64  `json:"pids_limit,omitempty"`
+	TimeoutSeconds *int    `json:"timeout_seconds,omitempty"`
+	NetworkMode    *string `json:"network_mode,omitempty"`
+}
+
 func ReadRuntimeSettings(db querier) (fleet.RuntimeSettings, error) {
 	var raw string
 	err := db.QueryRow("SELECT value FROM config WHERE key = ?", runtimeConfigKey).Scan(&raw)
@@ -29,6 +42,32 @@ func ReadRuntimeSettings(db querier) (fleet.RuntimeSettings, error) {
 	}
 	fleet.NormalizeRuntimeSettings(&settings)
 	return settings, nil
+}
+
+func PatchRuntimeSettings(db *sql.DB, patch RuntimeSettingsPatch) (fleet.RuntimeSettings, error) {
+	current, err := ReadRuntimeSettings(db)
+	if err != nil {
+		return fleet.RuntimeSettings{}, err
+	}
+	if patch.RunnerImage != nil {
+		current.RunnerImage = *patch.RunnerImage
+	}
+	if patch.Constraints.CPUs != nil {
+		current.Constraints.CPUs = *patch.Constraints.CPUs
+	}
+	if patch.Constraints.Memory != nil {
+		current.Constraints.Memory = *patch.Constraints.Memory
+	}
+	if patch.Constraints.PidsLimit != nil {
+		current.Constraints.PidsLimit = *patch.Constraints.PidsLimit
+	}
+	if patch.Constraints.TimeoutSeconds != nil {
+		current.Constraints.TimeoutSeconds = *patch.Constraints.TimeoutSeconds
+	}
+	if patch.Constraints.NetworkMode != nil {
+		current.Constraints.NetworkMode = *patch.Constraints.NetworkMode
+	}
+	return WriteRuntimeSettings(db, current)
 }
 
 func WriteRuntimeSettings(db *sql.DB, settings fleet.RuntimeSettings) (fleet.RuntimeSettings, error) {

--- a/internal/store/runtime_settings.go
+++ b/internal/store/runtime_settings.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -45,7 +46,13 @@ func ReadRuntimeSettings(db querier) (fleet.RuntimeSettings, error) {
 }
 
 func PatchRuntimeSettings(db *sql.DB, patch RuntimeSettingsPatch) (fleet.RuntimeSettings, error) {
-	current, err := ReadRuntimeSettings(db)
+	tx, err := db.BeginTx(context.Background(), nil)
+	if err != nil {
+		return fleet.RuntimeSettings{}, fmt.Errorf("store: begin patch runtime settings: %w", err)
+	}
+	defer tx.Rollback()
+
+	current, err := ReadRuntimeSettings(tx)
 	if err != nil {
 		return fleet.RuntimeSettings{}, err
 	}
@@ -67,10 +74,25 @@ func PatchRuntimeSettings(db *sql.DB, patch RuntimeSettingsPatch) (fleet.Runtime
 	if patch.Constraints.NetworkMode != nil {
 		current.Constraints.NetworkMode = *patch.Constraints.NetworkMode
 	}
-	return WriteRuntimeSettings(db, current)
+	updated, err := writeRuntimeSettings(tx, current)
+	if err != nil {
+		return fleet.RuntimeSettings{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return fleet.RuntimeSettings{}, fmt.Errorf("store: commit patch runtime settings: %w", err)
+	}
+	return updated, nil
 }
 
 func WriteRuntimeSettings(db *sql.DB, settings fleet.RuntimeSettings) (fleet.RuntimeSettings, error) {
+	return writeRuntimeSettings(db, settings)
+}
+
+type runtimeSettingsWriter interface {
+	Exec(query string, args ...any) (sql.Result, error)
+}
+
+func writeRuntimeSettings(db runtimeSettingsWriter, settings fleet.RuntimeSettings) (fleet.RuntimeSettings, error) {
 	fleet.NormalizeRuntimeSettings(&settings)
 	if err := validateRuntimeSettings(settings); err != nil {
 		return fleet.RuntimeSettings{}, err

--- a/internal/store/runtime_settings_test.go
+++ b/internal/store/runtime_settings_test.go
@@ -100,6 +100,32 @@ func TestPatchRuntimeSettingsPreservesOmittedFields(t *testing.T) {
 	}
 }
 
+func TestPatchRuntimeSettingsEmptyRunnerImageResetsDefault(t *testing.T) {
+	t.Parallel()
+	db, err := store.Open(filepath.Join(t.TempDir(), "runtime-patch-image.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	st := store.New(db)
+	_, err = st.WriteRuntimeSettings(fleet.RuntimeSettings{
+		RunnerImage: "ghcr.io/example/custom-runner:v1",
+	})
+	if err != nil {
+		t.Fatalf("WriteRuntimeSettings: %v", err)
+	}
+
+	image := ""
+	updated, err := st.PatchRuntimeSettings(store.RuntimeSettingsPatch{RunnerImage: &image})
+	if err != nil {
+		t.Fatalf("PatchRuntimeSettings: %v", err)
+	}
+	if updated.RunnerImage != fleet.DefaultRunnerImage {
+		t.Fatalf("runner_image = %q, want default %q", updated.RunnerImage, fleet.DefaultRunnerImage)
+	}
+}
+
 func TestWorkspaceRunnerImageRoundTrip(t *testing.T) {
 	t.Parallel()
 	db, err := store.Open(filepath.Join(t.TempDir(), "workspace-runtime.db"))

--- a/internal/store/runtime_settings_test.go
+++ b/internal/store/runtime_settings_test.go
@@ -48,6 +48,58 @@ func TestRuntimeSettingsRoundTrip(t *testing.T) {
 	}
 }
 
+func TestPatchRuntimeSettingsPreservesOmittedFields(t *testing.T) {
+	t.Parallel()
+	db, err := store.Open(filepath.Join(t.TempDir(), "runtime-patch.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	st := store.New(db)
+	_, err = st.WriteRuntimeSettings(fleet.RuntimeSettings{
+		RunnerImage: "ghcr.io/example/custom-runner:v1",
+		Constraints: fleet.RuntimeConstraints{
+			CPUs:           "2",
+			Memory:         "4g",
+			PidsLimit:      256,
+			TimeoutSeconds: 900,
+			NetworkMode:    "bridge",
+		},
+	})
+	if err != nil {
+		t.Fatalf("WriteRuntimeSettings: %v", err)
+	}
+
+	timeout := 1200
+	cpus := ""
+	network := ""
+	updated, err := st.PatchRuntimeSettings(store.RuntimeSettingsPatch{
+		Constraints: store.RuntimeConstraintsPatch{
+			CPUs:           &cpus,
+			TimeoutSeconds: &timeout,
+			NetworkMode:    &network,
+		},
+	})
+	if err != nil {
+		t.Fatalf("PatchRuntimeSettings: %v", err)
+	}
+
+	want := fleet.RuntimeSettings{
+		RunnerImage: "ghcr.io/example/custom-runner:v1",
+		Constraints: fleet.RuntimeConstraints{
+			CPUs:           "",
+			Memory:         "4g",
+			PidsLimit:      256,
+			TimeoutSeconds: 1200,
+			NetworkMode:    "",
+		},
+	}
+	if updated != want {
+		t.Fatalf("patched runtime settings = %+v, want %+v", updated, want)
+	}
+}
+
 func TestWorkspaceRunnerImageRoundTrip(t *testing.T) {
 	t.Parallel()
 	db, err := store.Open(filepath.Join(t.TempDir(), "workspace-runtime.db"))


### PR DESCRIPTION
## Summary

Closes #546.

- Adds a shared `store.RuntimeSettingsPatch` path that reads current settings, applies only supplied fields, normalizes/validates, and persists.
- Keeps `PUT /runtime` as full replacement while making `PATCH /runtime` preserve omitted fields.
- Routes MCP `update_runtime` through patch semantics, including explicit empty-string clearing for clearable string constraints and explicit zero for numeric constraints.
- Updates REST/MCP docs and tool description to document patch behavior.

## Test plan

- `go test ./internal/store ./internal/daemon ./internal/mcp`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY go test ./...`
- `git diff --check`