### PR TITLE
refactor: parse first model field lazily

### DIFF
--- a/internal/backends/discovery.go
+++ b/internal/backends/discovery.go
@@ -582,11 +582,10 @@ func parseModels(raw string) []string {
 		if strings.HasPrefix(lower, "model") || strings.HasPrefix(lower, "available") || strings.HasPrefix(lower, "current") || strings.HasPrefix(lower, "you") || strings.HasPrefix(lower, "for ") {
 			continue
 		}
-		fields := strings.Fields(line)
-		if len(fields) == 0 {
-			continue
+		for field := range strings.FieldsSeq(line) {
+			names = append(names, field)
+			break
 		}
-		names = append(names, fields[0])
 	}
 	return dedupeSorted(names)
 }


### PR DESCRIPTION
## Summary

- Replaces the plain-text model parser's `strings.Fields` allocation with `strings.FieldsSeq` when only the first field is needed.
- Keeps the same first-token extraction behavior for fallback model discovery output.

## Verification

- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./internal/backends`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.