### PR TITLE
refactor: remove unused dispatch seed timing

### DIFF
--- a/cmd/screenshotseed/main.go
+++ b/cmd/screenshotseed/main.go
@@ -312,14 +312,12 @@ func seedActivity(obs *observe.Store, st *store.Store) {
 	for _, d := range []struct {
 		from, to, repo, reason string
 		number                 int
-		ago                    time.Duration
 	}{
-		{"coder", "pr-reviewer", "acme/widgets", "PR ready for review", 143, 17 * time.Minute},
-		{"coder", "pr-reviewer", "acme/widgets", "PR ready for review", 138, 45 * time.Minute},
-		{"scout", "coder", "acme/control-plane", "small fix worth doing now", 91, 5 * time.Minute},
+		{"coder", "pr-reviewer", "acme/widgets", "PR ready for review", 143},
+		{"coder", "pr-reviewer", "acme/widgets", "PR ready for review", 138},
+		{"scout", "coder", "acme/control-plane", "small fix worth doing now", 91},
 	} {
 		obs.RecordDispatch("default", d.from, d.to, d.repo, d.number, d.reason)
-		_ = d.ago
 	}
 
 	// Memory entry so the memory page renders something interesting.


### PR DESCRIPTION
## Summary

- Removes the unused `ago` field from screenshot dispatch-history seed rows.
- Drops the no-op `_ = d.ago` assignment so the fixture data only carries values consumed by `RecordDispatch`.

## Verification

- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./cmd/screenshotseed`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN -u CODEX_AUTH_JSON_BASE64 -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN go test ./...`
- `git diff --check`

Note: targeted secret scanning could not run because GitHub Advanced Security is not enabled for this repository.