### PR TITLE
refactor: compare raw messages as bytes

### DIFF
--- a/internal/anthropic_proxy/translate_test.go
+++ b/internal/anthropic_proxy/translate_test.go
@@ -1,6 +1,7 @@
 package anthropicproxy
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 )
@@ -371,7 +372,7 @@ func TestToAnthropic_ToolCalls(t *testing.T) {
 	if block.Type != "tool_use" || block.ID != "call_1" || block.Name != "get_weather" {
 		t.Errorf("tool_use block: %+v", block)
 	}
-	if string(block.Input) != `{"location":"Tokyo"}` {
+	if !bytes.Equal(block.Input, []byte(`{"location":"Tokyo"}`)) {
 		t.Errorf("input: got %s, want %s", block.Input, `{"location":"Tokyo"}`)
 	}
 }


### PR DESCRIPTION
## Summary

- Replaces a `json.RawMessage` string conversion in the Anthropic proxy test with `bytes.Equal`.
- Keeps the assertion byte-for-byte equivalent while avoiding a temporary string allocation.

## Verification

- `go test ./internal/anthropic_proxy`
- `go test ./...`
- `git diff --check`
