### PR TITLE
refactor: reuse agent reference list helper

### DIFF
--- a/internal/store/agents.go
+++ b/internal/store/agents.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strings"
 
 	"github.com/eloylp/agents/internal/config"
 	"github.com/eloylp/agents/internal/fleet"
@@ -324,10 +323,7 @@ func DeleteWorkspaceAgentTx(tx *sql.Tx, workspaceID, name string, cascade bool) 
 		// constraint fire. Callers can show the referenced repos and
 		// offer a cascade without parsing SQLite error strings.
 		distinct := slices.Compact(slices.Sorted(slices.Values(refs)))
-		list := strings.Join(distinct, ", ")
-		if len(distinct) > 8 {
-			list = strings.Join(distinct[:8], ", ") + fmt.Sprintf(", and %d more", len(distinct)-8)
-		}
+		list := formatReferenceList(refs)
 		return &ErrConflict{Msg: fmt.Sprintf("store: delete agent %s: still referenced by %d binding(s) across %d repo(s) (%s); use cascade to remove them", name, len(refs), len(distinct), list)}
 	}
 	res, err := tx.Exec("DELETE FROM agents WHERE workspace_id=? AND name=?", workspaceID, name)


### PR DESCRIPTION
## Summary

- Replaces the hand-built agent binding reference list with the existing store reference-list formatter.
- Keeps the same sorted, compacted display and distinct repo count while removing duplicate formatting logic.

## Verification

- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./internal/store`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.