### PR TITLE
refactor: name trace step limit

### DIFF
--- a/internal/observe/observe.go
+++ b/internal/observe/observe.go
@@ -23,6 +23,8 @@ import (
 	"github.com/eloylp/agents/internal/workflow"
 )
 
+const maxTraceSteps = 100
+
 // ─── Types ───────────────────────────────────────────────────────────────────
 
 // TimestampedEvent is a workflow event with an ingestion timestamp attached.
@@ -756,7 +758,7 @@ func (s *Store) RecordStep(spanID string, step workflow.TraceStep) {
 	err := s.db.QueryRow(`SELECT COUNT(*) FROM trace_steps WHERE span_id=?`, spanID).Scan(&idx)
 	if err != nil {
 		log.Printf("observe: count trace steps for %s: %v", spanID, err)
-	} else if idx < 100 {
+	} else if idx < maxTraceSteps {
 		_, err = s.db.Exec(
 			`INSERT INTO trace_steps (span_id, step_index, kind, tool_name, input_summary, output_summary, duration_ms) VALUES (?,?,?,?,?,?,?)`,
 			spanID, idx, step.Kind, step.ToolName, step.InputSummary, step.OutputSummary, step.DurationMs,
@@ -790,7 +792,7 @@ func (s *Store) RecordSteps(spanID string, steps []workflow.TraceStep) {
 		return
 	}
 	for i, step := range steps {
-		if i >= 100 {
+		if i >= maxTraceSteps {
 			break
 		}
 		kind := step.Kind


### PR DESCRIPTION
## Summary

- Adds a single named constant for the trace step persistence cap in `internal/observe`.
- Reuses the constant in both single-step and batch step recording paths.

## Verification

- `GOCACHE=/workspace/agents/.gocache go test ./internal/observe`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN GOCACHE=/workspace/agents/.gocache go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.