### PR TITLE
Add quickstart installer script

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,15 +6,13 @@ The daemon dispatches AI CLIs (`claude`, `codex`) with sandbox-bypass flags so a
 
 ## Bring up the daemon
 
+The quickstart script will ask for credentials while it runs. Have a GitHub token ready if you want agents to access repositories immediately; Claude and Codex credentials can be left blank and added later.
+
 ```bash
-mkdir agents && cd agents
-curl -fsSLO https://raw.githubusercontent.com/eloylp/agents/main/docker-compose.yaml
-curl -fsSLO https://raw.githubusercontent.com/eloylp/agents/main/.env.sample
-curl -fsSL https://raw.githubusercontent.com/eloylp/agents/main/scripts/init-env.sh | sh ## This will guide you adding credentials
-docker compose up -d
+curl -fsSL https://raw.githubusercontent.com/eloylp/agents/main/scripts/quickstart.sh | bash
 ```
 
-The shipped [`docker-compose.yaml`](../docker-compose.yaml) is the source of truth for what gets mounted and exposed. The daemon image (`ghcr.io/eloylp/agents`) is the control plane: UI, REST/MCP, scheduler, queue, traces, and SQLite. Agent work runs in fresh ephemeral containers from the runner image (`ghcr.io/eloylp/agents-runner`), which contains Claude Code, Codex, `gh`, git, Go, Rust/Cargo, Node/npm, TypeScript, and the other execution tools. The daemon boots against an empty database with built-in defaults, no YAML seed is required.
+This requires Bash, `curl`, Docker, and Docker Compose v2. The one-liner creates `./agents`, downloads the shipped [`docker-compose.yaml`](../docker-compose.yaml), `.env.sample`, and credential helper, guides you through credentials, then runs `docker compose up -d`. Your shell stays in its original directory after the script exits, so run later `docker compose` commands from `./agents`. The Compose file is the source of truth for what gets mounted and exposed. The daemon image (`ghcr.io/eloylp/agents`) is the control plane: UI, REST/MCP, scheduler, queue, traces, and SQLite. Agent work runs in fresh ephemeral containers from the runner image (`ghcr.io/eloylp/agents-runner`), which contains Claude Code, Codex, `gh`, git, Go, Rust/Cargo, Node/npm, TypeScript, and the other execution tools. The daemon boots against an empty database with built-in defaults, no YAML seed is required.
 
 Compose mounts `/var/run/docker.sock` into the daemon so it can start runner containers. The shipped Compose file runs the daemon process as root inside the container because Docker socket group IDs vary by host; Docker socket access is root-equivalent on the host, so treat it as a production security boundary.
 
@@ -26,18 +24,19 @@ Verify the daemon is healthy:
 curl -s http://localhost:8080/status | jq
 ```
 
-## Configure credentials
+## Credential reference
 
-Production runs are env-driven. Put credentials in `.env`; they are injected into each short-lived runner container and are not exported through UI, REST, MCP, or fleet YAML.
+The quickstart script writes credentials to `.env`. Production runs are env-driven: credentials are injected into each short-lived runner container and are not exported through UI, REST, MCP, or fleet YAML.
 
 - `GITHUB_TOKEN`: used for GitHub MCP and `gh` fallback. Use `repo` scope minimum; add `workflow` if agents touch CI.
 - Git identity: set `AGENTS_GIT_USER_NAME` and `AGENTS_GIT_USER_EMAIL`; the runner configures them as `git config --global user.name/user.email` before each AI CLI starts.
 - Claude: preferred path, run `claude setup-token` locally and set the returned value as `CLAUDE_CODE_OAUTH_TOKEN`. API-key deployments may instead set `ANTHROPIC_API_KEY` or `ANTHROPIC_AUTH_TOKEN`.
 - Codex: for ChatGPT/Plus/Pro subscription access, run `codex login` locally with file-based credential storage and set `CODEX_AUTH_JSON_BASE64` from `~/.codex/auth.json`; alternatively set `OPENAI_API_KEY` for OpenAI Platform API-billed usage. When both are set, `CODEX_AUTH_JSON_BASE64` wins for Codex runs.
 
-The one-liner above runs [`scripts/init-env.sh`](../scripts/init-env.sh), which generates `GITHUB_WEBHOOK_SECRET`, explains each credential, and prompts for the values interactively. To rerun it later after rotating credentials:
+Under the hood, quickstart runs [`scripts/init-env.sh`](../scripts/init-env.sh), which generates `GITHUB_WEBHOOK_SECRET`, explains each credential, and prompts for values interactively. To rerun only the credential helper later after rotating credentials:
 
 ```bash
+cd agents
 curl -fsSL https://raw.githubusercontent.com/eloylp/agents/main/scripts/init-env.sh | sh
 docker compose restart agents
 ```
@@ -79,6 +78,8 @@ Before exposing the daemon publicly, open the root login page and create the fir
 ## Day-2 operations
 
 ```bash
