### PR TITLE
fix: add graph prompt editing and transcripts

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -29,7 +29,9 @@ Primary workflow designer showing agents as draggable graph nodes and dispatch p
 
 The graph deliberately keeps one node per real agent. Repo-scoped agents are grouped inside thin dashed repo boundaries; workspace-scoped agents sit outside those boundaries. Repo trigger bindings are visualised as thin lines from the agent to passive repo anchors, so the user can see where an agent runs without duplicating the agent into one node per repo. Dispatch wiring remains the editable agent-to-agent relationship.
 
-The right-side **Agent editor** is the graph's main editing surface. Click an agent to inspect or edit its definition, run it against bound repos, manage repo triggers, add or remove dispatch wiring, and review recent runner rows / trace links. The editor is tabbed by concept: Overview, Settings, Triggers, Dispatch, and Activity. Operators can create agents without leaving the designer.
+The right-side **Agent editor** is the graph's main editing surface. Click an agent to inspect or edit its definition, run it against bound repos, manage repo triggers, add or remove dispatch wiring, edit the referenced catalog prompt, and review recent runner rows / trace links. The editor is tabbed by concept: Overview, Settings, Prompt, Triggers, Dispatch, and Activity. The Prompt tab updates the same reusable prompt catalog entry selected by the agent and calls out that shared ownership before saving. Operators can create agents without leaving the designer.
+
+The Activity tab can open the same live transcript modal used by the Runners page. In-flight spans stream from `/traces/{span_id}/stream`; completed spans replay the persisted `trace_steps` rows through the same surface, with a link back to the full trace detail.
 
 Dispatch wiring is always editable: drag from one agent to another to add a connection, or click an edge to inspect its Overview, History, and Danger tabs. Dispatch changes write back to the source agent's `can_dispatch` list and the target's `allow_dispatch` flag.
 

--- a/internal/ui/src/app/graph/page.tsx
+++ b/internal/ui/src/app/graph/page.tsx
@@ -24,11 +24,14 @@ import dagre from 'dagre'
 import Card from '@/components/Card'
 import AgentForm, { emptyAgentForm, type BackendOption } from '@/components/AgentForm'
 import BadgePicker from '@/components/BadgePicker'
+import LiveTraceModal, { type LiveTraceSpan } from '@/components/LiveTraceModal'
+import MarkdownEditor from '@/components/MarkdownEditor'
 import RunButton from '@/components/RunButton'
 import WorkspaceSelect from '@/components/WorkspaceSelect'
 import { useSelectedWorkspace, withWorkspace, type CatalogItem } from '@/lib/workspace'
 import { type Binding } from '@/lib/bindings'
 import { fmtDuration } from '@/lib/format'
