### PR TITLE
fix: persist observability records synchronously

### DIFF
--- a/internal/daemon/runners/runners_test.go
+++ b/internal/daemon/runners/runners_test.go
@@ -109,15 +109,6 @@ func TestList_CompletedEventFannedOutToTwoAgentsShowsTwoRows(t *testing.T) {
 		StartedAt: now, FinishedAt: now.Add(2 * time.Second),
 		Status: "error", ErrorMsg: "claude command timed out after 10m0s",
 	})
-	// RecordSpan persists asynchronously into SQLite; poll until both
-	// rows are visible before asking the handler to JOIN.
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if len(fx.observe.TracesByRootEventID("ev-fan")) >= 2 {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
 	_ = fx.store.MarkEventCompleted(id)
 
 	req := httptest.NewRequest(http.MethodGet, "/runners", nil)

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -831,9 +831,7 @@ func TestToolTriggerAgentMissingArgs(t *testing.T) {
 }
 
 // seedEvent inserts an event row directly into the SQLite events table so
-// observe.Store.ListEvents reads it back deterministically. The Store's own
-// RecordEvent is async (goroutine), which would race with the immediate
-// ListEvents call our tool tests need.
+// observe.Store.ListEvents reads fixture rows back deterministically.
 func seedEvent(t *testing.T, db *sql.DB, ev observe.TimestampedEvent) {
 	t.Helper()
 	payload, _ := json.Marshal(ev.Payload)
@@ -847,7 +845,6 @@ func seedEvent(t *testing.T, db *sql.DB, ev observe.TimestampedEvent) {
 }
 
 // seedSpan inserts a trace span row directly into the SQLite traces table.
-// Same async-vs-sync rationale as seedEvent.
 func seedSpan(t *testing.T, db *sql.DB, sp observe.Span) {
 	t.Helper()
 	workspaceID := fleet.NormalizeWorkspaceID(sp.WorkspaceID)
@@ -1111,15 +1108,6 @@ func TestToolGetTracePromptReturnsBody(t *testing.T) {
 		Status: "success",
 		Prompt: "system: do the thing\n\nuser: please",
 	})
-	// RecordSpan persists asynchronously; poll briefly until visible.
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if got, err := deps.Observe.PromptForSpan("sp-prompt"); err == nil && got != "" {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-
 	req := mcpgo.CallToolRequest{}
 	req.Params.Arguments = map[string]any{"span_id": "sp-prompt"}
 	res, err := toolGetTracePrompt(deps)(context.Background(), req)

--- a/internal/observe/observe.go
+++ b/internal/observe/observe.go
@@ -650,16 +650,14 @@ func (s *Store) RecordEvent(at time.Time, ev workflow.Event) {
 		Payload:     ev.Payload,
 	}
 	if s.db != nil {
-		go func() {
-			payload, _ := json.Marshal(te.Payload)
-			_, err := s.db.Exec(
-				`INSERT OR IGNORE INTO events (id, workspace_id, at, repo, kind, number, actor, payload) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-				te.ID, te.WorkspaceID, te.At, te.Repo, te.Kind, te.Number, te.Actor, string(payload),
-			)
-			if err != nil {
-				log.Printf("observe: persist event %s: %v", te.ID, err)
-			}
-		}()
+		payload, _ := json.Marshal(te.Payload)
+		_, err := s.db.Exec(
+			`INSERT OR IGNORE INTO events (id, workspace_id, at, repo, kind, number, actor, payload) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+			te.ID, te.WorkspaceID, te.At, te.Repo, te.Kind, te.Number, te.Actor, string(payload),
+		)
+		if err != nil {
+			log.Printf("observe: persist event %s: %v", te.ID, err)
+		}
 	}
 	if b, err := sseData(te); err == nil {
 		s.EventsSSE.Publish(b)
@@ -709,22 +707,20 @@ func (s *Store) RecordSpan(in workflow.SpanInput) {
 		}
 	}
 	if s.db != nil {
-		go func() {
-			_, err := s.db.Exec(
-				`INSERT OR IGNORE INTO traces (span_id, workspace_id, root_event_id, parent_span_id, agent, backend, repo, number, event_kind, invoked_by, dispatch_depth, queue_wait_ms, artifacts_count, summary, started_at, finished_at, duration_ms, status, error, prompt_gz, prompt_size, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
-				sp.SpanID, sp.WorkspaceID, sp.RootEventID, sp.ParentSpanID,
-				sp.Agent, sp.Backend, sp.Repo, sp.Number,
-				sp.EventKind, sp.InvokedBy, sp.DispatchDepth,
-				sp.QueueWaitMs, sp.ArtifactsCount, sp.Summary,
-				sp.StartedAt, sp.FinishedAt, sp.DurationMs,
-				sp.Status, sp.ErrorMsg,
-				promptGz, sp.PromptSize,
-				sp.InputTokens, sp.OutputTokens, sp.CacheReadTokens, sp.CacheWriteTokens,
-			)
-			if err != nil {
-				log.Printf("observe: persist trace %s: %v", sp.SpanID, err)
-			}
-		}()
+		_, err := s.db.Exec(
+			`INSERT OR IGNORE INTO traces (span_id, workspace_id, root_event_id, parent_span_id, agent, backend, repo, number, event_kind, invoked_by, dispatch_depth, queue_wait_ms, artifacts_count, summary, started_at, finished_at, duration_ms, status, error, prompt_gz, prompt_size, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+			sp.SpanID, sp.WorkspaceID, sp.RootEventID, sp.ParentSpanID,
+			sp.Agent, sp.Backend, sp.Repo, sp.Number,
+			sp.EventKind, sp.InvokedBy, sp.DispatchDepth,
+			sp.QueueWaitMs, sp.ArtifactsCount, sp.Summary,
+			sp.StartedAt, sp.FinishedAt, sp.DurationMs,
+			sp.Status, sp.ErrorMsg,
+			promptGz, sp.PromptSize,
+			sp.InputTokens, sp.OutputTokens, sp.CacheReadTokens, sp.CacheWriteTokens,
+		)
+		if err != nil {
+			log.Printf("observe: persist trace %s: %v", sp.SpanID, err)
+		}
 	}
 	if b, err := sseData(sp); err == nil {
 		s.TracesSSE.Publish(b)
@@ -735,15 +731,13 @@ func (s *Store) RecordSpan(in workflow.SpanInput) {
 func (s *Store) RecordDispatch(workspaceID, from, to, repo string, number int, reason string) {
 	workspaceID = fleet.NormalizeWorkspaceID(workspaceID)
 	if s.db != nil {
-		go func() {
-			_, err := s.db.Exec(
-				`INSERT INTO dispatch_history (workspace_id, from_agent, to_agent, repo, number, reason) VALUES (?,?,?,?,?,?)`,
-				workspaceID, from, to, repo, number, reason,
-			)
-			if err != nil {
-				log.Printf("observe: persist dispatch %s->%s: %v", from, to, err)
-			}
-		}()
+		_, err := s.db.Exec(
+			`INSERT INTO dispatch_history (workspace_id, from_agent, to_agent, repo, number, reason) VALUES (?,?,?,?,?,?)`,
+			workspaceID, from, to, repo, number, reason,
+		)
+		if err != nil {
+			log.Printf("observe: persist dispatch %s->%s: %v", from, to, err)
+		}
 	}
 }
 

--- a/internal/observe/observe_test.go
+++ b/internal/observe/observe_test.go
@@ -473,9 +473,6 @@ func TestStoreRecordEventPersistsAndPublishesToSSE(t *testing.T) {
 	}
 	s.RecordEvent(at, ev)
 
-	// Wait briefly for the async goroutine to persist.
-	time.Sleep(50 * time.Millisecond)
-
 	// Verify SQLite received the event via ListEvents.
 	stored := s.ListEvents(time.Time{})
 	if len(stored) != 1 {
@@ -574,9 +571,6 @@ func TestStoreRecordSpanPersistsAndPublishesToSSE(t *testing.T) {
 		Status: "success",
 	})
 
-	// Wait for async persistence.
-	time.Sleep(50 * time.Millisecond)
-
 	// Verify SQLite via ListTraces.
 	spans := s.ListTraces()
 	if len(spans) != 1 {
@@ -617,9 +611,6 @@ func TestStoreRecordDispatchPersistsToDB(t *testing.T) {
 
 	s.RecordDispatch("default", "coder", "reviewer", "owner/repo", 42, "needs review")
 
-	// Wait for async persistence.
-	time.Sleep(50 * time.Millisecond)
-
 	edges := s.ListEdges()
 	if len(edges) != 1 {
 		t.Fatalf("want 1 edge, got %d", len(edges))
@@ -650,9 +641,6 @@ func TestStoreListEventsSinceFilter(t *testing.T) {
 	s.RecordEvent(base, workflow.Event{ID: "old", Kind: "push"})
 	s.RecordEvent(base.Add(2*time.Second), workflow.Event{ID: "new", Kind: "push"})
 
-	// Wait for async persistence.
-	time.Sleep(50 * time.Millisecond)
-
 	events := s.ListEvents(base.Add(time.Second))
 	if len(events) != 1 {
 		t.Fatalf("want 1 event after filter, got %d", len(events))
@@ -673,16 +661,7 @@ func TestStoreTracesByRootEventID(t *testing.T) {
 	s.RecordSpan(workflow.SpanInput{SpanID: "s2", RootEventID: "root-B", Agent: "reviewer", Backend: "claude", Repo: "r", EventKind: "push", StartedAt: now, FinishedAt: now.Add(time.Second), Status: "success"})
 	s.RecordSpan(workflow.SpanInput{SpanID: "s3", RootEventID: "root-A", Agent: "coder", Backend: "claude", Repo: "r", EventKind: "agent.dispatch", Number: 1, DispatchDepth: 1, StartedAt: now.Add(time.Second), FinishedAt: now.Add(2 * time.Second), Status: "success"})
 
-	// Poll until both spans for root-A are persisted (RecordSpan is async).
-	deadline := time.Now().Add(500 * time.Millisecond)
-	var rootA []observe.Span
-	for time.Now().Before(deadline) {
-		rootA = s.TracesByRootEventID("root-A")
-		if len(rootA) == 2 {
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
+	rootA := s.TracesByRootEventID("root-A")
 	if len(rootA) != 2 {
 		t.Fatalf("want 2 spans for root-A, got %d", len(rootA))
 	}


### PR DESCRIPTION
## Summary

Closes #529.

- Removes fire-and-forget SQLite writes from `RecordEvent`, `RecordSpan`, and `RecordDispatch`.
- Keeps existing persistence error logging while publishing event/trace SSE only after the write attempt returns.
- Updates observe, runners, and MCP tests to rely on immediate row visibility instead of sleeps or polling.

## Test plan

- `go test ./internal/observe`
- `go test -race ./internal/observe`
- `go test ./internal/observe ./internal/daemon/runners ./internal/mcp`
- `go test -race ./internal/observe ./internal/daemon/runners ./internal/mcp`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY go test ./...`
- `git diff --check`