### PR TITLE
Fix webhook dedup for distinct issue events

### DIFF
--- a/internal/workflow/engine_prompt.go
+++ b/internal/workflow/engine_prompt.go
@@ -47,6 +47,16 @@ func dedupRepoKey(workspaceID, repo string) string {
 	return fleet.NormalizeWorkspaceID(workspaceID) + "\x00" + repo
 }
 
+func eventDedupRepoKey(ev Event) string {
+	key := dedupRepoKey(eventWorkspaceID(ev), ev.Repo.FullName) + "\x00" + ev.Kind
+	if slices.Contains(labeledKinds, ev.Kind) {
+		if label, _ := ev.Payload["label"].(string); strings.TrimSpace(label) != "" {
+			key += "\x00" + strings.ToLower(strings.TrimSpace(label))
+		}
+	}
+	return key
+}
+
 func agentScopeAllowsRepo(agent fleet.Agent, repo fleet.Repo) bool {
 	agentWorkspace := fleet.NormalizeWorkspaceID(agent.WorkspaceID)
 	repoWorkspace := fleet.NormalizeWorkspaceID(repo.WorkspaceID)

--- a/internal/workflow/engine_routing.go
+++ b/internal/workflow/engine_routing.go
@@ -16,9 +16,10 @@ import (
 
 // fanOut runs all agents matched for ev in parallel, capped by e.maxConcurrent.
 // When a dedup store is configured, each agent run is gated through a
-// TryClaim/CommitClaim/AbandonClaim sequence keyed on (agent, repo, number) so
-// that concurrent or near-simultaneous events for the same item do not produce
-// duplicate runs within the dedup window.
+// TryClaim/CommitClaim/AbandonClaim sequence keyed on
+// (agent, workspace, repo, event kind, label, number) so repeated deliveries of
+// the same intent are suppressed without collapsing distinct issue transitions
+// such as issue_comment.created followed by issues.labeled(ai ready).
 // A failing agent does not abort the others; all errors are joined and returned.
 func (e *Engine) fanOut(ctx context.Context, ev Event) error {
 	// Read the four entity sets from SQLite for this event. The cfg
@@ -53,7 +54,7 @@ func (e *Engine) fanOut(ctx context.Context, ev Event) error {
 		go func(a fleet.Agent) {
 			defer wg.Done()
 			defer sem.Release(1)
-			dedupRepo := dedupRepoKey(eventWorkspaceID(ev), ev.Repo.FullName)
+			dedupRepo := eventDedupRepoKey(ev)
 
 			// Gate through the dedup store when configured, but only for
 			// item-scoped events (number > 0).  Repo-level events such as

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -866,6 +866,41 @@ func TestFanOutDifferentNumbersAreNotDeduped(t *testing.T) {
 	}
 }
 
+func TestFanOutDifferentEventKindsAreNotDeduped(t *testing.T) {
+	t.Parallel()
+	e, runner, _ := newTestEngineWithDedup(t, func(c *config.Config) {
+		c.Repos[0].Use = []fleet.Binding{
+			{Agent: "pr-reviewer", Events: []string{"issue_comment.created", "issues.labeled"}},
+		}
+	})
+	comment := Event{
+		Repo:    RepoRef{FullName: "owner/repo", Enabled: true},
+		Kind:    "issue_comment.created",
+		Number:  42,
+		Payload: map[string]any{"body": "ready when labelled"},
+	}
+	label := Event{
+		Repo:    RepoRef{FullName: "owner/repo", Enabled: true},
+		Kind:    "issues.labeled",
+		Number:  42,
+		Payload: map[string]any{"label": "ai ready"},
+	}
+
+	if err := e.HandleEvent(context.Background(), comment); err != nil {
+		t.Fatalf("comment event: %v", err)
+	}
+	if err := e.HandleEvent(context.Background(), label); err != nil {
+		t.Fatalf("label event: %v", err)
+	}
+
+	if got := runner.callCount(); got != 2 {
+		t.Errorf("expected 2 runs for distinct event kinds on same issue, got %d", got)
+	}
+	if stats := e.DispatchStats(); stats.RunsDeduped != 0 {
+		t.Errorf("expected RunsDeduped=0, got %d", stats.RunsDeduped)
+	}
+}
+
 // TestFanOutClaimAbandonedOnRunFailure verifies that a failed agent run
 // releases the pending dedup claim so that a subsequent event for the same
 // (agent, repo, number) is allowed to proceed.


### PR DESCRIPTION
## Summary
- Scope webhook fan-out dedup by event intent instead of only agent/workspace/repo/number.
- Include event kind, and label value for labeled events, in the dedup key.
- Preserve dedup for repeated identical deliveries while allowing issue comments followed by `issues.labeled` to both run.

## Tests
- `GOCACHE=/tmp/go-build-agents go test ./internal/workflow -run 'TestFanOut(DeduplicatesSequentialEventsWithinTTL|DifferentEventKindsAreNotDeduped)' -count=1`
