### PR TITLE
refactor: use cutprefix for SSE workspace parsing

### DIFF
--- a/internal/daemon/observe/observe.go
+++ b/internal/daemon/observe/observe.go
@@ -614,14 +614,15 @@ func ServeSSEWithIntervalFiltered(w http.ResponseWriter, r *http.Request, hub SS
 func workspaceFromSSEMessage(msg []byte) string {
 	for line := range bytes.Lines(msg) {
 		line = bytes.TrimSpace(line)
-		if !bytes.HasPrefix(line, []byte("data:")) {
+		data, ok := bytes.CutPrefix(line, []byte("data:"))
+		if !ok {
 			continue
 		}
 		var payload struct {
 			WorkspaceID string `json:"workspace_id"`
 			Workspace   string `json:"workspace"`
 		}
-		data := bytes.TrimSpace(bytes.TrimPrefix(line, []byte("data:")))
+		data = bytes.TrimSpace(data)
 		if err := json.Unmarshal(data, &payload); err != nil {
 			return ""
 		}


### PR DESCRIPTION
## Summary

- Replaces the `bytes.HasPrefix` plus `bytes.TrimPrefix` pair in SSE workspace message parsing with `bytes.CutPrefix`.
- Keeps the same handling for non-data lines, whitespace trimming, and workspace normalization.

## Verification

- `go test ./internal/daemon/observe`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.