### PR TITLE
refactor: remove loop capture workaround

### DIFF
--- a/internal/fleet/prompt_resolution_test.go
+++ b/internal/fleet/prompt_resolution_test.go
@@ -72,7 +72,6 @@ func TestResolvePromptForAgentRejectsUnresolvablePromptRefs(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
## Summary

- Removes the obsolete `tc := tc` loop-capture workaround from the fleet prompt resolution table test.
- Relies on the module's Go 1.25 range-variable semantics while keeping the same parallel subtest behavior.

## Verification

- `go test ./internal/fleet`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.