### PR TITLE
refactor: simplify allow-memory error fragment check

### DIFF
--- a/internal/config/allow_memory_test.go
+++ b/internal/config/allow_memory_test.go
@@ -1,9 +1,11 @@
 package config
 
 import (
-	"github.com/eloylp/agents/internal/fleet"
+	"slices"
 	"strings"
 	"testing"
+
+	"github.com/eloylp/agents/internal/fleet"
 )
 
 // TestAgentIsAllowMemoryDefaultsTrue confirms that an fleet.Agent with no
@@ -116,7 +118,9 @@ func TestLoadAllowMemoryRejectsNonBoolean(t *testing.T) {
 	path := writeConfig(t, yaml)
 	if _, err := Load(path); err == nil {
 		t.Fatal("expected YAML parse error for non-boolean allow_memory, got nil")
-	} else if !strings.Contains(err.Error(), "parse") && !strings.Contains(err.Error(), "bool") && !strings.Contains(err.Error(), "yaml") {
+	} else if !slices.ContainsFunc([]string{"parse", "bool", "yaml"}, func(fragment string) bool {
+		return strings.Contains(err.Error(), fragment)
+	}) {
 		t.Logf("error message: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- Replaces the manual allow-memory parse error substring OR-chain with `slices.ContainsFunc` over the accepted fragments.
- Keeps the same test behavior while making the set of acceptable fragments explicit.

## Verification

- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./internal/config`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `git diff --check`