### PR TITLE
refactor: use bytes trim for first byte scan

### DIFF
--- a/internal/anthropic_proxy/translate.go
+++ b/internal/anthropic_proxy/translate.go
@@ -316,12 +316,11 @@ func parseContent(raw json.RawMessage) (blocks []ContentBlock, text string, err 
 }
 
 func firstNonSpace(b []byte) byte {
-	for _, c := range b {
-		if c != ' ' && c != '\t' && c != '\n' && c != '\r' {
-			return c
-		}
+	trimmed := bytes.TrimLeft(b, " \t\n\r")
+	if len(trimmed) == 0 {
+		return 0
 	}
-	return 0
+	return trimmed[0]
 }
 
 // toolResultContent extracts the string content from a tool_result block.


### PR DESCRIPTION
## Summary

- Replaces the manual ASCII whitespace scan in `firstNonSpace` with `bytes.TrimLeft` using the same whitespace set.
- Keeps the same zero return for all-whitespace input and the same first-byte result for non-empty JSON payloads.

## Verification

- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./internal/anthropic_proxy`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.