### PR TITLE
refactor: use max for runner offset clamp

### DIFF
--- a/internal/store/runners.go
+++ b/internal/store/runners.go
@@ -162,9 +162,7 @@ func (s *Store) ListWorkspaceRunners(workspaceID string, status RunnerStatus, li
 	if limit <= 0 {
 		limit = 100
 	}
-	if offset < 0 {
-		offset = 0
-	}
+	offset = max(offset, 0)
 	where, args := runnerStatusFilter(status)
 	where = appendRunnerWorkspaceFilter(where)
 	args = slices.Concat([]any{workspaceID}, args)


### PR DESCRIPTION
## Summary

- Replaces the manual negative offset clamp in runner pagination with Go's built-in `max`.
- Keeps the existing default limit and query behavior unchanged.

## Verification

- `GOCACHE=/workspace/agents/.gocache go test ./internal/store`
- `GOCACHE=/workspace/agents/.gocache go test -race ./internal/store`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN GOCACHE=/workspace/agents/.gocache go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.