### PR TITLE
fix: reorganize graph agent overview

### DIFF
--- a/internal/ui/src/app/graph/page.tsx
+++ b/internal/ui/src/app/graph/page.tsx
@@ -1311,19 +1311,8 @@ export default function GraphPage() {
               />
               {agentPanelTab === 'overview' && (
                 <>
-                  <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', alignItems: 'center' }}>
-                    <button
-                      onClick={() => openEditAgent(selectedNode.name)}
-                      style={{ padding: '6px 12px', borderRadius: '6px', border: '1px solid var(--btn-primary-border)', background: 'var(--btn-primary-bg)', color: '#fff', cursor: 'pointer', fontSize: '0.8rem', fontWeight: 600 }}
-                    >
-                      Edit agent
-                    </button>
-                    {selectedNodeRepos.length > 0 && (
-                      <RunButton agent={selectedNode.name} repos={selectedNodeRepos} />
-                    )}
-                  </div>
                   <div>
-                    <div style={{ fontSize: '0.75rem', fontWeight: 600, color: 'var(--accent)', textTransform: 'uppercase', marginBottom: '0.25rem' }}>Options</div>
+                    <div style={{ fontSize: '0.75rem', fontWeight: 600, color: 'var(--accent)', textTransform: 'uppercase', marginBottom: '0.25rem' }}>Status</div>
                     <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
                       <span style={{ background: 'var(--accent-bg)', border: '1px solid var(--btn-primary-border)', borderRadius: '4px', padding: '2px 8px', fontSize: '0.75rem', color: 'var(--accent)' }}>
                         {selectedNode.current_status}
@@ -1343,6 +1332,17 @@ export default function GraphPage() {
                       </div>
                     </div>
                   )}
+                  <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', alignItems: 'center' }}>
+                    <button
+                      onClick={() => openEditAgent(selectedNode.name)}
+                      style={{ padding: '6px 12px', borderRadius: 0, border: '1px solid var(--btn-primary-border)', background: 'var(--btn-primary-bg)', color: '#fff', cursor: 'pointer', fontSize: '0.8rem', fontWeight: 600 }}
+                    >
+                      Edit agent
+                    </button>
+                    {selectedNodeRepos.length > 0 && (
+                      <RunButton agent={selectedNode.name} repos={selectedNodeRepos} />
+                    )}
+                  </div>
                 </>
               )}
 


### PR DESCRIPTION
## Summary

- Moves selected-agent Overview status information to the top and renames the section to `Status`.
- Keeps Skills as its own section after Status.
- Groups `Edit agent` and `Run` together at the bottom of the Overview tab while preserving existing handlers and RunButton behavior.

Closes #611

## Verification

- `git diff --check`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`

Note: UI `npm test` and `npm run build` could not run in this checkout because local dependencies are not installed (`vitest` and `next` are unavailable).