### PR TITLE
ci: extend main race test timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,4 +49,4 @@ jobs:
 
       - name: go test race
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: go test ./... -race -count=1
+        run: go test ./... -race -count=1 -timeout=20m


### PR DESCRIPTION
## Summary
- increase the main-branch race test package timeout from Go's default 10m to 20m
- keep the race suite otherwise unchanged

## Context
The main CI run for merge commit 2c1d8bf failed in the push-only race step because internal/daemon hit the default 600s package timeout. The log did not show a race detector report or assertion failure; the package timed out under the full ./... race run.

## Validation
- not run; workflow-only change