### PR TITLE
refactor: compare runtime network mode directly

### DIFF
--- a/internal/runtime/docker_test.go
+++ b/internal/runtime/docker_test.go
@@ -20,7 +20,7 @@ func TestHostConfigAppliesRuntimeConstraints(t *testing.T) {
 	if err != nil {
 		t.Fatalf("hostConfig: %v", err)
 	}
-	if string(cfg.NetworkMode) != "none" {
+	if cfg.NetworkMode != "none" {
 		t.Fatalf("NetworkMode = %q, want none", cfg.NetworkMode)
 	}
 	if cfg.Resources.NanoCPUs != 500_000_000 {


### PR DESCRIPTION
## Summary

- Removes an unnecessary string conversion when checking Docker network mode in the runtime host config test.
- Keeps the same typed value in the failure message.

## Verification

- go test ./internal/runtime
- go test ./...
- git diff --check
