### PR TITLE
fix: use hamburger icon for collapsed menu

### DIFF
--- a/internal/ui/src/components/DashboardShell.test.tsx
+++ b/internal/ui/src/components/DashboardShell.test.tsx
@@ -37,6 +37,7 @@ describe('<DashboardShell />', () => {
     expect(button).toHaveAttribute('aria-label', 'Open navigation')
     expect(button).toHaveAttribute('title', 'Open navigation')
     expect(button).not.toHaveTextContent('Menu')
+    expect(button.querySelector('.shell-menu-icon')).toHaveAttribute('aria-hidden', 'true')
     expect(button.querySelectorAll('.shell-menu-icon span')).toHaveLength(3)
 
     fireEvent.click(button)

--- a/internal/ui/src/components/DashboardShell.test.tsx
+++ b/internal/ui/src/components/DashboardShell.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import DashboardShell from './DashboardShell'
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/',
+}))
+
+function mockShellFetch() {
+  vi.stubGlobal('fetch', vi.fn((url: string) => {
+    if (url === '/status') {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ orphaned_agents: { count: 0 } }),
+      } as Response)
+    }
+    if (url === '/token_budgets/alerts') {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ count: 0 }),
+      } as Response)
+    }
+    return Promise.resolve({ ok: false, json: () => Promise.resolve({}) } as Response)
+  }))
+}
+
+describe('<DashboardShell />', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('renders the collapsed navigation toggle as an accessible hamburger icon', () => {
+    mockShellFetch()
+    const { container } = render(<DashboardShell><div>Content</div></DashboardShell>)
+
+    const button = screen.getByTitle('Open navigation')
+    expect(button).toHaveAttribute('aria-label', 'Open navigation')
+    expect(button).toHaveAttribute('title', 'Open navigation')
+    expect(button).not.toHaveTextContent('Menu')
+    expect(button.querySelectorAll('.shell-menu-icon span')).toHaveLength(3)
+
+    fireEvent.click(button)
+    expect(container.querySelector('.shell-sidebar.open')).toBeInTheDocument()
+  })
+})

--- a/internal/ui/src/components/DashboardShell.tsx
+++ b/internal/ui/src/components/DashboardShell.tsx
@@ -116,6 +116,16 @@ export default function DashboardShell({ children }: { children: React.ReactNode
         }
         .shell-content { padding: 1.25rem; max-width: 1480px; margin: 0 auto; }
         .shell-menu-button { display: none; }
+        .shell-menu-icon {
+          display: grid;
+          gap: 4px;
+          width: 18px;
+        }
+        .shell-menu-icon span {
+          display: block;
+          height: 2px;
+          background: currentColor;
+        }
         .shell-overlay { display: none; }
         .shell-nav-link:hover { text-decoration: none; background: var(--accent-bg); color: var(--accent); }
         @media (max-width: 860px) {
@@ -187,9 +197,14 @@ export default function DashboardShell({ children }: { children: React.ReactNode
             className="shell-menu-button"
             onClick={() => setSidebarOpen(true)}
             aria-label="Open navigation"
+            title="Open navigation"
             style={{ background: 'var(--bg-card)', border: '1px solid var(--border)', color: 'var(--text)', borderRadius: 0, padding: '5px 9px', cursor: 'pointer' }}
           >
-            Menu
+            <span className="shell-menu-icon" aria-hidden="true">
+              <span />
+              <span />
+              <span />
+            </span>
           </button>
           <div style={{ color: 'var(--text-muted)', fontSize: '0.8rem', fontWeight: 600 }}>
             {links.find(link => activePath(pathname, link.href))?.label ?? 'Agents'}


### PR DESCRIPTION
## Summary

- Replaces the collapsed/mobile navigation toggle text with a three-bar hamburger icon.
- Keeps the existing open behavior and accessible navigation label/title.
- Adds a focused DashboardShell test for the icon markup and click behavior.

Closes #601

## Verification

- `npm test`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.