### PR TITLE
refactor: use bytes clone for runner line capture

### DIFF
--- a/internal/ai/cmdrunner_test.go
+++ b/internal/ai/cmdrunner_test.go
@@ -190,7 +190,7 @@ func TestContainerCommandRunnerUsesRuntimeAndParsesOutput(t *testing.T) {
 		System:   "system",
 		User:     "user",
 		OnLine: func(line []byte) {
-			lines = append(lines, append([]byte(nil), line...))
+			lines = append(lines, bytes.Clone(line))
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary

- Replaces the manual `append([]byte(nil), line...)` byte-slice clone in the container runner test callback with `bytes.Clone`.
- Keeps the captured line isolation behavior unchanged while using the stdlib helper already imported by the test file.

## Verification

- `GOCACHE=/workspace/agents/.gocache go test ./internal/ai`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN GOCACHE=/workspace/agents/.gocache go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.