### PR TITLE
feat: add persistent sidebar focus mode

### DIFF
--- a/internal/ui/src/app/graph/page.tsx
+++ b/internal/ui/src/app/graph/page.tsx
@@ -32,6 +32,7 @@ import { useSelectedWorkspace, withWorkspace, type CatalogItem } from '@/lib/wor
 import { type Binding } from '@/lib/bindings'
 import { fmtDuration } from '@/lib/format'
 import { graphPromptIdentifier, resolveGraphPrompt, type GraphPromptItem } from '@/lib/graph-prompt'
+import { SIDEBAR_COLLAPSE_EVENT } from '@/lib/shell-events'
 import {
   addCanDispatch,
   availableDispatchTargets,
@@ -1141,7 +1142,7 @@ export default function GraphPage() {
   }, [loadLookups, promptDraft, selectedPrompt])
 
   const enterFocusMode = useCallback(() => {
-    window.dispatchEvent(new Event('agents:shell-collapse-sidebar'))
+    window.dispatchEvent(new Event(SIDEBAR_COLLAPSE_EVENT))
   }, [])
 
   return (

--- a/internal/ui/src/app/graph/page.tsx
+++ b/internal/ui/src/app/graph/page.tsx
@@ -1140,6 +1140,10 @@ export default function GraphPage() {
     }
   }, [loadLookups, promptDraft, selectedPrompt])
 
