### PR TITLE
refactor: use cmp compare for roster sorting

### DIFF
--- a/internal/ai/prompt.go
+++ b/internal/ai/prompt.go
@@ -1,6 +1,7 @@
 package ai
 
 import (
+	"cmp"
 	"fmt"
 	"maps"
 	"path/filepath"
@@ -125,7 +126,7 @@ func renderRoster(roster []RosterEntry) string {
 	}
 	sorted := slices.Clone(roster)
 	slices.SortFunc(sorted, func(a, b RosterEntry) int {
-		return strings.Compare(a.Name, b.Name)
+		return cmp.Compare(a.Name, b.Name)
 	})
 	var b strings.Builder
 	b.WriteString("## Available experts\n\n")


### PR DESCRIPTION
## Summary

- Replaces the roster sort comparator's `strings.Compare` call with `cmp.Compare`.
- Keeps the same alphabetical ordering while matching the newer comparator style used elsewhere in the repo.

## Verification

- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./internal/ai`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.