### PR TITLE
Fix Config Runtime workspace override selector

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,7 +99,7 @@ runtime:
 
 Runtime settings are fleet state because operators may need to switch runner images or constraints without rebuilding the daemon. They are stored in SQLite, returned by `/config`, included in import/export, and editable through Config -> Runtime, REST, and MCP. They are not startup env overrides; use the database-backed surfaces for runner image and container policy changes.
 
-The global runner image applies to every run unless a workspace sets `runner_image`. Constraints are passed to Docker where supported: CPU, memory, PID limit, timeout, and network mode. Advanced egress filtering is not part of the v1 runtime settings.
+The global runner image applies to every run unless a workspace sets `runner_image`. In the dashboard, workspace runner image overrides are edited from Config -> Runtime with the local workspace selector in the Workspace override section. Constraints are passed to Docker where supported: CPU, memory, PID limit, timeout, and network mode. Advanced egress filtering is not part of the v1 runtime settings.
 When patching global runtime settings through REST or MCP, omitted fields are preserved. Empty string clears string constraints such as `cpus`, `memory`, and `network_mode`; empty `runner_image` resets to the built-in default because the global image cannot be unset.
 
 ## `backends`

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -101,7 +101,7 @@ Raw agent memory markdown per `(workspace, agent, repo)` key. Useful for inspect
 
 ### Config
 
-Current fleet config snapshot. Includes YAML import/export for shareable fleet strategy. The Runtime tab controls the global runner image, basic Docker constraints, and the selected workspace's optional runner image override. Secret values are not shown in the dashboard; Claude, Codex, GitHub MCP, `gh` credentials, and runner git identity come from daemon environment variables and are injected into each ephemeral runner container.
+Current fleet config snapshot. Includes YAML import/export for shareable fleet strategy. The Runtime tab controls the global runner image and basic Docker constraints. Per-workspace runner image overrides are edited from Config -> Runtime with the local workspace selector in the Workspace override section. Secret values are not shown in the dashboard; Claude, Codex, GitHub MCP, `gh` credentials, and runner git identity come from daemon environment variables and are injected into each ephemeral runner container.
 
 ![Config inspector, webhook_secret rendered as `[redacted]`](img/config.png)
 

--- a/internal/ui/src/app/config/page.test.tsx
+++ b/internal/ui/src/app/config/page.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import ConfigPage from './page'
+
+vi.mock('@/lib/workspace', () => ({
+  defaultWorkspaceID: 'default',
+  useSelectedWorkspace: () => ({
+    workspace: 'team-a',
+    workspaces: [],
+    workspaceNotice: '',
+    setWorkspace: vi.fn(),
+  }),
+  withWorkspace: (path: string, workspace: string) => `${path}?workspace=${encodeURIComponent(workspace)}`,
+}))
+
+describe('<ConfigPage /> runtime workspace overrides', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    window.history.replaceState(null, '', '/')
+  })
+
+  it('switches workspace override inputs and saves to the selected workspace endpoint', async () => {
+    window.history.replaceState(null, '', '/ui/config?tab=runtime')
+
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (url === '/config') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            workspaces: [
+              { id: 'team-a', name: 'Team A', runner_image: 'ghcr.io/example/team-a:v1' },
+              { id: 'team-b', name: 'Team B', runner_image: 'ghcr.io/example/team-b:v1' },
+            ],
+          }),
+        } as Response)
+      }
+      if (url === '/runtime') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ runner_image: 'ghcr.io/example/global:v1', constraints: {} }),
+        } as Response)
+      }
+      if (url === '/workspaces/team-b/runtime' && init?.method === 'PUT') {
+        expect(JSON.parse(String(init.body))).toEqual({ runner_image: 'ghcr.io/example/team-b:v2' })
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ id: 'team-b', name: 'Team B', runner_image: 'ghcr.io/example/team-b:v2' }),
+        } as Response)
+      }
+      return Promise.resolve({
+        ok: false,
+        text: () => Promise.resolve(`unexpected request: ${url}`),
+        json: () => Promise.resolve({}),
+      } as Response)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<ConfigPage />)
+
+    const workspaceSelect = await screen.findByLabelText('Workspace')
+    await waitFor(() => {
+      expect(screen.getByLabelText('Runner image for Team A')).toHaveValue('ghcr.io/example/team-a:v1')
+    })
+
+    fireEvent.change(workspaceSelect, { target: { value: 'team-b' } })
+
+    const teamBInput = await screen.findByLabelText('Runner image for Team B')
+    expect(teamBInput).toHaveValue('ghcr.io/example/team-b:v1')
+
+    fireEvent.change(teamBInput, { target: { value: 'ghcr.io/example/team-b:v2' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save override for Team B' }))
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/workspaces/team-b/runtime', expect.objectContaining({ method: 'PUT' }))
+    })
+    expect(await screen.findByText('Workspace runner override saved for Team B.')).toBeInTheDocument()
+  })
+})

