### PR TITLE
fix: reorganize graph agent overview

### DIFF
--- a/internal/ui/src/app/graph/page.tsx
+++ b/internal/ui/src/app/graph/page.tsx
@@ -1274,33 +1274,38 @@ export default function GraphPage() {
               />
               {agentPanelTab === 'overview' && (
                 <>
-              <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
-                <span style={{ background: 'var(--accent-bg)', border: '1px solid var(--btn-primary-border)', borderRadius: '4px', padding: '2px 8px', fontSize: '0.75rem', color: 'var(--accent)' }}>
-                  {selectedNode.current_status}
-                </span>
-                {selectedNode.allow_dispatch && (
-                  <span style={{ background: 'var(--accent-bg)', border: '1px solid var(--btn-primary-border)', borderRadius: '4px', padding: '2px 8px', fontSize: '0.75rem', color: 'var(--accent)' }}>dispatchable</span>
-                )}
-              </div>
-              <button
-                onClick={() => openEditAgent(selectedNode.name)}
-                style={{ justifySelf: 'start', padding: '6px 12px', borderRadius: '6px', border: '1px solid var(--btn-primary-border)', background: 'var(--btn-primary-bg)', color: '#fff', cursor: 'pointer', fontSize: '0.8rem', fontWeight: 600 }}
-              >
-                Edit agent
-              </button>
-              {selectedNodeRepos.length > 0 && (
-                <RunButton agent={selectedNode.name} repos={selectedNodeRepos} />
-              )}
-              {(selectedNode.skills ?? []).length > 0 && (
-                <div>
-                  <div style={{ fontSize: '0.75rem', fontWeight: 600, color: 'var(--accent)', textTransform: 'uppercase', marginBottom: '0.25rem' }}>Skills</div>
-                  <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
-                    {selectedNode.skills!.map(s => (
-                      <span key={s} style={{ background: 'rgba(100,116,139,0.15)', border: '1px solid var(--border-subtle)', borderRadius: '4px', padding: '2px 8px', fontSize: '0.75rem', color: 'var(--text-faint)' }}>{s}</span>
-                    ))}
+                  <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', alignItems: 'center' }}>
+                    <button
+                      onClick={() => openEditAgent(selectedNode.name)}
+                      style={{ padding: '6px 12px', borderRadius: '6px', border: '1px solid var(--btn-primary-border)', background: 'var(--btn-primary-bg)', color: '#fff', cursor: 'pointer', fontSize: '0.8rem', fontWeight: 600 }}
+                    >
+                      Edit agent
+                    </button>
+                    {selectedNodeRepos.length > 0 && (
+                      <RunButton agent={selectedNode.name} repos={selectedNodeRepos} />
+                    )}
                   </div>
-                </div>
-              )}
+                  <div>
+                    <div style={{ fontSize: '0.75rem', fontWeight: 600, color: 'var(--accent)', textTransform: 'uppercase', marginBottom: '0.25rem' }}>Options</div>
+                    <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+                      <span style={{ background: 'var(--accent-bg)', border: '1px solid var(--btn-primary-border)', borderRadius: '4px', padding: '2px 8px', fontSize: '0.75rem', color: 'var(--accent)' }}>
+                        {selectedNode.current_status}
+                      </span>
+                      {selectedNode.allow_dispatch && (
+                        <span style={{ background: 'var(--accent-bg)', border: '1px solid var(--btn-primary-border)', borderRadius: '4px', padding: '2px 8px', fontSize: '0.75rem', color: 'var(--accent)' }}>dispatchable</span>
+                      )}
+                    </div>
+                  </div>
+                  {(selectedNode.skills ?? []).length > 0 && (
+                    <div>
+                      <div style={{ fontSize: '0.75rem', fontWeight: 600, color: 'var(--accent)', textTransform: 'uppercase', marginBottom: '0.25rem' }}>Skills</div>
+                      <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+                        {selectedNode.skills!.map(s => (
+                          <span key={s} style={{ background: 'rgba(100,116,139,0.15)', border: '1px solid var(--border-subtle)', borderRadius: '4px', padding: '2px 8px', fontSize: '0.75rem', color: 'var(--text-faint)' }}>{s}</span>
+                        ))}
+                      </div>
+                    </div>
+                  )}
                 </>
               )}
 


### PR DESCRIPTION
## Summary

- Groups `Edit agent` and the existing `RunButton` in one wrapping action row in the graph agent overview.
- Adds an `Options` section below the action row for the current status and dispatchability badges.
- Keeps `Skills` visible as its own section after options without changing graph, edit, or run behavior.

Closes #604

## Verification

- `npm test`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.