+cd agents
+
 # Tail logs.
 docker compose logs -f agents
 

--- a/scripts/init-env.sh
+++ b/scripts/init-env.sh
@@ -4,24 +4,56 @@ set -eu
 ENV_FILE=${AGENTS_ENV_FILE:-.env}
 SAMPLE_FILE=${AGENTS_ENV_SAMPLE:-.env.sample}
 
+if [ -t 1 ] && command -v tput >/dev/null 2>&1; then
+  BOLD=$(tput bold 2>/dev/null || true)
+  DIM=$(tput dim 2>/dev/null || true)
+  RESET=$(tput sgr0 2>/dev/null || true)
+  CYAN=$(tput setaf 6 2>/dev/null || true)
+  GREEN=$(tput setaf 2 2>/dev/null || true)
+else
+  BOLD=
+  DIM=
+  RESET=
+  CYAN=
+  GREEN=
+fi
+
 say() {
   printf '%s\n' "$*"
 }
 
-read_secret() {
-  prompt=$1
+section() {
+  say ""
+  printf '%s%s%s\n' "$BOLD$CYAN" "$*" "$RESET"
+  say ""
+}
+
+ok() {
+  printf '%sOK%s %s\n' "$GREEN" "$RESET" "$*"
+}
+
+prompt() {
+  printf '%s? %s%s' "$BOLD" "$*" "$RESET" >&2
+}
+
+read_answer() {
+  message=$1
+  secret=${2:-false}
+  value=
+
+  prompt "$message"
   if [ -t 0 ]; then
-    printf '%s' "$prompt"
-    if stty -echo 2>/dev/null; then
+    if [ "$secret" = "true" ] && stty -echo 2>/dev/null; then
       IFS= read -r value || value=
       stty echo 2>/dev/null || true
-      printf '\n'
+      printf '\n' >&2
     else
       IFS= read -r value || value=
     fi
   else
     IFS= read -r value || value=
   fi
+
   printf '%s' "$value"
 }
 
@@ -84,70 +116,121 @@ ensure_env_file() {
 
 prompt_optional() {
   key=$1
-  prompt=$2
+  message=$2
+  secret=${3:-true}
   current=$(get_env "$key" || true)
   if [ -n "$current" ]; then
-    say "$key is already set. Leave blank to keep it."
+    say "${DIM}$key is already set. Leave blank to keep it.${RESET}"
   fi
-  value=$(read_secret "$prompt")
+  value=$(read_answer "$message" "$secret")
   if [ -n "$value" ]; then
     set_env "$key" "$value"
+    ok "Saved $key"
   fi
+}
+
+prompt_choice() {
+  message=$1
+  while :; do
+    choice=$(read_answer "$message" false)
+    case "$choice" in
+      ""|1|2|3) printf '%s' "$choice"; return 0 ;;
+      *)
+        printf '%s\n' "Please enter 1, 2, or 3." >&2
+        if [ ! -t 0 ]; then
+          printf '3'
+          return 0
+        fi
+        ;;
+    esac
+  done
 }
 
 ensure_env_file
 
+section "Webhook secret"
 if [ -z "$(get_env GITHUB_WEBHOOK_SECRET || true)" ]; then
   set_env GITHUB_WEBHOOK_SECRET "$(generate_secret)"
-  say "Generated GITHUB_WEBHOOK_SECRET."
+  ok "Generated GITHUB_WEBHOOK_SECRET"
 else
-  say "GITHUB_WEBHOOK_SECRET is already set."
+  ok "GITHUB_WEBHOOK_SECRET is already set"
 fi
 
-say ""
-say "GitHub token"
+section "GitHub access"
 say "Create a GitHub token with repo scope. Add workflow scope if agents will touch CI."
 say "Token page: https://github.com/settings/tokens"
-prompt_optional GITHUB_TOKEN "Paste GITHUB_TOKEN (blank to keep/skip): "
-
 say ""
-say "Git commit identity"
-say "These values are configured with 'git config --global user.name/user.email' inside each runner container."
+prompt_optional GITHUB_TOKEN "Paste GITHUB_TOKEN and press Enter (input hidden; blank to skip): " true
+
+section "Git commit identity"
+say "These values are configured inside each runner container before the AI CLI starts."
 say "Set them explicitly so agents do not invent commit authors."
+say ""
+
 current_name=$(get_env AGENTS_GIT_USER_NAME || true)
 if [ -z "$current_name" ]; then
   set_env AGENTS_GIT_USER_NAME "Agents Bot"
-  say "Defaulted AGENTS_GIT_USER_NAME to Agents Bot."
+  ok "Defaulted AGENTS_GIT_USER_NAME to Agents Bot"
 fi