+  const enterFocusMode = useCallback(() => {
+    window.dispatchEvent(new Event('agents:shell-collapse-sidebar'))
+  }, [])
+
   return (
     <div>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1.5rem' }}>
@@ -1152,6 +1156,9 @@ export default function GraphPage() {
         <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
           <WorkspaceSelect compact />
           <RepoFilter selected={repoFilter} onChange={setRepoFilter} workspace={workspace} />
+          <button onClick={enterFocusMode} style={{ background: 'var(--bg-card)', border: '1px solid var(--border)', color: 'var(--accent)', padding: '6px 12px', borderRadius: '6px', cursor: 'pointer', fontSize: '0.875rem', fontWeight: 500 }}>
+            Focus
+          </button>
           <button onClick={openCreateAgent} style={{ background: 'var(--btn-primary-bg)', border: '1px solid var(--btn-primary-border)', color: '#fff', padding: '6px 12px', borderRadius: '6px', cursor: 'pointer', fontSize: '0.875rem', fontWeight: 600 }}>
             + Create agent
           </button>

--- a/internal/ui/src/components/DashboardShell.test.tsx
+++ b/internal/ui/src/components/DashboardShell.test.tsx
@@ -1,5 +1,6 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { SIDEBAR_COLLAPSE_EVENT } from '@/lib/shell-events'
 import DashboardShell from './DashboardShell'
 
 vi.mock('next/navigation', () => ({
@@ -65,9 +66,22 @@ describe('<DashboardShell />', () => {
     mockViewport(false)
     const { container } = render(<DashboardShell><div>Content</div></DashboardShell>)
 
-    fireEvent(window, new Event('agents:shell-collapse-sidebar'))
+    fireEvent(window, new Event(SIDEBAR_COLLAPSE_EVENT))
 
     expect(container.querySelector('.dashboard-shell.nav-collapsed')).toBeInTheDocument()
+    expect(window.localStorage.getItem('agents.sidebarCollapsed')).toBe('true')
+  })
+
+  it('restores collapsed desktop navigation after reload', async () => {
+    window.localStorage.setItem('agents.sidebarCollapsed', 'true')
+    mockShellFetch()
+    mockViewport(false)
+    const { container } = render(<DashboardShell><div>Content</div></DashboardShell>)
+
+    await waitFor(() => {
+      expect(container.querySelector('.dashboard-shell.nav-collapsed')).toBeInTheDocument()
+    })
+    expect(screen.getByTitle('Open navigation')).toBeInTheDocument()
     expect(window.localStorage.getItem('agents.sidebarCollapsed')).toBe('true')
   })
 

--- a/internal/ui/src/components/DashboardShell.test.tsx
+++ b/internal/ui/src/components/DashboardShell.test.tsx
@@ -24,23 +24,60 @@ function mockShellFetch() {
   }))
 }
 
+function mockViewport(matches: boolean) {
+  vi.stubGlobal('matchMedia', vi.fn(() => ({
+    matches,
+    media: '(max-width: 860px)',
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })))
+}
+
 describe('<DashboardShell />', () => {
   afterEach(() => {
+    window.localStorage.clear()
     vi.unstubAllGlobals()
   })
 
   it('renders the collapsed navigation toggle as an accessible hamburger icon', () => {
     mockShellFetch()
+    mockViewport(false)
     const { container } = render(<DashboardShell><div>Content</div></DashboardShell>)
 
-    const button = screen.getByTitle('Open navigation')
-    expect(button).toHaveAttribute('aria-label', 'Open navigation')
-    expect(button).toHaveAttribute('title', 'Open navigation')
+    const button = screen.getByTitle('Collapse navigation')
+    expect(button).toHaveAttribute('aria-label', 'Collapse navigation')
+    expect(button).toHaveAttribute('title', 'Collapse navigation')
     expect(button).not.toHaveTextContent('Menu')
     expect(button.querySelector('.shell-menu-icon')).toHaveAttribute('aria-hidden', 'true')
     expect(button.querySelectorAll('.shell-menu-icon span')).toHaveLength(3)
 
     fireEvent.click(button)
+    expect(container.querySelector('.dashboard-shell.nav-collapsed')).toBeInTheDocument()
+    expect(button).toHaveAttribute('aria-label', 'Open navigation')
+  })
+
+  it('persists desktop navigation collapse and responds to graph focus events', () => {
+    mockShellFetch()
+    mockViewport(false)
+    const { container } = render(<DashboardShell><div>Content</div></DashboardShell>)
+
+    fireEvent(window, new Event('agents:shell-collapse-sidebar'))
+
+    expect(container.querySelector('.dashboard-shell.nav-collapsed')).toBeInTheDocument()
+    expect(window.localStorage.getItem('agents.sidebarCollapsed')).toBe('true')
+  })
+
+  it('keeps the hamburger opening mobile navigation', () => {
+    mockShellFetch()
+    mockViewport(true)
+    const { container } = render(<DashboardShell><div>Content</div></DashboardShell>)
+
+    fireEvent.click(screen.getByTitle('Open navigation'))
+
     expect(container.querySelector('.shell-sidebar.open')).toBeInTheDocument()
   })
 })

--- a/internal/ui/src/components/DashboardShell.tsx
+++ b/internal/ui/src/components/DashboardShell.tsx
@@ -2,10 +2,10 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useEffect, useState } from 'react'
+import { SIDEBAR_COLLAPSE_EVENT } from '@/lib/shell-events'
 import { useTheme } from '@/lib/theme'
 
 const SIDEBAR_COLLAPSED_KEY = 'agents.sidebarCollapsed'
-const SIDEBAR_COLLAPSE_EVENT = 'agents:shell-collapse-sidebar'
 
 const links = [
   { href: '/graph/', label: 'Graph', group: 'Design' },
@@ -28,10 +28,8 @@ export default function DashboardShell({ children }: { children: React.ReactNode
   const pathname = usePathname()
   const { theme, toggle } = useTheme()
   const [sidebarOpen, setSidebarOpen] = useState(false)
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
-    if (typeof window === 'undefined') return false
-    return window.localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === 'true'
-  })
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
+  const [sidebarPreferenceLoaded, setSidebarPreferenceLoaded] = useState(false)
   const [mobileViewport, setMobileViewport] = useState(false)
   const [orphanCount, setOrphanCount] = useState(0)
   const [budgetAlertCount, setBudgetAlertCount] = useState(0)
@@ -54,8 +52,14 @@ export default function DashboardShell({ children }: { children: React.ReactNode
   }, [])
 
   useEffect(() => {
+    setSidebarCollapsed(window.localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === 'true')
+    setSidebarPreferenceLoaded(true)
+  }, [])
+
+  useEffect(() => {
+    if (!sidebarPreferenceLoaded) return
     window.localStorage.setItem(SIDEBAR_COLLAPSED_KEY, String(sidebarCollapsed))
-  }, [sidebarCollapsed])
+  }, [sidebarCollapsed, sidebarPreferenceLoaded])
 
   useEffect(() => {
     const collapse = () => {

--- a/internal/ui/src/components/DashboardShell.tsx
+++ b/internal/ui/src/components/DashboardShell.tsx
@@ -4,6 +4,9 @@ import { usePathname } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import { useTheme } from '@/lib/theme'
 
+const SIDEBAR_COLLAPSED_KEY = 'agents.sidebarCollapsed'
+const SIDEBAR_COLLAPSE_EVENT = 'agents:shell-collapse-sidebar'
+
 const links = [
   { href: '/graph/', label: 'Graph', group: 'Design' },
   { href: '/', label: 'Fleet', group: 'Design' },
@@ -25,6 +28,11 @@ export default function DashboardShell({ children }: { children: React.ReactNode
   const pathname = usePathname()
   const { theme, toggle } = useTheme()
   const [sidebarOpen, setSidebarOpen] = useState(false)
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
+    if (typeof window === 'undefined') return false
+    return window.localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === 'true'
+  })
+  const [mobileViewport, setMobileViewport] = useState(false)
   const [orphanCount, setOrphanCount] = useState(0)
   const [budgetAlertCount, setBudgetAlertCount] = useState(0)
 
@@ -36,6 +44,27 @@ export default function DashboardShell({ children }: { children: React.ReactNode
   useEffect(() => {
     setSidebarOpen(false)
   }, [pathname])
+
+  useEffect(() => {
+    const media = window.matchMedia('(max-width: 860px)')
+    const sync = () => setMobileViewport(media.matches)
+    sync()
+    media.addEventListener('change', sync)
+    return () => media.removeEventListener('change', sync)
+  }, [])
+
+  useEffect(() => {
+    window.localStorage.setItem(SIDEBAR_COLLAPSED_KEY, String(sidebarCollapsed))
+  }, [sidebarCollapsed])
+
+  useEffect(() => {
+    const collapse = () => {
+      setSidebarCollapsed(true)
+      setSidebarOpen(false)
+    }
+    window.addEventListener(SIDEBAR_COLLAPSE_EVENT, collapse)
+    return () => window.removeEventListener(SIDEBAR_COLLAPSE_EVENT, collapse)
+  }, [])
 
   useEffect(() => {
     let cancelled = false
@@ -82,9 +111,10 @@ export default function DashboardShell({ children }: { children: React.ReactNode
     acc[link.group].push(link)
     return acc
   }, {})
+  const navToggleLabel = sidebarCollapsed || mobileViewport ? 'Open navigation' : 'Collapse navigation'
 
   return (
-    <div className="dashboard-shell">
+    <div className={`dashboard-shell ${sidebarCollapsed ? 'nav-collapsed' : ''}`}>
       <style jsx global>{`
         .dashboard-shell { min-height: 100vh; }
         .shell-sidebar {
@@ -101,6 +131,8 @@ export default function DashboardShell({ children }: { children: React.ReactNode
           box-shadow: 10px 0 28px rgba(15,23,42,0.08);
         }
         .shell-main { margin-left: 244px; min-height: 100vh; }
+        .dashboard-shell.nav-collapsed .shell-sidebar { transform: translateX(-102%); visibility: hidden; }
+        .dashboard-shell.nav-collapsed .shell-main { margin-left: 0; }
         .shell-topbar {
           min-height: 50px;
           display: flex;
@@ -115,7 +147,7 @@ export default function DashboardShell({ children }: { children: React.ReactNode
           z-index: 500;
         }
         .shell-content { padding: 1.25rem; max-width: 1480px; margin: 0 auto; }
-        .shell-menu-button { display: none; }
+        .shell-menu-button { display: inline-flex; }
         .shell-menu-icon {
           display: grid;
           gap: 4px;
@@ -131,8 +163,8 @@ export default function DashboardShell({ children }: { children: React.ReactNode
         @media (max-width: 860px) {
           .shell-sidebar { transform: translateX(-102%); transition: transform 160ms ease; }
           .shell-sidebar.open { transform: translateX(0); }
+          .dashboard-shell.nav-collapsed .shell-sidebar.open { transform: translateX(0); visibility: visible; }
           .shell-main { margin-left: 0; }
-          .shell-menu-button { display: inline-flex; }
           .shell-overlay.open {
             display: block;
             position: fixed;
@@ -195,9 +227,18 @@ export default function DashboardShell({ children }: { children: React.ReactNode
         <header className="shell-topbar">
           <button
             className="shell-menu-button"
-            onClick={() => setSidebarOpen(true)}
-            aria-label="Open navigation"
-            title="Open navigation"
+            onClick={() => {
+              if (sidebarCollapsed) {
+                setSidebarCollapsed(false)
+                if (mobileViewport) setSidebarOpen(true)
+              } else if (mobileViewport) {
+                setSidebarOpen(true)
+              } else {
+                setSidebarCollapsed(true)
+              }
+            }}
+            aria-label={navToggleLabel}
+            title={navToggleLabel}
             style={{ background: 'var(--bg-card)', border: '1px solid var(--border)', color: 'var(--text)', borderRadius: 0, padding: '5px 9px', cursor: 'pointer' }}
           >
             <span className="shell-menu-icon" aria-hidden="true">

--- a/internal/ui/src/lib/shell-events.ts
+++ b/internal/ui/src/lib/shell-events.ts
@@ -1,0 +1,3 @@
+'use client'
+
+export const SIDEBAR_COLLAPSE_EVENT = 'agents:shell-collapse-sidebar'


### PR DESCRIPTION
## Summary

- Adds a persistent desktop sidebar collapse state in the dashboard shell, stored in `localStorage`.
- Keeps the hamburger control visible so users can collapse or reopen navigation, while preserving mobile menu behavior.
- Adds a graph toolbar `Focus` action that collapses the global sidebar so the graph/editor surface gains horizontal space.
- Restores the saved collapse preference after mount to avoid static-export hydration mismatch, and shares the shell-collapse event name between the shell and graph page.

Closes #616

## Verification

- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `git diff --check`
- `npm test -- DashboardShell.test.tsx` (blocked: fresh checkout has no installed Node dependencies; `vitest` not found)
- `npm ci --offline` (blocked: npm cache is incomplete for `zwitch-2.0.4.tgz`; no network install attempted under run guardrails)
- `npm run build` (not run because Node dependencies are unavailable in this checkout)

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.