### PR TITLE
refactor: use cutprefix for runtime env lookup

### DIFF
--- a/internal/runtime/backend_setup.go
+++ b/internal/runtime/backend_setup.go
@@ -148,8 +148,8 @@ func setEnvValues(env []string, kvs ...string) []string {
 func getEnv(env []string, key string) string {
 	prefix := key + "="
 	for _, entry := range env {
-		if strings.HasPrefix(entry, prefix) {
-			return strings.TrimPrefix(entry, prefix)
+		if value, ok := strings.CutPrefix(entry, prefix); ok {
+			return value
 		}
 	}
 	return ""


### PR DESCRIPTION
## Summary

- Replaces the manual `HasPrefix` plus `TrimPrefix` environment lookup in runtime backend setup with `strings.CutPrefix`.
- Keeps the same first-match and empty-string behavior while using the standard helper for this pattern.

## Verification

- `go test ./internal/runtime`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.