### PR TITLE
refactor: compare raw json null as bytes

### DIFF
--- a/internal/ai/stream_steps.go
+++ b/internal/ai/stream_steps.go
@@ -269,7 +269,7 @@ func codexOutput(result, output json.RawMessage) string {
 // quoted strings to their textual content. Empty / null values become "".
 func rawJSONString(raw json.RawMessage) string {
 	trimmed := bytes.TrimSpace(raw)
-	if len(trimmed) == 0 || string(trimmed) == "null" {
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
 		return ""
 	}
 	if trimmed[0] == '"' {


### PR DESCRIPTION
## Summary

- Replaces the `rawJSONString` null sentinel check with `bytes.Equal` so the byte-oriented helper does not convert the trimmed raw JSON value to a string for comparison.
- Keeps the same empty and `null` handling before quoted string unwrapping.

## Verification

- `go test ./internal/ai`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.