### PR TITLE
refactor: compare observe test bytes directly

### DIFF
--- a/internal/observe/observe_test.go
+++ b/internal/observe/observe_test.go
@@ -309,7 +309,7 @@ func TestExtractSSEData(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got := extractSSEData(tc.in)
-			if string(got) != string(tc.want) {
+			if !bytes.Equal(got, tc.want) {
 				t.Errorf("extractSSEData(%q) = %q, want %q", tc.in, got, tc.want)
 			}
 		})


### PR DESCRIPTION
## Summary

- Replaces the `string` conversions in the `extractSSEData` byte-slice assertion with `bytes.Equal`.
- Keeps the same table test behavior and failure output while avoiding unnecessary byte-to-string conversions.

## Verification

- `go test ./internal/observe`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.