### PR TITLE
refactor: simplify local backend reserved-name check

### DIFF
--- a/internal/daemon/fleet/fleet.go
+++ b/internal/daemon/fleet/fleet.go
@@ -915,7 +915,7 @@ func (h *Handler) handleBackendsLocal(w http.ResponseWriter, r *http.Request) {
 	if name == "" {
 		name = backends.ClaudeLocalName
 	}
-	if name == backends.ClaudeName || name == backends.CodexName {
+	if slices.Contains([]string{backends.ClaudeName, backends.CodexName}, name) {
 		http.Error(w, "name is reserved for built-in backends", http.StatusBadRequest)
 		return
 	}


### PR DESCRIPTION
## Summary

- Replaces the manual built-in backend reserved-name OR-chain with `slices.Contains`.
- Keeps the same rejection behavior for `claude` and `codex` local backend names while using the package's existing slices import.

## Verification

- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./internal/daemon/fleet`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.