### PR TITLE
refactor: use cmp compare for store migrations

### DIFF
--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"cmp"
 	"database/sql"
 	"embed"
 	"fmt"
@@ -29,7 +30,7 @@ func migrate(db *sql.DB) error {
 		return fmt.Errorf("store: read migrations dir: %w", err)
 	}
 	slices.SortFunc(entries, func(a, b fs.DirEntry) int {
-		return strings.Compare(a.Name(), b.Name())
+		return cmp.Compare(a.Name(), b.Name())
 	})
 
 	for _, entry := range entries {


### PR DESCRIPTION
## Summary

- Replaces the store migration sort comparator's `strings.Compare` call with `cmp.Compare`.
- Keeps the same lexicographic migration ordering while using the standard comparator helper.

## Verification

- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./internal/store`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.