### PR TITLE
refactor: stream failure detail lines

### DIFF
--- a/internal/ai/failures.go
+++ b/internal/ai/failures.go
@@ -71,7 +71,7 @@ func stringField(obj map[string]any, key string) string {
 }
 
 func firstNonEmptyLine(s string) string {
-	for _, line := range strings.Split(s, "\n") {
+	for line := range strings.SplitSeq(s, "\n") {
 		if trimmed := strings.TrimSpace(line); trimmed != "" {
 			return trimmed
 		}
@@ -80,7 +80,7 @@ func firstNonEmptyLine(s string) string {
 }
 
 func firstErrorLine(s string) string {
-	for _, line := range strings.Split(s, "\n") {
+	for line := range strings.SplitSeq(s, "\n") {
 		trimmed := strings.TrimSpace(line)
 		if trimmed != "" && errorLineRE.MatchString(trimmed) {
 			return trimmed


### PR DESCRIPTION
## Summary

- Replaces two `strings.Split` line scans in failure-detail helpers with `strings.SplitSeq`.
- Keeps the existing trim, first-match, and empty-string behavior while avoiding temporary slice allocation.

## Verification

- `GOCACHE=/workspace/agents/.gocache go test ./internal/ai`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN GOCACHE=/workspace/agents/.gocache go test ./...`
- `git diff --check`

Note: the first unsanitized `go test ./...` run failed because ambient auth environment variables affected `internal/backends`; rerunning with those variables unset passed. Targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.