### PR TITLE
refactor: simplify backend prefix detection

### DIFF
--- a/internal/ai/cmdrunner.go
+++ b/internal/ai/cmdrunner.go
@@ -352,7 +352,9 @@ func (r *CommandRunner) isCodexBackend() bool  { return r.hasBackendPrefix("code
 func (r *CommandRunner) hasBackendPrefix(prefix string) bool {
 	name := strings.ToLower(strings.TrimSpace(r.backendName))
 	cmd := strings.ToLower(filepath.Base(strings.TrimSpace(r.command)))
-	return strings.HasPrefix(name, prefix) || strings.HasPrefix(cmd, prefix)
+	return slices.ContainsFunc([]string{name, cmd}, func(candidate string) bool {
+		return strings.HasPrefix(candidate, prefix)
+	})
 }
 
 // buildClaudeDelivery builds hardcoded Claude CLI args and delivers system


### PR DESCRIPTION
## Summary

- Replaces the manual backend name or command prefix OR-chain with `slices.ContainsFunc` over the normalized candidates.
- Keeps the same case-insensitive name and command basename matching behavior.

## Verification

- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./internal/ai`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.