### PR TITLE
refactor: clarify mcp traversal component check

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1115,5 +1115,10 @@ func trimmedStringOptional(req mcpgo.CallToolRequest, key string) (string, bool)
 // canonicalised by ai.NormalizeToken downstream and cannot escape the store.
 func isTraversalComponent(s string) bool {
 	c := filepath.Clean(s)
-	return c == "." || c == ".."
+	switch c {
+	case ".", "..":
+		return true
+	default:
+		return false
+	}
 }


### PR DESCRIPTION
## Summary

- Replaces the manual boolean expression in the MCP traversal component helper with an explicit switch over the cleaned sentinel values.
- Keeps the same rejection behavior for `.` and `..` components while making the two accepted cases easier to scan.

## Verification

- `go test ./internal/mcp`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.