### PR TITLE
fix: prevent graph prompt field flicker

### DIFF
--- a/internal/ui/src/app/graph/page.tsx
+++ b/internal/ui/src/app/graph/page.tsx
@@ -426,6 +426,7 @@ export default function GraphPage() {
   const [skillOptions, setSkillOptions] = useState<CatalogItem[]>([])
   const [agentNames, setAgentNames] = useState<string[]>([])
   const [promptOptions, setPromptOptions] = useState<GraphPromptItem[]>([])
+  const [promptOptionsLoaded, setPromptOptionsLoaded] = useState(false)
   const [panelMode, setPanelMode] = useState<'details' | 'edge' | 'create' | null>(null)
   const [agentPanelTab, setAgentPanelTab] = useState<AgentPanelTab>('overview')
   const [edgePanelTab, setEdgePanelTab] = useState<EdgePanelTab>('overview')
@@ -479,8 +480,11 @@ export default function GraphPage() {
       .catch(() => {})
     fetch('/prompts')
       .then(r => r.ok ? r.json() : [])
-      .then((data: GraphPromptItem[]) => setPromptOptions(data ?? []))
-      .catch(() => {})
+      .then((data: GraphPromptItem[]) => {
+        setPromptOptions(data ?? [])
+        setPromptOptionsLoaded(true)
+      })
+      .catch(() => setPromptOptionsLoaded(true))
   }, [workspace])
 
   const load = useCallback(() => {
@@ -818,7 +822,7 @@ export default function GraphPage() {
       .then(full => setAgentForm({ ...emptyAgentForm, ...full, allow_memory: full.allow_memory ?? true }))
       .catch(() => {})
     loadLookups()
-  }, [agentPanelTab, agents, fetchStoreAgent, loadLookups, panelMode, selectedNodeName])
+  }, [agentPanelTab, fetchStoreAgent, loadLookups, panelMode, selectedNodeName])
 
   const postStoreAgent = useCallback(async (a: StoreAgent): Promise<void> => {
     const res = await fetch(withWorkspace('/agents', workspace), {
@@ -1180,6 +1184,7 @@ export default function GraphPage() {
               skillOptions={skillOptions}
               agentNames={agentNames}
               promptOptions={promptOptions}
+              promptOptionsLoaded={promptOptionsLoaded}
               repoNames={repos.map(r => r.name)}
               onSave={saveAgent}
               onCancel={closePanel}
@@ -1323,6 +1328,7 @@ export default function GraphPage() {
                   skillOptions={skillOptions}
                   agentNames={agentNames}
                   promptOptions={promptOptions}
+                  promptOptionsLoaded={promptOptionsLoaded}
                   repoNames={repos.map(r => r.name)}
                   onSave={saveAgent}
                   onCancel={() => setAgentPanelTab('overview')}

--- a/internal/ui/src/components/AgentForm.test.tsx
+++ b/internal/ui/src/components/AgentForm.test.tsx
@@ -11,7 +11,72 @@ const baseAgent = {
 }
 
 describe('<AgentForm />', () => {
-  it('clears prompt_ref when it is no longer visible in the prompt catalog', async () => {
+  it('does not show a missing prompt error before prompt lookups load', () => {
+    render(
+      <AgentForm
+        initial={baseAgent}
+        isNew
+        workspace="default"
+        backends={[{ name: 'claude', detected: true }]}
+        skillOptions={[]}
+        agentNames={[]}
+        promptOptions={[]}
+        promptOptionsLoaded={false}
+        repoNames={[]}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+        saving={false}
+        error=""
+      />,
+    )
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(screen.getByDisplayValue('missing')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+  })
+
+  it('keeps the selected prompt while lookups are loading', () => {
+    const { rerender } = render(
+      <AgentForm
+        initial={baseAgent}
+        isNew
+        workspace="default"
+        backends={[{ name: 'claude', detected: true }]}
+        skillOptions={[]}
+        agentNames={[]}
+        promptOptions={[]}
+        promptOptionsLoaded={false}
+        repoNames={[]}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+        saving={false}
+        error=""
+      />,
+    )
+
+    rerender(
+      <AgentForm
+        initial={baseAgent}
+        isNew
+        workspace="default"
+        backends={[{ name: 'claude', detected: true }]}
+        skillOptions={[]}
+        agentNames={[]}
+        promptOptions={[{ name: 'missing' }]}
+        promptOptionsLoaded
+        repoNames={[]}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+        saving={false}
+        error=""
+      />,
+    )
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled()
+  })
+
+  it('keeps a missing prompt selected after prompt lookups load', async () => {
     render(
       <AgentForm
         initial={baseAgent}
@@ -30,8 +95,32 @@ describe('<AgentForm />', () => {
     )
 
     await waitFor(() => {
-      expect(screen.getByDisplayValue('Select prompt...')).toBeInTheDocument()
+      expect(screen.getByDisplayValue('missing (not visible)')).toBeInTheDocument()
     })
+    expect(screen.getByRole('alert')).toHaveTextContent('Selected prompt is no longer in the catalog.')
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+  })
+
+  it('shows a missing prompt error after prompt lookups load', () => {
+    render(
+      <AgentForm
+        initial={baseAgent}
+        isNew
+        workspace="default"
+        backends={[{ name: 'claude', detected: true }]}
+        skillOptions={[]}
+        agentNames={[]}
+        promptOptions={[{ name: 'approved' }]}
+        promptOptionsLoaded
+        repoNames={[]}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+        saving={false}
+        error=""
+      />,
+    )
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Selected prompt is no longer in the catalog.')
     expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
   })
 

--- a/internal/ui/src/components/AgentForm.tsx
+++ b/internal/ui/src/components/AgentForm.tsx
@@ -30,6 +30,7 @@ export const emptyAgentForm: StoreAgent = {
 
 export default function AgentForm({
   initial, isNew, workspace, backends, skillOptions, agentNames, promptOptions, repoNames, onSave, onCancel, saving, error,
+  promptOptionsLoaded = true,
 }: {
   initial: StoreAgent
   isNew: boolean
@@ -38,6 +39,7 @@ export default function AgentForm({
   skillOptions: CatalogItem[]
   agentNames: string[]
   promptOptions: PromptOption[]
+  promptOptionsLoaded?: boolean
   repoNames: string[]
   onSave: (a: StoreAgent) => void
   onCancel: () => void
@@ -66,12 +68,12 @@ export default function AgentForm({
   const visibleSkills = visibleCatalogItems(skillOptions, workspace, catalogRepo)
   const promptValues = visiblePrompts.map(catalogValue)
   const skillValues = visibleSkills.map(catalogValue)
-  const promptScopeKeys = visiblePrompts.map(p => `${catalogValue(p)}:${p.name}:${catalogScope(p)}`).join('|')
   const selectedPromptByRef = visiblePrompts.find(p => p.name === form.prompt_ref && catalogScope(p) === form.prompt_scope)
   const selectedPrompt = (form.prompt_id || (selectedPromptByRef ? catalogValue(selectedPromptByRef) : form.prompt_ref)).trim()
-  const promptRefMissing = selectedPrompt !== '' && !promptValues.includes(selectedPrompt)
+  const promptRefHidden = selectedPrompt !== '' && !promptValues.includes(selectedPrompt)
+  const promptRefMissing = promptOptionsLoaded && promptRefHidden
   const canSave = !saving && form.name.trim() !== '' && form.backend.trim() !== '' && form.description.trim() !== '' &&
-    selectedPrompt !== '' && !promptRefMissing && (form.scope_type !== 'repo' || scopeRepo !== '')
+    selectedPrompt !== '' && promptOptionsLoaded && !promptRefMissing && (form.scope_type !== 'repo' || scopeRepo !== '')
 
   const setPrompt = (value: string) => {
     const prompt = visiblePrompts.find(p => catalogValue(p) === value)
@@ -85,20 +87,14 @@ export default function AgentForm({
 
   useEffect(() => {
     setForm(f => {
-      const selectedByRef = visiblePrompts.find(p => p.name === f.prompt_ref && catalogScope(p) === f.prompt_scope)
-      const selected = (f.prompt_id || (selectedByRef ? catalogValue(selectedByRef) : f.prompt_ref)).trim()
       const nextSkills = f.skills.filter(s => skillValues.includes(s))
-      const promptVisible = selected === '' || promptValues.includes(selected)
-      if (promptVisible && nextSkills.length === f.skills.length) return f
+      if (nextSkills.length === f.skills.length) return f
       return {
         ...f,
         skills: nextSkills,
-        prompt_id: promptVisible ? f.prompt_id : '',
-        prompt_ref: promptVisible ? f.prompt_ref : '',
-        prompt_scope: promptVisible ? f.prompt_scope : '',
       }
     })
-  }, [workspace, catalogRepo, promptScopeKeys, promptValues.join('|'), skillValues.join('|')])
+  }, [skillValues.join('|')])
 
   useEffect(() => {
     if (!form.model) return
@@ -145,7 +141,7 @@ export default function AgentForm({
         <label style={labelStyle}>Prompt *</label>
         <select style={inputStyle} value={selectedPrompt} onChange={e => setPrompt(e.target.value)}>
           <option value="">Select prompt...</option>
-          {promptRefMissing && <option value={selectedPrompt}>{selectedPrompt} (not visible)</option>}
+          {promptRefHidden && <option value={selectedPrompt}>{selectedPrompt}{promptRefMissing ? ' (not visible)' : ''}</option>}
           {visiblePrompts.map(prompt => <option key={catalogValue(prompt)} value={catalogValue(prompt)}>{catalogLabel(prompt)}</option>)}
         </select>
         {promptRefMissing && (


### PR DESCRIPTION
## Summary

- Track prompt catalog lookup readiness in the graph page and pass it into `AgentForm`.
- Keep selected prompt refs visible while lookups are pending, then show the missing-prompt error only after lookups have completed.
- Stop the graph settings form from reseeding on periodic `agents` refreshes while the selected agent/settings tab is unchanged.

Closes #618

## Verification

- `npm test -- AgentForm.test.tsx`
- `npm test`
- `npm run build`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go vet ./...`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./... -count=1`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./... -race -count=1`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.