### PR TITLE
refactor: move store migrations into focused file

### DIFF
--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -1,0 +1,72 @@
+package store
+
+import (
+	"database/sql"
+	"embed"
+	"fmt"
+	"io/fs"
+	"slices"
+	"strings"
+)
+
+//go:embed migrations/*.sql
+var migrationsFS embed.FS
+
+// migrate applies all embedded SQL migration files in lexicographic order.
+// Each file is applied as a single transaction; already-applied files are
+// tracked via a schema_migrations table.
+func migrate(db *sql.DB) error {
+	// Ensure the migrations tracking table exists.
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS schema_migrations (
+		name TEXT PRIMARY KEY,
+		applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+	)`); err != nil {
+		return fmt.Errorf("store: create schema_migrations: %w", err)
+	}
+
+	entries, err := fs.ReadDir(migrationsFS, "migrations")
+	if err != nil {
+		return fmt.Errorf("store: read migrations dir: %w", err)
+	}
+	slices.SortFunc(entries, func(a, b fs.DirEntry) int {
+		return strings.Compare(a.Name(), b.Name())
+	})
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".sql") {
+			continue
+		}
+
+		var applied bool
+		row := db.QueryRow("SELECT EXISTS(SELECT 1 FROM schema_migrations WHERE name=?)", name)
+		if err := row.Scan(&applied); err != nil {
+			return fmt.Errorf("store: check migration %s: %w", name, err)
+		}
+		if applied {
+			continue
+		}
+
+		data, err := migrationsFS.ReadFile("migrations/" + name)
+		if err != nil {
+			return fmt.Errorf("store: read migration %s: %w", name, err)
+		}
+
+		tx, err := db.Begin()
+		if err != nil {
+			return fmt.Errorf("store: begin migration %s: %w", name, err)
+		}
+		if _, err := tx.Exec(string(data)); err != nil {
+			tx.Rollback()
+			return fmt.Errorf("store: apply migration %s: %w", name, err)
+		}
+		if _, err := tx.Exec("INSERT INTO schema_migrations(name) VALUES(?)", name); err != nil {
+			tx.Rollback()
+			return fmt.Errorf("store: record migration %s: %w", name, err)
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("store: commit migration %s: %w", name, err)
+		}
+	}
+	return nil
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -19,12 +19,10 @@ package store
 import (
 	"crypto/rand"
 	"database/sql"
-	"embed"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/fs"
 	"maps"
 	"slices"
 	"strings"
@@ -43,9 +41,6 @@ type querier interface {
 	Query(query string, args ...any) (*sql.Rows, error)
 	QueryRow(query string, args ...any) *sql.Row
 }
-
-//go:embed migrations/*.sql
-var migrationsFS embed.FS
 
 // Open opens (or creates) a SQLite database at path and runs all pending
 // schema migrations. It returns a ready-to-use *sql.DB.
@@ -81,65 +76,6 @@ func Open(path string) (*sql.DB, error) {
 		return nil, err
 	}
 	return db, nil
-}
-
-// migrate applies all embedded SQL migration files in lexicographic order.
-// Each file is applied as a single transaction; already-applied files are
-// tracked via a schema_migrations table.
-func migrate(db *sql.DB) error {
-	// Ensure the migrations tracking table exists.
-	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS schema_migrations (
-		name TEXT PRIMARY KEY,
-		applied_at TEXT NOT NULL DEFAULT (datetime('now'))
-	)`); err != nil {
-		return fmt.Errorf("store: create schema_migrations: %w", err)
-	}
-
-	entries, err := fs.ReadDir(migrationsFS, "migrations")
-	if err != nil {
-		return fmt.Errorf("store: read migrations dir: %w", err)
-	}
-	slices.SortFunc(entries, func(a, b fs.DirEntry) int {
-		return strings.Compare(a.Name(), b.Name())
-	})
-
-	for _, entry := range entries {
-		name := entry.Name()
-		if !strings.HasSuffix(name, ".sql") {
-			continue
-		}
-
-		var applied bool
-		row := db.QueryRow("SELECT EXISTS(SELECT 1 FROM schema_migrations WHERE name=?)", name)
-		if err := row.Scan(&applied); err != nil {
-			return fmt.Errorf("store: check migration %s: %w", name, err)
-		}
-		if applied {
-			continue
-		}
-
-		data, err := migrationsFS.ReadFile("migrations/" + name)
-		if err != nil {
-			return fmt.Errorf("store: read migration %s: %w", name, err)
-		}
-
-		tx, err := db.Begin()
-		if err != nil {
-			return fmt.Errorf("store: begin migration %s: %w", name, err)
-		}
-		if _, err := tx.Exec(string(data)); err != nil {
-			tx.Rollback()
-			return fmt.Errorf("store: apply migration %s: %w", name, err)
-		}
-		if _, err := tx.Exec("INSERT INTO schema_migrations(name) VALUES(?)", name); err != nil {
-			tx.Rollback()
-			return fmt.Errorf("store: record migration %s: %w", name, err)
-		}
-		if err := tx.Commit(); err != nil {
-			return fmt.Errorf("store: commit migration %s: %w", name, err)
-		}
-	}
-	return nil
 }
 
 // Import writes cfg into the database, upserting every entity. Existing rows


### PR DESCRIPTION
## Summary

- Moves the embedded migration filesystem and migration runner from `internal/store/store.go` to `internal/store/migrations.go`.
- Leaves `Open` in `store.go` and keeps migration ordering/application behavior unchanged.

## Verification

- `GOCACHE=/workspace/agents/.gocache go test ./internal/store`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN GOCACHE=/workspace/agents/.gocache go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.