### PR TITLE
fix: clear stale graph repo filters

### DIFF
--- a/internal/ui/src/components/RepoFilter.test.tsx
+++ b/internal/ui/src/components/RepoFilter.test.tsx
@@ -68,6 +68,13 @@ describe('<RepoFilter />', () => {
     expect(container).toBeEmptyDOMElement()
   })
 
+  it('evicts a stale selected value when there are zero repos', async () => {
+    mockReposResponse([])
+    const onChange = vi.fn()
+    render(<RepoFilter selected="owner/old" onChange={onChange} />)
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith(''))
+  })
+
   it('renders nothing when there is a single repo (no meaningful choice to offer)', async () => {
     mockReposResponse(['owner/solo'])
     const onChange = vi.fn()

--- a/internal/ui/src/components/RepoFilter.tsx
+++ b/internal/ui/src/components/RepoFilter.tsx
@@ -23,20 +23,27 @@ export function useRepoFilter(): [string, (r: string) => void] {
 
 export default function RepoFilter({ selected, onChange, workspace }: { selected: string; onChange: (r: string) => void; workspace?: string }) {
   const [repos, setRepos] = useState<string[]>([])
+  const [loaded, setLoaded] = useState(false)
 
   useEffect(() => {
+    setLoaded(false)
     fetch(workspace ? withWorkspace('/repos', workspace) : '/repos')
       .then(r => r.ok ? r.json() : [])
-      .then((data: { name: string }[]) => setRepos((data ?? []).map(r => r.name)))
-      .catch(() => {})
+      .then((data: { name: string }[]) => {
+        setRepos((data ?? []).map(r => r.name))
+        setLoaded(true)
+      })
+      .catch(() => setLoaded(true))
   }, [workspace])
 
-  // Evict stale localStorage value when the stored repo no longer exists
+  // Evict stale localStorage values after the workspace repo list loads. This
+  // matters when switching to a workspace with no repos: the filter is hidden,
+  // but a stale selected repo would still filter every graph node out.
   useEffect(() => {
-    if (repos.length > 0 && selected && !repos.includes(selected)) {
+    if (loaded && selected && !repos.includes(selected)) {
       onChange('')
     }
-  }, [repos, selected, onChange])
+  }, [loaded, repos, selected, onChange])
 
   // Hide the filter when there's nothing to choose between (0 or 1 repos).
   // Single-repo installs shouldn't carry extra chrome for a filter that has no effect.


### PR DESCRIPTION
## Summary
- clear stale repo filter selections after the workspace repo list loads, including zero-repo workspaces
- keep the graph from hiding unbound workspace agents behind an invisible stale repo filter
- add a focused RepoFilter regression test

## Tests
- npm test -- --run RepoFilter
- npm test
- git diff --check