### PR TITLE
refactor: simplify mcp graph edge sort

### DIFF
--- a/internal/mcp/tools_observe.go
+++ b/internal/mcp/tools_observe.go
@@ -195,10 +195,7 @@ func toolGetGraph(deps Deps) server.ToolHandlerFunc {
 			wireEdges = append(wireEdges, e)
 		}
 		slices.SortFunc(wireEdges, func(a, b mcpGraphEdge) int {
-			if byFrom := cmp.Compare(a.From, b.From); byFrom != 0 {
-				return byFrom
-			}
-			return cmp.Compare(a.To, b.To)
+			return cmp.Or(cmp.Compare(a.From, b.From), cmp.Compare(a.To, b.To))
 		})
 
 		return jsonResult(map[string]any{


### PR DESCRIPTION
## Summary

- Replaces the manual two-key MCP graph edge comparator with `cmp.Or` and `cmp.Compare`.
- Keeps the same `from` then `to` ordering while matching the concise comparator style already used elsewhere.

## Verification

- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./internal/mcp`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.