+
 current_email=$(get_env AGENTS_GIT_USER_EMAIL || true)
 if [ -z "$current_email" ]; then
   set_env AGENTS_GIT_USER_EMAIL "agents@example.com"
-  say "Defaulted AGENTS_GIT_USER_EMAIL to agents@example.com."
+  ok "Defaulted AGENTS_GIT_USER_EMAIL to agents@example.com"
 fi
-prompt_optional AGENTS_GIT_USER_NAME "Paste AGENTS_GIT_USER_NAME (blank to keep default/current): "
-prompt_optional AGENTS_GIT_USER_EMAIL "Paste AGENTS_GIT_USER_EMAIL (blank to keep default/current): "
 
-say ""
-say "Claude credentials"
+prompt_optional AGENTS_GIT_USER_NAME "Type git user name and press Enter (blank to keep current): " false
+prompt_optional AGENTS_GIT_USER_EMAIL "Type git user email and press Enter (blank to keep current): " false
+
+section "Claude credentials"
 say "Preferred path: run 'claude setup-token' locally and paste the returned token."
 say "This sets CLAUDE_CODE_OAUTH_TOKEN for runner containers."
-prompt_optional CLAUDE_CODE_OAUTH_TOKEN "Paste CLAUDE_CODE_OAUTH_TOKEN (blank to keep/skip): "
+say ""
+prompt_optional CLAUDE_CODE_OAUTH_TOKEN "Paste CLAUDE_CODE_OAUTH_TOKEN and press Enter (input hidden; blank to skip): " true
+
+section "Codex credentials"
+say "Select one Codex authentication mode:"
+say "  1. ChatGPT/Codex subscription auth (CODEX_AUTH_JSON_BASE64)."
+say "     Uses ~/.codex/auth.json. Caveat: refreshed session state is not persisted out of ephemeral runners."
+say "  2. OpenAI Platform API billing (OPENAI_API_KEY)."
+say "     Better for stateless, parallel automation."
+say "  3. Skip Codex credentials for now."
+say ""
+codex_choice=$(prompt_choice "Type 1, 2, or 3 and press Enter (blank to keep/skip): ")
+
+case "$codex_choice" in
+  1)
+    say ""
+    say "Prepare this value with:"
+    say "  1. Add 'cli_auth_credentials_store = \"file\"' to ~/.codex/config.toml"
+    say "  2. Run 'codex login' locally"
+    say "  3. Run: base64 < ~/.codex/auth.json | tr -d '\\n'"
+    say ""
+    say "Paste the base64 value below. It is secret-equivalent to a password."
+    if [ -n "$(get_env OPENAI_API_KEY || true)" ]; then
+      set_env OPENAI_API_KEY ""
+      ok "Cleared OPENAI_API_KEY so CODEX_AUTH_JSON_BASE64 can be used"
+    fi
+    say ""
+    prompt_optional CODEX_AUTH_JSON_BASE64 "Paste CODEX_AUTH_JSON_BASE64 and press Enter (input hidden; blank to skip): " true
+    ;;
+  2)
+    say ""
+    say "This stores your OpenAI Platform API credential as OPENAI_API_KEY."
+    if [ -n "$(get_env CODEX_AUTH_JSON_BASE64 || true)" ]; then
+      set_env CODEX_AUTH_JSON_BASE64 ""
+      ok "Cleared CODEX_AUTH_JSON_BASE64 so OPENAI_API_KEY can be used"
+    fi
+    say ""
+    prompt_optional OPENAI_API_KEY "Paste OPENAI_API_KEY and press Enter (input hidden; blank to skip): " true
+    ;;
+  3)
+    ok "Skipped Codex credentials"
+    ;;
+  "")
+    ok "Kept existing Codex credential settings"
+    ;;
+esac
 
 say ""
