### PR TITLE
refactor: use cmp compare for backend status sorting

### DIFF
--- a/internal/backends/discovery.go
+++ b/internal/backends/discovery.go
@@ -2,6 +2,7 @@ package backends
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -202,7 +203,7 @@ func fillRuntimeDiagnostics(ctx context.Context, diag *Diagnostics, runner runti
 
 	diag.Backends = backendsOut
 	slices.SortFunc(diag.Backends, func(a, b BackendStatus) int {
-		return strings.Compare(a.Name, b.Name)
+		return cmp.Compare(a.Name, b.Name)
 	})
 	diag.Tools = toolsOut
 	for i := range diag.Tools {
@@ -238,7 +239,7 @@ func diagnoseToolsInRuntime(ctx context.Context, runner runtimeexec.Runner, sett
 		diagnoseVersionedToolInRuntime(ctx, runner, settings, "typescript", "tsc", []string{"--version"}),
 	}
 	slices.SortFunc(tools, func(a, b ToolStatus) int {
-		return strings.Compare(a.Name, b.Name)
+		return cmp.Compare(a.Name, b.Name)
 	})
 	return tools
 }


### PR DESCRIPTION
## Summary

- Replaces two single-field backend diagnostic sort comparators with `cmp.Compare`.
- Keeps the existing backend and tool name ordering unchanged while matching the repo's newer comparator style.

## Verification

- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./internal/backends`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.