### PR TITLE
refactor: simplify error event type checks

### DIFF
--- a/internal/ai/failures.go
+++ b/internal/ai/failures.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 )
 
@@ -60,9 +61,9 @@ func backendFailureDetailFromJSON(line []byte) string {
 func isErrorEvent(obj map[string]any) bool {
 	typ := strings.ToLower(stringField(obj, "type"))
 	level := strings.ToLower(stringField(obj, "level"))
-	return strings.Contains(typ, "error") ||
-		strings.Contains(typ, "failed") ||
-		level == "error"
+	return slices.ContainsFunc([]string{"error", "failed"}, func(token string) bool {
+		return strings.Contains(typ, token)
+	}) || level == "error"
 }
 
 func stringField(obj map[string]any, key string) string {


### PR DESCRIPTION
## Summary

- Replaces the manual `strings.Contains` OR-chain for backend error event type tokens with `slices.ContainsFunc`.
- Keeps the same `error` and `failed` type matching plus `level == "error"` behavior.

## Verification

- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./internal/ai`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.