### PR TITLE
test: cover mcp agent update semantics

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -31,6 +31,8 @@ The same pattern works for Cursor, Cline, and any other MCP-compatible client; c
 
 Most fleet tools accept `workspace` for workspace-local resources and default to `Default` when omitted. Prompt catalog tools expose stable public prompt refs as `id`, and agent tools accept either `prompt_id` or the human selector `prompt_ref` plus optional `prompt_scope`. `prompt_scope` is case-insensitive and accepts `global`, `workspace`, or `workspace/owner/repo`, for example `default/eloylp/agents`. Agent creation is prompt-first: call `create_prompt` or select an existing prompt with `list_prompts`/`get_prompt`, then call `create_agent` with `prompt_ref` or `prompt_id`; inline agent prompt bodies are unsupported.
 
+For agent lifecycle changes, use `create_agent` when adding a new agent or intentionally importing an upserted full definition. Use `update_agent` when changing an existing agent's backend, model, prompt reference, skills, dispatch permissions, PR permission, memory setting, scope, or description. `update_agent` patches only the supplied fields, preserves the stable agent ID, and returns a not-found error when the target agent does not exist.
+
 ### Fleet management
 
 | Tool | Description |

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -2798,6 +2798,10 @@ func TestToolDeleteBindingForwardsID(t *testing.T) {
 func TestToolUpdateAgentForwardsPatch(t *testing.T) {
 	t.Parallel()
 	deps := testFixture(t)
+	before, ok := agentByName(t, deps.Store, "coder")
+	if !ok {
+		t.Fatal("coder missing before update")
+	}
 
 	req := mcpgo.CallToolRequest{}
 	req.Params.Arguments = map[string]any{
@@ -2820,12 +2824,36 @@ func TestToolUpdateAgentForwardsPatch(t *testing.T) {
 	if !updated.AllowPRs {
 		t.Errorf("allow_prs not patched")
 	}
+	if updated.ID != before.ID {
+		t.Errorf("agent id changed: got %q, want %q", updated.ID, before.ID)
+	}
 	if len(updated.Skills) != 1 || updated.Skills[0] != "testing" {
 		t.Errorf("skills not patched: %+v", updated.Skills)
 	}
 	// Fields not in payload are preserved (description was set in seed).
 	if updated.Description != "writes code" {
 		t.Errorf("description should be preserved, got %q", updated.Description)
+	}
+}
+
+func TestToolUpdateAgentMissingTargetRejected(t *testing.T) {
+	t.Parallel()
+	deps := testFixture(t)
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"name":        "missing",
+		"description": "should not create",
+	}
+	res, err := toolUpdateAgent(deps)(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.IsError || !strings.Contains(textOf(t, res), "not found") {
+		t.Fatalf("expected not-found tool error, got error=%v body=%s", res.IsError, textOf(t, res))
+	}
+	if _, ok := agentByName(t, deps.Store, "missing"); ok {
+		t.Fatal("update_agent created a missing agent")
 	}
 }
 


### PR DESCRIPTION
## Summary

- add MCP update_agent coverage proving existing-agent updates preserve the stable agent ID
- add MCP update_agent coverage proving missing targets return a not-found error instead of creating agents
- document when operators should use create_agent upserts versus update_agent patches

## Verification

- go test ./internal/mcp
- go test ./...
- git diff --check

Closes #649