### PR TITLE
refactor: use max for processor peak tracking

### DIFF
--- a/internal/workflow/processor_test.go
+++ b/internal/workflow/processor_test.go
@@ -130,9 +130,7 @@ func (b *blockingProcessorHandler) HandleEvent(_ context.Context, _ Event) error
 	b.mu.Lock()
 	b.active++
 	b.calls++
-	if b.active > b.peak {
-		b.peak = b.active
-	}
+	b.peak = max(b.peak, b.active)
 	b.mu.Unlock()
 	b.started <- struct{}{}
 	<-b.blockUntil


### PR DESCRIPTION
## Summary

- Replaces the manual peak-concurrency comparison in the processor test helper with Go's built-in `max`.
- Keeps the worker pool test behavior unchanged.

## Verification

- `GOCACHE=/workspace/agents/.gocache go test ./internal/workflow`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN GOCACHE=/workspace/agents/.gocache go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.