+import { graphPromptIdentifier, resolveGraphPrompt, type GraphPromptItem } from '@/lib/graph-prompt'
 import {
   addCanDispatch,
   availableDispatchTargets,
@@ -142,7 +145,7 @@ const AGENT_NODE_WIDTH = 220
 const AGENT_NODE_HEIGHT = 105
 const REPO_BOUNDARY_PADDING = 52
 const REPO_BOUNDARY_HEADER = 26
-type AgentPanelTab = 'overview' | 'settings' | 'triggers' | 'dispatch' | 'activity'
+type AgentPanelTab = 'overview' | 'settings' | 'prompt' | 'triggers' | 'dispatch' | 'activity'
 type EdgePanelTab = 'overview' | 'history' | 'danger'
 
 const SUPPORTED_EVENTS = [
@@ -421,7 +424,7 @@ export default function GraphPage() {
   const [backendOptions, setBackendOptions] = useState<BackendOption[]>([])
   const [skillOptions, setSkillOptions] = useState<CatalogItem[]>([])
   const [agentNames, setAgentNames] = useState<string[]>([])
-  const [promptOptions, setPromptOptions] = useState<CatalogItem[]>([])
+  const [promptOptions, setPromptOptions] = useState<GraphPromptItem[]>([])
   const [panelMode, setPanelMode] = useState<'details' | 'edge' | 'create' | 'edit' | null>(null)
   const [agentPanelTab, setAgentPanelTab] = useState<AgentPanelTab>('overview')
   const [edgePanelTab, setEdgePanelTab] = useState<EdgePanelTab>('overview')
@@ -430,6 +433,10 @@ export default function GraphPage() {
   const [agentSaveError, setAgentSaveError] = useState('')
   const [agentRuns, setAgentRuns] = useState<RunnerRow[]>([])
   const [agentActivityLoading, setAgentActivityLoading] = useState(false)
+  const [promptDraft, setPromptDraft] = useState('')
+  const [promptSaving, setPromptSaving] = useState(false)
+  const [promptSaveError, setPromptSaveError] = useState('')
+  const [streamSpan, setStreamSpan] = useState<LiveTraceSpan | null>(null)
   const [bindingDraft, setBindingDraft] = useState<BindingDraft>(emptyBindingDraft)
   const [bindingSaving, setBindingSaving] = useState(false)
   const [bindingError, setBindingError] = useState('')
@@ -471,7 +478,7 @@ export default function GraphPage() {
       .catch(() => {})
     fetch('/prompts')
       .then(r => r.ok ? r.json() : [])
-      .then((data: CatalogItem[]) => setPromptOptions(data ?? []))
+      .then((data: GraphPromptItem[]) => setPromptOptions(data ?? []))
       .catch(() => {})
   }, [workspace])
 
@@ -1086,6 +1093,8 @@ export default function GraphPage() {
   }, [])
 
   const selectedNode = selectedNodeName ? agents.find(a => a.name === selectedNodeName) ?? null : null
+  const selectedPrompt = selectedNode ? resolveGraphPrompt(selectedNode, promptOptions, workspace) : null
+  const selectedPromptID = selectedPrompt ? graphPromptIdentifier(selectedPrompt) : ''
   const selectedNodeOutgoing = selectedNode ? outgoingDispatchTargets(selectedNode, relationshipAgents) : []
   const selectedNodeIncoming = selectedNode ? incomingDispatchSources(selectedNode.name, relationshipAgents) : []
   const selectedNodeTargets = selectedNode ? availableDispatchTargets(selectedNode.name, selectedNode.can_dispatch ?? [], relationshipAgents) : []
@@ -1103,6 +1112,33 @@ export default function GraphPage() {
     }
     return Array.from(set).sort()
   }, [repos])
