### PR TITLE
refactor: remove defensive migration table creates

### DIFF
--- a/internal/store/migrations/022_workspace_memory.sql
+++ b/internal/store/migrations/022_workspace_memory.sql
@@ -1,16 +1,6 @@
 -- Scope daemon-managed agent memory by workspace. Existing memory rows belong
 -- to the migrated Default workspace.
 
--- Keep this compatibility definition aligned with 013_memory_store.sql; fresh
--- installs may reach this migration without a pre-existing memory table.
-CREATE TABLE IF NOT EXISTS memory (
-    agent      TEXT NOT NULL REFERENCES agents(name) ON DELETE CASCADE,
-    repo       TEXT NOT NULL,
-    content    TEXT NOT NULL DEFAULT '',
-    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    PRIMARY KEY (agent, repo)
-);
-
 CREATE TABLE memory_new (
     workspace_id TEXT NOT NULL DEFAULT 'default' REFERENCES workspaces(id) ON DELETE CASCADE,
     agent        TEXT NOT NULL REFERENCES agents(name) ON DELETE CASCADE,

--- a/internal/store/migrations/023_workspace_graph_layouts.sql
+++ b/internal/store/migrations/023_workspace_graph_layouts.sql
@@ -1,16 +1,5 @@
 -- Scope existing agent graph layout rows to the migrated Default workspace.
 -- The table already stores a generic scope column from 020_agent_ids_and_graph_layouts.sql.
-CREATE TABLE IF NOT EXISTS graph_layouts (
-    id         INTEGER PRIMARY KEY AUTOINCREMENT,
-    scope      TEXT NOT NULL DEFAULT 'global',
-    node_kind  TEXT NOT NULL,
-    node_id    TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
-    x          REAL NOT NULL,
-    y          REAL NOT NULL,
-    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
-    UNIQUE(scope, node_kind, node_id)
-);
-
 UPDATE graph_layouts
 SET scope = 'workspace:default'
 WHERE scope = 'global';

--- a/internal/store/migrations/024_workspace_observe_budgets.sql
+++ b/internal/store/migrations/024_workspace_observe_budgets.sql
@@ -1,34 +1,6 @@
 -- Add workspace dimensions to observability/event rows and token budgets.
 -- Existing rows are assigned to the Default workspace for compatibility.
 
-CREATE TABLE IF NOT EXISTS traces (
-    span_id          TEXT PRIMARY KEY,
-    root_event_id    TEXT NOT NULL,
-    parent_span_id   TEXT NOT NULL DEFAULT '',
-    agent            TEXT NOT NULL,
-    backend          TEXT NOT NULL,
-    repo             TEXT NOT NULL,
-    number           INTEGER NOT NULL DEFAULT 0,
-    event_kind       TEXT NOT NULL,
-    invoked_by       TEXT NOT NULL DEFAULT '',
-    dispatch_depth   INTEGER NOT NULL DEFAULT 0,
-    queue_wait_ms    INTEGER NOT NULL DEFAULT 0,
-    artifacts_count  INTEGER NOT NULL DEFAULT 0,
-    summary          TEXT NOT NULL DEFAULT '',
-    started_at       TIMESTAMP NOT NULL,
-    finished_at      TIMESTAMP NOT NULL,
-    duration_ms      INTEGER NOT NULL,
-    status           TEXT NOT NULL,
-    error            TEXT NOT NULL DEFAULT '',
-    prompt_gz        BLOB NULL,
-    prompt_size      INTEGER NULL,
-    input_tokens     INTEGER NULL,
-    output_tokens    INTEGER NULL,
-    cache_read_tokens INTEGER NULL,
-    cache_write_tokens INTEGER NULL,
-    created_at       TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
-
 ALTER TABLE traces RENAME TO traces_legacy_workspace_024;
 
 CREATE TABLE traces (
@@ -80,16 +52,6 @@ CREATE INDEX IF NOT EXISTS idx_traces_agent ON traces(workspace_id, agent);
 CREATE INDEX IF NOT EXISTS idx_traces_started ON traces(workspace_id, started_at);
 CREATE INDEX IF NOT EXISTS idx_traces_workspace_repo ON traces(workspace_id, repo);
 
-CREATE TABLE IF NOT EXISTS events (
-    id       TEXT PRIMARY KEY,
-    at       TIMESTAMP NOT NULL,
-    repo     TEXT NOT NULL,
-    kind     TEXT NOT NULL,
-    number   INTEGER NOT NULL DEFAULT 0,
-    actor    TEXT NOT NULL DEFAULT '',
-    payload  TEXT NOT NULL DEFAULT '{}'
-);
-
 ALTER TABLE events RENAME TO events_legacy_workspace_024;
 
 CREATE TABLE events (
@@ -111,14 +73,6 @@ DROP TABLE events_legacy_workspace_024;
 
 CREATE INDEX IF NOT EXISTS idx_events_at ON events(workspace_id, at);
 CREATE INDEX IF NOT EXISTS idx_events_kind ON events(workspace_id, kind);
-
-CREATE TABLE IF NOT EXISTS event_queue (
-    id           INTEGER PRIMARY KEY AUTOINCREMENT,
-    event_blob   TEXT NOT NULL,
-    enqueued_at  TEXT NOT NULL,
-    started_at   TEXT NULL,
-    completed_at TEXT NULL
-);
 
 ALTER TABLE event_queue RENAME TO event_queue_legacy_workspace_024;
 
@@ -143,16 +97,6 @@ CREATE INDEX idx_event_queue_pending
 CREATE INDEX idx_event_queue_workspace
     ON event_queue(workspace_id, id);
 
-CREATE TABLE IF NOT EXISTS dispatch_history (
-    id         INTEGER PRIMARY KEY AUTOINCREMENT,
-    from_agent TEXT NOT NULL,
-    to_agent   TEXT NOT NULL,
-    repo       TEXT NOT NULL,
-    number     INTEGER NOT NULL DEFAULT 0,
-    reason     TEXT NOT NULL DEFAULT '',
-    at         TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
-
 ALTER TABLE dispatch_history RENAME TO dispatch_history_legacy_workspace_024;
 
 CREATE TABLE dispatch_history (
@@ -174,16 +118,6 @@ DROP TABLE dispatch_history_legacy_workspace_024;
 
 CREATE INDEX IF NOT EXISTS idx_dispatch_from ON dispatch_history(workspace_id, from_agent);
 CREATE INDEX IF NOT EXISTS idx_dispatch_at ON dispatch_history(workspace_id, at);
-
-CREATE TABLE IF NOT EXISTS token_budgets (
-    id           INTEGER PRIMARY KEY AUTOINCREMENT,
-    scope_kind   TEXT    NOT NULL DEFAULT 'global',
-    scope_name   TEXT    NOT NULL DEFAULT '',
-    period       TEXT    NOT NULL DEFAULT 'daily',
-    cap_tokens   INTEGER NOT NULL DEFAULT 0,
-    alert_at_pct INTEGER NOT NULL DEFAULT 80,
-    enabled      INTEGER NOT NULL DEFAULT 1
-);
 
 ALTER TABLE token_budgets RENAME TO token_budgets_legacy_workspace_024;
 

--- a/internal/store/migrations/027_scoped_skills_guardrails.sql
+++ b/internal/store/migrations/027_scoped_skills_guardrails.sql
@@ -2,14 +2,6 @@
 -- global catalog items whose stable id matches the old name, preserving every
 -- existing agent skill reference and workspace guardrail reference.
 
--- Normal migrations already have skills from migration 001. The compatibility
--- create keeps older migration tests that seed from later snapshots able to
--- apply this migration in isolation.
-CREATE TABLE IF NOT EXISTS skills (
-    name   TEXT PRIMARY KEY,
-    prompt TEXT NOT NULL
-);
-
 CREATE TABLE skills_new (
     id           TEXT PRIMARY KEY,
     workspace_id TEXT DEFAULT NULL,

--- a/internal/store/migrations/028_runtime_settings.sql
+++ b/internal/store/migrations/028_runtime_settings.sql
@@ -1,9 +1,4 @@
 -- Runtime settings for ephemeral agent runner containers.
-CREATE TABLE IF NOT EXISTS config (
-    key   TEXT PRIMARY KEY,
-    value TEXT NOT NULL
-);
-
 INSERT OR IGNORE INTO config (key, value)
 VALUES ('runtime', '{"runner_image":"ghcr.io/eloylp/agents-runner:latest","constraints":{}}');
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -413,6 +413,14 @@ func TestWorkspacePromptMigrationBackfillsExistingAgents(t *testing.T) {
 	}
 	if _, err := db.Exec(`
 		CREATE TABLE schema_migrations (name TEXT PRIMARY KEY, applied_at TEXT NOT NULL DEFAULT (datetime('now')));
+		CREATE TABLE config (
+			key TEXT PRIMARY KEY,
+			value TEXT NOT NULL
+		);
+		CREATE TABLE skills (
+			name TEXT PRIMARY KEY,
+			prompt TEXT NOT NULL
+		);
 		CREATE TABLE agents (
 			name TEXT PRIMARY KEY,
 			backend TEXT NOT NULL DEFAULT 'auto',
@@ -435,6 +443,88 @@ func TestWorkspacePromptMigrationBackfillsExistingAgents(t *testing.T) {
 			events TEXT NOT NULL DEFAULT '[]',
 			cron TEXT NOT NULL DEFAULT '',
 			enabled INTEGER NOT NULL DEFAULT 1
+		);
+		CREATE TABLE memory (
+			agent TEXT NOT NULL REFERENCES agents(name) ON DELETE CASCADE,
+			repo TEXT NOT NULL,
+			content TEXT NOT NULL DEFAULT '',
+			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (agent, repo)
+		);
+		CREATE TABLE traces (
+			span_id TEXT PRIMARY KEY,
+			root_event_id TEXT NOT NULL,
+			parent_span_id TEXT NOT NULL DEFAULT '',
+			agent TEXT NOT NULL,
+			backend TEXT NOT NULL,
+			repo TEXT NOT NULL,
+			number INTEGER NOT NULL DEFAULT 0,
+			event_kind TEXT NOT NULL,
+			invoked_by TEXT NOT NULL DEFAULT '',
+			dispatch_depth INTEGER NOT NULL DEFAULT 0,
+			queue_wait_ms INTEGER NOT NULL DEFAULT 0,
+			artifacts_count INTEGER NOT NULL DEFAULT 0,
+			summary TEXT NOT NULL DEFAULT '',
+			started_at TIMESTAMP NOT NULL,
+			finished_at TIMESTAMP NOT NULL,
+			duration_ms INTEGER NOT NULL,
+			status TEXT NOT NULL,
+			error TEXT NOT NULL DEFAULT '',
+			prompt_gz BLOB NULL,
+			prompt_size INTEGER NULL,
+			input_tokens INTEGER NULL,
+			output_tokens INTEGER NULL,
+			cache_read_tokens INTEGER NULL,
+			cache_write_tokens INTEGER NULL,
+			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);
+		CREATE TABLE events (
+			id TEXT PRIMARY KEY,
+			at TIMESTAMP NOT NULL,
+			repo TEXT NOT NULL,
+			kind TEXT NOT NULL,
+			number INTEGER NOT NULL DEFAULT 0,
+			actor TEXT NOT NULL DEFAULT '',
+			payload TEXT NOT NULL DEFAULT '{}'
+		);
+		CREATE TABLE event_queue (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			event_blob TEXT NOT NULL,
+			enqueued_at TEXT NOT NULL,
+			started_at TEXT NULL,
+			completed_at TEXT NULL
+		);
+		CREATE INDEX idx_event_queue_pending
+			ON event_queue(id)
+			WHERE completed_at IS NULL;
+		CREATE TABLE dispatch_history (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			from_agent TEXT NOT NULL,
+			to_agent TEXT NOT NULL,
+			repo TEXT NOT NULL,
+			number INTEGER NOT NULL DEFAULT 0,
+			reason TEXT NOT NULL DEFAULT '',
+			at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);
+		CREATE TABLE token_budgets (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			scope_kind TEXT NOT NULL DEFAULT 'global',
+			scope_name TEXT NOT NULL DEFAULT '',
+			period TEXT NOT NULL DEFAULT 'daily',
+			cap_tokens INTEGER NOT NULL DEFAULT 0,
+			alert_at_pct INTEGER NOT NULL DEFAULT 80,
+			enabled INTEGER NOT NULL DEFAULT 1,
+			UNIQUE(scope_kind, scope_name, period)
+		);
+		CREATE TABLE graph_layouts (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			scope TEXT NOT NULL DEFAULT 'global',
+			node_kind TEXT NOT NULL,
+			node_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+			x REAL NOT NULL,
+			y REAL NOT NULL,
+			updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+			UNIQUE(scope, node_kind, node_id)
 		);
 		CREATE TABLE guardrails (
 			name TEXT PRIMARY KEY,


### PR DESCRIPTION
## Summary

- Removes defensive `CREATE TABLE IF NOT EXISTS` blocks from later migrations when the table is owned by an earlier migration.
- Keeps migrations strict: missing earlier tables now fail loudly instead of being silently recreated with compatibility schemas.
- Updates the pre-021 migration test fixture so it seeds the earlier tables it marks as already applied.

## Rationale

Later migrations should not hide drifted or partially-applied database state. A migration that rebuilds or alters an existing table should assume prior migrations ran successfully. If that assumption is false, startup should fail with a clear migration error rather than continuing on a partial schema.

## Verification

- `GOCACHE=/tmp/go-build-agents go test ./internal/store`
- `TMPDIR=/tmp GOCACHE=/tmp/go-build-agents go test ./internal/store -run TestOpenAndMigrate -count=1 -v`
- `git diff --check`

## Notes

This PR intentionally does not touch PR #565's new `030_trace_error_metadata.sql` because that PR is still open. A maintainer comment was added there asking the author to remove the same defensive `traces` table creation from that migration.
