### PR TITLE
refactor: use cutsuffix for memory watcher paths

### DIFF
--- a/internal/observe/watch.go
+++ b/internal/observe/watch.go
@@ -100,7 +100,7 @@ func buildMemoryChangeEvent(rel string) MemoryChangeEvent {
 	agent, repoPath, ok := strings.Cut(rel, string(filepath.Separator))
 	if ok {
 		ev.Agent = agent
-		ev.Repo = strings.TrimSuffix(repoPath, ".md")
+		ev.Repo, _ = strings.CutSuffix(repoPath, ".md")
 	}
 	return ev
 }


### PR DESCRIPTION
## Summary

- Replaces the manual `.md` suffix trim in memory watcher event construction with `strings.CutSuffix`.
- Keeps the same repo name derivation while using the standard helper for suffix tests.

## Verification

- `go test ./internal/observe`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.