### PR TITLE
refactor: use slices.Equal in MCP array test

### DIFF
--- a/internal/mcp/tools_arrays_test.go
+++ b/internal/mcp/tools_arrays_test.go
@@ -48,13 +48,8 @@ func TestStringSliceArgAcceptsShapes(t *testing.T) {
 			if tc.wantErr != "" {
 				return
 			}
-			if len(got) != len(tc.want) {
-				t.Fatalf("len = %d, want %d (got=%v)", len(got), len(tc.want), got)
-			}
-			for i := range got {
-				if got[i] != tc.want[i] {
-					t.Errorf("[%d] = %q, want %q", i, got[i], tc.want[i])
-				}
+			if !slices.Equal(got, tc.want) {
+				t.Fatalf("got = %v, want %v", got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Replaces a manual string-slice length check plus indexed comparison with `slices.Equal` in the MCP array argument test.
- Keeps the assertion focused on the full got/want slice value.

## Verification

- `GOCACHE=/workspace/agents/.gocache go test ./internal/mcp`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN GOCACHE=/workspace/agents/.gocache go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.