### PR TITLE
refactor: simplify observe memory path checks

### DIFF
--- a/internal/daemon/observe/observe.go
+++ b/internal/daemon/observe/observe.go
@@ -474,7 +474,7 @@ func (h *Handler) HandleMemory(w http.ResponseWriter, r *http.Request) {
 	workspace := r.URL.Query().Get("workspace")
 
 	// Reject path traversal attempts.
-	if agent == "." || repo == "." || agent == ".." || repo == ".." {
+	if slices.Contains([]string{".", ".."}, agent) || slices.Contains([]string{".", ".."}, repo) {
 		http.Error(w, "invalid path", http.StatusBadRequest)
 		return
 	}


### PR DESCRIPTION
## Summary

- Replaces the manual dot and dot-dot path sentinel equality chain in the observe memory handler with `slices.Contains`.
- Keeps the same path traversal rejection behavior while making the checked sentinel set explicit.

## Verification

- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./internal/daemon/observe`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.