### PR TITLE
docs: align documentation with current runtime model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Repo-specific guidance for any coding agent (Claude Code, Codex, Cursor, Aider, 
 
 ## What this repo is
 
-**agents** is a self-hosted Go daemon that dispatches AI CLIs (Claude Code, Codex, or any CLI pointed at a local LLM via the built-in proxy) to work on GitHub repos. Agents are declared in YAML, bound to repos via **labels**, **GitHub event subscriptions**, or **cron schedules**, and execute inside fresh ephemeral runner containers, which in turn use GitHub MCP tools first and `gh` fallback for complex local checkout/test/PR loops. The daemon itself is strictly read-only against GitHub.
+**agents** is a self-hosted Go daemon that dispatches AI CLIs (Claude Code, Codex, or any CLI pointed at a local LLM via the built-in proxy) to work on GitHub repos. The fleet lives in SQLite and is managed through the dashboard, REST, MCP, or YAML import/export. Agents are bound to repos via **labels**, **GitHub event subscriptions**, or **cron schedules**, and execute inside fresh ephemeral runner containers, which in turn use GitHub MCP tools first and `gh` fallback for complex local checkout/test/PR loops. The daemon itself is strictly read-only against GitHub.
 
 Agents can also invoke each other at runtime via the **reactive inter-agent dispatcher**: an agent returns `dispatch: [{agent, number, reason}]` in its response JSON, the daemon validates against per-agent whitelists and safety limits, then enqueues a synthetic `agent.dispatch` event that runs the target agent.
 
@@ -27,7 +27,7 @@ The supported runtime is Docker Compose, there is no local-binary workflow. On-d
 ## Code map (current)
 
 ```
-cmd/agents/main.go              # daemon entrypoint + --db / --import flags
+cmd/agents/main.go              # daemon entrypoint + --db / legacy --import flags
 internal/
   fleet/                        # domain entities: Workspace, Agent, Prompt, Skill, Guardrail, Repo, Backend, Binding (zero deps)
   config/                       # YAML parsing, defaults, validation (uses fleet)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,15 +2,15 @@
 
 ## Project Overview
 
-**agents** is a self-hosted Go daemon that dispatches AI CLIs (Claude, Codex) to work on GitHub repos. Agents are configured declaratively in YAML and bound to repos via labels, GitHub event subscriptions (event-driven), and/or cron schedules (autonomous). GitHub operations happen through the AI backend inside a fresh runner container: GitHub MCP tools are preferred, with `gh` available as fallback for complex local checkout/test/PR loops. The daemon itself is read-only against GitHub. The daemon also ships a built-in Anthropic↔OpenAI translation proxy so the `claude` CLI can be routed through any OpenAI-compatible backend (local `llama.cpp`, hosted Qwen, vLLM, etc.), see [`docs/local-models.md`](docs/local-models.md). Agents can additionally invoke each other at runtime via the reactive inter-agent dispatcher (see Architecture Notes).
+**agents** is a self-hosted Go daemon that dispatches AI CLIs (Claude, Codex) to work on GitHub repos. The fleet lives in SQLite and is managed through the dashboard, REST, MCP, or YAML import/export; YAML is a portable strategy format, not the only configuration path. Agents are bound to repos via labels, GitHub event subscriptions (event-driven), and/or cron schedules (autonomous). GitHub operations happen through the AI backend inside a fresh runner container: GitHub MCP tools are preferred, with `gh` available as fallback for complex local checkout/test/PR loops. The daemon itself is read-only against GitHub. The daemon also ships a built-in Anthropic↔OpenAI translation proxy so the `claude` CLI can be routed through any OpenAI-compatible backend (local `llama.cpp`, hosted Qwen, vLLM, etc.), see [`docs/local-models.md`](docs/local-models.md). Agents can additionally invoke each other at runtime via the reactive inter-agent dispatcher (see Architecture Notes).
 
 ## Directory Structure
 
 ```
-cmd/agents/main.go          # Daemon entry point + --db / --import flags
+cmd/agents/main.go          # Daemon entry point + --db / legacy --import flags
 internal/
   fleet/                    # Domain entities: Workspace, Agent, Prompt, Skill, Guardrail, Repo, Backend, Binding (zero deps)
-  config/                   # YAML parsing, prompt/skill file resolution, validation (uses fleet)
+  config/                   # Normalized runtime config types, YAML parsing, defaults, validation (uses fleet)
   ai/                       # Prompt composition + command-based CLI runner (per-backend env)
   anthropic_proxy/          # Built-in Anthropic↔OpenAI Chat Completions translation proxy
   observe/                  # Observability store: events, traces, dispatch graph, SSE hubs

--- a/cmd/agents/main.go
+++ b/cmd/agents/main.go
@@ -28,7 +28,7 @@ func run() error {
 	_ = godotenv.Load()
 
 	dbPath := flag.String("db", "agents.db", "path to SQLite database file")
-	importPath := flag.String("import", "", "YAML config file to import into the database")
+	importPath := flag.String("import", "", "legacy normalized YAML config file to import into the database; prefer POST /import for workspace-aware exports")
 	flag.Parse()
 
 	cfg, st, err := daemon.LoadConfig(ctx, *dbPath, *importPath, os.Stderr)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -33,7 +33,7 @@
 #
 # To re-seed a running daemon, POST this file at /import:
 #
-#   curl -X POST -H 'Content-Type: application/x-yaml' \
+#   curl -H "Authorization: Bearer $AGENTS_API_TOKEN" -X POST -H 'Content-Type: application/x-yaml' \
 #     --data-binary @config.yaml http://localhost:8080/import
 #
 # This example is intentionally small enough to read in one pass. Start here,

--- a/config_examples/autonomous-fleet.yaml
+++ b/config_examples/autonomous-fleet.yaml
@@ -1,16 +1,16 @@
 # autonomous-fleet.yaml, production-shaped fleet
 #
-# Mirrors the maintainer's own running setup: a scout that surveys
-# the repo on a cron and opens issues, a coder that picks up
-# `ai ready`-labelled issues, and a pr-reviewer that watches PR
-# events. The scout's findings flow into issues; the maintainer
-# triages and applies `ai ready` to admit them into the work queue.
+# Mirrors the maintainer's own running setup: a scout that surveys the repo on
+# a cron and opens issues, a coder that picks up `ai ready`-labelled issues,
+# and a pr-reviewer that watches PR events. The scout's findings flow into
+# issues; the maintainer triages and applies `ai ready` to admit them into the
+# work queue.
 #
-# Memory is enabled by default on the cron-scheduled scout so it
-# remembers what it has already filed across runs and avoids
-# re-filing the same finding day after day.
+# Memory is enabled by default on the cron-scheduled scout so it remembers what
+# it has already filed across runs and avoids re-filing the same finding day
+# after day.
 #
-# Import: curl -X POST -H 'Content-Type: application/x-yaml' --data-binary @autonomous-fleet.yaml http://localhost:8080/import
+# Import: curl -H "Authorization: Bearer $AGENTS_API_TOKEN" -X POST -H 'Content-Type: application/x-yaml' --data-binary @autonomous-fleet.yaml http://localhost:8080/import
 
 backends:
   claude:
@@ -36,49 +36,57 @@ skills:
     prompt: |
       Focus on onboarding friction, naming, docs drift, and actionable errors.
 
-agents:
+prompts:
   - name: scout
-    backend: claude
-    description: "Surveys the codebase for issues worth tracking; files findings as GitHub issues"
-    skills: [architect, dx]
-    prompt: |
+    content: |
       Inspect the repository for user-visible bugs, stale docs, or maintenance gaps.
       Open or update GitHub issues with concrete evidence and next steps.
       Do not refile findings already captured in your memory of prior runs.
-
   - name: coder
-    backend: claude
-    description: "Implements fixes and features from `ai ready` issues; opens pull requests"
-    skills: [architect, testing]
-    prompt: |
+    content: |
       Implement the requested change end-to-end.
       Run the narrowest meaningful tests and open a pull request when the work is ready.
-    allow_prs: true
-    allow_dispatch: true            # pr-reviewer dispatches the coder back on REQUEST_CHANGES
-    can_dispatch: [pr-reviewer]     # coder asks for review when the PR is ready
-
   - name: pr-reviewer
-    backend: codex
-    description: "Reviews pull requests for correctness, regressions, and missing tests"
-    skills: [architect, testing, security]
-    prompt: |
+    content: |
       Review pull requests for correctness, regressions, and missing tests.
       Prefer concrete findings over broad summaries.
-    allow_dispatch: true            # coder dispatches the reviewer when its PR is ready
-    can_dispatch: [coder]           # reviewer dispatches the coder back on REQUEST_CHANGES
 
-repos:
-  - name: "owner/repo"
-    enabled: true
-    use:
-      # Scout surveys the repo every hour at minute 0.
-      - agent: scout
-        cron: "0 * * * *"
+workspaces:
+  - id: default
+    name: Default
+    agents:
+      - name: scout
+        backend: claude
+        description: "Surveys the codebase for issues worth tracking; files findings as GitHub issues"
+        skills: [architect, dx]
+        prompt_ref: scout
+        scope_type: workspace
 
-      # Coder picks up issues admitted by the maintainer.
-      - agent: coder
-        labels: ["ai ready"]
+      - name: coder
+        backend: claude
+        description: "Implements fixes and features from ai ready issues; opens pull requests"
+        skills: [architect, testing]
+        prompt_ref: coder
+        scope_type: workspace
+        allow_prs: true
+        allow_dispatch: true
+        can_dispatch: [pr-reviewer]
 
-      # PR-reviewer watches every PR open and push.
-      - agent: pr-reviewer
-        events: ["pull_request.opened", "pull_request.synchronize"]
+      - name: pr-reviewer
+        backend: codex
+        description: "Reviews pull requests for correctness, regressions, and missing tests"
+        skills: [architect, testing, security]
+        prompt_ref: pr-reviewer
+        scope_type: workspace
+        allow_dispatch: true
+        can_dispatch: [coder]
+    repos:
+      - name: "owner/repo"
+        enabled: true
+        use:
+          - agent: scout
+            cron: "0 * * * *"
+          - agent: coder
+            labels: ["ai ready"]
+          - agent: pr-reviewer
+            events: ["pull_request.opened", "pull_request.synchronize"]

--- a/config_examples/coder-and-reviewer.yaml
+++ b/config_examples/coder-and-reviewer.yaml
@@ -1,17 +1,14 @@
 # coder-and-reviewer.yaml, minimal dispatch protocol
 #
-# Two agents wired so the coder can hand off to the reviewer when
-# its PR is ready, and the reviewer can dispatch back to the coder
-# on REQUEST_CHANGES. Smallest config that demonstrates the
-# `can_dispatch` / `allow_dispatch` handshake.
+# Two agents wired so the coder can hand off to the reviewer when its PR is
+# ready, and the reviewer can dispatch back to the coder on REQUEST_CHANGES.
+# Smallest config that demonstrates the `can_dispatch` / `allow_dispatch`
+# handshake.
 #
-# coder, implements changes from labelled issues; opens PRs.
-# pr-reviewer, reviews PR opens/syncs and approves or requests changes.
+# The coder uses Claude (good at implementation), the pr-reviewer uses Codex
+# (good at fresh-eyes review). Switch backends to taste.
 #
-# The coder uses Claude (good at implementation), the pr-reviewer
-# uses Codex (good at fresh-eyes review). Switch backends to taste.
-#
-# Import: curl -X POST -H 'Content-Type: application/x-yaml' --data-binary @coder-and-reviewer.yaml http://localhost:8080/import
+# Import: curl -H "Authorization: Bearer $AGENTS_API_TOKEN" -X POST -H 'Content-Type: application/x-yaml' --data-binary @coder-and-reviewer.yaml http://localhost:8080/import
 
 backends:
   claude:
@@ -31,33 +28,43 @@ skills:
     prompt: |
       Focus on behavioral regressions, missing tests, and weak assertions.
 
-agents:
+prompts:
   - name: coder
-    backend: claude
-    description: "Implements fixes and features; opens pull requests"
-    skills: [architect, testing]
-    prompt: |
+    content: |
       Implement the requested change end-to-end.
       Run the narrowest meaningful tests and open a pull request when the work is ready.
-    allow_prs: true
-    allow_dispatch: true            # pr-reviewer dispatches back here on REQUEST_CHANGES
-    can_dispatch: [pr-reviewer]     # coder dispatches the reviewer when the PR is ready
-
   - name: pr-reviewer
-    backend: codex
-    description: "Reviews pull requests for quality, test coverage, and correctness"
-    skills: [architect, testing]
-    prompt: |
+    content: |
       Review pull requests for correctness, regressions, and missing tests.
       Prefer concrete findings over broad summaries.
-    allow_dispatch: true            # coder dispatches the reviewer when its PR is ready
-    can_dispatch: [coder]           # reviewer dispatches the coder back on REQUEST_CHANGES
 
-repos:
-  - name: "owner/repo"
-    enabled: true
-    use:
-      - agent: coder
-        labels: ["coder:run"]
-      - agent: pr-reviewer
-        events: ["pull_request.opened", "pull_request.synchronize"]
+workspaces:
+  - id: default
+    name: Default
+    agents:
+      - name: coder
+        backend: claude
+        description: "Implements fixes and features; opens pull requests"
+        skills: [architect, testing]
+        prompt_ref: coder
+        scope_type: workspace
+        allow_prs: true
+        allow_dispatch: true
+        can_dispatch: [pr-reviewer]
+
+      - name: pr-reviewer
+        backend: codex
+        description: "Reviews pull requests for quality, test coverage, and correctness"
+        skills: [architect, testing]
+        prompt_ref: pr-reviewer
+        scope_type: workspace
+        allow_dispatch: true
+        can_dispatch: [coder]
+    repos:
+      - name: "owner/repo"
+        enabled: true
+        use:
+          - agent: coder
+            labels: ["coder:run"]
+          - agent: pr-reviewer
+            events: ["pull_request.opened", "pull_request.synchronize"]

--- a/config_examples/local-llm.yaml
+++ b/config_examples/local-llm.yaml
@@ -1,23 +1,21 @@
-# local-llm.yaml, fleet pinned to a local OpenAI-compatible LLM
+# local-llm.yaml, fleet pinned to a local Anthropic-compatible LLM endpoint
 #
-# Adds a custom backend with `local_model_url` and enables the built-
-# in Anthropic↔OpenAI translation proxy, so the unmodified `claude`
-# CLI talks to llama.cpp, Ollama, vLLM, or anything else that speaks
-# OpenAI Chat Completions.
+# Adds a custom backend with `local_model_url`, so the unmodified `claude` CLI
+# in the runner container talks to a runner-reachable local model bridge.
+# If your model server only speaks OpenAI Chat Completions, run an
+# Anthropic-compatible bridge on the same Docker network and point
+# `local_model_url` at that bridge.
 #
 # How the routing works at runtime:
-#   1. The agent invokes the `claude` CLI.
-#   2. The daemon injects ANTHROPIC_BASE_URL pointing at its own
-#      proxy endpoint (default `/v1/messages` on the daemon).
-#   3. The proxy translates the Anthropic request shape into OpenAI
-#      Chat Completions and forwards it to `upstream.url`.
-#   4. The OpenAI response is translated back into Anthropic shape.
+#   1. The agent invokes the `claude` CLI inside an ephemeral runner container.
+#   2. The daemon injects ANTHROPIC_BASE_URL from `local_model_url` into that
+#      container for this backend only.
+#   3. The URL must be reachable from the runner container; localhost means the
+#      runner itself, not the daemon or host.
 #
-# See docs/local-models.md for verification steps and how to point
-# `claude_local` at a different upstream (Ollama on :11434, vLLM on
-# :8000, llama.cpp on :8080 etc.).
+# See docs/local-models.md for verification steps and production caveats.
 #
-# Import: curl -X POST -H 'Content-Type: application/x-yaml' --data-binary @local-llm.yaml http://localhost:8080/import
+# Import: curl -H "Authorization: Bearer $AGENTS_API_TOKEN" -X POST -H 'Content-Type: application/x-yaml' --data-binary @local-llm.yaml http://localhost:8080/import
 
 backends:
   claude:
@@ -25,21 +23,11 @@ backends:
     timeout_seconds: 1500
     max_prompt_chars: 12000
 
-  # Custom backend: same `claude` CLI, but routed at runtime to the
-  # local upstream below. The presence of `local_model_url` is what
-  # marks this as a local backend.
   claude_local:
     command: claude
-    local_model_url: http://local-llm:18000/v1
+    local_model_url: http://anthropic-bridge:8080/v1/messages
     timeout_seconds: 3600
     max_prompt_chars: 8000
-
-# Built-in translation proxy settings are daemon runtime env vars, not YAML.
-# For this example, set:
-# AGENTS_PROXY_ENABLED=true
-# AGENTS_PROXY_UPSTREAM_URL=http://local-llm:18000/v1
-# AGENTS_PROXY_UPSTREAM_MODEL=qwen3-coder
-# AGENTS_PROXY_UPSTREAM_TIMEOUT_SECONDS=3600
 
 skills:
   architect:
@@ -49,19 +37,26 @@ skills:
     prompt: |
       Focus on behavioral regressions, missing tests, and weak assertions.
 
-agents:
+prompts:
   - name: refactorer
-    backend: claude_local            # routed through the local LLM
-    description: "Cleans up code style and small refactors using the local model"
-    skills: [architect, testing]
-    prompt: |
+    content: |
       Refactor code for clarity and maintainability without changing behavior.
       Leave the repo in a state where tests still pass.
-    allow_prs: true
 
-repos:
-  - name: "owner/repo"
-    enabled: true
-    use:
-      - agent: refactorer
-        labels: ["refactor:run"]
+workspaces:
+  - id: default
+    name: Default
+    agents:
+      - name: refactorer
+        backend: claude_local
+        description: "Cleans up code style and small refactors using the local model"
+        skills: [architect, testing]
+        prompt_ref: refactorer
+        scope_type: workspace
+        allow_prs: true
+    repos:
+      - name: "owner/repo"
+        enabled: true
+        use:
+          - agent: refactorer
+            labels: ["refactor:run"]

--- a/config_examples/multi-repo.yaml
+++ b/config_examples/multi-repo.yaml
@@ -1,17 +1,17 @@
 # multi-repo.yaml, same agents, several repos, mixed triggers
 #
-# Demonstrates that agent definitions are independent of where they
-# run. Three agents are defined once and bound to three different
-# repos with different triggers per repo:
+# Demonstrates that agent definitions are independent of where they run.
+# Three agents are defined once and bound to three different repos with
+# different triggers per repo:
 #
 #   - service-a: label-triggered coder + cron-scheduled refactorer
 #   - service-b: label-triggered coder + PR-event-triggered reviewer
 #   - service-c: PR-event-triggered reviewer only
 #
-# Adding a new repo to the fleet means adding another `repos:`
-# entry and binding the agents it needs, no agent duplication.
+# Adding a new repo to the fleet means adding another `repos:` entry inside the
+# workspace and binding the agents it needs, no agent duplication.
 #
-# Import: curl -X POST -H 'Content-Type: application/x-yaml' --data-binary @multi-repo.yaml http://localhost:8080/import
+# Import: curl -H "Authorization: Bearer $AGENTS_API_TOKEN" -X POST -H 'Content-Type: application/x-yaml' --data-binary @multi-repo.yaml http://localhost:8080/import
 
 backends:
   claude:
@@ -34,55 +34,65 @@ skills:
     prompt: |
       Focus on onboarding friction, naming, docs drift, and actionable errors.
 
-agents:
+prompts:
   - name: coder
-    backend: claude
-    description: "Implements fixes and features; opens pull requests"
-    skills: [architect, testing]
-    prompt: |
+    content: |
       Implement the requested change end-to-end.
       Run the narrowest meaningful tests and open a pull request when the work is ready.
-    allow_prs: true
-
   - name: refactorer
-    backend: claude
-    description: "Refactors existing code for readability and maintainability"
-    skills: [architect, testing, dx]
-    prompt: |
+    content: |
       Refactor code for clarity and maintainability without changing behavior.
       Leave the repo in a state where tests still pass.
-    allow_prs: true
-
   - name: pr-reviewer
-    backend: codex
-    description: "Reviews pull requests for correctness, regressions, and missing tests"
-    skills: [architect, testing]
-    prompt: |
+    content: |
       Review pull requests for correctness, regressions, and missing tests.
       Prefer concrete findings over broad summaries.
 
-repos:
-  # service-a: feature work + nightly tidy-up.
-  - name: "owner/service-a"
-    enabled: true
-    use:
-      - agent: coder
-        labels: ["coder:run"]
-      - agent: refactorer
-        cron: "0 3 * * *"
+workspaces:
+  - id: default
+    name: Default
+    agents:
+      - name: coder
+        backend: claude
+        description: "Implements fixes and features; opens pull requests"
+        skills: [architect, testing]
+        prompt_ref: coder
+        scope_type: workspace
+        allow_prs: true
 
-  # service-b: feature work + automated review on every PR.
-  - name: "owner/service-b"
-    enabled: true
-    use:
-      - agent: coder
-        labels: ["coder:run"]
-      - agent: pr-reviewer
-        events: ["pull_request.opened", "pull_request.synchronize"]
+      - name: refactorer
+        backend: claude
+        description: "Refactors existing code for readability and maintainability"
+        skills: [architect, testing, dx]
+        prompt_ref: refactorer
+        scope_type: workspace
+        allow_prs: true
 
-  # service-c: review-only, no agents authoring code here.
-  - name: "owner/service-c"
-    enabled: true
-    use:
-      - agent: pr-reviewer
-        events: ["pull_request.opened", "pull_request.synchronize"]
+      - name: pr-reviewer
+        backend: codex
+        description: "Reviews pull requests for correctness, regressions, and missing tests"
+        skills: [architect, testing]
+        prompt_ref: pr-reviewer
+        scope_type: workspace
+    repos:
+      - name: "owner/service-a"
+        enabled: true
+        use:
+          - agent: coder
+            labels: ["coder:run"]
+          - agent: refactorer
+            cron: "0 3 * * *"
+
+      - name: "owner/service-b"
+        enabled: true
+        use:
+          - agent: coder
+            labels: ["coder:run"]
+          - agent: pr-reviewer
+            events: ["pull_request.opened", "pull_request.synchronize"]
+
+      - name: "owner/service-c"
+        enabled: true
+        use:
+          - agent: pr-reviewer
+            events: ["pull_request.opened", "pull_request.synchronize"]

--- a/config_examples/solo-coder.yaml
+++ b/config_examples/solo-coder.yaml
@@ -2,15 +2,13 @@
 #
 # One repo, one agent, one trigger. Open an issue on the bound repo
 # with the label `coder:run` and the daemon dispatches the coder to
-# implement it. The coder opens a PR; closing or merging is up to
-# you.
+# implement it. The coder opens a PR; closing or merging is up to you.
 #
-# Use this as a starting point if you want a single AI teammate
-# picking up labelled issues and don't yet need review or
-# multi-agent flows. Grow into coder-and-reviewer.yaml when you
-# want a second agent reviewing the coder's PRs.
+# Use this as a starting point if you want a single AI teammate picking up
+# labelled issues and don't yet need review or multi-agent flows. Grow into
+# coder-and-reviewer.yaml when you want a second agent reviewing the coder's PRs.
 #
-# Import: curl -X POST -H 'Content-Type: application/x-yaml' --data-binary @solo-coder.yaml http://localhost:8080/import
+# Import: curl -H "Authorization: Bearer $AGENTS_API_TOKEN" -X POST -H 'Content-Type: application/x-yaml' --data-binary @solo-coder.yaml http://localhost:8080/import
 
 backends:
   claude:
@@ -26,19 +24,26 @@ skills:
     prompt: |
       Focus on behavioral regressions, missing tests, and weak assertions.
 
-agents:
+prompts:
   - name: coder
-    backend: claude
-    description: "Implements fixes and features from labelled issues; opens pull requests"
-    skills: [architect, testing]
-    prompt: |
+    content: |
       Implement the requested change end-to-end.
       Run the narrowest meaningful tests and open a pull request when the work is ready.
-    allow_prs: true
 
-repos:
-  - name: "owner/repo"
-    enabled: true
-    use:
-      - agent: coder
-        labels: ["coder:run"]
+workspaces:
+  - id: default
+    name: Default
+    agents:
+      - name: coder
+        backend: claude
+        description: "Implements fixes and features from labelled issues; opens pull requests"
+        skills: [architect, testing]
+        prompt_ref: coder
+        scope_type: workspace
+        allow_prs: true
+    repos:
+      - name: "owner/repo"
+        enabled: true
+        use:
+          - agent: coder
+            labels: ["coder:run"]

--- a/docs/api.md
+++ b/docs/api.md
@@ -109,6 +109,9 @@ Prompt catalog rows expose a stable `id` plus a display `name`. Agents persist `
 | `POST` | `/guardrails/{id}/reset` | Copy a built-in guardrail's `default_content` back into its `content`. Legacy global names are accepted as a compatibility fallback. Returns 400 for operator-added rows (no default to fall back to). |
 | `GET` | `/workspaces/{workspace}/guardrails` | List the selected guardrail references for one workspace in render order. |
 | `PUT` | `/workspaces/{workspace}/guardrails` | Replace the selected guardrail references for one workspace. |
+| `GET` | `/graph/layout` | Read saved graph node positions for a workspace. |
+| `PUT` | `/graph/layout` | Replace saved graph node positions for a workspace. |
+| `DELETE` | `/graph/layout` | Clear saved graph node positions for a workspace so the UI falls back to automatic layout. |
 | `GET` | `/export` | Export full fleet config as workspace-aware YAML, including reusable prompts, skills, guardrails, and workspace-local agents/repos/budgets. |
 | `POST` | `/import` | Import workspace-aware YAML into the SQLite store. Legacy top-level agents/repos remain accepted into `default`. |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,6 +28,8 @@ internal/
 ├─ store/                       SQLite schema, migrations, *store.Store facade,
 │                                 snapshot import/load, concept CRUD primitives,
 │                                 event_queue, memory, runtime settings, budgets
+├─ service/                     mutable fleet/config use cases shared by REST and MCP,
+│                                 transaction orchestration and domain validation
 │
 ├─ workflow/                    Engine, Processor, Dispatcher, DataChannels, dispatch dedup
 ├─ scheduler/                   cron registration + event producer
@@ -39,7 +41,8 @@ internal/
 │
 ├─ daemon/                      daemon as a single composed unit: lifecycle, router,
 │   │                             /status, /run, proxy/UI/MCP mounts
-│   ├─ fleet/                   /agents (CRUD + view + orphans), /skills, /backends
+│   ├─ fleet/                   /agents (CRUD + view + orphans), /workspaces,
+│   │                             /prompts, /skills, /guardrails, /backends
 │   ├─ repos/                   /repos, /repos/{}/bindings
 │   ├─ config/                  /config snapshot, /export, /import
 │   ├─ observe/                 /events, /traces, /graph, /dispatches, /memory + SSE
@@ -53,11 +56,13 @@ internal/
 
 The tiers, from bottom to top:
 
-**Domain (zero or near-zero deps):** `fleet`, `config`, `store`, `logging`. Pure data shapes and persistence. `fleet` has no transitive deps at all, it's structs and pure functions like `NormalizeAgent`. `config` and `store` import `fleet`. `*store.Store` wraps the bare `*sql.DB`; runtime components hold the facade, not the connection.
+**Domain and persistence:** `fleet`, `config`, `store`, `logging`. `fleet` has no transitive deps at all, it's structs and pure functions like `NormalizeAgent`. `config` owns normalized runtime config types and validation. `store` owns SQLite migrations, load/import helpers, and tx-aware persistence primitives. `*store.Store` wraps the bare `*sql.DB`; runtime components hold the facade, not the connection.
+
+**Use-case layer:** `service` imports `store`, `config`, and `fleet`. REST and MCP handlers decode wire shapes and delegate mutable operations here so transaction boundaries and domain validations stay shared across surfaces.
 
 **Runtime engine:** `workflow`, `scheduler`, `ai`, `runtime`, `backends`, `anthropic_proxy`, `observe`. The actual fleet runtime. An event arrives on the queue, the processor pulls it, the engine looks up the right binding (or resolves the target agent from the payload), the AI runner starts a fresh execution container through the runtime abstraction, the CLI response is parsed, traces and steps are recorded, and any returned `dispatch` array is enqueued as new events.
 
-**HTTP layer:** `internal/daemon` and its sub-packages, plus `webhook` and `mcp`. Each domain handler is a small package with a constructor that takes its dependencies as concrete pointers and a `RegisterRoutes(router, withTimeout)` method. The composing root is `internal/daemon/daemon.go`, which constructs every component, holds them as fields on the `*Daemon` value, and registers all routes from one place.
+**HTTP layer:** `internal/daemon` and its sub-packages, plus `webhook` and `mcp`. Each domain handler is a small package with a constructor that takes its dependencies as concrete pointers and a `RegisterRoutes(router, withTimeout)` method. Handlers stay thin: decode/encode HTTP or MCP, call `service` for mutable use cases, and map typed errors. The composing root is `internal/daemon/daemon.go`, which constructs every component, holds them as fields on the `*Daemon` value, and registers all routes from one place.
 
 **Entry:** `cmd/agents/main.go` is six lines of real work, load config, build a logger, call `daemon.New`, call `d.Run(ctx)`. Everything else is in the daemon package.
 
@@ -79,12 +84,14 @@ func New(cfg *config.Config, st *store.Store, logger zerolog.Logger) (*Daemon, e
     engine.WithGraphRecorder(obs)
     engine.WithRunTracker(obs.ActiveRuns)
     engine.WithStepRecorder(obs)
+    engine.WithRunStreamPublisher(obs)
     memBackend.SetChangeNotifier(obs.PublishMemoryChange)
 
     // 2. scheduler is a cron event producer; engine notifies it on completion
     sched, _ := scheduler.NewScheduler(st, scheduler.DefaultReconcileInterval, logger)
     sched.WithEventQueue(channels)
     engine.WithLastRunRecorder(sched)
+    engine.WithBudgetStore(st)
 
     // 3. domain HTTP handlers, concrete pointers, no With-pattern wiring
     fleetH   := daemonfleet.New(st, cfg.Daemon.HTTP.MaxBodyBytes, sched, obs, logger)
@@ -239,7 +246,8 @@ async on a worker goroutine:
 mux router
   → daemonfleet.Handler.HandleAgentsCreate
       h.UpsertAgent(req.toConfig())
-        → store.UpsertAgent       single SQLite UPSERT
+        → service.UpsertAgent     transaction + validation
+          → store.UpsertAgentTx   SQLite write primitive
       ← canonical agent JSON
   ← canonical agent JSON
 ```
@@ -251,7 +259,8 @@ There is no reload step. The runtime reads from SQLite on every event, no in-mem
 ```
 mcp/server → toolUpdateAgent
   → deps.Fleet.UpdateAgentPatch     (same *daemonfleet.Handler the REST surface uses)
-  → store.UpsertAgent
+  → service.UpdateAgentPatch
+    → store.UpsertAgentTx
   ← same canonical shape as REST
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,7 @@
 
 The agent fleet lives in a SQLite database that the daemon boots from. You manage it through the web dashboard at `/ui/` and the CRUD API. **`config.yaml` is optional**: it is a portable serialization of shareable fleet strategy, useful for one-time seeding, version-controlled fleet definitions, or moving a fleet between environments. The example file [`config.example.yaml`](../config.example.yaml) shows the shape.
 
-This page documents the schema, using YAML examples for clarity. Every field shown here also exists as a column in the SQLite store and as a JSON field on the CRUD endpoints; the three surfaces are interchangeable.
+This page documents the schema, using YAML examples for clarity. The same concepts are persisted in SQLite and exposed through JSON CRUD endpoints; field names are kept aligned where the wire shapes overlap.
 
 The import/export schema is split into reusable catalog domains and workspace-local
 runtime wiring:
@@ -363,10 +363,13 @@ The daemon always boots from the SQLite database. YAML is an optional import / e
 
 ```bash
 # Export the current fleet back to YAML at any time.
-curl -s http://localhost:8080/export > fleet.yaml
+curl -s -H "Authorization: Bearer $AGENTS_API_TOKEN" \
+  http://localhost:8080/export > fleet.yaml
 
 # Import a YAML payload into a running daemon (merges into the SQLite store).
-curl -X POST http://localhost:8080/import --data-binary @fleet.yaml
+curl -H "Authorization: Bearer $AGENTS_API_TOKEN" \
+  -X POST -H 'Content-Type: application/x-yaml' \
+  --data-binary @fleet.yaml http://localhost:8080/import
 ```
 
 The CRUD endpoints for `/workspaces`, `/prompts`, `/agents`, `/skills`, `/backends`, `/repos`, and `/guardrails` are always mounted and backed by the SQLite database. Workspace-scoped endpoints accept `?workspace=<id>` and default to `default` for compatibility. `agents`, `skills`, `backends`, `prompts`, and `guardrails` support partial update routes where documented; `PATCH /repos/{owner}/{repo}` is enabled-only; binding edits go through `/repos/{owner}/{repo}/bindings/{id}`, and full repo replacement goes through `POST /repos`. Catalog item routes (`/prompts/{id}`, `/skills/{id}`, `/guardrails/{id}`) use stable IDs because scoped catalog entries may share display names; legacy global names remain accepted as a compatibility fallback. Guardrails additionally support `POST /guardrails/{id}/reset` for built-ins. The daemon auto-reloads cron schedules after writes that affect runnable fleet state. Agent memory is stored in the same SQLite database and is scoped by workspace.

--- a/docs/local-models.md
+++ b/docs/local-models.md
@@ -231,9 +231,11 @@ Neither is a proxy bug. Both are Qwen-family disposition issues vs Claude. The g
 
 If your model runs on a separate box reached via Tailscale, userspace-networking mode relays through DERP and adds ~500 ms per request. Fine for agent workloads (the run is 5–30 s end-to-end anyway) but noticeable if you compare raw latency to local loopback.
 
-### `OAuth in ~/.claude.json` does NOT override `ANTHROPIC_BASE_URL`
+### Claude credentials do NOT override `ANTHROPIC_BASE_URL`
 
-We initially thought we needed `--bare` to skip OAuth and force env-based routing. Empirically, the current claude CLI honours `ANTHROPIC_BASE_URL` cleanly even when OAuth credentials are present in the mounted `~/.claude.json`. You get the full tool surface (32 tools) without `--bare`. Keep your arg list clean.
+We initially thought we needed `--bare` to skip OAuth and force env-based routing. Empirically, the current claude CLI honours `ANTHROPIC_BASE_URL` cleanly when the daemon injects it into the runner container for a backend with `local_model_url`. You get the full tool surface without `--bare`.
+
+The daemon does not mount host Claude home directories into runners. Provide Claude credentials through the daemon environment (`CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, or `ANTHROPIC_AUTH_TOKEN`) and let the runner receive them per invocation.
 
 ### Long sub-agent tool loops can hit the proxy timeout
 
@@ -254,13 +256,15 @@ The Anthropic `cache_control: {type: "ephemeral"}` markers the `claude` CLI emit
 
 ### "Invalid API key" on every run
 
-`ANTHROPIC_BASE_URL` is not reaching the subprocess. Check that `local_model_url` is set on the `claude_local` backend in your fleet config, the daemon injects `ANTHROPIC_BASE_URL` from that field. `ANTHROPIC_API_KEY` must still be present in the container environment (any non-empty value works; the local endpoint ignores it). Set it in your `.env` file or compose `environment:` block.
+`ANTHROPIC_BASE_URL` is not reaching the subprocess. Check that `local_model_url` is set on the `claude_local` backend in your fleet config; the daemon injects `ANTHROPIC_BASE_URL` from that field into the ephemeral runner container. `ANTHROPIC_API_KEY` or another Claude credential must still be present in the daemon environment so it can be allowlisted into the runner.
 
-Verify with:
+Verify the daemon-side environment with:
 
 ```bash
 docker compose exec agents env | grep ANTHROPIC_
 ```
+
+Then run backend diagnostics from Config -> Backends and tools, or `POST /backends/discover`; diagnostics execute probes inside the configured runner image and catch missing runner-side env/setup.
 
 ### Model responds in `<think>...</think>` blocks and burns all tokens before producing output
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -94,11 +94,11 @@ Most fleet tools accept `workspace` for workspace-local resources and default to
 | `get_trace` | Full dispatch chain by root event ID. |
 | `get_trace_steps` | Tool-loop transcript for one span. |
 | `get_trace_prompt` | Composed prompt the daemon sent to the AI CLI for one span (gzipped on disk; decompressed on the fly). The "what did the agent see" debug artefact. Errors when no prompt is recorded (pre-009-migration spans). |
-
-The live stdout stream (`GET /traces/{span_id}/stream`) is intentionally not mirrored as an MCP tool, SSE is a long-lived streaming protocol that doesn't fit MCP's request/response contract. MCP clients that need the post-completion transcript use `get_trace_steps` instead.
 | `get_graph` | Workspace-scoped agent interaction graph with dispatch edges. |
 | `get_dispatches` | Dispatch counters and drop reasons. |
 | `get_memory` | Agent memory for an agent/repo pair. |
+
+The live stdout stream (`GET /traces/{span_id}/stream`) is intentionally not mirrored as an MCP tool, SSE is a long-lived streaming protocol that doesn't fit MCP's request/response contract. MCP clients that need the post-completion transcript use `get_trace_steps` instead.
 
 ### Runners
 
@@ -133,3 +133,11 @@ Scope kinds are explicit about global versus workspace-isolated coverage:
 For workspace isolation, use `workspace+repo`, `workspace+agent`, or
 `workspace+backend`; use `workspace+repo+agent` for one agent/repo pair inside
 one workspace.
+
+| Tool | Description |
+|---|---|
+| `list_token_budgets` | List all token budgets. |
+| `create_token_budget` | Create a token budget for one of the supported scope kinds. |
+| `update_token_budget` | Partially update a token budget by ID; omitted fields are preserved. |
+| `delete_token_budget` | Delete a token budget by ID. |
+| `get_token_leaderboard` | Return per-agent usage for a UTC period, including total tokens, run count, and average tokens per run. |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -97,7 +97,9 @@ docker compose pull agents && docker compose up -d agents
 # image: ghcr.io/eloylp/agents:dev-<short_sha>
 
 # Re-run backend discovery (after rotating env credentials or changing runner image).
-curl -X POST http://localhost:8080/backends/discover
+# Create AGENTS_API_TOKEN in Config -> Authentication first.
+curl -H "Authorization: Bearer $AGENTS_API_TOKEN" \
+  -X POST http://localhost:8080/backends/discover
 
 # Snapshot the SQLite store while the daemon runs (the agents image
 # does not ship sqlite3, use a one-shot Alpine sidecar against the
@@ -109,8 +111,10 @@ docker run --rm \
     sqlite3 /src/agents.db ".backup /dst/agents-$(date +%F).db"'
 
 # Export / re-import the fleet as YAML.
-curl -s http://localhost:8080/export > fleet.yaml
-curl -X POST -H 'Content-Type: application/x-yaml' \
+curl -s -H "Authorization: Bearer $AGENTS_API_TOKEN" \
+  http://localhost:8080/export > fleet.yaml
+curl -H "Authorization: Bearer $AGENTS_API_TOKEN" \
+  -X POST -H 'Content-Type: application/x-yaml' \
   --data-binary @fleet.yaml http://localhost:8080/import
 ```
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -8,7 +8,7 @@ The daemon ships an embedded web dashboard at `/ui/`. The public root path `/` s
 
 ### Events
 
-Live event firehose with SSE streaming. Every kind of event flows through here: webhooks (`issues.*`, `pull_request.*`, `push`, ...), cron ticks (`cron`), on-demand triggers (`agents.run`), and inter-agent dispatches (`agent.dispatch`). Each row carries time, kind, repo, number, actor, an **agents** column with badges for every agent that ran (or is running) for that event, each badge links to the Fleet page, and a **View runners** link that opens the Runners page filtered to the event id with the matching rows pulsing on arrival.
+Live event firehose with SSE streaming. Every kind of event flows through here: webhooks (`issues.*`, `pull_request.*`, `push`, ...), cron ticks (`cron`), on-demand triggers (`agents.run`), and inter-agent dispatches (`agent.dispatch`). Each row carries time, kind, repo, number, actor, an **agents** column with badges for every agent that ran (or is running) for that event, each badge focuses that agent in the graph-first dashboard, and a **View runners** link that opens the Runners page filtered to the event id with the matching rows pulsing on arrival.
 
 ![Events firehose](img/events.png)
 
@@ -41,7 +41,7 @@ Dispatch wiring is always editable: drag from one agent to another to add a conn
 
 Fleet snapshot with per-agent status, prompt reference, skills, bindings, dispatch wiring. Create, edit, and delete agents from this page; prompt content is managed through the prompt catalog and selected on agents by reference.
 
-<!-- The Fleet page (above) is the agents page: same surface, same capture. -->
+<!-- The Agents page uses the same fleet snapshot capture. -->
 ![Fleet / Agents page](img/fleet.png)
 
 ### Prompts and Skills
@@ -54,7 +54,7 @@ Manage reusable prompt contracts and reusable guidance blocks composed into agen
 
 Backend discovery status, including per-backend GitHub MCP connectivity, plus supporting tool health for `gh`, `git`, Go, Rust/Cargo, Node/npm, and TypeScript. The Tools column shows whether GitHub CLI is authenticated, because agents prefer MCP but may fall back to `gh` for complex local checkout/test/PR loops. Manage runtime limits (timeout, max prompt chars), local-backend URLs, and orphaned-model remediation. Lives as a tab inside the Config page.
 
-![Config page, Backends and tools tab is one of three tabs at the top](img/config.png)
+![Config page, Backends and tools tab](img/config.png)
 
 ### Guardrails
 
@@ -76,7 +76,7 @@ Operator view of the work that's running and recently ran. Each row is one runne
 
 The page combines two sources: the durable `event_queue` table for in-flight lifecycle (so freshly queued and currently fanning-out events stay visible), plus per-agent trace spans for completed runs. Once the event_queue row is pruned (>7 days), the trace alone is the source of truth.
 
-Each row carries: event id, queue lifecycle status (`enqueued` / `running`) or trace status (`success` / `error`), agent badge (links to the Fleet page), repo, kind, started at, duration. Click any row to expand: actor, payload, and a **View trace detail** link to `/ui/traces/<event_id>`.
+Each row carries: event id, queue lifecycle status (`enqueued` / `running`) or trace status (`success` / `error`), agent badge (focuses that agent in the graph-first dashboard), repo, kind, started at, duration. Click any row to expand: actor, payload, and a **View trace detail** link to `/ui/traces/?id=<event_id>`.
 
 Two per-row actions, both **event-level** (a single event_queue row drives multiple displayed rows after fan-out, so the actions affect every fanned-out agent for that event, the confirm dialog says so explicitly):
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,11 +1,20 @@
 // Package config defines the agents daemon configuration schema and loader.
 //
-// The import/export config file is structured in fleet-owned top-level sections:
+// The startup Config type is the normalized in-memory shape the daemon runtime
+// consumes after importing from SQLite or a legacy top-level YAML file. The
+// public /export and /import HTTP/MCP surfaces use a workspace-aware YAML shape
+// owned by internal/daemon/config and then flatten it into this runtime shape.
+//
+// The normalized fleet-owned sections are:
 //
 //	backends, AI CLI/runtime definitions used by agents
+//	runtime, global runner image and container constraints
+//	workspaces, operational contexts and selected guardrails
+//	prompts, reusable prompt catalog entries
 //	skills, reusable guidance blocks referenced by agents
-//	agents, named capabilities (backend + skills + prompt)
-//	repos, wiring: which agents run on which repo, and when
+//	guardrails, reusable policy blocks selected by workspaces
+//	agents, workspace-local capabilities (backend + skills + prompt ref)
+//	repos, workspace-local wiring: which agents run on which repo, and when
 //
 // See config.example.yaml for a complete annotated example.
 //
@@ -30,7 +39,7 @@ import (
 	"github.com/eloylp/agents/internal/fleet"
 )
 
-// Config is the root configuration loaded from YAML.
+// Config is the root normalized runtime configuration.
 type Config struct {
 	Daemon     DaemonConfig             `yaml:"-"`
 	Backends   map[string]fleet.Backend `yaml:"backends,omitempty"`
@@ -80,7 +89,8 @@ type LogConfig struct {
 	Format string `yaml:"format"`
 }
 
-// HTTPConfig controls the daemon's HTTP server (webhooks + /status + /agents/run).
+// HTTPConfig controls the daemon's HTTP server: status, webhooks, auth, REST,
+// MCP, optional proxy, and the embedded UI.
 type HTTPConfig struct {
 	ListenAddr             string `yaml:"listen_addr"`
 	StatusPath             string `yaml:"status_path"`

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -629,11 +629,13 @@ func (d *Daemon) handleAgentsRun(w http.ResponseWriter, r *http.Request) {
 }
 
 // LoadConfig is the daemon's startup config-load helper. It opens the
-// SQLite database, optionally imports a YAML file into it, runs auto-
-// discovery for AI backends if none are configured, and returns the
-// validated *config.Config plus the data-access store. The caller owns
-// and closes the store. Status / import progress messages are written
-// to msg (typically os.Stderr); pass nil to silence them.
+// SQLite database, optionally imports a legacy normalized YAML file into it,
+// runs auto-discovery for AI backends if none are configured, and returns the
+// validated *config.Config plus the data-access store. The public
+// workspace-aware export/import shape is handled by internal/daemon/config
+// after startup via POST /import or MCP import_config. The caller owns and
+// closes the store. Status / import progress messages are written to msg
+// (typically os.Stderr); pass nil to silence them.
 //
 // An empty database boots cleanly with built-in defaults, no YAML
 // import is required. Operators configure the fleet through the


### PR DESCRIPTION
## Summary
- align README-adjacent docs with the current SQLite/dashboard/REST/MCP runtime model
- convert config examples to workspace-aware prompt catalog imports
- document missing API/MCP/UI/runtime details found during code audit

## Tests
- GOCACHE=/tmp/go-build-agents go test ./internal/config ./internal/store ./internal/daemon/config
- GOCACHE=/tmp/go-build-agents go test ./internal/daemon