### PR TITLE
refactor: use cutprefix for bearer redaction

### DIFF
--- a/internal/ai/failures.go
+++ b/internal/ai/failures.go
@@ -116,7 +116,7 @@ func redactSecretAssignments(detail string) string {
 		if len(parts) < 3 {
 			return match
 		}
-		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(parts[2])), "bearer ") {
+		if _, ok := strings.CutPrefix(strings.ToLower(strings.TrimSpace(parts[2])), "bearer "); ok {
 			return parts[1] + "=Bearer [REDACTED]"
 		}
 		return parts[1] + "=[REDACTED]"


### PR DESCRIPTION
## Summary

- Replaces the manual case-normalized bearer prefix check in secret assignment redaction with `strings.CutPrefix`.
- Keeps the same trim, lowercase, and redacted output behavior while using the standard helper for this prefix test.

## Verification

- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./internal/ai`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.