### PR TITLE
refactor: clone graph edge maps

### DIFF
--- a/internal/daemon/observe/observe.go
+++ b/internal/daemon/observe/observe.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"path/filepath"
 	"slices"
@@ -418,10 +419,7 @@ func (h *Handler) HandleGraph(w http.ResponseWriter, r *http.Request) {
 	}
 	slices.SortFunc(nodes, func(a, b graphNode) int { return cmp.Compare(a.ID, b.ID) })
 
-	edgeByKey := make(map[string]graphEdge, len(edges)+len(configuredEdges))
-	for key, e := range configuredEdges {
-		edgeByKey[key] = e
-	}
+	edgeByKey := maps.Clone(configuredEdges)
 	for _, e := range edges {
 		recs := make([]dispatchRecord, 0, len(e.Dispatches))
 		for _, d := range e.Dispatches {

--- a/internal/mcp/tools_observe.go
+++ b/internal/mcp/tools_observe.go
@@ -169,10 +169,7 @@ func toolGetGraph(deps Deps) server.ToolHandlerFunc {
 			nodes = append(nodes, mcpGraphNode{ID: name})
 		}
 
-		edgeByKey := make(map[string]mcpGraphEdge, len(edges)+len(configuredEdges))
-		for key, e := range configuredEdges {
-			edgeByKey[key] = e
-		}
+		edgeByKey := maps.Clone(configuredEdges)
 		for _, e := range edges {
 			recs := make([]mcpGraphDispatch, 0, len(e.Dispatches))
 			for _, d := range e.Dispatches {


### PR DESCRIPTION
## Summary

- Replaces manual configured-edge map copy loops with `maps.Clone` in the HTTP graph handler and MCP graph tool.
- Keeps the existing observed-edge overlay and response sorting behavior unchanged.

## Verification

- `GOCACHE=/workspace/agents/.gocache go test ./internal/daemon/observe ./internal/mcp`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN GOCACHE=/workspace/agents/.gocache go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.