### PR TITLE
refactor: use slices.Equal in backend test

### DIFF
--- a/internal/backends/discovery_test.go
+++ b/internal/backends/discovery_test.go
@@ -102,13 +102,8 @@ For building AI applications, default to the latest capable model.`
 
 	got := parseModels(raw)
 	want := []string{"claude-haiku-4-5-20251001", "claude-opus-4-7", "claude-sonnet-4-6"}
-	if len(got) != len(want) {
-		t.Fatalf("parseModels() length = %d, want %d (got=%v)", len(got), len(want), got)
-	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Fatalf("parseModels()[%d] = %q, want %q", i, got[i], want[i])
-		}
+	if !slices.Equal(got, want) {
+		t.Fatalf("parseModels() = %v, want %v", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replaces a manual length check plus indexed loop in the backend model parser test with `slices.Equal`.
- Keeps the assertion behavior focused on the full expected slice value.

## Verification

- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./internal/backends`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.