### PR TITLE
feat: add run attribution metadata

### DIFF
--- a/docs/run-attribution.md
+++ b/docs/run-attribution.md
@@ -3,11 +3,12 @@
 Agent runs persist a compact attribution snapshot so later feedback can be
 linked back to the run that produced a PR, comment, or commit.
 
-The snapshot is stored in `run_attributions` and includes workspace, repository,
-issue or PR number, event id, event queue row, trace span id, agent/backend
-identity, prompt reference, nullable catalog version ids, head SHA, branch, and
-creation time. Public metadata must never include prompt bodies, secrets, token
-values, trace content, or other sensitive runtime details.
+The private snapshot is stored in `run_attributions` and includes workspace,
+repository, issue or PR number, event id, event queue row, trace span id,
+agent/backend identity, prompt reference, nullable catalog version ids, head SHA,
+branch, and creation time. Public metadata is a smaller lookup token and must
+never include prompt bodies, secrets, token values, trace content, event queue
+ids, or other sensitive runtime details.
 
 When an agent creates or updates GitHub content, the runtime prompt asks it to
 include a hidden HTML comment:
@@ -26,6 +27,10 @@ Agents-Agent: <agent_name>
 The daemon does not rewrite PR bodies, comments, or commits to add this data.
 Metadata is supplied through the agent workflow contract so repository writes
 remain owned by the normal agent action path.
+
+Exact resolver lookups are scoped to the query workspace. Inferred resolver
+lookups also require repository, issue/PR number, and a non-zero event time; a
+zero event time fails closed instead of searching all historical snapshots.
 
 The resolver uses three outcomes:
 

--- a/docs/run-attribution.md
+++ b/docs/run-attribution.md
@@ -1,0 +1,40 @@
+# Run Attribution Metadata
+
+Agent runs persist a compact attribution snapshot so later feedback can be
+linked back to the run that produced a PR, comment, or commit.
+
+The snapshot is stored in `run_attributions` and includes workspace, repository,
+issue or PR number, event id, event queue row, trace span id, agent/backend
+identity, prompt reference, nullable catalog version ids, head SHA, branch, and
+creation time. Public metadata must never include prompt bodies, secrets, token
+values, trace content, or other sensitive runtime details.
+
+When an agent creates or updates GitHub content, the runtime prompt asks it to
+include a hidden HTML comment:
+
+```markdown
+<!-- agents-run: {"workspace":"default","span_id":"...","agent_id":"..."} -->
+```
+
+For commits, agents should add trailers instead:
+
+```text
+Agents-Run: <span_id>
+Agents-Agent: <agent_name>
+```
+
+The daemon does not rewrite PR bodies, comments, or commits to add this data.
+Metadata is supplied through the agent workflow contract so repository writes
+remain owned by the normal agent action path.
+
+The resolver uses three outcomes:
+
+- `exact`: a hidden comment or commit trailer names a known span.
+- `inferred`: repo, issue/PR number, optional SHA, and time window match exactly
+  one stored attribution snapshot.
+- `unresolved`: no match exists, the exact span is unknown, or inference is
+  ambiguous.
+
+Catalog version ids are nullable on deployments that do not yet have immutable
+catalog versioning. Once versioned prompts, skills, and guardrails are available,
+the same snapshot fields should carry exact version ids.

--- a/internal/ai/prompt.go
+++ b/internal/ai/prompt.go
@@ -42,6 +42,10 @@ type PromptContext struct {
 	Reason        string // reason provided by the dispatching agent
 	RootEventID   string // ID of the root (non-dispatch) event that started the chain
 	DispatchDepth int    // 0 for direct triggers; increments with each dispatch hop
+
+	// RunAttributionComment is a public-safe hidden HTML comment identifying
+	// this run. Agents should include it in GitHub content they author.
+	RunAttributionComment string
 }
 
 // RenderAgentPrompt composes the prompt for an agent and returns it as a
@@ -176,6 +180,11 @@ func renderRuntimeContext(ctx PromptContext) string {
 			fmt.Fprintf(&b, "Root event ID: %s\n", ctx.RootEventID)
 		}
 		fmt.Fprintf(&b, "Dispatch depth: %d\n", ctx.DispatchDepth)
+	}
+	if ctx.RunAttributionComment != "" {
+		fmt.Fprintf(&b, "Run attribution metadata: %s\n", ctx.RunAttributionComment)
+		b.WriteString("When you create or update a GitHub pull request body or GitHub comment for this run, include that exact hidden HTML comment in the content when feasible.\n")
+		b.WriteString("For commits authored for this run, add commit trailers `Agents-Run: <span_id>` and `Agents-Agent: <agent_name>` using the values in the metadata.\n")
 	}
 	if len(ctx.Payload) > 0 {
 		// Sort keys for deterministic output.

--- a/internal/ai/prompt_test.go
+++ b/internal/ai/prompt_test.go
@@ -104,6 +104,24 @@ func TestRenderAgentPromptSystemAndUserAreSeparate(t *testing.T) {
 	}
 }
 
