### PR TITLE
fix: scope running status by workspace

### DIFF
--- a/internal/daemon/fleet/view.go
+++ b/internal/daemon/fleet/view.go
@@ -87,7 +87,7 @@ func (h *Handler) HandleAgentsView(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		currentStatus := "idle"
-		if h.obs != nil && h.obs.IsRunning(a.Name) {
+		if h.obs != nil && h.obs.IsRunningInWorkspace(workspaceID, a.Name) {
 			currentStatus = "running"
 		}
 		entry := apiAgentJSON{

--- a/internal/daemon/observe/observe.go
+++ b/internal/daemon/observe/observe.go
@@ -372,7 +372,7 @@ func (h *Handler) HandleGraph(w http.ResponseWriter, r *http.Request) {
 	}
 
 	nodeStatus := func(name string) string {
-		if h.events != nil && h.events.IsRunning(name) {
+		if h.events != nil && h.events.IsRunningInWorkspace(workspaceID, name) {
 			return "running"
 		}
 		if _, ok := lastErrorByAgent[name]; ok {

--- a/internal/daemon/observe/observe_test.go
+++ b/internal/daemon/observe/observe_test.go
@@ -755,8 +755,15 @@ func TestHandleGraphNodeStatusReflectsRuntimeState(t *testing.T) {
 		{Name: "idle-err", Backend: "claude", PromptRef: "idle-err", Description: "idle err agent"},
 	}
 	fx := newFixture(t, cfg)
-	// Mark "runner" as in-flight via the same hook the engine uses.
-	fx.events.ActiveRuns.StartRun("runner")
+	// Mark "runner" as in-flight via the live span hook the engine uses.
+	fx.events.BeginRun(workflow.BeginRunInput{
+		SpanID:      "span-runner",
+		EventID:     "event-runner",
+		WorkspaceID: fleet.DefaultWorkspaceID,
+		Agent:       "runner",
+		Repo:        "owner/r",
+		StartedAt:   time.Now(),
+	})
 	// Seed the scheduler so "idle-err" has a recorded last_status="error".
 	sched := newSchedulerWithStatuses(t, []scheduler.AgentStatus{
 		{Name: "idle-err", Repo: "owner/r", LastStatus: "error"},
@@ -786,6 +793,55 @@ func TestHandleGraphNodeStatusReflectsRuntimeState(t *testing.T) {
 	}
 	if statusByID["idle-ok"] != "" {
 		t.Errorf("idle-ok agent: want empty status, got %q", statusByID["idle-ok"])
+	}
+}
+
+func TestHandleGraphRunningStatusIsWorkspaceScoped(t *testing.T) {
+	t.Parallel()
+	cfg := minimalCfg()
+	cfg.Agents = []fleet.Agent{
+		{Name: "coder", WorkspaceID: fleet.DefaultWorkspaceID, Backend: "claude", PromptRef: "coder", Description: "default coder"},
+		{Name: "coder", WorkspaceID: "team-a", Backend: "claude", PromptRef: "coder", Description: "team coder"},
+	}
+	fx := newFixture(t, cfg)
+	fx.events.BeginRun(workflow.BeginRunInput{
+		SpanID:      "span-team-coder",
+		EventID:     "event-team",
+		WorkspaceID: "team-a",
+		Agent:       "coder",
+		Repo:        "owner/repo",
+		StartedAt:   time.Now(),
+	})
+	h := New(fx.events, fx.store, nil, nil, nil, zerolog.Nop())
+
+	req := httptest.NewRequest(http.MethodGet, "/graph", nil)
+	rec := httptest.NewRecorder()
+	h.HandleGraph(rec, req)
+
+	var defaultGraph graphJSON
+	if err := json.NewDecoder(rec.Body).Decode(&defaultGraph); err != nil {
+		t.Fatalf("decode default graph: %v", err)
+	}
+	if len(defaultGraph.Nodes) != 1 || defaultGraph.Nodes[0].ID != "coder" {
+		t.Fatalf("default nodes = %+v, want only coder", defaultGraph.Nodes)
+	}
+	if defaultGraph.Nodes[0].Status == "running" {
+		t.Fatalf("default coder leaked running status from team-a: %+v", defaultGraph.Nodes[0])
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/graph?workspace=team-a", nil)
+	rec = httptest.NewRecorder()
+	h.HandleGraph(rec, req)
+
+	var teamGraph graphJSON
+	if err := json.NewDecoder(rec.Body).Decode(&teamGraph); err != nil {
+		t.Fatalf("decode team graph: %v", err)
+	}
+	if len(teamGraph.Nodes) != 1 || teamGraph.Nodes[0].ID != "coder" {
+		t.Fatalf("team nodes = %+v, want only coder", teamGraph.Nodes)
+	}
+	if teamGraph.Nodes[0].Status != "running" {
+		t.Fatalf("team coder status = %q, want running", teamGraph.Nodes[0].Status)
 	}
 }
 

--- a/internal/observe/observe.go
+++ b/internal/observe/observe.go
@@ -343,6 +343,21 @@ func (r *RunRegistry) EndRun(spanID string) {
 	}
 }
 
+// IsRunningInWorkspace reports whether agentName has at least one active span
+// in workspaceID. Agent names are workspace-local, so workspace-filtered views
+// must not use the legacy global ActiveRuns counter.
+func (r *RunRegistry) IsRunningInWorkspace(workspaceID, agentName string) bool {
+	workspaceID = fleet.NormalizeWorkspaceID(workspaceID)
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, run := range r.active {
+		if fleet.NormalizeWorkspaceID(run.WorkspaceID) == workspaceID && run.Agent == agentName {
+			return true
+		}
+	}
+	return false
+}
+
 // ListActive returns the currently-running spans matching eventID, in
 // arbitrary order. Used by the runners handler to surface in-flight
 // rows (one per agent that's currently fanned out for this event).
@@ -612,6 +627,16 @@ func (s *Store) ListEdgesForWorkspace(workspaceID string) []Edge {
 // /graph view.
 func (s *Store) IsRunning(agentName string) bool {
 	return s.ActiveRuns.IsRunning(agentName)
+}
+
+// IsRunningInWorkspace returns true when the named workspace-local agent has
+// at least one active span. This is the correct status source for workspace
+// scoped UI surfaces where agent names may repeat across workspaces.
+func (s *Store) IsRunningInWorkspace(workspaceID, agentName string) bool {
+	if s.Runs == nil {
+		return false
+	}
+	return s.Runs.IsRunningInWorkspace(workspaceID, agentName)
 }
 
 // ─── workflow interface implementations ──────────────────────────────────────

--- a/internal/observe/observe_test.go
+++ b/internal/observe/observe_test.go
@@ -451,6 +451,34 @@ func TestStoreIsRunningDelegates(t *testing.T) {
 	}
 }
 
+func TestStoreIsRunningInWorkspaceUsesActiveSpans(t *testing.T) {
+	t.Parallel()
+	s := testDB(t)
+
+	s.BeginRun(workflow.BeginRunInput{
+		SpanID:      "span-team",
+		EventID:     "event-team",
+		WorkspaceID: "team-a",
+		Agent:       "coder",
+		Repo:        "owner/repo",
+		StartedAt:   time.Now(),
+	})
+	if !s.IsRunningInWorkspace("team-a", "coder") {
+		t.Fatal("want coder running in team-a")
+	}
+	if s.IsRunningInWorkspace(fleet.DefaultWorkspaceID, "coder") {
+		t.Fatal("want coder not running in default workspace")
+	}
+	if s.IsRunningInWorkspace("team-a", "reviewer") {
+		t.Fatal("want reviewer not running in team-a")
+	}
+
+	s.EndRun("span-team")
+	if s.IsRunningInWorkspace("team-a", "coder") {
+		t.Fatal("want coder not running after EndRun")
+	}
+}
+
 // ─── Store.RecordEvent ────────────────────────────────────────────────────────
 
 // TestStoreRecordEventPersistsAndPublishesToSSE verifies that RecordEvent


### PR DESCRIPTION
## Summary
- make running-status checks use active spans scoped by workspace and agent
- switch Graph and Fleet status rendering to the workspace-aware helper
- add regression coverage for same-name agents across workspaces

## Tests
- GOCACHE=/tmp/go-build-agents go test ./internal/observe ./internal/daemon/observe ./internal/daemon/fleet
- git diff --check