--- a/internal/ui/src/app/config/page.tsx
+++ b/internal/ui/src/app/config/page.tsx
@@ -7,7 +7,7 @@ import RepoFilter from '@/components/RepoFilter'
 import WorkspaceSelect from '@/components/WorkspaceSelect'
 import { AuthTokenSettings } from '@/lib/auth'
 import { budgetScopeDescription, budgetScopeLabel, budgetScopeOptions, isGlobalSimpleBudgetScope } from '@/lib/budget-copy'
-import { useSelectedWorkspace, withWorkspace } from '@/lib/workspace'
+import { defaultWorkspaceID, useSelectedWorkspace, withWorkspace } from '@/lib/workspace'
 
 type Config = Record<string, unknown>
 
@@ -263,7 +263,7 @@ function JsonTree({ value, depth = 0 }: { value: unknown; depth?: number }) {
 }
 
 export default function ConfigPage() {
-  const { workspace } = useSelectedWorkspace()
+  const { workspace, workspaces: workspaceCatalog } = useSelectedWorkspace()
   const [orphanFocus, setOrphanFocus] = useState(false)
   const [config, setConfig] = useState<Config | null>(null)
   const [loading, setLoading] = useState(true)
@@ -294,6 +294,8 @@ export default function ConfigPage() {
   const [settingsLocalModelURL, setSettingsLocalModelURL] = useState('')
   const [runtime, setRuntime] = useState<RuntimeSettings | null>(null)
   const [runtimeForm, setRuntimeForm] = useState<RuntimeSettings>({ runner_image: '', constraints: {} })
+  const [selectedRuntimeWorkspace, setSelectedRuntimeWorkspace] = useState('')
+  const [runtimeWorkspaceNotice, setRuntimeWorkspaceNotice] = useState('')
   const [workspaceRunnerImage, setWorkspaceRunnerImage] = useState('')
   const [runtimeLoading, setRuntimeLoading] = useState(false)
   const [runtimeSaving, setRuntimeSaving] = useState(false)
@@ -399,8 +401,34 @@ export default function ConfigPage() {
       })
   }
 