-say "Codex credentials"
-say "Preferred path for ChatGPT/Plus/Pro subscription usage:"
-say "  1. Add 'cli_auth_credentials_store = \"file\"' to ~/.codex/config.toml"
-say "  2. Run 'codex login' locally"
-say "  3. Run: base64 < ~/.codex/auth.json | tr -d '\\n'"
-say "Paste that value below. It is secret-equivalent to a password."
-prompt_optional CODEX_AUTH_JSON_BASE64 "Paste CODEX_AUTH_JSON_BASE64 (blank to keep/skip): "
-
-if [ -z "$(get_env CODEX_AUTH_JSON_BASE64 || true)" ]; then
-  say ""
-  say "Optional Codex API fallback"
-  say "Use OPENAI_API_KEY only when you want OpenAI Platform API-billed Codex usage."
-  prompt_optional OPENAI_API_KEY "Paste OPENAI_API_KEY (blank to keep/skip): "
-fi
-
-say ""
-say "Wrote $ENV_FILE. Review it, then start the daemon with: docker compose up -d"
+ok "Wrote $ENV_FILE"

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL=${AGENTS_QUICKSTART_BASE_URL:-https://raw.githubusercontent.com/eloylp/agents/${AGENTS_QUICKSTART_REF:-main}}
+INSTALL_DIR=${AGENTS_QUICKSTART_DIR:-agents}
+
+if [[ -t 1 ]] && command -v tput >/dev/null 2>&1; then
+  BOLD=$(tput bold || true)
+  DIM=$(tput dim || true)
+  RESET=$(tput sgr0 || true)
+  CYAN=$(tput setaf 6 || true)
+  GREEN=$(tput setaf 2 || true)
+  YELLOW=$(tput setaf 3 || true)
+else
+  BOLD=
+  DIM=
+  RESET=
+  CYAN=
+  GREEN=
+  YELLOW=
+fi
+
+say() {
+  printf '%b\n' "$*"
+}
+
+step() {
+  say ""
+  say "${BOLD}${CYAN}$*${RESET}"
+}
+
+ok() {
+  say "${GREEN}OK${RESET} $*"
+}
+
+warn() {
+  say "${YELLOW}WARN${RESET} $*"
+}
+
+fail() {
+  say ""
+  say "${YELLOW}ERROR${RESET} $*" >&2
+  exit 1
+}
+
+logo() {
+  say "${CYAN}${BOLD}"
+  cat <<'EOF'
+    _                    _        .----.   .----.   .----.
+   / \   __ _  ___ _ __ | |_ ___  |o  o|<->|o  o|<->|o  o|
+  / _ \ / _` |/ _ \ '_ \| __/ __| | -- |   | -- |   | -- |
+ / ___ \ (_| |  __/ | | | |_\__ \  '----'   '----'   '----'
+/_/   \_\__, |\___|_| |_|\__|___/    /|\      /|\      /|\
+        |___/
+EOF
+  say "${RESET}${BOLD}Self-hosted agent orchestration, ready for Docker.${RESET}"
+  say "${DIM}This installer downloads the Compose bundle, prepares .env, and starts the daemon.${RESET}"
+}
+
+need_cmd() {
+  local cmd=$1
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    fail "Missing required command: $cmd"
+  fi
+}
+
+download_if_missing() {
+  local url=$1
+  local dest=$2
+  if [[ -f "$dest" ]]; then
+    ok "Keeping existing $dest"
+    return
+  fi
+  say "Downloading $dest"
+  curl -fsSL "$url" -o "$dest"
+}
+
+refresh_file() {
+  local url=$1
+  local dest=$2
+  local tmp
+  tmp="$dest.tmp.$$"
+  say "Refreshing $dest"
+  curl -fsSL "$url" -o "$tmp"
+  mv "$tmp" "$dest"
+}
+
+logo
+
+step "1. Checking local requirements"
+need_cmd curl
+need_cmd docker
+
+if ! docker compose version >/dev/null 2>&1; then
+  fail "Docker Compose v2 is required. Install Docker with the 'docker compose' plugin and rerun this script."
+fi
+ok "Found curl, Docker, and Docker Compose v2"
+
+step "2. Preparing ./$(basename "$INSTALL_DIR")"
+mkdir -p "$INSTALL_DIR"
+cd "$INSTALL_DIR"
+mkdir -p scripts
+ok "Using $(pwd)"
+
+step "3. Downloading quickstart files"
+say "Source: $BASE_URL"
+download_if_missing "$BASE_URL/docker-compose.yaml" docker-compose.yaml
+download_if_missing "$BASE_URL/.env.sample" .env.sample
+refresh_file "$BASE_URL/scripts/init-env.sh" scripts/init-env.sh
+chmod +x scripts/init-env.sh 2>/dev/null || true
+
+step "4. Configuring credentials"
+say "You can leave optional backend credentials blank and add them later."
+if [[ -r /dev/tty ]]; then
+  sh scripts/init-env.sh < /dev/tty
+else
+  warn "No terminal is available for interactive prompts; running credential setup on standard input."
+  sh scripts/init-env.sh
+fi
+
+step "5. Starting the daemon"
+docker compose up -d
+
+say ""
+ok "Agents is starting."
+say ""
+say "${BOLD}Next:${RESET}"
+say "  cd $(pwd)"
+say "  open http://localhost:8080/"
+say ""
+say "${DIM}If 'open' is not available on your system, visit http://localhost:8080/ in your browser.${RESET}"


### PR DESCRIPTION
Summary:
- add a Bash quickstart script that downloads compose/env files, runs the credential helper, and starts Docker Compose
- update quickstart docs to use the one-line installer and make the credential section reference-oriented

Verification:
- bash -n scripts/quickstart.sh
- git diff --cached --check