### PR TITLE
refactor: use slices.Contains for public routes

### DIFF
--- a/internal/daemon/auth.go
+++ b/internal/daemon/auth.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -92,13 +93,13 @@ func (d *Daemon) isPublicRoute(r *http.Request) bool {
 	if path == d.daemonCfg.HTTP.WebhookPath {
 		return true
 	}
-	if path == "/auth/status" || path == "/auth/login" || path == "/auth/bootstrap" {
+	if slices.Contains([]string{"/auth/status", "/auth/login", "/auth/bootstrap"}, path) {
 		return true
 	}
-	if path == "/" || path == "/ui" || path == "/ui/" || strings.HasPrefix(path, "/ui/") {
+	if slices.Contains([]string{"/", "/ui", "/ui/"}, path) || strings.HasPrefix(path, "/ui/") {
 		return true
 	}
-	if d.proxy != nil && (path == d.daemonCfg.Proxy.Path || path == "/v1/models") && isLoopbackRequest(r) {
+	if d.proxy != nil && slices.Contains([]string{d.daemonCfg.Proxy.Path, "/v1/models"}, path) && isLoopbackRequest(r) {
 		return true
 	}
 	return false


### PR DESCRIPTION
## Summary

- Replaces repeated public-route equality checks in daemon auth with `slices.Contains`.
- Keeps the existing status, webhook, auth, UI, and loopback proxy route behavior unchanged.

## Verification

- `GOCACHE=/workspace/agents/.gocache go test ./internal/daemon`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN GOCACHE=/workspace/agents/.gocache go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.