### PR TITLE
refactor: use cutsuffix for migration filtering

### DIFF
--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -35,7 +35,7 @@ func migrate(db *sql.DB) error {
 
 	for _, entry := range entries {
 		name := entry.Name()
-		if !strings.HasSuffix(name, ".sql") {
+		if _, ok := strings.CutSuffix(name, ".sql"); !ok {
 			continue
 		}
 


### PR DESCRIPTION
## Summary

- Replaces the manual `.sql` suffix check in store migration loading with `strings.CutSuffix`.
- Keeps the same migration filtering behavior while using the standard helper for suffix tests.

## Verification

- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./internal/store`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.