-  const workspaces = ((config?.workspaces as WorkspaceRuntime[] | undefined) ?? [])
-  const selectedWorkspaceRuntime = workspaces.find(w => w.id === workspace)
+  const configWorkspaces = ((config?.workspaces as WorkspaceRuntime[] | undefined) ?? [])
+  const runtimeWorkspaces = configWorkspaces.length > 0 ? configWorkspaces : (workspaceCatalog as WorkspaceRuntime[])
+  const selectedWorkspaceRuntime = runtimeWorkspaces.find(w => w.id === selectedRuntimeWorkspace)
+  const selectedRuntimeWorkspaceLabel = selectedWorkspaceRuntime?.name || selectedRuntimeWorkspace || defaultWorkspaceID
+
+  useEffect(() => {
+    if (runtimeWorkspaces.length === 0) {
+      if (!selectedRuntimeWorkspace) {
+        setSelectedRuntimeWorkspace(workspace || defaultWorkspaceID)
+      }
+      return
+    }
+
+    const hasSelection = runtimeWorkspaces.some(w => w.id === selectedRuntimeWorkspace)
+    if (hasSelection) return
+
+    if (selectedRuntimeWorkspace) {
+      const next = runtimeWorkspaces[0]
+      setSelectedRuntimeWorkspace(next.id)
+      setRuntimeWorkspaceNotice(`Workspace ${selectedRuntimeWorkspace} is no longer available. Switched to ${next.name || next.id}.`)
+      return
+    }
+
+    const persisted = runtimeWorkspaces.find(w => w.id === workspace)
+    const defaultWorkspace = runtimeWorkspaces.find(w => w.id === defaultWorkspaceID)
+    const next = persisted ?? defaultWorkspace ?? runtimeWorkspaces[0]
+    setSelectedRuntimeWorkspace(next.id)
+  }, [runtimeWorkspaces, selectedRuntimeWorkspace, workspace])
 
   const loadRuntime = () => {
     setRuntimeLoading(true)
@@ -431,7 +459,7 @@ export default function ConfigPage() {
 
   useEffect(() => {
     setWorkspaceRunnerImage(selectedWorkspaceRuntime?.runner_image ?? '')
-  }, [workspace, selectedWorkspaceRuntime?.runner_image])
+  }, [selectedRuntimeWorkspace, selectedWorkspaceRuntime?.runner_image])
 
   const updateRuntimeConstraint = (key: keyof RuntimeConstraints, value: string) => {
     setRuntimeForm(prev => {
@@ -477,7 +505,7 @@ export default function ConfigPage() {
     setRuntimeSaving(true)
     setRuntimeError('')
     setRuntimeStatus('')
-    fetch(`/workspaces/${encodeURIComponent(workspace)}/runtime`, {
+    fetch(`/workspaces/${encodeURIComponent(selectedRuntimeWorkspace)}/runtime`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ runner_image: workspaceRunnerImage }),
@@ -490,10 +518,13 @@ export default function ConfigPage() {
         setConfig(prev => {
           if (!prev) return prev
           const current = ((prev.workspaces as WorkspaceRuntime[] | undefined) ?? [])
-          return { ...prev, workspaces: current.map(w => w.id === data.id ? data : w) }
+          const next = current.some(w => w.id === data.id)
+            ? current.map(w => w.id === data.id ? data : w)
+            : current.concat(data)
+          return { ...prev, workspaces: next }
         })
         setWorkspaceRunnerImage(data.runner_image ?? '')
-        setRuntimeStatus('Workspace runner override saved.')
+        setRuntimeStatus(`Workspace runner override saved for ${data.name || data.id}.`)
         setRuntimeSaving(false)
       })
       .catch((e: unknown) => {
@@ -985,11 +1016,30 @@ export default function ConfigPage() {
               <div>
                 <h3 style={{ fontSize: '0.95rem', color: 'var(--text-heading)', marginBottom: '0.25rem' }}>Workspace override</h3>
                 <p style={{ color: 'var(--text-muted)', fontSize: '0.825rem' }}>
-                  {selectedWorkspaceRuntime?.name ?? workspace} uses the global runner image unless an override is set.
+                  {selectedRuntimeWorkspaceLabel} uses the global runner image unless an override is set.
                 </p>
               </div>
+              {runtimeWorkspaceNotice && <div style={{ color: 'var(--text-muted)', fontSize: '0.825rem' }}>{runtimeWorkspaceNotice}</div>}
               <label style={{ display: 'grid', gap: '0.35rem', color: 'var(--text)', fontSize: '0.875rem' }}>
-                Runner image for this workspace
+                Workspace
+                <select
+                  value={selectedRuntimeWorkspace}
+                  onChange={e => {
+                    setRuntimeWorkspaceNotice('')
+                    setSelectedRuntimeWorkspace(e.target.value)
+                  }}
+                  disabled={runtimeWorkspaces.length === 0}
+                  style={{ background: 'var(--bg)', border: '1px solid var(--border)', borderRadius: '6px', color: 'var(--text)', padding: '8px' }}
+                >
+                  {runtimeWorkspaces.length === 0 && <option value={selectedRuntimeWorkspace}>{selectedRuntimeWorkspace || defaultWorkspaceID}</option>}
+                  {runtimeWorkspaces.map(w => <option key={w.id} value={w.id}>{w.name || w.id}</option>)}
+                </select>
+              </label>
+              <p style={{ color: 'var(--text-muted)', fontSize: '0.8rem', margin: 0 }}>
+                Empty uses {runtime?.runner_image || 'the global runner image'} for {selectedRuntimeWorkspaceLabel}.
+              </p>
+              <label style={{ display: 'grid', gap: '0.35rem', color: 'var(--text)', fontSize: '0.875rem' }}>
+                Runner image for {selectedRuntimeWorkspaceLabel}
                 <input
                   value={workspaceRunnerImage}
                   onChange={e => setWorkspaceRunnerImage(e.target.value)}
@@ -999,10 +1049,10 @@ export default function ConfigPage() {
               </label>
               <button
                 onClick={saveWorkspaceRuntime}
-                disabled={runtimeSaving || runtimeLoading}
+                disabled={runtimeSaving || runtimeLoading || !selectedRuntimeWorkspace}
                 style={{ justifySelf: 'start', background: 'var(--bg-card)', border: '1px solid var(--border)', color: 'var(--text)', padding: '7px 14px', borderRadius: '6px', cursor: runtimeSaving ? 'default' : 'pointer', fontSize: '0.875rem', fontWeight: 600 }}
               >
-                Save workspace override
+                Save override for {selectedRuntimeWorkspaceLabel}
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Summary

- Adds a local workspace selector to Config -> Runtime's Workspace override section.
- Keeps workspace runner image editing independent from the app-wide workspace filter and saves to the selected workspace endpoint.
- Updates docs and adds a focused UI test for switching workspaces and saving the selected override.

Closes #639

## Verification

- `npm test -- src/app/config/page.test.tsx`
- `npm test`
- `npm run build`
- `go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.