### PR TITLE
fix: remove auth redirect background image

### DIFF
--- a/internal/ui/src/lib/auth.test.tsx
+++ b/internal/ui/src/lib/auth.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { AuthTokenSettings } from './auth'
+import { AuthProvider, AuthTokenSettings } from './auth'
 
 function mockFetch(handler: (url: string, init?: RequestInit) => Response | Promise<Response>) {
   const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
@@ -19,6 +19,27 @@ function jsonResponse(body: unknown, init?: ResponseInit) {
     ...init,
   })
 }
+
+describe('AuthProvider', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('renders the checking session screen without an image-backed background', () => {
+    vi.stubGlobal('fetch', vi.fn(() => new Promise<Response>(() => {})))
+
+    const { container } = render(
+      <AuthProvider>
+        <div>Authenticated app</div>
+      </AuthProvider>,
+    )
+
+    expect(screen.getByRole('heading', { name: 'Checking session' })).toBeInTheDocument()
+    const redirectScreen = container.firstElementChild as HTMLElement
+    expect(redirectScreen.style.background).not.toContain('agents.jpg')
+    expect(redirectScreen.style.background).not.toContain('url(')
+  })
+})
 
 describe('AuthTokenSettings', () => {
   afterEach(() => {

--- a/internal/ui/src/lib/auth.tsx
+++ b/internal/ui/src/lib/auth.tsx
@@ -310,7 +310,7 @@ export function AuthTokenSettings() {
 
 function AuthRedirectScreen({ loading }: { loading: boolean }) {
   return (
-    <div style={authPageStyle}>
+    <div style={authRedirectPageStyle}>
       <div style={authBackdropStyle} />
       <div style={authCardStyle}>
         <p style={authEyebrowStyle}>Agents dashboard</p>
@@ -374,7 +374,7 @@ const pillStyle: React.CSSProperties = {
   padding: '0.15rem 0.45rem',
 }
 
-const authPageStyle: React.CSSProperties = {
+const authRedirectPageStyle: React.CSSProperties = {
   minHeight: '100vh',
   display: 'flex',
   alignItems: 'center',
@@ -383,7 +383,7 @@ const authPageStyle: React.CSSProperties = {
   overflow: 'hidden',
   padding: '1.25rem',
   background:
-    'linear-gradient(135deg, rgba(7,17,31,0.82), rgba(13,34,55,0.58) 44%, rgba(238,246,255,0.18)), url("/ui/agents.jpg") center / cover no-repeat, linear-gradient(135deg, #07111f 0%, #0d2237 48%, #eef6ff 100%)',
+    'linear-gradient(135deg, rgba(7,17,31,0.92), rgba(13,34,55,0.74) 48%, rgba(238,246,255,0.28)), linear-gradient(135deg, #07111f 0%, #0d2237 48%, #eef6ff 100%)',
 }
 
 const authBackdropStyle: React.CSSProperties = {


### PR DESCRIPTION
## Summary

- Gives the checking-session / redirect auth screen its own image-free gradient background.
- Keeps the existing auth copy, card, redirect behavior, and session validation flow unchanged.
- Adds a focused AuthProvider regression test that guards against `agents.jpg` or any `url(...)` background on the checking-session screen.

Closes #602

## Verification

- `npm test -- src/lib/auth.test.tsx`
- `npm test`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.