### PR TITLE
refactor: compare observe SSE prefixes as bytes

### DIFF
--- a/internal/observe/observe_test.go
+++ b/internal/observe/observe_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -496,7 +495,7 @@ func TestStoreRecordEventPersistsAndPublishesToSSE(t *testing.T) {
 	// SSEHub.Publish sends synchronously to the buffered subscriber channels.
 	select {
 	case msg := <-ch:
-		if !strings.HasPrefix(string(msg), "data: ") {
+		if !bytes.HasPrefix(msg, []byte("data: ")) {
 			t.Fatalf("SSE message should start with \"data: \", got %q", msg)
 		}
 	default:
@@ -597,7 +596,7 @@ func TestStoreRecordSpanPersistsAndPublishesToSSE(t *testing.T) {
 	// Verify SSE fan-out.
 	select {
 	case msg := <-ch:
-		if !strings.HasPrefix(string(msg), "data: ") {
+		if !bytes.HasPrefix(msg, []byte("data: ")) {
 			t.Fatalf("SSE message should start with \"data: \", got %q", msg)
 		}
 	default:


### PR DESCRIPTION
## Summary

- Replaces `strings.HasPrefix(string(msg), "data: ")` assertions in observe SSE tests with `bytes.HasPrefix`.
- Removes the now-unused `strings` import while keeping the same prefix checks and failure output.

## Verification

- `go test ./internal/observe -race`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.