+func TestRenderAgentPromptIncludesRunAttributionContract(t *testing.T) {
+	t.Parallel()
+	comment := `<!-- agents-run: {"workspace":"default","span_id":"span-1","agent_id":"agent-1"} -->`
+	got := renderUser(t, fleet.Agent{Name: "coder"}, "Build.", nil, ai.PromptContext{
+		Repo: "owner/repo", Number: 42, RunAttributionComment: comment,
+	})
+	for _, want := range []string{
+		"Run attribution metadata: " + comment,
+		"include that exact hidden HTML comment",
+		"Agents-Run: <span_id>",
+		"Agents-Agent: <agent_name>",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("User prompt missing %q:\n%s", want, got)
+		}
+	}
+}
+
 func TestRenderAgentPromptWithMemory(t *testing.T) {
 	t.Parallel()
 	agent := fleet.Agent{

--- a/internal/ai/prompt_test.go
+++ b/internal/ai/prompt_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/eloylp/agents/internal/ai"
 	"github.com/eloylp/agents/internal/fleet"
+	"github.com/eloylp/agents/internal/workflow"
 )
 
 // renderSystem is a test helper that returns the System part of a rendered
@@ -106,7 +107,27 @@ func TestRenderAgentPromptSystemAndUserAreSeparate(t *testing.T) {
 
 func TestRenderAgentPromptIncludesRunAttributionContract(t *testing.T) {
 	t.Parallel()
-	comment := `<!-- agents-run: {"workspace":"default","span_id":"span-1","agent_id":"agent-1"} -->`
+	comment := workflow.RunAttribution{
+		WorkspaceID:     "default",
+		RepoOwner:       "owner",
+		RepoName:        "repo",
+		IssueOrPRNumber: 42,
+		EventID:         "event-1",
+		EventQueueID:    123,
+		SpanID:          "span-1",
+		AgentID:         "agent-1",
+		AgentName:       "coder",
+		BackendID:       "codex",
+		BackendName:     "codex",
+		PromptVersionID: "prompt-v1",
+		PromptRef:       "coder",
+		SkillVersionIDs: []string{"skill-v1"},
+		HeadSHA:         "abc123",
+		Branch:          "fix/example",
+	}.HiddenComment()
+	if want := `<!-- agents-run: {"workspace":"default","span_id":"span-1","agent_id":"agent-1"} -->`; comment != want {
+		t.Fatalf("HiddenComment() = %q, want %q", comment, want)
+	}
 	got := renderUser(t, fleet.Agent{Name: "coder"}, "Build.", nil, ai.PromptContext{
 		Repo: "owner/repo", Number: 42, RunAttributionComment: comment,
 	})

--- a/internal/observe/attribution.go
+++ b/internal/observe/attribution.go
@@ -280,10 +280,3 @@ func firstNonZero64(a, b int64) int64 {
 	}
 	return b
 }
-
-func boolInt(v bool) int {
-	if v {
-		return 1
-	}
-	return 0
-}

--- a/internal/observe/attribution.go
+++ b/internal/observe/attribution.go
@@ -64,13 +64,13 @@ var agentsRunCommentRE = regexp.MustCompile(`(?s)<!--\s*agents-run:\s*(\{.*?\})\
 func (s *Store) ResolveRunAttribution(q AttributionQuery) AttributionResolution {
 	workspaceID := fleet.NormalizeWorkspaceID(q.WorkspaceID)
 	if spanID := spanIDFromBody(q.Body); spanID != "" {
-		if snap, ok := s.runAttributionBySpan(spanID); ok {
+		if snap, ok := s.runAttributionBySpan(workspaceID, spanID); ok {
 			return AttributionResolution{Confidence: AttributionExact, Mode: "exact", Snapshot: &snap}
 		}
 		return AttributionResolution{Confidence: AttributionUnresolved, Mode: "exact", Diagnostic: fmt.Sprintf("metadata names unknown span %q", spanID)}
 	}
 	if spanID := spanIDFromCommitTrailers(q.CommitMessage); spanID != "" {
-		if snap, ok := s.runAttributionBySpan(spanID); ok {
+		if snap, ok := s.runAttributionBySpan(workspaceID, spanID); ok {
 			return AttributionResolution{Confidence: AttributionExact, Mode: "exact", Snapshot: &snap}
 		}
 		return AttributionResolution{Confidence: AttributionUnresolved, Mode: "exact", Diagnostic: fmt.Sprintf("commit trailer names unknown span %q", spanID)}
@@ -165,14 +165,20 @@ func attributionSnapshotFromSpan(in workflow.SpanInput, createdAt time.Time) Att
 	return out
 }
 
-func (s *Store) runAttributionBySpan(spanID string) (AttributionSnapshot, bool) {
-	row := s.db.QueryRow(`SELECT workspace_id, repo_owner, repo_name, issue_or_pr_number, event_id, event_queue_id, span_id, agent_id, agent_name, backend_id, backend_name, COALESCE(prompt_version_id, ''), prompt_ref, skill_version_ids, guardrail_version_ids, head_sha, branch, created_at FROM run_attributions WHERE span_id=?`, spanID)
+func (s *Store) runAttributionBySpan(workspaceID, spanID string) (AttributionSnapshot, bool) {
+	if s.db == nil {
+		return AttributionSnapshot{}, false
+	}
+	row := s.db.QueryRow(`SELECT workspace_id, repo_owner, repo_name, issue_or_pr_number, event_id, event_queue_id, span_id, agent_id, agent_name, backend_id, backend_name, COALESCE(prompt_version_id, ''), prompt_ref, skill_version_ids, guardrail_version_ids, head_sha, branch, created_at FROM run_attributions WHERE workspace_id=? AND span_id=?`, workspaceID, spanID)
 	snap, err := scanAttribution(row)
 	return snap, err == nil
 }
 
 func (s *Store) inferRunAttributions(workspaceID string, q AttributionQuery) []AttributionSnapshot {
 	if s.db == nil || q.RepoOwner == "" || q.RepoName == "" {
+		return nil
+	}
+	if q.At.IsZero() {
 		return nil
 	}
 	window := q.Window
@@ -186,11 +192,11 @@ func (s *Store) inferRunAttributions(workspaceID string, q AttributionQuery) []A
 		FROM run_attributions
 		WHERE workspace_id=? AND repo_owner=? AND repo_name=? AND issue_or_pr_number=?
 		  AND (?='' OR head_sha=?)
-		  AND (?=1 OR created_at BETWEEN ? AND ?)
+		  AND created_at BETWEEN ? AND ?
 		ORDER BY created_at DESC`,
 		workspaceID, q.RepoOwner, q.RepoName, q.IssueOrPRNumber,
 		strings.TrimSpace(q.HeadSHA), strings.TrimSpace(q.HeadSHA),
-		boolInt(q.At.IsZero()), from, to,
+		from, to,
 	)
 	if err != nil {
 		return nil

--- a/internal/observe/attribution.go
+++ b/internal/observe/attribution.go
@@ -1,0 +1,283 @@
+package observe
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/eloylp/agents/internal/fleet"
+	"github.com/eloylp/agents/internal/workflow"
+)
+
+type AttributionSnapshot struct {
+	WorkspaceID         string    `json:"workspace"`
+	RepoOwner           string    `json:"repo_owner"`
+	RepoName            string    `json:"repo_name"`
+	IssueOrPRNumber     int       `json:"issue_or_pr_number"`
+	EventID             string    `json:"event_id"`
+	EventQueueID        int64     `json:"event_queue_id"`
+	SpanID              string    `json:"span_id"`
+	AgentID             string    `json:"agent_id,omitempty"`
+	AgentName           string    `json:"agent_name"`
+	BackendID           string    `json:"backend_id,omitempty"`
+	BackendName         string    `json:"backend_name"`
+	PromptVersionID     string    `json:"prompt_version_id,omitempty"`
+	PromptRef           string    `json:"prompt_ref,omitempty"`
+	SkillVersionIDs     []string  `json:"skill_version_ids,omitempty"`
+	GuardrailVersionIDs []string  `json:"guardrail_version_ids,omitempty"`
+	HeadSHA             string    `json:"head_sha,omitempty"`
+	Branch              string    `json:"branch,omitempty"`
+	CreatedAt           time.Time `json:"created_at"`
+}
+
+type AttributionQuery struct {
+	Body            string
+	CommitMessage   string
+	WorkspaceID     string
+	RepoOwner       string
+	RepoName        string
+	IssueOrPRNumber int
+	HeadSHA         string
+	At              time.Time
+	Window          time.Duration
+}
+
+type AttributionResolution struct {
+	Confidence string               `json:"confidence"`
+	Mode       string               `json:"mode,omitempty"`
+	Snapshot   *AttributionSnapshot `json:"snapshot,omitempty"`
+	Diagnostic string               `json:"diagnostic,omitempty"`
+}
+
+const (
+	AttributionExact      = "exact"
+	AttributionInferred   = "inferred"
+	AttributionUnresolved = "unresolved"
+)
+
+var agentsRunCommentRE = regexp.MustCompile(`(?s)<!--\s*agents-run:\s*(\{.*?\})\s*-->`)
+
+func (s *Store) ResolveRunAttribution(q AttributionQuery) AttributionResolution {
+	workspaceID := fleet.NormalizeWorkspaceID(q.WorkspaceID)
+	if spanID := spanIDFromBody(q.Body); spanID != "" {
+		if snap, ok := s.runAttributionBySpan(spanID); ok {
+			return AttributionResolution{Confidence: AttributionExact, Mode: "exact", Snapshot: &snap}
+		}
+		return AttributionResolution{Confidence: AttributionUnresolved, Mode: "exact", Diagnostic: fmt.Sprintf("metadata names unknown span %q", spanID)}
+	}
+	if spanID := spanIDFromCommitTrailers(q.CommitMessage); spanID != "" {
+		if snap, ok := s.runAttributionBySpan(spanID); ok {
+			return AttributionResolution{Confidence: AttributionExact, Mode: "exact", Snapshot: &snap}
+		}
+		return AttributionResolution{Confidence: AttributionUnresolved, Mode: "exact", Diagnostic: fmt.Sprintf("commit trailer names unknown span %q", spanID)}
+	}
+	matches := s.inferRunAttributions(workspaceID, q)
+	switch len(matches) {
+	case 0:
+		return AttributionResolution{Confidence: AttributionUnresolved, Mode: "inferred", Diagnostic: "no matching run attribution snapshot"}
+	case 1:
+		return AttributionResolution{Confidence: AttributionInferred, Mode: "inferred", Snapshot: &matches[0]}
+	default:
+		return AttributionResolution{Confidence: AttributionUnresolved, Mode: "inferred", Diagnostic: fmt.Sprintf("ambiguous run attribution: %d matches", len(matches))}
+	}
+}
+
+func spanIDFromBody(body string) string {
+	m := agentsRunCommentRE.FindStringSubmatch(body)
+	if len(m) != 2 {
+		return ""
+	}
+	var meta struct {
+		SpanID string `json:"span_id"`
+	}
+	if err := json.Unmarshal([]byte(m[1]), &meta); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(meta.SpanID)
+}
+
+func spanIDFromCommitTrailers(message string) string {
+	var spanID string
+	for _, line := range strings.Split(message, "\n") {
+		k, v, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(k), "Agents-Run") {
+			spanID = strings.TrimSpace(v)
+		}
+	}
+	return spanID
+}
+
+func (s *Store) recordRunAttribution(in workflow.SpanInput, createdAt time.Time) {
+	if s.db == nil || in.SpanID == "" {
+		return
+	}
+	a := attributionSnapshotFromSpan(in, createdAt)
+	_, err := s.db.Exec(
+		`INSERT OR REPLACE INTO run_attributions (
+			span_id, workspace_id, repo_owner, repo_name, issue_or_pr_number,
+			event_id, event_queue_id, agent_id, agent_name, backend_id, backend_name,
+			prompt_version_id, prompt_ref, skill_version_ids, guardrail_version_ids,
+			head_sha, branch, created_at
+		) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		a.SpanID, a.WorkspaceID, a.RepoOwner, a.RepoName, a.IssueOrPRNumber,
+		a.EventID, a.EventQueueID, a.AgentID, a.AgentName, a.BackendID, a.BackendName,
+		nullString(a.PromptVersionID), a.PromptRef, strings.Join(a.SkillVersionIDs, ","), strings.Join(a.GuardrailVersionIDs, ","),
+		a.HeadSHA, a.Branch, a.CreatedAt,
+	)
+	if err != nil {
+		log.Printf("observe: persist run attribution %s: %v", in.SpanID, err)
+	}
+}
+
+func attributionSnapshotFromSpan(in workflow.SpanInput, createdAt time.Time) AttributionSnapshot {
+	a := in.Attribution
+	owner, name := repoParts(in.Repo)
+	out := AttributionSnapshot{
+		WorkspaceID:         fleet.NormalizeWorkspaceID(firstNonEmpty(a.WorkspaceID, in.WorkspaceID)),
+		RepoOwner:           firstNonEmpty(a.RepoOwner, owner),
+		RepoName:            firstNonEmpty(a.RepoName, name),
+		IssueOrPRNumber:     firstNonZero(a.IssueOrPRNumber, in.Number),
+		EventID:             a.EventID,
+		EventQueueID:        firstNonZero64(a.EventQueueID, in.EventQueueID),
+		SpanID:              firstNonEmpty(a.SpanID, in.SpanID),
+		AgentID:             a.AgentID,
+		AgentName:           firstNonEmpty(a.AgentName, in.Agent),
+		BackendID:           firstNonEmpty(a.BackendID, in.Backend),
+		BackendName:         firstNonEmpty(a.BackendName, in.Backend),
+		PromptVersionID:     a.PromptVersionID,
+		PromptRef:           a.PromptRef,
+		SkillVersionIDs:     a.SkillVersionIDs,
+		GuardrailVersionIDs: a.GuardrailVersionIDs,
+		HeadSHA:             a.HeadSHA,
+		Branch:              a.Branch,
+		CreatedAt:           createdAt,
+	}
+	if out.CreatedAt.IsZero() {
+		out.CreatedAt = time.Now()
+	}
+	return out
+}
+
+func (s *Store) runAttributionBySpan(spanID string) (AttributionSnapshot, bool) {
+	row := s.db.QueryRow(`SELECT workspace_id, repo_owner, repo_name, issue_or_pr_number, event_id, event_queue_id, span_id, agent_id, agent_name, backend_id, backend_name, COALESCE(prompt_version_id, ''), prompt_ref, skill_version_ids, guardrail_version_ids, head_sha, branch, created_at FROM run_attributions WHERE span_id=?`, spanID)
+	snap, err := scanAttribution(row)
+	return snap, err == nil
+}
+
+func (s *Store) inferRunAttributions(workspaceID string, q AttributionQuery) []AttributionSnapshot {
+	if s.db == nil || q.RepoOwner == "" || q.RepoName == "" {
+		return nil
+	}
+	window := q.Window
+	if window <= 0 {
+		window = 24 * time.Hour
+	}
+	from := q.At.Add(-window)
+	to := q.At.Add(window)
+	rows, err := s.db.Query(
+		`SELECT workspace_id, repo_owner, repo_name, issue_or_pr_number, event_id, event_queue_id, span_id, agent_id, agent_name, backend_id, backend_name, COALESCE(prompt_version_id, ''), prompt_ref, skill_version_ids, guardrail_version_ids, head_sha, branch, created_at
+		FROM run_attributions
+		WHERE workspace_id=? AND repo_owner=? AND repo_name=? AND issue_or_pr_number=?
+		  AND (?='' OR head_sha=?)
+		  AND (?=1 OR created_at BETWEEN ? AND ?)
+		ORDER BY created_at DESC`,
+		workspaceID, q.RepoOwner, q.RepoName, q.IssueOrPRNumber,
+		strings.TrimSpace(q.HeadSHA), strings.TrimSpace(q.HeadSHA),
+		boolInt(q.At.IsZero()), from, to,
+	)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+	var out []AttributionSnapshot
+	for rows.Next() {
+		snap, err := scanAttribution(rows)
+		if err == nil {
+			out = append(out, snap)
+		}
+	}
+	return out
+}
+
+type attributionScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanAttribution(row attributionScanner) (AttributionSnapshot, error) {
+	var snap AttributionSnapshot
+	var skills, guardrails string
+	err := row.Scan(
+		&snap.WorkspaceID, &snap.RepoOwner, &snap.RepoName, &snap.IssueOrPRNumber,
+		&snap.EventID, &snap.EventQueueID, &snap.SpanID, &snap.AgentID, &snap.AgentName,
+		&snap.BackendID, &snap.BackendName, &snap.PromptVersionID, &snap.PromptRef,
+		&skills, &guardrails, &snap.HeadSHA, &snap.Branch, &snap.CreatedAt,
+	)
+	if err != nil {
+		return AttributionSnapshot{}, err
+	}
+	snap.SkillVersionIDs = splitList(skills)
+	snap.GuardrailVersionIDs = splitList(guardrails)
+	return snap, nil
+}
+
+func repoParts(repo string) (string, string) {
+	owner, name, ok := strings.Cut(repo, "/")
+	if !ok {
+		return "", strings.TrimSpace(repo)
+	}
+	return strings.TrimSpace(owner), strings.TrimSpace(name)
+}
+
+func splitList(s string) []string {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	var out []string
+	for _, part := range strings.Split(s, ",") {
+		if part = strings.TrimSpace(part); part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+func nullString(s string) sql.NullString {
+	return sql.NullString{String: s, Valid: strings.TrimSpace(s) != ""}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}
+
+func firstNonZero(a, b int) int {
+	if a != 0 {
+		return a
+	}
+	return b
+}
+
+func firstNonZero64(a, b int64) int64 {
+	if a != 0 {
+		return a
+	}
+	return b
+}
+
+func boolInt(v bool) int {
+	if v {
+		return 1
+	}
+	return 0
+}

--- a/internal/observe/observe.go
+++ b/internal/observe/observe.go
@@ -778,6 +778,7 @@ func (s *Store) RecordSpan(in workflow.SpanInput) {
 		if err != nil {
 			log.Printf("observe: persist trace %s: %v", sp.SpanID, err)
 		}
+		s.recordRunAttribution(in, sp.StartedAt)
 	}
 	if b, err := sseData(sp); err == nil {
 		s.TracesSSE.Publish(b)

--- a/internal/observe/observe_test.go
+++ b/internal/observe/observe_test.go
@@ -637,6 +637,11 @@ func TestResolveRunAttributionExactMetadata(t *testing.T) {
 	t.Parallel()
 	s := testDB(t)
 	start := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+	comment := workflow.RunAttribution{
+		WorkspaceID: "default",
+		SpanID:      "span-exact",
+		AgentID:     "agent-1",
+	}.HiddenComment()
 	s.RecordSpan(workflow.SpanInput{
 		SpanID: "span-exact", WorkspaceID: "default", Agent: "coder", Backend: "codex",
 		Repo: "owner/repo", Number: 42, EventKind: "issues.labeled", StartedAt: start, FinishedAt: start.Add(time.Second), Status: "success",
@@ -647,13 +652,42 @@ func TestResolveRunAttributionExactMetadata(t *testing.T) {
 	})
 
 	got := s.ResolveRunAttribution(observe.AttributionQuery{
-		Body: `body <!-- agents-run: {"workspace":"default","span_id":"span-exact","agent_id":"agent-1"} -->`,
+		WorkspaceID: "default",
+		Body:        "body " + comment,
 	})
 	if got.Confidence != observe.AttributionExact {
 		t.Fatalf("Confidence = %q, want %q (%s)", got.Confidence, observe.AttributionExact, got.Diagnostic)
 	}
 	if got.Snapshot == nil || got.Snapshot.SpanID != "span-exact" {
 		t.Fatalf("Snapshot = %+v, want span-exact", got.Snapshot)
+	}
+}
+
+func TestResolveRunAttributionExactMetadataRequiresWorkspaceMatch(t *testing.T) {
+	t.Parallel()
+	s := testDB(t)
+	start := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+	s.RecordSpan(workflow.SpanInput{
+		SpanID: "span-workspace-a", WorkspaceID: "workspace-a", Agent: "coder", Backend: "codex",
+		Repo: "owner/repo", Number: 42, EventKind: "issues.labeled", StartedAt: start, FinishedAt: start.Add(time.Second), Status: "success",
+		Attribution: workflow.RunAttribution{
+			WorkspaceID: "workspace-a", RepoOwner: "owner", RepoName: "repo", IssueOrPRNumber: 42,
+			SpanID: "span-workspace-a", AgentName: "coder", BackendName: "codex",
+		},
+	})
+
+	got := s.ResolveRunAttribution(observe.AttributionQuery{
+		WorkspaceID: "workspace-b",
+		Body:        `<!-- agents-run: {"workspace":"workspace-a","span_id":"span-workspace-a","agent_id":"agent-1"} -->`,
+	})
+	if got.Confidence != observe.AttributionUnresolved {
+		t.Fatalf("Confidence = %q, want %q", got.Confidence, observe.AttributionUnresolved)
+	}
+	if got.Snapshot != nil {
+		t.Fatalf("Snapshot = %+v, want nil", got.Snapshot)
+	}
+	if !strings.Contains(got.Diagnostic, `metadata names unknown span "span-workspace-a"`) {
+		t.Fatalf("Diagnostic = %q, want unknown span", got.Diagnostic)
 	}
 }
 
@@ -667,6 +701,7 @@ func TestResolveRunAttributionExactCommitTrailer(t *testing.T) {
 	})
 
 	got := s.ResolveRunAttribution(observe.AttributionQuery{
+		WorkspaceID:   "default",
 		CommitMessage: "fix: thing\n\nAgents-Run: span-trailer\nAgents-Agent: coder\n",
 	})
 	if got.Confidence != observe.AttributionExact {
@@ -674,6 +709,42 @@ func TestResolveRunAttributionExactCommitTrailer(t *testing.T) {
 	}
 	if got.Snapshot == nil || got.Snapshot.SpanID != "span-trailer" {
 		t.Fatalf("Snapshot = %+v, want span-trailer", got.Snapshot)
+	}
+}
+
+func TestResolveRunAttributionExactUnknownSpanDiagnostics(t *testing.T) {
+	t.Parallel()
+	s := testDB(t)
+
+	for _, tc := range []struct {
+		name       string
+		query      observe.AttributionQuery
+		diagnostic string
+	}{
+		{
+			name:       "metadata",
+			query:      observe.AttributionQuery{WorkspaceID: "default", Body: `<!-- agents-run: {"workspace":"default","span_id":"missing-span"} -->`},
+			diagnostic: `metadata names unknown span "missing-span"`,
+		},
+		{
+			name:       "commit trailer",
+			query:      observe.AttributionQuery{WorkspaceID: "default", CommitMessage: "fix: thing\n\nAgents-Run: missing-span\n"},
+			diagnostic: `commit trailer names unknown span "missing-span"`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := s.ResolveRunAttribution(tc.query)
+			if got.Confidence != observe.AttributionUnresolved {
+				t.Fatalf("Confidence = %q, want %q", got.Confidence, observe.AttributionUnresolved)
+			}
+			if got.Mode != "exact" {
+				t.Fatalf("Mode = %q, want exact", got.Mode)
+			}
+			if got.Diagnostic != tc.diagnostic {
+				t.Fatalf("Diagnostic = %q, want %q", got.Diagnostic, tc.diagnostic)
+			}
+		})
 	}
 }
 

--- a/internal/observe/observe_test.go
+++ b/internal/observe/observe_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -629,6 +630,97 @@ func TestStoreRecordSpanPersistsAndPublishesToSSE(t *testing.T) {
 		}
 	default:
 		t.Fatal("want SSE message on TracesSSE, got nothing")
+	}
+}
+
+func TestResolveRunAttributionExactMetadata(t *testing.T) {
+	t.Parallel()
+	s := testDB(t)
+	start := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+	s.RecordSpan(workflow.SpanInput{
+		SpanID: "span-exact", WorkspaceID: "default", Agent: "coder", Backend: "codex",
+		Repo: "owner/repo", Number: 42, EventKind: "issues.labeled", StartedAt: start, FinishedAt: start.Add(time.Second), Status: "success",
+		Attribution: workflow.RunAttribution{
+			WorkspaceID: "default", RepoOwner: "owner", RepoName: "repo", IssueOrPRNumber: 42,
+			SpanID: "span-exact", AgentName: "coder", BackendName: "codex", PromptRef: "coder",
+		},
+	})
+
+	got := s.ResolveRunAttribution(observe.AttributionQuery{
+		Body: `body <!-- agents-run: {"workspace":"default","span_id":"span-exact","agent_id":"agent-1"} -->`,
+	})
+	if got.Confidence != observe.AttributionExact {
+		t.Fatalf("Confidence = %q, want %q (%s)", got.Confidence, observe.AttributionExact, got.Diagnostic)
+	}
+	if got.Snapshot == nil || got.Snapshot.SpanID != "span-exact" {
+		t.Fatalf("Snapshot = %+v, want span-exact", got.Snapshot)
+	}
+}
+
+func TestResolveRunAttributionExactCommitTrailer(t *testing.T) {
+	t.Parallel()
+	s := testDB(t)
+	start := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+	s.RecordSpan(workflow.SpanInput{
+		SpanID: "span-trailer", Agent: "coder", Backend: "codex", Repo: "owner/repo", Number: 42,
+		EventKind: "issues.labeled", StartedAt: start, FinishedAt: start.Add(time.Second), Status: "success",
+	})
+
+	got := s.ResolveRunAttribution(observe.AttributionQuery{
+		CommitMessage: "fix: thing\n\nAgents-Run: span-trailer\nAgents-Agent: coder\n",
+	})
+	if got.Confidence != observe.AttributionExact {
+		t.Fatalf("Confidence = %q, want %q (%s)", got.Confidence, observe.AttributionExact, got.Diagnostic)
+	}
+	if got.Snapshot == nil || got.Snapshot.SpanID != "span-trailer" {
+		t.Fatalf("Snapshot = %+v, want span-trailer", got.Snapshot)
+	}
+}
+
+func TestResolveRunAttributionInferredAmbiguousAndUnresolved(t *testing.T) {
+	t.Parallel()
+	s := testDB(t)
+	base := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+	record := func(span string, number int, at time.Time, sha string) {
+		t.Helper()
+		s.RecordSpan(workflow.SpanInput{
+			SpanID: span, Agent: "coder", Backend: "codex", Repo: "owner/repo", Number: number,
+			EventKind: "pull_request.labeled", StartedAt: at, FinishedAt: at.Add(time.Second), Status: "success",
+			Attribution: workflow.RunAttribution{
+				WorkspaceID: "default", RepoOwner: "owner", RepoName: "repo", IssueOrPRNumber: number,
+				SpanID: span, AgentName: "coder", BackendName: "codex", HeadSHA: sha,
+			},
+		})
+	}
+	record("span-a", 7, base, "abc")
+	record("span-b", 8, base.Add(time.Minute), "def")
+	record("span-c", 8, base.Add(2*time.Minute), "def")
+
+	inferred := s.ResolveRunAttribution(observe.AttributionQuery{
+		WorkspaceID: "default", RepoOwner: "owner", RepoName: "repo", IssueOrPRNumber: 7,
+		HeadSHA: "abc", At: base.Add(30 * time.Second), Window: 2 * time.Minute,
+	})
+	if inferred.Confidence != observe.AttributionInferred {
+		t.Fatalf("inferred Confidence = %q, want %q (%s)", inferred.Confidence, observe.AttributionInferred, inferred.Diagnostic)
+	}
+	if inferred.Snapshot == nil || inferred.Snapshot.SpanID != "span-a" {
+		t.Fatalf("inferred Snapshot = %+v, want span-a", inferred.Snapshot)
+	}
+
+	ambiguous := s.ResolveRunAttribution(observe.AttributionQuery{
+		WorkspaceID: "default", RepoOwner: "owner", RepoName: "repo", IssueOrPRNumber: 8,
+		HeadSHA: "def", At: base.Add(time.Minute), Window: 5 * time.Minute,
+	})
+	if ambiguous.Confidence != observe.AttributionUnresolved || !strings.Contains(ambiguous.Diagnostic, "ambiguous") {
+		t.Fatalf("ambiguous result = %+v, want unresolved ambiguous", ambiguous)
+	}
+
+	unresolved := s.ResolveRunAttribution(observe.AttributionQuery{
+		WorkspaceID: "default", RepoOwner: "owner", RepoName: "repo", IssueOrPRNumber: 99,
+		At: base, Window: time.Minute,
+	})
+	if unresolved.Confidence != observe.AttributionUnresolved {
+		t.Fatalf("unresolved Confidence = %q, want %q", unresolved.Confidence, observe.AttributionUnresolved)
 	}
 }
 

--- a/internal/store/migrations/036_run_attributions.sql
+++ b/internal/store/migrations/036_run_attributions.sql
@@ -1,0 +1,29 @@
+-- 036_run_attributions: durable lookup table for linking GitHub feedback back
+-- to the agent run that produced the public artifact being reviewed.
+
+CREATE TABLE IF NOT EXISTS run_attributions (
+    span_id               TEXT PRIMARY KEY,
+    workspace_id          TEXT NOT NULL DEFAULT 'default',
+    repo_owner            TEXT NOT NULL,
+    repo_name             TEXT NOT NULL,
+    issue_or_pr_number    INTEGER NOT NULL DEFAULT 0,
+    event_id              TEXT NOT NULL DEFAULT '',
+    event_queue_id        INTEGER NOT NULL DEFAULT 0,
+    agent_id              TEXT NOT NULL DEFAULT '',
+    agent_name            TEXT NOT NULL,
+    backend_id            TEXT NOT NULL DEFAULT '',
+    backend_name          TEXT NOT NULL,
+    prompt_version_id     TEXT NULL,
+    prompt_ref            TEXT NOT NULL DEFAULT '',
+    skill_version_ids     TEXT NOT NULL DEFAULT '',
+    guardrail_version_ids TEXT NOT NULL DEFAULT '',
+    head_sha              TEXT NOT NULL DEFAULT '',
+    branch                TEXT NOT NULL DEFAULT '',
+    created_at            TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_run_attributions_repo_number
+    ON run_attributions(workspace_id, repo_owner, repo_name, issue_or_pr_number, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_run_attributions_head_sha
+    ON run_attributions(workspace_id, repo_owner, repo_name, head_sha);

--- a/internal/workflow/attribution.go
+++ b/internal/workflow/attribution.go
@@ -7,9 +7,9 @@ import (
 	"github.com/eloylp/agents/internal/fleet"
 )
 
-// RunAttribution is the compact, public-safe identity for one agent run.
-// It is persisted privately and rendered into prompts as the hidden metadata
-// contract agents should copy into GitHub PR bodies and comments they author.
+// RunAttribution is the private identity for one agent run. It is persisted as
+// a snapshot, while HiddenComment renders a smaller public lookup token for
+// GitHub PR bodies and comments agents author.
 type RunAttribution struct {
 	WorkspaceID         string   `json:"workspace"`
 	RepoOwner           string   `json:"repo_owner"`
@@ -31,11 +31,21 @@ type RunAttribution struct {
 }
 
 func (a RunAttribution) HiddenComment() string {
-	b, err := json.Marshal(a)
+	b, err := json.Marshal(publicRunAttribution{
+		WorkspaceID: a.WorkspaceID,
+		SpanID:      a.SpanID,
+		AgentID:     a.AgentID,
+	})
 	if err != nil {
 		return ""
 	}
 	return "<!-- agents-run: " + string(b) + " -->"
+}
+
+type publicRunAttribution struct {
+	WorkspaceID string `json:"workspace"`
+	SpanID      string `json:"span_id"`
+	AgentID     string `json:"agent_id,omitempty"`
 }
 
 func buildRunAttribution(ev Event, agent fleet.Agent, backend, spanID string) RunAttribution {

--- a/internal/workflow/attribution.go
+++ b/internal/workflow/attribution.go
@@ -1,0 +1,89 @@
+package workflow
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/eloylp/agents/internal/fleet"
+)
+
+// RunAttribution is the compact, public-safe identity for one agent run.
+// It is persisted privately and rendered into prompts as the hidden metadata
+// contract agents should copy into GitHub PR bodies and comments they author.
+type RunAttribution struct {
+	WorkspaceID         string   `json:"workspace"`
+	RepoOwner           string   `json:"repo_owner"`
+	RepoName            string   `json:"repo_name"`
+	IssueOrPRNumber     int      `json:"issue_or_pr_number,omitempty"`
+	EventID             string   `json:"event_id,omitempty"`
+	EventQueueID        int64    `json:"event_queue_id,omitempty"`
+	SpanID              string   `json:"span_id"`
+	AgentID             string   `json:"agent_id,omitempty"`
+	AgentName           string   `json:"agent_name"`
+	BackendID           string   `json:"backend_id,omitempty"`
+	BackendName         string   `json:"backend_name"`
+	PromptVersionID     string   `json:"prompt_version_id,omitempty"`
+	PromptRef           string   `json:"prompt_ref,omitempty"`
+	SkillVersionIDs     []string `json:"skill_version_ids,omitempty"`
+	GuardrailVersionIDs []string `json:"guardrail_version_ids,omitempty"`
+	HeadSHA             string   `json:"head_sha,omitempty"`
+	Branch              string   `json:"branch,omitempty"`
+}
+
+func (a RunAttribution) HiddenComment() string {
+	b, err := json.Marshal(a)
+	if err != nil {
+		return ""
+	}
+	return "<!-- agents-run: " + string(b) + " -->"
+}
+
+func buildRunAttribution(ev Event, agent fleet.Agent, backend, spanID string) RunAttribution {
+	owner, name, _ := strings.Cut(ev.Repo.FullName, "/")
+	if name == "" {
+		name = owner
+		owner = ""
+	}
+	return RunAttribution{
+		WorkspaceID:     eventWorkspaceID(ev),
+		RepoOwner:       owner,
+		RepoName:        name,
+		IssueOrPRNumber: ev.Number,
+		EventID:         ev.ID,
+		EventQueueID:    ev.QueueID,
+		SpanID:          spanID,
+		AgentID:         agent.ID,
+		AgentName:       agent.Name,
+		BackendID:       backend,
+		BackendName:     backend,
+		PromptRef:       promptRef(agent),
+		HeadSHA:         payloadStringValue(ev.Payload, "head_sha"),
+		Branch:          payloadBranch(ev.Payload),
+	}
+}
+
+func promptRef(agent fleet.Agent) string {
+	if strings.TrimSpace(agent.PromptID) != "" {
+		return strings.TrimSpace(agent.PromptID)
+	}
+	return strings.TrimSpace(agent.PromptRef)
+}
+
+func payloadStringValue(payload map[string]any, key string) string {
+	if len(payload) == 0 {
+		return ""
+	}
+	v, _ := payload[key].(string)
+	return strings.TrimSpace(v)
+}
+
+func payloadBranch(payload map[string]any) string {
+	if branch := payloadStringValue(payload, "branch"); branch != "" {
+		return branch
+	}
+	ref := payloadStringValue(payload, "ref")
+	if branch, ok := strings.CutPrefix(ref, "refs/heads/"); ok {
+		return branch
+	}
+	return ref
+}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -34,7 +34,9 @@ type SpanInput struct {
 	WorkspaceID                       string
 	Agent, Backend, Repo              string
 	EventKind, InvokedBy              string
+	Attribution                       RunAttribution
 	Number, DispatchDepth             int
+	EventQueueID                      int64
 	QueueWaitMs                       int64
 	ArtifactsCount                    int
 	Summary                           string

--- a/internal/workflow/engine_run.go
+++ b/internal/workflow/engine_run.go
@@ -54,6 +54,9 @@ func (e *Engine) runAgent(ctx context.Context, ev Event, agent fleet.Agent, cfg 
 		parentSpanID = payload.ParentSpanID
 	}
 
+	spanID := GenEventID()
+	attribution := buildRunAttribution(ev, agent, backend, spanID)
+
 	// Serialise the read/run/write sequence for this (agent, repo) pair to
 	// prevent a lost-update race on memory. Without this lock two overlapping
 	// runs (cron tick + dispatch, two manual triggers, or any combination)
@@ -117,19 +120,20 @@ func (e *Engine) runAgent(ctx context.Context, ev Event, agent fleet.Agent, cfg 
 	guardrailVersionIDs := catalogGuardrailVersionIDs(guardrails)
 
 	rendered, err := ai.RenderAgentPrompt(agent, promptBody, skillsForRun, guardrails, ai.PromptContext{
-		Repo:          ev.Repo.FullName,
-		Number:        ev.Number,
-		Backend:       backend,
-		EventKind:     ev.Kind,
-		Actor:         ev.Actor,
-		Payload:       promptPayload,
-		Roster:        roster,
-		InvokedBy:     invokedBy,
-		Reason:        reason,
-		RootEventID:   rootEventID,
-		DispatchDepth: dispatchDepth,
-		Memory:        existingMemory,
-		HasMemory:     memoryEnabled,
+		Repo:                  ev.Repo.FullName,
+		Number:                ev.Number,
+		Backend:               backend,
+		EventKind:             ev.Kind,
+		Actor:                 ev.Actor,
+		Payload:               promptPayload,
+		Roster:                roster,
+		InvokedBy:             invokedBy,
+		Reason:                reason,
+		RootEventID:           rootEventID,
+		DispatchDepth:         dispatchDepth,
+		Memory:                existingMemory,
+		HasMemory:             memoryEnabled,
+		RunAttributionComment: attribution.HiddenComment(),
 	})
 	if err != nil {
 		return fmt.Errorf("agent %q: render prompt: %w", agent.Name, err)
@@ -148,7 +152,6 @@ func (e *Engine) runAgent(ctx context.Context, ev Event, agent fleet.Agent, cfg 
 	}
 
 	spanStart := time.Now()
-	spanID := GenEventID()
 	composedPrompt := rendered.System
 	if rendered.User != "" {
 		if composedPrompt != "" {
@@ -180,7 +183,9 @@ func (e *Engine) runAgent(ctx context.Context, ev Event, agent fleet.Agent, cfg 
 					Repo:                ev.Repo.FullName,
 					EventKind:           ev.Kind,
 					InvokedBy:           invokedBy,
+					Attribution:         attribution,
 					Number:              ev.Number,
+					EventQueueID:        ev.QueueID,
 					DispatchDepth:       dispatchDepth,
 					QueueWaitMs:         queueWaitMs,
 					StartedAt:           spanStart,
@@ -279,7 +284,9 @@ func (e *Engine) runAgent(ctx context.Context, ev Event, agent fleet.Agent, cfg 
 			Repo:                ev.Repo.FullName,
 			EventKind:           ev.Kind,
 			InvokedBy:           invokedBy,
+			Attribution:         attribution,
 			Number:              ev.Number,
+			EventQueueID:        ev.QueueID,
 			DispatchDepth:       dispatchDepth,
 			QueueWaitMs:         queueWaitMs,
 			ArtifactsCount:      len(resp.Artifacts),

--- a/internal/workflow/processor.go
+++ b/internal/workflow/processor.go
@@ -83,6 +83,7 @@ func (p *Processor) runWorker(ctx context.Context, wg *sync.WaitGroup) {
 	st := p.channels.Store()
 	for qe := range p.channels.EventChan() {
 		ev := qe.Event
+		ev.QueueID = qe.ID
 		if err := st.MarkEventStarted(qe.ID); err != nil {
 			p.logger.Warn().Err(err).Int64("event_id", qe.ID).Msg("mark event started failed")
 		}

--- a/internal/workflow/types.go
+++ b/internal/workflow/types.go
@@ -32,6 +32,7 @@ type QueuedEvent struct {
 // before the event is enqueued.
 type Event struct {
 	ID          string // unique event identifier; delivery ID for webhook events
+	QueueID     int64  // event_queue row id, set by the processor before handling
 	WorkspaceID string // workspace that owns this run; empty means default for compatibility
 	Repo        RepoRef
 	Kind        string         // e.g. "issues.labeled", "pull_request.opened", "push", "agent.dispatch"


### PR DESCRIPTION
## Summary
- persist per-run attribution snapshots keyed by trace span with repo, event queue, agent/backend, prompt ref, nullable catalog version fields, branch, and head SHA metadata
- inject a safe hidden metadata/comment and commit-trailer contract into the agent runtime prompt without daemon-side GitHub mutation
- add attribution resolution for exact hidden metadata/trailers, inferred repo/PR/SHA/time-window matches, ambiguous matches, and unresolved cases
- document the public metadata contract and daemon read-only boundary

Closes #661

## Validation
- go test ./internal/ai ./internal/observe ./internal/workflow
- go test ./...
- go test -race ./internal/ai ./internal/observe ./internal/workflow
- git diff --check