### PR TITLE
refactor: use cutprefix for webhook signature

### DIFF
--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -485,7 +485,7 @@ func (h *Handler) enqueue(ctx context.Context, w http.ResponseWriter, ev workflo
 // hmac.Equal is used for the final comparison to avoid timing attacks that
 // could leak information about the expected value through execution time.
 func verifySignature(payload []byte, secret, signature string) bool {
-	signature = strings.TrimPrefix(strings.TrimSpace(signature), "sha256=")
+	signature, _ = strings.CutPrefix(strings.TrimSpace(signature), "sha256=")
 	if signature == "" || secret == "" {
 		return false
 	}


### PR DESCRIPTION
## Summary

- Replaces the manual `TrimPrefix` signature prefix strip in webhook HMAC verification with `strings.CutPrefix`.
- Keeps the existing behavior for already-trimmed signatures and missing prefixes while using the clearer standard helper.

## Verification

- `go test ./internal/webhook`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.