### PR TITLE
refactor: simplify import mode validation

### DIFF
--- a/internal/daemon/config/config.go
+++ b/internal/daemon/config/config.go
@@ -473,7 +473,7 @@ func (h *Handler) HandleImport(w http.ResponseWriter, r *http.Request) {
 //
 // On success it returns the per-section counts.
 func (h *Handler) ImportYAML(body []byte, mode string) (map[string]int, error) {
-	if mode != "" && mode != "merge" && mode != "replace" {
+	if !slices.Contains([]string{"", "merge", "replace"}, mode) {
 		return nil, &store.ErrValidation{Msg: fmt.Sprintf("invalid mode %q: must be empty, \"merge\", or \"replace\"", mode)}
 	}
 	var payload exportYAML


### PR DESCRIPTION
## Summary

- Replaces the manual import mode inequality chain with `slices.Contains` over the allowed mode set.
- Keeps the same accepted values: empty, `merge`, and `replace`.

## Verification

- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./internal/daemon/config`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.