### PR TITLE
refactor: use max for daemon runner offset clamp

### DIFF
--- a/internal/daemon/runners/runners.go
+++ b/internal/daemon/runners/runners.go
@@ -148,9 +148,7 @@ func (h *Handler) List(workspace, status string, limit, offset int) (ListRespons
 	if limit <= 0 {
 		limit = 100
 	}
-	if offset < 0 {
-		offset = 0
-	}
+	offset = max(offset, 0)
 	rows := make([]RunnerRow, 0, len(events))
 	for _, ev := range events {
 		rows = append(rows, h.expand(ev)...)


### PR DESCRIPTION
## Summary

- Replaces the manual negative offset clamp in the daemon runners list handler with Go's built-in `max`.
- Keeps the existing pagination defaulting and response behavior unchanged.

## Verification

- `GOCACHE=/workspace/agents/.gocache go test ./internal/daemon/runners`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN GOCACHE=/workspace/agents/.gocache go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.