### PR TITLE
refactor: simplify orphan sort comparator

### DIFF
--- a/internal/daemon/fleet/orphans.go
+++ b/internal/daemon/fleet/orphans.go
@@ -1,6 +1,7 @@
 package fleet
 
 import (
+	"cmp"
 	"encoding/json"
 	"fmt"
 	"maps"
@@ -110,13 +111,11 @@ func computeOrphanedAgents(cfg *config.Config) []OrphanedAgent {
 	}
 
 	slices.SortFunc(orphan, func(a, b OrphanedAgent) int {
-		if c := strings.Compare(a.WorkspaceID, b.WorkspaceID); c != 0 {
-			return c
-		}
-		if c := strings.Compare(a.Backend, b.Backend); c != 0 {
-			return c
-		}
-		return strings.Compare(a.Name, b.Name)
+		return cmp.Or(
+			cmp.Compare(a.WorkspaceID, b.WorkspaceID),
+			cmp.Compare(a.Backend, b.Backend),
+			cmp.Compare(a.Name, b.Name),
+		)
 	})
 	return orphan
 }


### PR DESCRIPTION
## Summary

- Replaces the hand-written three-key orphan-agent sort comparator with `cmp.Or` and `cmp.Compare`.
- Keeps the existing ordering by workspace, backend, then agent name while using the standard comparator helpers.

## Verification

- `go test ./internal/daemon/fleet`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.