+
+  useEffect(() => {
+    setPromptDraft(selectedPrompt?.content ?? '')
+    setPromptSaveError('')
+  }, [selectedPromptID, selectedPrompt?.content])
+
+  const saveSelectedPrompt = useCallback(async () => {
+    if (!selectedPrompt) return
+    setPromptSaving(true)
+    setPromptSaveError('')
+    try {
+      const res = await fetch(`/prompts/${encodeURIComponent(graphPromptIdentifier(selectedPrompt))}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ description: selectedPrompt.description ?? '', content: promptDraft }),
+      })
+      if (!res.ok) {
+        setPromptSaveError(await res.text() || 'Prompt save failed')
+        return
+      }
+      loadLookups()
+    } catch (e) {
+      setPromptSaveError(String(e))
+    } finally {
+      setPromptSaving(false)
+    }
+  }, [loadLookups, promptDraft, selectedPrompt])
 
   return (
     <div>
@@ -1267,6 +1303,7 @@ export default function GraphPage() {
                 tabs={[
                   { id: 'overview', label: 'Overview' },
                   { id: 'settings', label: 'Settings' },
+                  { id: 'prompt', label: 'Prompt' },
                   { id: 'triggers', label: 'Triggers' },
                   { id: 'dispatch', label: 'Dispatch' },
                   { id: 'activity', label: 'Activity' },
@@ -1320,6 +1357,45 @@ export default function GraphPage() {
                   saving={agentSaving}
                   error={agentSaveError}
                 />
+              )}
+
+              {agentPanelTab === 'prompt' && (
+                <div style={{ display: 'grid', gap: '0.85rem' }}>
+                  {!selectedPrompt ? (
+                    <div style={{ background: 'var(--bg)', border: '1px solid var(--border-danger)', borderRadius: 0, padding: '10px', color: 'var(--text-danger)', fontSize: '0.8rem' }}>
+                      No visible catalog prompt matches this agent&apos;s prompt reference. Open Settings and choose a prompt from the visible catalog before editing content here.
+                    </div>
+                  ) : (
+                    <>
+                      <div style={{ background: 'var(--bg)', border: '1px solid var(--border-subtle)', borderRadius: 0, padding: '10px', display: 'grid', gap: '6px' }}>
+                        <div style={{ display: 'flex', justifyContent: 'space-between', gap: '0.75rem', alignItems: 'center' }}>
+                          <div>
+                            <div style={{ color: 'var(--text)', fontWeight: 700, fontSize: '0.85rem' }}>{selectedPrompt.name}</div>
+                            <div style={{ color: 'var(--text-faint)', fontSize: '0.75rem' }}>
+                              {selectedPrompt.repo ? `${selectedPrompt.workspace_id || 'default'} / ${selectedPrompt.repo}` : selectedPrompt.workspace_id ? `${selectedPrompt.workspace_id} workspace` : 'Global'} · <code>{selectedPromptID}</code>
+                            </div>
+                          </div>
+                          <Link href="/prompts/" style={{ color: 'var(--accent)', fontSize: '0.75rem', textDecoration: 'none' }}>Open catalog →</Link>
+                        </div>
+                        <div style={{ color: 'var(--text-muted)', fontSize: '0.78rem' }}>
+                          Saving updates the shared catalog prompt used by every agent that references it.
+                        </div>
+                      </div>
+                      <div>
+                        <label style={{ display: 'block', fontSize: '0.75rem', fontWeight: 600, color: 'var(--accent)', textTransform: 'uppercase', marginBottom: '0.5rem' }}>Prompt content</label>
+                        <MarkdownEditor value={promptDraft} onChange={setPromptDraft} minHeight={300} />
+                      </div>
+                      {promptSaveError && <p style={{ color: 'var(--text-danger)', fontSize: '0.8rem' }}>{promptSaveError}</p>}
+                      <button
+                        onClick={saveSelectedPrompt}
+                        disabled={promptSaving || !promptDraft.trim() || promptDraft === (selectedPrompt.content ?? '')}
+                        style={{ justifySelf: 'start', padding: '6px 12px', borderRadius: 0, border: '1px solid var(--btn-primary-border)', background: 'var(--btn-primary-bg)', color: '#fff', cursor: promptSaving ? 'wait' : 'pointer', fontSize: '0.8rem', fontWeight: 600, opacity: promptSaving || !promptDraft.trim() || promptDraft === (selectedPrompt.content ?? '') ? 0.65 : 1 }}
+                      >
+                        {promptSaving ? 'Saving...' : 'Save prompt'}
+                      </button>
+                    </>
+                  )}
+                </div>
               )}
 
               {agentPanelTab === 'triggers' && (
@@ -1524,10 +1600,22 @@ export default function GraphPage() {
                           {run.kind || '-'} · {fmtTime(run.started_at ?? run.completed_at)} · {fmtDuration(run.run_duration_ms)}
                         </div>
                         {run.summary && <div style={{ color: 'var(--text-faint)', fontSize: '0.75rem', fontStyle: 'italic' }}>{run.summary}</div>}
-                        {run.event_id && (
-                          <Link href={`/traces/?id=${encodeURIComponent(run.event_id)}`} style={{ color: 'var(--accent)', fontSize: '0.75rem', textDecoration: 'none' }}>
-                            Open trace →
-                          </Link>
+                        {(run.span_id || run.event_id) && (
+                          <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', alignItems: 'center' }}>
+                            {run.span_id && (
+                              <button
+                                onClick={() => setStreamSpan({ id: run.span_id!, agent: run.agent || run.target_agent || selectedNode.name, repo: run.repo, kind: run.kind, rootEventId: run.event_id })}
+                                style={{ background: 'var(--bg-card)', border: '1px solid var(--accent)', color: 'var(--accent)', padding: '3px 10px', borderRadius: 0, cursor: 'pointer', fontSize: '0.75rem' }}
+                              >
+                                Open transcript
+                              </button>
+                            )}
+                            {run.event_id && (
+                              <Link href={`/traces/?id=${encodeURIComponent(run.event_id)}`} style={{ color: 'var(--accent)', fontSize: '0.75rem', textDecoration: 'none' }}>
+                                Open trace →
+                              </Link>
+                            )}
+                          </div>
                         )}
                       </div>
                     ))}
@@ -1635,6 +1723,7 @@ export default function GraphPage() {
             </div>
           </Card>
       )}
+      {streamSpan && <LiveTraceModal span={streamSpan} onClose={() => setStreamSpan(null)} />}
     </div>
   )
 }

--- a/internal/ui/src/app/runners/page.tsx
+++ b/internal/ui/src/app/runners/page.tsx
@@ -3,13 +3,12 @@ import { Suspense, useEffect, useMemo, useRef, useState } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
 import Link from 'next/link'
 import Card from '@/components/Card'
+import LiveTraceModal, { type LiveTraceSpan } from '@/components/LiveTraceModal'
 import Modal from '@/components/Modal'
 import RepoFilter from '@/components/RepoFilter'
 import WorkspaceSelect from '@/components/WorkspaceSelect'
-import { StreamCard, TranscriptFilter, allStreamCardKinds, stepToCardEntries, type PersistedStep, type StreamCardEntry, type StreamCardKind } from '@/components/StreamCard'
 import { fmtDuration } from '@/lib/format'
 import { newRunnerTimeoutTracker, observeRunnerTimeouts } from '@/lib/runner-timeouts'
-import { openAuthenticatedSSE } from '@/lib/sse'
 import { useSelectedWorkspace, withWorkspace } from '@/lib/workspace'
 
 interface RunnerRow {
@@ -91,139 +90,6 @@ export default function RunnersPage() {
   )
 }
 
-function LiveStreamModal({ span, onClose }: { span: { id: string; agent: string; repo: string; kind: string }; onClose: () => void }) {
-  const [entries, setEntries] = useState<StreamCardEntry[]>([])
-  const [status, setStatus] = useState<'connecting' | 'live' | 'ended' | 'error'>('connecting')
-  const [visibleKinds, setVisibleKinds] = useState<Set<StreamCardKind>>(allStreamCardKinds)
-  const scrollRef = useRef<HTMLDivElement>(null)
-  const stuckToBottom = useRef(true)
-  const [hasNewWhileDetached, setHasNewWhileDetached] = useState(false)
-  const visibleEntries = entries.filter(e => visibleKinds.has(e.kind))
-
-  useEffect(() => {
-    const stream = openAuthenticatedSSE(`/traces/${encodeURIComponent(span.id)}/stream`, {
-      onOpen: () => setStatus('live'),
-      onMessage: data => {
-        try {
-          const step = JSON.parse(data) as PersistedStep
-          setEntries(prev => [...prev, ...stepToCardEntries(step, prev.length)])
-        } catch {
-          // Malformed stream rows are ignored; the durable /steps endpoint is
-          // still the source of truth for transcript recovery.
-        }
-      },
-      onEvent: event => {
-        if (event === 'end') setStatus('ended')
-      },
-      onError: () => setStatus('error'),
-    })
-    return () => stream.close()
-  }, [span.id])
-
-  useEffect(() => {
-    const el = scrollRef.current
-    if (!el) return
-    if (stuckToBottom.current) {
-      el.scrollTop = el.scrollHeight
-    } else {
-      setHasNewWhileDetached(true)
-    }
-  }, [visibleEntries.length])
-
-  const onScroll = () => {
-    const el = scrollRef.current
-    if (!el) return
-    const distance = el.scrollHeight - (el.scrollTop + el.clientHeight)
-    const atBottom = distance < 32
-    stuckToBottom.current = atBottom
-    if (atBottom && hasNewWhileDetached) setHasNewWhileDetached(false)
-  }
-
-  const jumpToLatest = () => {
-    const el = scrollRef.current
-    if (!el) return
-    el.scrollTop = el.scrollHeight
-    stuckToBottom.current = true
-    setHasNewWhileDetached(false)
-  }
-
-  return (
-    <div onClick={onClose} style={{
-      position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.6)',
-      display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000,
-    }}>
-      <div onClick={e => e.stopPropagation()} style={{
-        width: 'min(900px, 92vw)', maxHeight: '90vh',
-        background: 'var(--bg-card)', border: '1px solid var(--border)',
-        borderRadius: '8px', display: 'flex', flexDirection: 'column',
-        position: 'relative',
-      }}>
-        <div style={{
-          padding: '0.75rem 1rem',
-          borderBottom: '1px solid var(--border)',
-          display: 'flex', justifyContent: 'space-between', alignItems: 'center',
-        }}>
-          <div>
-            <div style={{ fontSize: '0.95rem', fontWeight: 700, color: 'var(--text-heading)' }}>
-              Live: {span.agent} · {span.repo} · {span.kind}
-            </div>
-            <div style={{ fontSize: '0.75rem', color: 'var(--text-muted)', marginTop: '2px' }}>
-              span <code>{span.id}</code> · {status === 'live' ? '🟢 streaming' : status === 'ended' ? '✓ run completed' : status === 'error' ? '🔴 disconnected' : '⏳ connecting'} · {entries.length} event{entries.length !== 1 ? 's' : ''}
-            </div>
-          </div>
-          <button onClick={onClose} style={{
-            background: 'var(--bg-input)', border: '1px solid var(--border)',
-            color: 'var(--text)', padding: '4px 12px', borderRadius: '4px',
-            cursor: 'pointer', fontSize: '0.85rem',
-          }}>Close</button>
-        </div>
-        <div
-          ref={scrollRef}
-          onScroll={onScroll}
-          style={{ flex: 1, overflowY: 'auto', padding: '0.75rem 1rem', minHeight: 0 }}
-        >
-          {entries.length === 0 && status === 'connecting' && (
-            <p style={{ color: 'var(--text-muted)', fontSize: '0.85rem' }}>Waiting for output...</p>
-          )}
-          {entries.length === 0 && status === 'ended' && (
-            <p style={{ color: 'var(--text-muted)', fontSize: '0.85rem' }}>Run finished without emitting any output that the daemon captured.</p>
-          )}
-          {entries.length === 0 && status === 'error' && (
-            <p style={{ color: 'var(--text-danger)', fontSize: '0.85rem' }}>Lost connection to the live stream. The run may still be in flight; close and reopen to retry.</p>
-          )}
-          {entries.length > 0 && (
-            <TranscriptFilter entries={entries} visibleKinds={visibleKinds} onChange={setVisibleKinds} />
-          )}
-          {visibleEntries.map((e, i) => <StreamCard key={i} entry={e} />)}
-          {entries.length > 0 && visibleEntries.length === 0 && (
-            <p style={{ color: 'var(--text-faint)', fontSize: '0.78rem', fontStyle: 'italic' }}>All cards filtered out. Toggle a chip above to show them.</p>
-          )}
-          {status === 'ended' && entries.length > 0 && (
-            <div style={{ marginTop: '1rem', padding: '0.5rem 0.75rem', background: 'var(--bg-input)', borderRadius: '4px', fontSize: '0.8rem' }}>
-              ✓ Run completed.{' '}
-              <Link href={`/traces/?id=${encodeURIComponent(span.id)}`} style={{ color: 'var(--accent)' }}>
-                View full trace detail →
-              </Link>
-            </div>
-          )}
-        </div>
-        {hasNewWhileDetached && (
-          <button
-            onClick={jumpToLatest}
-            style={{
-              position: 'absolute', bottom: 12, left: '50%', transform: 'translateX(-50%)',
-              background: 'var(--accent)', color: 'var(--bg-card)',
-              border: 'none', borderRadius: '999px',
-              padding: '4px 14px', fontSize: '0.8rem', fontWeight: 600,
-              cursor: 'pointer', boxShadow: '0 4px 12px rgba(0,0,0,0.25)',
-            }}
-          >↓ Latest</button>
-        )}
-      </div>
-    </div>
-  )
-}
-
 function RunnersInner() {
   const params = useSearchParams()
   const router = useRouter()
@@ -245,7 +111,7 @@ function RunnersInner() {
   const [pendingId, setPendingId] = useState<number | null>(null)
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
   const [highlightUntil, setHighlightUntil] = useState<number | null>(null)
-  const [streamSpan, setStreamSpan] = useState<{ id: string; agent: string; repo: string; kind: string } | null>(null)
+  const [streamSpan, setStreamSpan] = useState<LiveTraceSpan | null>(null)
   const [timeoutToast, setTimeoutToast] = useState<RunnerRow | null>(null)
   const [failureToast, setFailureToast] = useState<RunnerRow | null>(null)
   const timeoutTracker = useRef(newRunnerTimeoutTracker())
@@ -539,7 +405,7 @@ function RunnersInner() {
                   <span style={{ display: 'flex', gap: '0.4rem' }} onClick={e => e.stopPropagation()}>
                     {r.status === 'running' && r.span_id && (
                       <button
-                        onClick={() => setStreamSpan({ id: r.span_id!, agent: r.agent || '', repo: r.repo, kind: r.kind })}
+                        onClick={() => setStreamSpan({ id: r.span_id!, agent: r.agent || '', repo: r.repo, kind: r.kind, rootEventId: r.event_id })}
                         title="Watch the agent's live thinking process"
                         style={{
                           background: 'var(--bg-card)',
@@ -655,7 +521,7 @@ function RunnersInner() {
           })}
         </div>
       </Card>
-      {streamSpan && <LiveStreamModal span={streamSpan} onClose={() => setStreamSpan(null)} />}
+      {streamSpan && <LiveTraceModal span={streamSpan} onClose={() => setStreamSpan(null)} />}
       {dialog?.kind === 'confirm-delete' && (
         <Modal title={`Delete runner #${dialog.id}?`} onClose={() => setDialog(null)}>
           <p style={{ color: 'var(--text)', fontSize: '0.85rem', marginBottom: '1rem' }}>

--- a/internal/ui/src/components/LiveTraceModal.tsx
+++ b/internal/ui/src/components/LiveTraceModal.tsx
@@ -1,0 +1,148 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import Link from 'next/link'
+import { StreamCard, TranscriptFilter, allStreamCardKinds, stepToCardEntries, type PersistedStep, type StreamCardEntry, type StreamCardKind } from '@/components/StreamCard'
+import { openAuthenticatedSSE } from '@/lib/sse'
+
+export interface LiveTraceSpan {
+  id: string
+  agent: string
+  repo: string
+  kind: string
+  rootEventId?: string
+}
+
+export default function LiveTraceModal({ span, onClose }: { span: LiveTraceSpan; onClose: () => void }) {
+  const [entries, setEntries] = useState<StreamCardEntry[]>([])
+  const [status, setStatus] = useState<'connecting' | 'live' | 'ended' | 'error'>('connecting')
+  const [visibleKinds, setVisibleKinds] = useState<Set<StreamCardKind>>(allStreamCardKinds)
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const stuckToBottom = useRef(true)
+  const [hasNewWhileDetached, setHasNewWhileDetached] = useState(false)
+  const visibleEntries = entries.filter(e => visibleKinds.has(e.kind))
+  const traceHref = `/traces/?id=${encodeURIComponent(span.rootEventId || span.id)}`
+
+  useEffect(() => {
+    const stream = openAuthenticatedSSE(`/traces/${encodeURIComponent(span.id)}/stream`, {
+      onOpen: () => setStatus('live'),
+      onMessage: data => {
+        try {
+          const step = JSON.parse(data) as PersistedStep
+          setEntries(prev => [...prev, ...stepToCardEntries(step, prev.length)])
+        } catch {
+          // Malformed stream rows are ignored; the durable /steps endpoint is
+          // still the source of truth for transcript recovery.
+        }
+      },
+      onEvent: event => {
+        if (event === 'end') setStatus('ended')
+      },
+      onError: () => setStatus('error'),
+    })
+    return () => stream.close()
+  }, [span.id])
+
+  useEffect(() => {
+    const el = scrollRef.current
+    if (!el) return
+    if (stuckToBottom.current) {
+      el.scrollTop = el.scrollHeight
+    } else {
+      setHasNewWhileDetached(true)
+    }
+  }, [visibleEntries.length])
+
+  const onScroll = () => {
+    const el = scrollRef.current
+    if (!el) return
+    const distance = el.scrollHeight - (el.scrollTop + el.clientHeight)
+    const atBottom = distance < 32
+    stuckToBottom.current = atBottom
+    if (atBottom && hasNewWhileDetached) setHasNewWhileDetached(false)
+  }
+
+  const jumpToLatest = () => {
+    const el = scrollRef.current
+    if (!el) return
+    el.scrollTop = el.scrollHeight
+    stuckToBottom.current = true
+    setHasNewWhileDetached(false)
+  }
+
+  return (
+    <div onClick={onClose} style={{
+      position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.6)',
+      display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000,
+    }}>
+      <div onClick={e => e.stopPropagation()} style={{
+        width: 'min(900px, 92vw)', maxHeight: '90vh',
+        background: 'var(--bg-card)', border: '1px solid var(--border)',
+        borderRadius: '8px', display: 'flex', flexDirection: 'column',
+        position: 'relative',
+      }}>
+        <div style={{
+          padding: '0.75rem 1rem',
+          borderBottom: '1px solid var(--border)',
+          display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+        }}>
+          <div>
+            <div style={{ fontSize: '0.95rem', fontWeight: 700, color: 'var(--text-heading)' }}>
+              Live: {span.agent} · {span.repo} · {span.kind}
+            </div>
+            <div style={{ fontSize: '0.75rem', color: 'var(--text-muted)', marginTop: '2px' }}>
+              span <code>{span.id}</code> · {status === 'live' ? 'streaming' : status === 'ended' ? 'run completed' : status === 'error' ? 'disconnected' : 'connecting'} · {entries.length} event{entries.length !== 1 ? 's' : ''}
+            </div>
+          </div>
+          <button onClick={onClose} style={{
+            background: 'var(--bg-input)', border: '1px solid var(--border)',
+            color: 'var(--text)', padding: '4px 12px', borderRadius: '4px',
+            cursor: 'pointer', fontSize: '0.85rem',
+          }}>Close</button>
+        </div>
+        <div
+          ref={scrollRef}
+          onScroll={onScroll}
+          style={{ flex: 1, overflowY: 'auto', padding: '0.75rem 1rem', minHeight: 0 }}
+        >
+          {entries.length === 0 && status === 'connecting' && (
+            <p style={{ color: 'var(--text-muted)', fontSize: '0.85rem' }}>Waiting for output...</p>
+          )}
+          {entries.length === 0 && status === 'ended' && (
+            <p style={{ color: 'var(--text-muted)', fontSize: '0.85rem' }}>Run finished without emitting any output that the daemon captured.</p>
+          )}
+          {entries.length === 0 && status === 'error' && (
+            <p style={{ color: 'var(--text-danger)', fontSize: '0.85rem' }}>Lost connection to the live stream. The run may still be in flight; close and reopen to retry.</p>
+          )}
+          {entries.length > 0 && (
+            <TranscriptFilter entries={entries} visibleKinds={visibleKinds} onChange={setVisibleKinds} />
+          )}
+          {visibleEntries.map((e, i) => <StreamCard key={i} entry={e} />)}
+          {entries.length > 0 && visibleEntries.length === 0 && (
+            <p style={{ color: 'var(--text-faint)', fontSize: '0.78rem', fontStyle: 'italic' }}>All cards filtered out. Toggle a chip above to show them.</p>
+          )}
+          {status === 'ended' && entries.length > 0 && (
+            <div style={{ marginTop: '1rem', padding: '0.5rem 0.75rem', background: 'var(--bg-input)', borderRadius: '4px', fontSize: '0.8rem' }}>
+              Run completed.{' '}
+              <Link href={traceHref} style={{ color: 'var(--accent)' }}>
+                View full trace detail →
+              </Link>
+            </div>
+          )}
+        </div>
+        {hasNewWhileDetached && (
+          <button
+            onClick={jumpToLatest}
+            style={{
+              position: 'absolute', bottom: 12, left: '50%', transform: 'translateX(-50%)',
+              background: 'var(--accent)', color: 'var(--bg-card)',
+              border: 'none', borderRadius: '999px',
+              padding: '4px 14px', fontSize: '0.8rem', fontWeight: 600,
+              cursor: 'pointer', boxShadow: '0 4px 12px rgba(0,0,0,0.25)',
+            }}
+          >↓ Latest</button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/internal/ui/src/lib/graph-prompt.test.ts
+++ b/internal/ui/src/lib/graph-prompt.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { graphPromptIdentifier, resolveGraphPrompt, type GraphPromptItem } from './graph-prompt'
+
+const prompts: GraphPromptItem[] = [
+  { id: 'global_review', name: 'review', content: 'global' },
+  { id: 'workspace_review', name: 'review', workspace_id: 'default', content: 'workspace' },
+  { id: 'repo_review', name: 'review', workspace_id: 'default', repo: 'owner/repo', content: 'repo' },
+]
+
+describe('resolveGraphPrompt', () => {
+  it('resolves a visible prompt by stable prompt id', () => {
+    const prompt = resolveGraphPrompt({ prompt_id: 'repo_review', scope_type: 'repo', scope_repo: 'owner/repo' }, prompts, 'default')
+
+    expect(prompt?.content).toBe('repo')
+    expect(prompt ? graphPromptIdentifier(prompt) : '').toBe('repo_review')
+  })
+
+  it('rejects repo-scoped prompts outside the agent visible catalog scope', () => {
+    const prompt = resolveGraphPrompt({ prompt_id: 'repo_review', scope_type: 'repo', scope_repo: 'owner/other' }, prompts, 'default')
+
+    expect(prompt).toBeNull()
+  })
+
+  it('resolves legacy prompt ref and scope selectors', () => {
+    const prompt = resolveGraphPrompt({ prompt_ref: 'review', prompt_scope: 'default' }, prompts, 'default')
+
+    expect(prompt?.content).toBe('workspace')
+  })
+})

--- a/internal/ui/src/lib/graph-prompt.ts
+++ b/internal/ui/src/lib/graph-prompt.ts
@@ -1,0 +1,37 @@
+import { catalogScope, catalogValue, defaultWorkspaceID, visibleCatalogItems, type CatalogItem } from '@/lib/workspace'
+
+export interface GraphPromptItem extends CatalogItem {
+  description?: string
+  content?: string
+}
+
+export interface GraphPromptAgent {
+  prompt_id?: string
+  prompt_ref?: string
+  prompt_scope?: string
+  scope_type?: string
+  scope_repo?: string
+}
+
+export function resolveGraphPrompt(agent: GraphPromptAgent, prompts: GraphPromptItem[], workspace: string): GraphPromptItem | null {
+  const repo = agent.scope_type === 'repo' ? (agent.scope_repo ?? '') : ''
+  const visiblePrompts = visibleCatalogItems(prompts, workspace, repo)
+  const promptID = (agent.prompt_id ?? '').trim()
+  if (promptID) {
+    return visiblePrompts.find(prompt => catalogValue(prompt) === promptID) ?? null
+  }
+
+  const promptRef = (agent.prompt_ref ?? '').trim()
+  if (!promptRef) return null
+
+  const promptScope = (agent.prompt_scope ?? '').trim()
+  if (promptScope) {
+    return visiblePrompts.find(prompt => prompt.name === promptRef && catalogScope(prompt) === promptScope) ?? null
+  }
+
+  return visiblePrompts.find(prompt => prompt.name === promptRef && (!prompt.workspace_id || prompt.workspace_id === workspace || prompt.workspace_id === defaultWorkspaceID)) ?? null
+}
+
+export function graphPromptIdentifier(prompt: GraphPromptItem): string {
+  return catalogValue(prompt)
+}


### PR DESCRIPTION
## Summary

- Adds a graph Prompt tab that resolves the selected agent's visible catalog prompt and edits it through the existing prompt PATCH path.
- Reuses the live trace transcript modal as a shared component and opens it from graph activity rows for active or completed spans.
- Updates the dashboard UI docs for graph prompt editing and transcript access.

Closes #600

## Verification

- `npm test`
- `npm run build`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.