### PR TITLE
refactor: simplify bcrypt prefix detection

### DIFF
--- a/internal/store/auth.go
+++ b/internal/store/auth.go
@@ -11,6 +11,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -435,7 +436,9 @@ func pbkdf2SHA256WithIter(password string, salt []byte, iter, keyLen int) ([]byt
 }
 
 func verifyPassword(password, encoded string) (verified bool, needsRehash bool) {
-	if strings.HasPrefix(encoded, "$2a$") || strings.HasPrefix(encoded, "$2b$") || strings.HasPrefix(encoded, "$2y$") {
+	if slices.ContainsFunc([]string{"$2a$", "$2b$", "$2y$"}, func(prefix string) bool {
+		return strings.HasPrefix(encoded, prefix)
+	}) {
 		return bcrypt.CompareHashAndPassword([]byte(encoded), bcryptPasswordInput(password)) == nil, false
 	}
 	algorithm, rest, ok := strings.Cut(encoded, "$")


### PR DESCRIPTION
## Summary

- Replaces the manual bcrypt hash prefix OR-chain with `slices.ContainsFunc` over the supported bcrypt prefixes.
- Keeps the same bcrypt verification path and PBKDF2 fallback behavior.

## Verification

- `go test ./internal/store`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.