### PR TITLE
feat: ingest self-improvement feedback

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -49,7 +49,18 @@ The `/run` body is `{"agent": "<name>", "repo": "owner/repo"}`. It returns `202 
 | `GET` | `/dispatches` | Dispatch dedup store contents + counters |
 | `GET` | `/memory/{agent}/{repo}` | Raw agent memory markdown. `{repo}` uses `owner_repo` format (underscore-separated) |
 | `GET` | `/memory/stream` | Memory file change notifications (SSE) |
+| `GET` | `/improvements/feedback` | Stored `#ai_improvement` feedback events. Query params: `workspace`, optional `status` (`new`, `ignored`, etc.). |
 | `GET` | `/config` | Current fleet config snapshot |
+
+## Self-Improvement Feedback
+
+GitHub `issue_comment`, `pull_request_review`, and `pull_request_review_comment` webhooks are scanned deterministically for the exact `#ai_improvement` tag outside fenced code blocks. Authorized tagged comments are stored as raw evidence in `status=new`; unauthorized tagged comments are retained as `status=ignored` audit rows and never become actionable recommendation input.
+
+Feedback events preserve the raw comment, source URL, repo/issue/PR/file context, delivery ids, author authorization, and any run attribution resolved from public hidden metadata or repo/PR/SHA/time context. The ingestion path does not call AI and does not mutate prompts, skills, guardrails, agents, or dispatch wiring.
+
+Configure trusted authors at startup with `AGENTS_SELF_IMPROVEMENT_FEEDBACK_AUTHOR_ALLOWLIST=maintainer-login,agents-bot`.
+
+When the allowlist is omitted, the daemon uses `GITHUB_ACTOR` if that environment variable is present. If no trusted author can be determined, tagged feedback is stored as ignored.
 
 ## Runners management
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -49,18 +49,18 @@ The `/run` body is `{"agent": "<name>", "repo": "owner/repo"}`. It returns `202 
 | `GET` | `/dispatches` | Dispatch dedup store contents + counters |
 | `GET` | `/memory/{agent}/{repo}` | Raw agent memory markdown. `{repo}` uses `owner_repo` format (underscore-separated) |
 | `GET` | `/memory/stream` | Memory file change notifications (SSE) |
-| `GET` | `/improvements/feedback` | Stored `#ai_improvement` feedback events. Query params: `workspace`, optional `status` (`new`, `ignored`, etc.). |
+| `GET` | `/improvements/feedback` | Stored `/agents improve` feedback events. Query params: `workspace`, optional `status` (`new`, `ignored`, etc.). |
 | `GET` | `/config` | Current fleet config snapshot |
 
 ## Self-Improvement Feedback
 
-GitHub `issue_comment`, `pull_request_review`, and `pull_request_review_comment` webhooks are scanned deterministically for the exact `#ai_improvement` tag outside fenced code blocks. Authorized tagged comments are stored as raw evidence in `status=new`; unauthorized tagged comments are retained as `status=ignored` audit rows and never become actionable recommendation input.
+GitHub `issue_comment`, `pull_request_review`, and `pull_request_review_comment` webhooks are scanned deterministically for the exact `/agents improve` marker outside fenced code blocks. Authorized marked comments are stored as raw evidence in `status=new`; unauthorized marked comments are retained as `status=ignored` audit rows and never become actionable recommendation input.
 
 Feedback events preserve the raw comment, source URL, repo/issue/PR/file context, delivery ids, author authorization, and any run attribution resolved from public hidden metadata or repo/PR/SHA/time context. The ingestion path does not call AI and does not mutate prompts, skills, guardrails, agents, or dispatch wiring.
 
 Configure trusted authors at startup with `AGENTS_SELF_IMPROVEMENT_FEEDBACK_AUTHOR_ALLOWLIST=maintainer-login,agents-bot`.
 
-When the allowlist is omitted, the daemon uses `GITHUB_ACTOR` if that environment variable is present. If no trusted author can be determined, tagged feedback is stored as ignored.
+When the allowlist is omitted, the daemon uses `GITHUB_ACTOR` if that environment variable is present. If no trusted author can be determined, marked feedback is stored as ignored.
 
 ## Runners management
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,7 +99,7 @@ func New(cfg *config.Config, st *store.Store, logger zerolog.Logger) (*Daemon, e
     configH  := daemonconfig.New(st, cfg.Daemon, logger)
     observeH := daemonobserve.New(obs, st, sched, engine, st.NewMemoryReader(), logger)
     runnersH := daemonrunners.New(st, channels, obs, logger)
-    webhookH := webhook.NewHandler(deliveryStore, channels, st, cfg.Daemon.HTTP, logger)
+    webhookH := webhook.NewHandler(deliveryStore, channels, st, obs, cfg.Daemon.HTTP, cfg.Daemon.SelfImprovement, logger)
 
     // 4. processor over the queue
     processor := workflow.NewProcessor(channels, engine, workers, shutdown, logger)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,6 +50,7 @@ See [`.env.sample`](../.env.sample) for a copy-pasteable list with current defau
 | `AGENTS_PROXY_UPSTREAM_MODEL` | upstream model name |
 | `AGENTS_PROXY_UPSTREAM_API_KEY_ENV` | env var name holding upstream API key |
 | `AGENTS_PROXY_UPSTREAM_TIMEOUT_SECONDS` | upstream request timeout |
+| `AGENTS_SELF_IMPROVEMENT_FEEDBACK_AUTHOR_ALLOWLIST` | comma-separated GitHub logins allowed to create actionable `#ai_improvement` feedback |
 
 Secrets keep their integration-specific names:
 
@@ -74,6 +75,8 @@ SSH_AUTH_SOCK=...
 ```
 
 AI and GitHub credentials are injected from the daemon environment into each ephemeral runner container. They are never part of `/config`, `/export`, MCP responses, or UI payloads.
+
+Self-improvement feedback ingestion has one startup-configured trust boundary. Set `AGENTS_SELF_IMPROVEMENT_FEEDBACK_AUTHOR_ALLOWLIST` to the GitHub logins allowed to create actionable `#ai_improvement` evidence. If the list is empty, the daemon falls back to `GITHUB_ACTOR` when present; otherwise tagged comments are stored as ignored audit rows instead of `new` feedback. Feedback memory here is not agent runtime memory: it stores raw, inspectable review evidence for later human-reviewed recommendation flows.
 
 `AGENTS_GIT_USER_NAME` and `AGENTS_GIT_USER_EMAIL` are not credentials, but they use the same env-driven runner setup path. When either is set, the runner setup runs `git config --global user.name "$AGENTS_GIT_USER_NAME"` and/or `git config --global user.email "$AGENTS_GIT_USER_EMAIL"` before starting the AI CLI. Set both explicitly so generated commits use a predictable author instead of letting agents invent one.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,7 +50,7 @@ See [`.env.sample`](../.env.sample) for a copy-pasteable list with current defau
 | `AGENTS_PROXY_UPSTREAM_MODEL` | upstream model name |
 | `AGENTS_PROXY_UPSTREAM_API_KEY_ENV` | env var name holding upstream API key |
 | `AGENTS_PROXY_UPSTREAM_TIMEOUT_SECONDS` | upstream request timeout |
-| `AGENTS_SELF_IMPROVEMENT_FEEDBACK_AUTHOR_ALLOWLIST` | comma-separated GitHub logins allowed to create actionable `#ai_improvement` feedback |
+| `AGENTS_SELF_IMPROVEMENT_FEEDBACK_AUTHOR_ALLOWLIST` | comma-separated GitHub logins allowed to create actionable `/agents improve` feedback |
 
 Secrets keep their integration-specific names:
 
@@ -76,7 +76,7 @@ SSH_AUTH_SOCK=...
 
 AI and GitHub credentials are injected from the daemon environment into each ephemeral runner container. They are never part of `/config`, `/export`, MCP responses, or UI payloads.
 
-Self-improvement feedback ingestion has one startup-configured trust boundary. Set `AGENTS_SELF_IMPROVEMENT_FEEDBACK_AUTHOR_ALLOWLIST` to the GitHub logins allowed to create actionable `#ai_improvement` evidence. If the list is empty, the daemon falls back to `GITHUB_ACTOR` when present; otherwise tagged comments are stored as ignored audit rows instead of `new` feedback. Feedback memory here is not agent runtime memory: it stores raw, inspectable review evidence for later human-reviewed recommendation flows.
+Self-improvement feedback ingestion has one startup-configured trust boundary. Set `AGENTS_SELF_IMPROVEMENT_FEEDBACK_AUTHOR_ALLOWLIST` to the GitHub logins allowed to create actionable `/agents improve` evidence. If the list is empty, the daemon falls back to `GITHUB_ACTOR` when present; otherwise marked comments are stored as ignored audit rows instead of `new` feedback. Feedback memory here is not agent runtime memory: it stores raw, inspectable review evidence for later human-reviewed recommendation flows.
 
 `AGENTS_GIT_USER_NAME` and `AGENTS_GIT_USER_EMAIL` are not credentials, but they use the same env-driven runner setup path. When either is set, the runner setup runs `git config --global user.name "$AGENTS_GIT_USER_NAME"` and/or `git config --global user.email "$AGENTS_GIT_USER_EMAIL"` before starting the AI CLI. Set both explicitly so generated commits use a predictable author instead of letting agents invent one.
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -92,7 +92,7 @@ For agent lifecycle changes, use `create_agent` when adding a new agent or inten
 | Tool | Description |
 |---|---|
 | `list_events` | Recent events with optional `since` filter. |
-| `list_improvement_feedback` | Stored `#ai_improvement` feedback evidence for a workspace, optionally filtered by status. |
+| `list_improvement_feedback` | Stored `/agents improve` feedback evidence for a workspace, optionally filtered by status. |
 | `list_traces` | Recent agent run spans with timing, summary, and token usage (`input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_write_tokens`, `prompt_size`). The composed prompt body is fetched separately via the `/traces/{span_id}/prompt` REST endpoint, not an MCP tool, since it can be many KB. |
 | `get_trace` | Full dispatch chain by root event ID. |
 | `get_trace_steps` | Tool-loop transcript for one span. |

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -92,6 +92,7 @@ For agent lifecycle changes, use `create_agent` when adding a new agent or inten
 | Tool | Description |
 |---|---|
 | `list_events` | Recent events with optional `since` filter. |
+| `list_improvement_feedback` | Stored `#ai_improvement` feedback evidence for a workspace, optionally filtered by status. |
 | `list_traces` | Recent agent run spans with timing, summary, and token usage (`input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_write_tokens`, `prompt_size`). The composed prompt body is fetched separately via the `/traces/{span_id}/prompt` REST endpoint, not an MCP tool, since it can be many KB. |
 | `get_trace` | Full dispatch chain by root event ID. |
 | `get_trace_steps` | Tool-loop transcript for one span. |

--- a/docs/self-improvement-feedback.md
+++ b/docs/self-improvement-feedback.md
@@ -1,7 +1,7 @@
 # Self-Improvement Feedback
 
-The daemon can capture maintainer review lessons from GitHub comments tagged
-with `#ai_improvement`. This issue implements only deterministic ingestion and
+The daemon can capture maintainer review lessons from GitHub comments marked
+with `/agents improve`. This issue implements only deterministic ingestion and
 inspection. It does not invoke AI, create recommendations, or publish catalog
 changes.
 
@@ -11,7 +11,7 @@ Supported webhook sources:
 - pull request review comments
 - pull request reviews
 
-The tag match is exact and case-sensitive. Fenced code blocks are ignored so
+The marker match is exact and case-sensitive. Fenced code blocks are ignored so
 examples do not create feedback records accidentally.
 
 Only trusted GitHub authors create actionable feedback. Configure them at
@@ -22,7 +22,7 @@ AGENTS_SELF_IMPROVEMENT_FEEDBACK_AUTHOR_ALLOWLIST=maintainer-login,agents-bot
 ```
 
 When the allowlist is omitted, `GITHUB_ACTOR` is used if available. If no
-trusted actor can be determined, tagged comments are stored with
+trusted actor can be determined, marked comments are stored with
 `status=ignored`.
 
 Stored feedback keeps the raw comment as source of truth, plus GitHub source

--- a/docs/self-improvement-feedback.md
+++ b/docs/self-improvement-feedback.md
@@ -1,0 +1,38 @@
+# Self-Improvement Feedback
+
+The daemon can capture maintainer review lessons from GitHub comments tagged
+with `#ai_improvement`. This issue implements only deterministic ingestion and
+inspection. It does not invoke AI, create recommendations, or publish catalog
+changes.
+
+Supported webhook sources:
+
+- issue comments
+- pull request review comments
+- pull request reviews
+
+The tag match is exact and case-sensitive. Fenced code blocks are ignored so
+examples do not create feedback records accidentally.
+
+Only trusted GitHub authors create actionable feedback. Configure them at
+startup:
+
+```bash
+AGENTS_SELF_IMPROVEMENT_FEEDBACK_AUTHOR_ALLOWLIST=maintainer-login,agents-bot
+```
+
+When the allowlist is omitted, `GITHUB_ACTOR` is used if available. If no
+trusted actor can be determined, tagged comments are stored with
+`status=ignored`.
+
+Stored feedback keeps the raw comment as source of truth, plus GitHub source
+metadata, repo/issue/PR/file context, author authorization, delivery ids, and
+run attribution when it can be resolved. Exact attribution comes from the public
+`agents-run` hidden metadata or commit trailers; otherwise the resolver may
+infer from repo, PR/issue number, commit SHA, and time window. Unresolved
+feedback is still stored.
+
+Inspect feedback in the dashboard under **Improvements**, through
+`GET /improvements/feedback`, or through the MCP `list_improvement_feedback`
+tool. Later recommendation and proposal flows consume these records but remain
+separate human-gated steps.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,11 +55,18 @@ type Config struct {
 // DaemonConfig holds infrastructure-level configuration for the running
 // daemon. Nothing here is specific to any particular agent or repo.
 type DaemonConfig struct {
-	Log        LogConfig                `yaml:"log"`
-	HTTP       HTTPConfig               `yaml:"http"`
-	Processor  ProcessorConfig          `yaml:"processor"`
-	AIBackends map[string]fleet.Backend `yaml:"-"`
-	Proxy      ProxyConfig              `yaml:"proxy"`
+	Log             LogConfig                `yaml:"log"`
+	HTTP            HTTPConfig               `yaml:"http"`
+	Processor       ProcessorConfig          `yaml:"processor"`
+	SelfImprovement SelfImprovementConfig    `yaml:"self_improvement"`
+	AIBackends      map[string]fleet.Backend `yaml:"-"`
+	Proxy           ProxyConfig              `yaml:"proxy"`
+}
+
+// SelfImprovementConfig controls deterministic capture of maintainer feedback
+// that later assistant runs can analyze. The ingestion path never calls AI.
+type SelfImprovementConfig struct {
+	FeedbackAuthorAllowlist []string `yaml:"feedback_author_allowlist"`
 }
 
 // ProxyConfig controls the built-in Anthropic↔OpenAI translation proxy.

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"os"
+	"slices"
 	"strings"
 
 	"github.com/eloylp/agents/internal/fleet"
@@ -60,6 +62,12 @@ func (c *Config) applyDefaults() {
 	setDefault(&c.Daemon.Proxy.Path, defaultProxyPath)
 	setDefaultInt(&c.Daemon.Proxy.Upstream.TimeoutSeconds, defaultProxyTimeoutSeconds)
 
+	if len(c.Daemon.SelfImprovement.FeedbackAuthorAllowlist) == 0 {
+		if actor := strings.TrimSpace(os.Getenv("GITHUB_ACTOR")); actor != "" {
+			c.Daemon.SelfImprovement.FeedbackAuthorAllowlist = []string{actor}
+		}
+	}
+
 	fleet.NormalizeRuntimeSettings(&c.Runtime)
 
 	// backend defaults
@@ -111,6 +119,11 @@ func (c *Config) normalize() {
 	// Log.
 	c.Daemon.Log.Level = strings.ToLower(strings.TrimSpace(c.Daemon.Log.Level))
 	c.Daemon.Log.Format = strings.ToLower(strings.TrimSpace(c.Daemon.Log.Format))
+
+	for i := range c.Daemon.SelfImprovement.FeedbackAuthorAllowlist {
+		c.Daemon.SelfImprovement.FeedbackAuthorAllowlist[i] = strings.ToLower(strings.TrimSpace(c.Daemon.SelfImprovement.FeedbackAuthorAllowlist[i]))
+	}
+	c.Daemon.SelfImprovement.FeedbackAuthorAllowlist = slices.Compact(c.Daemon.SelfImprovement.FeedbackAuthorAllowlist)
 }
 
 // setDefault writes def into *dst if *dst is empty (after trimming).

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -34,6 +34,8 @@ const (
 	envProxyUpstreamModel          = "AGENTS_PROXY_UPSTREAM_MODEL"
 	envProxyUpstreamAPIKeyEnv      = "AGENTS_PROXY_UPSTREAM_API_KEY_ENV"
 	envProxyUpstreamTimeoutSeconds = "AGENTS_PROXY_UPSTREAM_TIMEOUT_SECONDS"
+
+	envSelfImprovementFeedbackAuthorAllowlist = "AGENTS_SELF_IMPROVEMENT_FEEDBACK_AUTHOR_ALLOWLIST"
 )
 
 // applyEnvOverrides applies startup-only daemon runtime overrides. Empty env
@@ -95,6 +97,9 @@ func (c *Config) applyEnvOverrides() error {
 	applyStringEnv(envProxyUpstreamAPIKeyEnv, &c.Daemon.Proxy.Upstream.APIKeyEnv)
 	if err := applyPositiveIntEnv(envProxyUpstreamTimeoutSeconds, &c.Daemon.Proxy.Upstream.TimeoutSeconds); err != nil {
 		return err
+	}
+	if value, ok := nonEmptyEnv(envSelfImprovementFeedbackAuthorAllowlist); ok {
+		c.Daemon.SelfImprovement.FeedbackAuthorAllowlist = splitCSVEnv(value)
 	}
 	return nil
 }
@@ -166,4 +171,16 @@ func nonEmptyEnv(name string) (string, bool) {
 		return "", false
 	}
 	return value, true
+}
+
+func splitCSVEnv(value string) []string {
+	parts := strings.Split(value, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -138,7 +138,7 @@ func New(cfg *config.Config, st *store.Store, logger zerolog.Logger) (*Daemon, e
 	runnersHandler := daemonrunners.New(st, channels, obs, logger)
 
 	deliveryStore := webhook.NewDeliveryStore(time.Duration(cfg.Daemon.HTTP.DeliveryTTLSeconds) * time.Second)
-	webhookHandler := webhook.NewHandler(deliveryStore, channels, st, cfg.Daemon.HTTP, logger)
+	webhookHandler := webhook.NewHandler(deliveryStore, channels, st, obs, cfg.Daemon.HTTP, cfg.Daemon.SelfImprovement, logger)
 
 	// Processor sits over the queue; event recorder writes into observe so
 	// /events shows the firehose.

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -131,6 +131,7 @@ func TestBuildRouterRegistersExpectedRoutes(t *testing.T) {
 		{http.MethodGet, "/graph"},
 		{http.MethodGet, "/dispatches"},
 		{http.MethodGet, "/memory/coder/owner_repo"},
+		{http.MethodGet, "/improvements/feedback"},
 		{http.MethodGet, "/runners"},
 		{http.MethodDelete, "/runners/1"},
 		{http.MethodPost, "/runners/1/retry"},

--- a/internal/daemon/observe/observe.go
+++ b/internal/daemon/observe/observe.go
@@ -79,6 +79,7 @@ func (h *Handler) RegisterRoutes(r *mux.Router, withTimeout func(http.Handler) h
 	r.Handle("/dispatches", withTimeout(http.HandlerFunc(h.HandleDispatches))).Methods(http.MethodGet)
 	r.Handle("/memory/{agent}/{repo}", withTimeout(http.HandlerFunc(h.HandleMemory))).Methods(http.MethodGet)
 	r.HandleFunc("/memory/stream", h.HandleMemoryStream)
+	r.Handle("/improvements/feedback", withTimeout(http.HandlerFunc(h.HandleImprovementFeedback))).Methods(http.MethodGet)
 }
 
 // ── /dispatches ────────────────────────────────────────────────────────────
@@ -142,6 +143,24 @@ func (h *Handler) HandleEvents(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(out)
+}
+
+// HandleImprovementFeedback serves GET /improvements/feedback, the durable
+// tagged feedback events that later recommendation runs consume.
+func (h *Handler) HandleImprovementFeedback(w http.ResponseWriter, r *http.Request) {
+	limit := 100
+	workspaceID := fleet.NormalizeWorkspaceID(r.URL.Query().Get("workspace"))
+	rows, err := h.store.ListSelfImprovementFeedback(workspaceID, r.URL.Query().Get("status"), limit)
+	if err != nil {
+		h.logger.Error().Err(err).Msg("list self-improvement feedback")
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	if rows == nil {
+		rows = []store.SelfImprovementFeedback{}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(rows)
 }
 
 // HandleEventsStream serves GET /events/stream as a Server-Sent Events

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -199,7 +199,7 @@ func registerTools(srv *server.MCPServer, deps Deps) {
 		)
 		srv.AddTool(
 			mcpgo.NewTool("list_improvement_feedback",
-				mcpgo.WithDescription("List stored #ai_improvement feedback events for one workspace. These are raw evidence records; recommendation generation is a later human-reviewed step."),
+				mcpgo.WithDescription("List stored /agents improve feedback events for one workspace. These are raw evidence records; recommendation generation is a later human-reviewed step."),
 				mcpgo.WithString("workspace",
 					mcpgo.Description("Optional workspace id or display name. Defaults to default."),
 				),

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -198,6 +198,18 @@ func registerTools(srv *server.MCPServer, deps Deps) {
 			toolListEvents(deps),
 		)
 		srv.AddTool(
+			mcpgo.NewTool("list_improvement_feedback",
+				mcpgo.WithDescription("List stored #ai_improvement feedback events for one workspace. These are raw evidence records; recommendation generation is a later human-reviewed step."),
+				mcpgo.WithString("workspace",
+					mcpgo.Description("Optional workspace id or display name. Defaults to default."),
+				),
+				mcpgo.WithString("status",
+					mcpgo.Description("Optional status filter such as new or ignored."),
+				),
+			),
+			toolListImprovementFeedback(deps),
+		)
+		srv.AddTool(
 			mcpgo.NewTool("list_traces",
 				mcpgo.WithDescription("List recent agent run spans for one workspace. Ordered newest→oldest, capped at 200. Each span records backend, repo, status, duration, and summary. Omitted workspace defaults to default."),
 				mcpgo.WithString("workspace",

--- a/internal/mcp/tools_observe.go
+++ b/internal/mcp/tools_observe.go
@@ -54,6 +54,18 @@ func toolListEvents(deps Deps) server.ToolHandlerFunc {
 	}
 }
 
+func toolListImprovementFeedback(deps Deps) server.ToolHandlerFunc {
+	return func(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		workspace, _ := trimmedStringOptional(req, "workspace")
+		status, _ := trimmedStringOptional(req, "status")
+		rows, err := deps.Store.ListSelfImprovementFeedback(workspace, status, 100)
+		if err != nil {
+			return mcpgo.NewToolResultErrorFromErr("list improvement feedback", err), nil
+		}
+		return jsonResult(nilSafe(rows))
+	}
+}
+
 // toolListTraces returns the 200 most recent spans verbatim. The Span JSON
 // shape already matches GET /traces so clients can parse both surfaces with
 // the same decoder.

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -957,6 +957,53 @@ func TestToolListEventsNilSlice(t *testing.T) {
 	}
 }
 
+func TestToolListImprovementFeedback(t *testing.T) {
+	t.Parallel()
+	deps := testFixture(t)
+	if _, err := deps.Store.UpsertSelfImprovementFeedback(store.SelfImprovementFeedbackInput{
+		WorkspaceID:      fleet.DefaultWorkspaceID,
+		RepoOwner:        "owner",
+		RepoName:         "one",
+		SourceType:       "issue_comment",
+		GitHubCommentID:  101,
+		AuthorLogin:      "maintainer",
+		AuthorAuthorized: true,
+		IssueNumber:      7,
+		RawBody:          "remember this #ai_improvement",
+		LinkConfidence:   "unresolved",
+		Status:           "new",
+	}); err != nil {
+		t.Fatalf("seed feedback: %v", err)
+	}
+	if _, err := deps.Store.UpsertSelfImprovementFeedback(store.SelfImprovementFeedbackInput{
+		WorkspaceID:      fleet.DefaultWorkspaceID,
+		RepoOwner:        "owner",
+		RepoName:         "one",
+		SourceType:       "issue_comment",
+		GitHubCommentID:  102,
+		AuthorLogin:      "stranger",
+		AuthorAuthorized: false,
+		IssueNumber:      7,
+		RawBody:          "ignored #ai_improvement",
+		LinkConfidence:   "unresolved",
+		Status:           "ignored",
+	}); err != nil {
+		t.Fatalf("seed ignored feedback: %v", err)
+	}
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"status": "new"}
+	res, err := toolListImprovementFeedback(deps)(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var got []map[string]any
+	decodeText(t, res, &got)
+	if len(got) != 1 || got[0]["github_comment_id"] != float64(101) || got[0]["status"] != "new" {
+		t.Fatalf("feedback filter returned %+v, want only comment 101", got)
+	}
+}
+
 func TestToolListTraces(t *testing.T) {
 	t.Parallel()
 	deps := testFixture(t)

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -969,7 +969,7 @@ func TestToolListImprovementFeedback(t *testing.T) {
 		AuthorLogin:      "maintainer",
 		AuthorAuthorized: true,
 		IssueNumber:      7,
-		RawBody:          "remember this #ai_improvement",
+		RawBody:          "remember this /agents improve",
 		LinkConfidence:   "unresolved",
 		Status:           "new",
 	}); err != nil {
@@ -984,7 +984,7 @@ func TestToolListImprovementFeedback(t *testing.T) {
 		AuthorLogin:      "stranger",
 		AuthorAuthorized: false,
 		IssueNumber:      7,
-		RawBody:          "ignored #ai_improvement",
+		RawBody:          "ignored /agents improve",
 		LinkConfidence:   "unresolved",
 		Status:           "ignored",
 	}); err != nil {

--- a/internal/store/migrations/037_self_improvement_feedback.sql
+++ b/internal/store/migrations/037_self_improvement_feedback.sql
@@ -1,0 +1,45 @@
+-- 037_self_improvement_feedback: immutable evidence records for tagged
+-- maintainer feedback that later self-improvement recommendation runs analyze.
+
+CREATE TABLE IF NOT EXISTS self_improvement_feedback (
+    id                         INTEGER PRIMARY KEY AUTOINCREMENT,
+    workspace_id               TEXT NOT NULL DEFAULT 'default',
+    repo_owner                 TEXT NOT NULL,
+    repo_name                  TEXT NOT NULL,
+    source_type                TEXT NOT NULL,
+    github_comment_id          INTEGER NOT NULL DEFAULT 0,
+    github_review_id           INTEGER NOT NULL DEFAULT 0,
+    github_delivery_id         TEXT NOT NULL DEFAULT '',
+    source_url                 TEXT NOT NULL DEFAULT '',
+    author_login               TEXT NOT NULL DEFAULT '',
+    author_authorized          INTEGER NOT NULL DEFAULT 0,
+    issue_number               INTEGER NOT NULL DEFAULT 0,
+    pr_number                  INTEGER NOT NULL DEFAULT 0,
+    raw_body                   TEXT NOT NULL DEFAULT '',
+    tag                        TEXT NOT NULL DEFAULT '#ai_improvement',
+    file_path                  TEXT NOT NULL DEFAULT '',
+    line                       INTEGER NOT NULL DEFAULT 0,
+    side                       TEXT NOT NULL DEFAULT '',
+    diff_hunk                  TEXT NOT NULL DEFAULT '',
+    commit_sha                 TEXT NOT NULL DEFAULT '',
+    github_created_at          TIMESTAMP NULL,
+    github_updated_at          TIMESTAMP NULL,
+    ingested_at                TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    linked_span_id             TEXT NOT NULL DEFAULT '',
+    linked_event_id            TEXT NOT NULL DEFAULT '',
+    linked_agent_id            TEXT NOT NULL DEFAULT '',
+    linked_agent_name          TEXT NOT NULL DEFAULT '',
+    linked_prompt_version_id   TEXT NOT NULL DEFAULT '',
+    linked_skill_version_ids   TEXT NOT NULL DEFAULT '',
+    linked_guardrail_version_ids TEXT NOT NULL DEFAULT '',
+    link_confidence            TEXT NOT NULL DEFAULT 'unresolved',
+    link_diagnostics           TEXT NOT NULL DEFAULT '',
+    status                     TEXT NOT NULL DEFAULT 'new',
+    UNIQUE(workspace_id, source_type, github_comment_id, github_review_id, tag)
+);
+
+CREATE INDEX IF NOT EXISTS idx_self_improvement_feedback_workspace_status
+    ON self_improvement_feedback(workspace_id, status, ingested_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_self_improvement_feedback_repo
+    ON self_improvement_feedback(workspace_id, repo_owner, repo_name, pr_number, issue_number);

--- a/internal/store/migrations/037_self_improvement_feedback.sql
+++ b/internal/store/migrations/037_self_improvement_feedback.sql
@@ -1,4 +1,4 @@
--- 037_self_improvement_feedback: immutable evidence records for tagged
+-- 037_self_improvement_feedback: immutable evidence records for marked
 -- maintainer feedback that later self-improvement recommendation runs analyze.
 
 CREATE TABLE IF NOT EXISTS self_improvement_feedback (
@@ -16,7 +16,7 @@ CREATE TABLE IF NOT EXISTS self_improvement_feedback (
     issue_number               INTEGER NOT NULL DEFAULT 0,
     pr_number                  INTEGER NOT NULL DEFAULT 0,
     raw_body                   TEXT NOT NULL DEFAULT '',
-    tag                        TEXT NOT NULL DEFAULT '#ai_improvement',
+    tag                        TEXT NOT NULL DEFAULT '/agents improve',
     file_path                  TEXT NOT NULL DEFAULT '',
     line                       INTEGER NOT NULL DEFAULT 0,
     side                       TEXT NOT NULL DEFAULT '',

--- a/internal/store/self_improvement.go
+++ b/internal/store/self_improvement.go
@@ -11,6 +11,7 @@ import (
 const (
 	FeedbackStatusNew     = "new"
 	FeedbackStatusIgnored = "ignored"
+	FeedbackTag           = "/agents improve"
 )
 
 type SelfImprovementFeedback struct {
@@ -99,7 +100,7 @@ func UpsertSelfImprovementFeedback(db *sql.DB, in SelfImprovementFeedbackInput) 
 	workspaceID := fleet.NormalizeWorkspaceID(in.WorkspaceID)
 	tag := strings.TrimSpace(in.Tag)
 	if tag == "" {
-		tag = "#ai_improvement"
+		tag = FeedbackTag
 	}
 	status := strings.TrimSpace(in.Status)
 	if status == "" {
@@ -176,7 +177,7 @@ func IgnoreSelfImprovementFeedback(db *sql.DB, in SelfImprovementFeedbackInput) 
 	workspaceID := fleet.NormalizeWorkspaceID(in.WorkspaceID)
 	tag := strings.TrimSpace(in.Tag)
 	if tag == "" {
-		tag = "#ai_improvement"
+		tag = FeedbackTag
 	}
 	res, err := db.Exec(
 		`UPDATE self_improvement_feedback SET

--- a/internal/store/self_improvement.go
+++ b/internal/store/self_improvement.go
@@ -87,6 +87,10 @@ func (s *Store) UpsertSelfImprovementFeedback(in SelfImprovementFeedbackInput) (
 	return UpsertSelfImprovementFeedback(s.db, in)
 }
 
+func (s *Store) IgnoreSelfImprovementFeedback(in SelfImprovementFeedbackInput) (bool, error) {
+	return IgnoreSelfImprovementFeedback(s.db, in)
+}
+
 func (s *Store) ListSelfImprovementFeedback(workspace, status string, limit int) ([]SelfImprovementFeedback, error) {
 	return ListSelfImprovementFeedback(s.db, workspace, status, limit)
 }
@@ -137,7 +141,11 @@ func UpsertSelfImprovementFeedback(db *sql.DB, in SelfImprovementFeedbackInput) 
 			linked_guardrail_version_ids=excluded.linked_guardrail_version_ids,
 			link_confidence=excluded.link_confidence,
 			link_diagnostics=excluded.link_diagnostics,
-			status=excluded.status`,
+			status=CASE
+				WHEN excluded.status = 'ignored' THEN excluded.status
+				WHEN self_improvement_feedback.raw_body <> excluded.raw_body THEN excluded.status
+				ELSE self_improvement_feedback.status
+			END`,
 		workspaceID, strings.TrimSpace(in.RepoOwner), strings.TrimSpace(in.RepoName), strings.TrimSpace(in.SourceType),
 		in.GitHubCommentID, in.GitHubReviewID, strings.TrimSpace(in.GitHubDeliveryID), strings.TrimSpace(in.SourceURL),
 		strings.TrimSpace(in.AuthorLogin), boolInt(in.AuthorAuthorized), in.IssueNumber, in.PRNumber, in.RawBody, tag,
@@ -162,6 +170,44 @@ func UpsertSelfImprovementFeedback(db *sql.DB, in SelfImprovementFeedbackInput) 
 		workspaceID, strings.TrimSpace(in.SourceType), in.GitHubCommentID, in.GitHubReviewID, tag,
 	)
 	return scanSelfImprovementFeedback(row)
+}
+
+func IgnoreSelfImprovementFeedback(db *sql.DB, in SelfImprovementFeedbackInput) (bool, error) {
+	workspaceID := fleet.NormalizeWorkspaceID(in.WorkspaceID)
+	tag := strings.TrimSpace(in.Tag)
+	if tag == "" {
+		tag = "#ai_improvement"
+	}
+	res, err := db.Exec(
+		`UPDATE self_improvement_feedback SET
+			github_delivery_id=?,
+			source_url=?,
+			author_login=?,
+			author_authorized=?,
+			issue_number=?,
+			pr_number=?,
+			raw_body=?,
+			file_path=?,
+			line=?,
+			side=?,
+			diff_hunk=?,
+			commit_sha=?,
+			github_updated_at=?,
+			status=?
+		WHERE workspace_id=? AND source_type=? AND github_comment_id=? AND github_review_id=? AND tag=?`,
+		strings.TrimSpace(in.GitHubDeliveryID), strings.TrimSpace(in.SourceURL), strings.TrimSpace(in.AuthorLogin),
+		boolInt(in.AuthorAuthorized), in.IssueNumber, in.PRNumber, in.RawBody, strings.TrimSpace(in.FilePath),
+		in.Line, strings.TrimSpace(in.Side), in.DiffHunk, strings.TrimSpace(in.CommitSHA), in.GitHubUpdatedAt,
+		FeedbackStatusIgnored, workspaceID, strings.TrimSpace(in.SourceType), in.GitHubCommentID, in.GitHubReviewID, tag,
+	)
+	if err != nil {
+		return false, err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return affected > 0, nil
 }
 
 func ListSelfImprovementFeedback(db *sql.DB, workspace, status string, limit int) ([]SelfImprovementFeedback, error) {

--- a/internal/store/self_improvement.go
+++ b/internal/store/self_improvement.go
@@ -1,0 +1,263 @@
+package store
+
+import (
+	"database/sql"
+	"strings"
+	"time"
+
+	"github.com/eloylp/agents/internal/fleet"
+)
+
+const (
+	FeedbackStatusNew     = "new"
+	FeedbackStatusIgnored = "ignored"
+)
+
+type SelfImprovementFeedback struct {
+	ID                        int64      `json:"id"`
+	WorkspaceID               string     `json:"workspace"`
+	RepoOwner                 string     `json:"repo_owner"`
+	RepoName                  string     `json:"repo_name"`
+	SourceType                string     `json:"source_type"`
+	GitHubCommentID           int64      `json:"github_comment_id,omitempty"`
+	GitHubReviewID            int64      `json:"github_review_id,omitempty"`
+	GitHubDeliveryID          string     `json:"github_delivery_id,omitempty"`
+	SourceURL                 string     `json:"source_url"`
+	AuthorLogin               string     `json:"author_login"`
+	AuthorAuthorized          bool       `json:"author_authorized"`
+	IssueNumber               int        `json:"issue_number,omitempty"`
+	PRNumber                  int        `json:"pr_number,omitempty"`
+	RawBody                   string     `json:"raw_body"`
+	Tag                       string     `json:"tag"`
+	FilePath                  string     `json:"file_path,omitempty"`
+	Line                      int        `json:"line,omitempty"`
+	Side                      string     `json:"side,omitempty"`
+	DiffHunk                  string     `json:"diff_hunk,omitempty"`
+	CommitSHA                 string     `json:"commit_sha,omitempty"`
+	GitHubCreatedAt           *time.Time `json:"github_created_at,omitempty"`
+	GitHubUpdatedAt           *time.Time `json:"github_updated_at,omitempty"`
+	IngestedAt                time.Time  `json:"ingested_at"`
+	LinkedSpanID              string     `json:"linked_span_id,omitempty"`
+	LinkedEventID             string     `json:"linked_event_id,omitempty"`
+	LinkedAgentID             string     `json:"linked_agent_id,omitempty"`
+	LinkedAgentName           string     `json:"linked_agent_name,omitempty"`
+	LinkedPromptVersionID     string     `json:"linked_prompt_version_id,omitempty"`
+	LinkedSkillVersionIDs     []string   `json:"linked_skill_version_ids,omitempty"`
+	LinkedGuardrailVersionIDs []string   `json:"linked_guardrail_version_ids,omitempty"`
+	LinkConfidence            string     `json:"link_confidence"`
+	LinkDiagnostics           string     `json:"link_diagnostics,omitempty"`
+	Status                    string     `json:"status"`
+}
+
+type SelfImprovementFeedbackInput struct {
+	WorkspaceID               string
+	RepoOwner                 string
+	RepoName                  string
+	SourceType                string
+	GitHubCommentID           int64
+	GitHubReviewID            int64
+	GitHubDeliveryID          string
+	SourceURL                 string
+	AuthorLogin               string
+	AuthorAuthorized          bool
+	IssueNumber               int
+	PRNumber                  int
+	RawBody                   string
+	Tag                       string
+	FilePath                  string
+	Line                      int
+	Side                      string
+	DiffHunk                  string
+	CommitSHA                 string
+	GitHubCreatedAt           *time.Time
+	GitHubUpdatedAt           *time.Time
+	LinkedSpanID              string
+	LinkedEventID             string
+	LinkedAgentID             string
+	LinkedAgentName           string
+	LinkedPromptVersionID     string
+	LinkedSkillVersionIDs     []string
+	LinkedGuardrailVersionIDs []string
+	LinkConfidence            string
+	LinkDiagnostics           string
+	Status                    string
+}
+
+func (s *Store) UpsertSelfImprovementFeedback(in SelfImprovementFeedbackInput) (SelfImprovementFeedback, error) {
+	return UpsertSelfImprovementFeedback(s.db, in)
+}
+
+func (s *Store) ListSelfImprovementFeedback(workspace, status string, limit int) ([]SelfImprovementFeedback, error) {
+	return ListSelfImprovementFeedback(s.db, workspace, status, limit)
+}
+
+func UpsertSelfImprovementFeedback(db *sql.DB, in SelfImprovementFeedbackInput) (SelfImprovementFeedback, error) {
+	workspaceID := fleet.NormalizeWorkspaceID(in.WorkspaceID)
+	tag := strings.TrimSpace(in.Tag)
+	if tag == "" {
+		tag = "#ai_improvement"
+	}
+	status := strings.TrimSpace(in.Status)
+	if status == "" {
+		status = FeedbackStatusNew
+	}
+	confidence := strings.TrimSpace(in.LinkConfidence)
+	if confidence == "" {
+		confidence = "unresolved"
+	}
+	_, err := db.Exec(
+		`INSERT INTO self_improvement_feedback (
+			workspace_id, repo_owner, repo_name, source_type, github_comment_id, github_review_id,
+			github_delivery_id, source_url, author_login, author_authorized, issue_number, pr_number,
+			raw_body, tag, file_path, line, side, diff_hunk, commit_sha, github_created_at,
+			github_updated_at, linked_span_id, linked_event_id, linked_agent_id, linked_agent_name,
+			linked_prompt_version_id, linked_skill_version_ids, linked_guardrail_version_ids,
+			link_confidence, link_diagnostics, status
+		) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+		ON CONFLICT(workspace_id, source_type, github_comment_id, github_review_id, tag) DO UPDATE SET
+			github_delivery_id=excluded.github_delivery_id,
+			source_url=excluded.source_url,
+			author_login=excluded.author_login,
+			author_authorized=excluded.author_authorized,
+			issue_number=excluded.issue_number,
+			pr_number=excluded.pr_number,
+			raw_body=excluded.raw_body,
+			file_path=excluded.file_path,
+			line=excluded.line,
+			side=excluded.side,
+			diff_hunk=excluded.diff_hunk,
+			commit_sha=excluded.commit_sha,
+			github_updated_at=excluded.github_updated_at,
+			linked_span_id=excluded.linked_span_id,
+			linked_event_id=excluded.linked_event_id,
+			linked_agent_id=excluded.linked_agent_id,
+			linked_agent_name=excluded.linked_agent_name,
+			linked_prompt_version_id=excluded.linked_prompt_version_id,
+			linked_skill_version_ids=excluded.linked_skill_version_ids,
+			linked_guardrail_version_ids=excluded.linked_guardrail_version_ids,
+			link_confidence=excluded.link_confidence,
+			link_diagnostics=excluded.link_diagnostics,
+			status=excluded.status`,
+		workspaceID, strings.TrimSpace(in.RepoOwner), strings.TrimSpace(in.RepoName), strings.TrimSpace(in.SourceType),
+		in.GitHubCommentID, in.GitHubReviewID, strings.TrimSpace(in.GitHubDeliveryID), strings.TrimSpace(in.SourceURL),
+		strings.TrimSpace(in.AuthorLogin), boolInt(in.AuthorAuthorized), in.IssueNumber, in.PRNumber, in.RawBody, tag,
+		strings.TrimSpace(in.FilePath), in.Line, strings.TrimSpace(in.Side), in.DiffHunk, strings.TrimSpace(in.CommitSHA),
+		in.GitHubCreatedAt, in.GitHubUpdatedAt, strings.TrimSpace(in.LinkedSpanID), strings.TrimSpace(in.LinkedEventID),
+		strings.TrimSpace(in.LinkedAgentID), strings.TrimSpace(in.LinkedAgentName), strings.TrimSpace(in.LinkedPromptVersionID),
+		strings.Join(in.LinkedSkillVersionIDs, ","), strings.Join(in.LinkedGuardrailVersionIDs, ","), confidence,
+		strings.TrimSpace(in.LinkDiagnostics), status,
+	)
+	if err != nil {
+		return SelfImprovementFeedback{}, err
+	}
+	row := db.QueryRow(
+		`SELECT id, workspace_id, repo_owner, repo_name, source_type, github_comment_id, github_review_id,
+			github_delivery_id, source_url, author_login, author_authorized, issue_number, pr_number,
+			raw_body, tag, file_path, line, side, diff_hunk, commit_sha, github_created_at,
+			github_updated_at, ingested_at, linked_span_id, linked_event_id, linked_agent_id,
+			linked_agent_name, linked_prompt_version_id, linked_skill_version_ids,
+			linked_guardrail_version_ids, link_confidence, link_diagnostics, status
+		FROM self_improvement_feedback
+		WHERE workspace_id=? AND source_type=? AND github_comment_id=? AND github_review_id=? AND tag=?`,
+		workspaceID, strings.TrimSpace(in.SourceType), in.GitHubCommentID, in.GitHubReviewID, tag,
+	)
+	return scanSelfImprovementFeedback(row)
+}
+
+func ListSelfImprovementFeedback(db *sql.DB, workspace, status string, limit int) ([]SelfImprovementFeedback, error) {
+	if limit <= 0 || limit > 500 {
+		limit = 100
+	}
+	workspaceID := fleet.NormalizeWorkspaceID(workspace)
+	status = strings.TrimSpace(status)
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if status == "" {
+		rows, err = db.Query(
+			`SELECT id, workspace_id, repo_owner, repo_name, source_type, github_comment_id, github_review_id,
+				github_delivery_id, source_url, author_login, author_authorized, issue_number, pr_number,
+				raw_body, tag, file_path, line, side, diff_hunk, commit_sha, github_created_at,
+				github_updated_at, ingested_at, linked_span_id, linked_event_id, linked_agent_id,
+				linked_agent_name, linked_prompt_version_id, linked_skill_version_ids,
+				linked_guardrail_version_ids, link_confidence, link_diagnostics, status
+			FROM self_improvement_feedback
+			WHERE workspace_id=?
+			ORDER BY ingested_at DESC, id DESC LIMIT ?`,
+			workspaceID, limit,
+		)
+	} else {
+		rows, err = db.Query(
+			`SELECT id, workspace_id, repo_owner, repo_name, source_type, github_comment_id, github_review_id,
+				github_delivery_id, source_url, author_login, author_authorized, issue_number, pr_number,
+				raw_body, tag, file_path, line, side, diff_hunk, commit_sha, github_created_at,
+				github_updated_at, ingested_at, linked_span_id, linked_event_id, linked_agent_id,
+				linked_agent_name, linked_prompt_version_id, linked_skill_version_ids,
+				linked_guardrail_version_ids, link_confidence, link_diagnostics, status
+			FROM self_improvement_feedback
+			WHERE workspace_id=? AND status=?
+			ORDER BY ingested_at DESC, id DESC LIMIT ?`,
+			workspaceID, status, limit,
+		)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []SelfImprovementFeedback
+	for rows.Next() {
+		ev, err := scanSelfImprovementFeedback(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, ev)
+	}
+	return out, rows.Err()
+}
+
+type selfImprovementScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanSelfImprovementFeedback(row selfImprovementScanner) (SelfImprovementFeedback, error) {
+	var ev SelfImprovementFeedback
+	var authorized int
+	var skillIDs, guardrailIDs string
+	if err := row.Scan(
+		&ev.ID, &ev.WorkspaceID, &ev.RepoOwner, &ev.RepoName, &ev.SourceType, &ev.GitHubCommentID, &ev.GitHubReviewID,
+		&ev.GitHubDeliveryID, &ev.SourceURL, &ev.AuthorLogin, &authorized, &ev.IssueNumber, &ev.PRNumber,
+		&ev.RawBody, &ev.Tag, &ev.FilePath, &ev.Line, &ev.Side, &ev.DiffHunk, &ev.CommitSHA, &ev.GitHubCreatedAt,
+		&ev.GitHubUpdatedAt, &ev.IngestedAt, &ev.LinkedSpanID, &ev.LinkedEventID, &ev.LinkedAgentID,
+		&ev.LinkedAgentName, &ev.LinkedPromptVersionID, &skillIDs, &guardrailIDs, &ev.LinkConfidence,
+		&ev.LinkDiagnostics, &ev.Status,
+	); err != nil {
+		return SelfImprovementFeedback{}, err
+	}
+	ev.AuthorAuthorized = authorized == 1
+	ev.LinkedSkillVersionIDs = splitCSV(skillIDs)
+	ev.LinkedGuardrailVersionIDs = splitCSV(guardrailIDs)
+	return ev, nil
+}
+
+func boolInt(v bool) int {
+	if v {
+		return 1
+	}
+	return 0
+}
+
+func splitCSV(s string) []string {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -123,6 +123,75 @@ func openTestDB(t *testing.T) *sql.DB {
 	return db
 }
 
+func TestSelfImprovementFeedbackUpsertAndList(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	st := store.New(db)
+	t.Cleanup(func() { st.Close() })
+
+	created := time.Date(2026, 5, 30, 10, 0, 0, 0, time.UTC)
+	first, err := st.UpsertSelfImprovementFeedback(store.SelfImprovementFeedbackInput{
+		WorkspaceID:               "team-a",
+		RepoOwner:                 "owner",
+		RepoName:                  "repo",
+		SourceType:                "issue_comment",
+		GitHubCommentID:           123,
+		GitHubDeliveryID:          "delivery-1",
+		SourceURL:                 "https://github.com/owner/repo/issues/7#issuecomment-123",
+		AuthorLogin:               "maintainer",
+		AuthorAuthorized:          true,
+		IssueNumber:               7,
+		RawBody:                   "first #ai_improvement",
+		GitHubCreatedAt:           &created,
+		LinkedSpanID:              "span-1",
+		LinkedEventID:             "event-1",
+		LinkedAgentID:             "agent-1",
+		LinkedAgentName:           "coder",
+		LinkedPromptVersionID:     "prompt-v1",
+		LinkedSkillVersionIDs:     []string{"skill-v1"},
+		LinkedGuardrailVersionIDs: []string{"guardrail-v1"},
+		LinkConfidence:            "exact",
+	})
+	if err != nil {
+		t.Fatalf("insert feedback: %v", err)
+	}
+	if first.ID == 0 || first.Status != "new" || !first.AuthorAuthorized {
+		t.Fatalf("inserted feedback = %+v, want new authorized row", first)
+	}
+
+	if _, err := st.UpsertSelfImprovementFeedback(store.SelfImprovementFeedbackInput{
+		WorkspaceID:      "team-a",
+		RepoOwner:        "owner",
+		RepoName:         "repo",
+		SourceType:       "issue_comment",
+		GitHubCommentID:  123,
+		GitHubDeliveryID: "delivery-2",
+		AuthorLogin:      "maintainer",
+		AuthorAuthorized: true,
+		IssueNumber:      7,
+		RawBody:          "edited #ai_improvement",
+		LinkConfidence:   "unresolved",
+		LinkDiagnostics:  "no matching run attribution snapshot",
+	}); err != nil {
+		t.Fatalf("update feedback: %v", err)
+	}
+
+	rows, err := st.ListSelfImprovementFeedback("team-a", "", 10)
+	if err != nil {
+		t.Fatalf("list feedback: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("feedback rows = %d, want 1", len(rows))
+	}
+	got := rows[0]
+	if got.ID != first.ID || got.RawBody != "edited #ai_improvement" || got.GitHubDeliveryID != "delivery-2" {
+		t.Fatalf("updated feedback = %+v, want same row with edited body", got)
+	}
+	if got.LinkedSpanID != "" || got.LinkConfidence != "unresolved" {
+		t.Fatalf("updated attribution = %+v, want unresolved with no linked span", got)
+	}
+}
+
 // TestGuardrailsSeed verifies that migrations 010, 012, 013, and 016 created
 // the generic guardrails table and seeded the built-in rows with content
 // equal to default_content (so a "Reset to default" from the unedited

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -141,7 +141,7 @@ func TestSelfImprovementFeedbackUpsertAndList(t *testing.T) {
 		AuthorLogin:               "maintainer",
 		AuthorAuthorized:          true,
 		IssueNumber:               7,
-		RawBody:                   "first #ai_improvement",
+		RawBody:                   "first /agents improve",
 		GitHubCreatedAt:           &created,
 		LinkedSpanID:              "span-1",
 		LinkedEventID:             "event-1",
@@ -169,7 +169,7 @@ func TestSelfImprovementFeedbackUpsertAndList(t *testing.T) {
 		AuthorLogin:      "maintainer",
 		AuthorAuthorized: true,
 		IssueNumber:      7,
-		RawBody:          "edited #ai_improvement",
+		RawBody:          "edited /agents improve",
 		LinkConfidence:   "unresolved",
 		LinkDiagnostics:  "no matching run attribution snapshot",
 	}); err != nil {
@@ -184,7 +184,7 @@ func TestSelfImprovementFeedbackUpsertAndList(t *testing.T) {
 		t.Fatalf("feedback rows = %d, want 1", len(rows))
 	}
 	got := rows[0]
-	if got.ID != first.ID || got.RawBody != "edited #ai_improvement" || got.GitHubDeliveryID != "delivery-2" {
+	if got.ID != first.ID || got.RawBody != "edited /agents improve" || got.GitHubDeliveryID != "delivery-2" {
 		t.Fatalf("updated feedback = %+v, want same row with edited body", got)
 	}
 	if got.LinkedSpanID != "" || got.LinkConfidence != "unresolved" {
@@ -208,7 +208,7 @@ func TestSelfImprovementFeedbackUpsertPreservesStatusOnRedelivery(t *testing.T) 
 		AuthorLogin:      "maintainer",
 		AuthorAuthorized: true,
 		IssueNumber:      7,
-		RawBody:          "first #ai_improvement",
+		RawBody:          "first /agents improve",
 		Status:           "analyzed",
 	}); err != nil {
 		t.Fatalf("insert feedback: %v", err)
@@ -223,7 +223,7 @@ func TestSelfImprovementFeedbackUpsertPreservesStatusOnRedelivery(t *testing.T) 
 		AuthorLogin:      "maintainer",
 		AuthorAuthorized: true,
 		IssueNumber:      7,
-		RawBody:          "first #ai_improvement",
+		RawBody:          "first /agents improve",
 	}); err != nil {
 		t.Fatalf("redeliver feedback: %v", err)
 	}
@@ -248,7 +248,7 @@ func TestSelfImprovementFeedbackUpsertPreservesStatusOnRedelivery(t *testing.T) 
 		AuthorLogin:      "maintainer",
 		AuthorAuthorized: true,
 		IssueNumber:      7,
-		RawBody:          "edited #ai_improvement",
+		RawBody:          "edited /agents improve",
 	}); err != nil {
 		t.Fatalf("edit feedback: %v", err)
 	}
@@ -256,7 +256,7 @@ func TestSelfImprovementFeedbackUpsertPreservesStatusOnRedelivery(t *testing.T) 
 	if err != nil {
 		t.Fatalf("list edited feedback: %v", err)
 	}
-	if rows[0].Status != store.FeedbackStatusNew || rows[0].RawBody != "edited #ai_improvement" {
+	if rows[0].Status != store.FeedbackStatusNew || rows[0].RawBody != "edited /agents improve" {
 		t.Fatalf("edited feedback = %+v, want new status with edited body", rows[0])
 	}
 }
@@ -289,7 +289,7 @@ func TestIgnoreSelfImprovementFeedbackUpdatesExistingRowOnly(t *testing.T) {
 		AuthorLogin:      "maintainer",
 		AuthorAuthorized: true,
 		IssueNumber:      7,
-		RawBody:          "first #ai_improvement",
+		RawBody:          "first /agents improve",
 		Status:           "analyzed",
 	}); err != nil {
 		t.Fatalf("insert feedback: %v", err)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -192,6 +192,136 @@ func TestSelfImprovementFeedbackUpsertAndList(t *testing.T) {
 	}
 }
 
+func TestSelfImprovementFeedbackUpsertPreservesStatusOnRedelivery(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	st := store.New(db)
+	t.Cleanup(func() { st.Close() })
+
+	if _, err := st.UpsertSelfImprovementFeedback(store.SelfImprovementFeedbackInput{
+		WorkspaceID:      "team-a",
+		RepoOwner:        "owner",
+		RepoName:         "repo",
+		SourceType:       "issue_comment",
+		GitHubCommentID:  123,
+		GitHubDeliveryID: "delivery-1",
+		AuthorLogin:      "maintainer",
+		AuthorAuthorized: true,
+		IssueNumber:      7,
+		RawBody:          "first #ai_improvement",
+		Status:           "analyzed",
+	}); err != nil {
+		t.Fatalf("insert feedback: %v", err)
+	}
+	if _, err := st.UpsertSelfImprovementFeedback(store.SelfImprovementFeedbackInput{
+		WorkspaceID:      "team-a",
+		RepoOwner:        "owner",
+		RepoName:         "repo",
+		SourceType:       "issue_comment",
+		GitHubCommentID:  123,
+		GitHubDeliveryID: "delivery-2",
+		AuthorLogin:      "maintainer",
+		AuthorAuthorized: true,
+		IssueNumber:      7,
+		RawBody:          "first #ai_improvement",
+	}); err != nil {
+		t.Fatalf("redeliver feedback: %v", err)
+	}
+	rows, err := st.ListSelfImprovementFeedback("team-a", "", 10)
+	if err != nil {
+		t.Fatalf("list feedback: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("feedback rows = %d, want 1", len(rows))
+	}
+	if rows[0].Status != "analyzed" {
+		t.Fatalf("redelivered status = %q, want analyzed", rows[0].Status)
+	}
+
+	if _, err := st.UpsertSelfImprovementFeedback(store.SelfImprovementFeedbackInput{
+		WorkspaceID:      "team-a",
+		RepoOwner:        "owner",
+		RepoName:         "repo",
+		SourceType:       "issue_comment",
+		GitHubCommentID:  123,
+		GitHubDeliveryID: "delivery-3",
+		AuthorLogin:      "maintainer",
+		AuthorAuthorized: true,
+		IssueNumber:      7,
+		RawBody:          "edited #ai_improvement",
+	}); err != nil {
+		t.Fatalf("edit feedback: %v", err)
+	}
+	rows, err = st.ListSelfImprovementFeedback("team-a", "", 10)
+	if err != nil {
+		t.Fatalf("list edited feedback: %v", err)
+	}
+	if rows[0].Status != store.FeedbackStatusNew || rows[0].RawBody != "edited #ai_improvement" {
+		t.Fatalf("edited feedback = %+v, want new status with edited body", rows[0])
+	}
+}
+
+func TestIgnoreSelfImprovementFeedbackUpdatesExistingRowOnly(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	st := store.New(db)
+	t.Cleanup(func() { st.Close() })
+
+	ignored, err := st.IgnoreSelfImprovementFeedback(store.SelfImprovementFeedbackInput{
+		WorkspaceID:     "team-a",
+		SourceType:      "issue_comment",
+		GitHubCommentID: 123,
+		RawBody:         "no tag",
+	})
+	if err != nil {
+		t.Fatalf("ignore missing feedback: %v", err)
+	}
+	if ignored {
+		t.Fatalf("ignore missing feedback = true, want false")
+	}
+	if _, err := st.UpsertSelfImprovementFeedback(store.SelfImprovementFeedbackInput{
+		WorkspaceID:      "team-a",
+		RepoOwner:        "owner",
+		RepoName:         "repo",
+		SourceType:       "issue_comment",
+		GitHubCommentID:  123,
+		GitHubDeliveryID: "delivery-1",
+		AuthorLogin:      "maintainer",
+		AuthorAuthorized: true,
+		IssueNumber:      7,
+		RawBody:          "first #ai_improvement",
+		Status:           "analyzed",
+	}); err != nil {
+		t.Fatalf("insert feedback: %v", err)
+	}
+	ignored, err = st.IgnoreSelfImprovementFeedback(store.SelfImprovementFeedbackInput{
+		WorkspaceID:      "team-a",
+		SourceType:       "issue_comment",
+		GitHubCommentID:  123,
+		GitHubDeliveryID: "delivery-2",
+		AuthorLogin:      "maintainer",
+		AuthorAuthorized: true,
+		IssueNumber:      7,
+		RawBody:          "tag removed",
+	})
+	if err != nil {
+		t.Fatalf("ignore feedback: %v", err)
+	}
+	if !ignored {
+		t.Fatalf("ignore feedback = false, want true")
+	}
+	rows, err := st.ListSelfImprovementFeedback("team-a", "", 10)
+	if err != nil {
+		t.Fatalf("list feedback: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("feedback rows = %d, want 1", len(rows))
+	}
+	if rows[0].Status != store.FeedbackStatusIgnored || rows[0].RawBody != "tag removed" {
+		t.Fatalf("ignored feedback = %+v, want ignored with edited body", rows[0])
+	}
+}
+
 // TestGuardrailsSeed verifies that migrations 010, 012, 013, and 016 created
 // the generic guardrails table and seeded the built-in rows with content
 // equal to default_content (so a "Reset to default" from the unedited

--- a/internal/ui/src/app/improvements/page.tsx
+++ b/internal/ui/src/app/improvements/page.tsx
@@ -1,0 +1,114 @@
+'use client'
+import { useEffect, useMemo, useState } from 'react'
+import WorkspaceSelect from '@/components/WorkspaceSelect'
+import { useSelectedWorkspace, withWorkspace } from '@/lib/workspace'
+
+interface FeedbackEvent {
+  id: number
+  workspace: string
+  repo_owner: string
+  repo_name: string
+  source_type: string
+  source_url: string
+  author_login: string
+  author_authorized: boolean
+  issue_number?: number
+  pr_number?: number
+  raw_body: string
+  tag: string
+  file_path?: string
+  line?: number
+  commit_sha?: string
+  link_confidence: string
+  link_diagnostics?: string
+  linked_agent_name?: string
+  linked_prompt_version_id?: string
+  status: string
+  ingested_at: string
+}
+
+export default function ImprovementsPage() {
+  const { workspace } = useSelectedWorkspace()
+  const [rows, setRows] = useState<FeedbackEvent[]>([])
+  const [status, setStatus] = useState('')
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    const qs = status ? `/improvements/feedback?status=${encodeURIComponent(status)}` : '/improvements/feedback'
+    fetch(withWorkspace(qs, workspace), { cache: 'no-store' })
+      .then(r => r.ok ? r.json() : [])
+      .then(data => {
+        if (!cancelled) setRows(data ?? [])
+      })
+      .catch(() => {
+        if (!cancelled) setRows([])
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => { cancelled = true }
+  }, [workspace, status])
+
+  const counts = useMemo(() => rows.reduce<Record<string, number>>((acc, row) => {
+    acc[row.status] = (acc[row.status] ?? 0) + 1
+    return acc
+  }, {}), [rows])
+
+  return (
+    <main style={{ display: 'grid', gap: '1rem' }}>
+      <section style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem', alignItems: 'center', flexWrap: 'wrap' }}>
+        <div>
+          <h1 style={{ fontSize: '1.45rem', color: 'var(--text-heading)', marginBottom: '0.25rem' }}>Improvements</h1>
+          <div style={{ color: 'var(--text-muted)', fontSize: '0.85rem' }}>
+            {loading ? 'Loading feedback' : `${rows.length} feedback events`}
+            {Object.keys(counts).length > 0 ? ` · ${Object.entries(counts).map(([k, v]) => `${k}: ${v}`).join(' · ')}` : ''}
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: '0.75rem', alignItems: 'center', flexWrap: 'wrap' }}>
+          <WorkspaceSelect />
+          <select value={status} onChange={e => setStatus(e.target.value)} style={{ background: 'var(--bg-input)', border: '1px solid var(--border)', color: 'var(--text)', padding: '7px 9px' }}>
+            <option value="">All statuses</option>
+            <option value="new">New</option>
+            <option value="ignored">Ignored</option>
+            <option value="analyzed">Analyzed</option>
+            <option value="linked_to_recommendation">Linked</option>
+          </select>
+        </div>
+      </section>
+
+      <section style={{ background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 6, overflow: 'hidden' }}>
+        <div style={{ display: 'grid', gridTemplateColumns: '135px 150px 92px 1fr 150px 110px', gap: '0.75rem', padding: '0.65rem 0.8rem', borderBottom: '1px solid var(--border-subtle)', color: 'var(--text-muted)', fontSize: '0.72rem', fontWeight: 700, textTransform: 'uppercase' }}>
+          <span>Captured</span>
+          <span>Source</span>
+          <span>Status</span>
+          <span>Feedback</span>
+          <span>Attribution</span>
+          <span>Author</span>
+        </div>
+        {rows.map(row => (
+          <article key={row.id} style={{ display: 'grid', gridTemplateColumns: '135px 150px 92px 1fr 150px 110px', gap: '0.75rem', padding: '0.75rem 0.8rem', borderBottom: '1px solid var(--border-subtle)', fontSize: '0.8rem', alignItems: 'start' }}>
+            <time style={{ color: 'var(--text-faint)' }}>{new Date(row.ingested_at).toLocaleString()}</time>
+            <div style={{ display: 'grid', gap: 3 }}>
+              <a href={row.source_url} target="_blank" rel="noreferrer">{row.repo_owner}/{row.repo_name}</a>
+              <span style={{ color: 'var(--text-faint)' }}>{row.source_type}{row.pr_number ? ` · PR #${row.pr_number}` : row.issue_number ? ` · issue #${row.issue_number}` : ''}</span>
+              {row.file_path && <span style={{ color: 'var(--text-faint)', overflowWrap: 'anywhere' }}>{row.file_path}{row.line ? `:${row.line}` : ''}</span>}
+            </div>
+            <span style={{ color: row.status === 'new' ? 'var(--success)' : 'var(--text-muted)', fontWeight: 700 }}>{row.status}</span>
+            <pre style={{ whiteSpace: 'pre-wrap', overflowWrap: 'anywhere', color: 'var(--text)', fontSize: '0.78rem', lineHeight: 1.45 }}>{row.raw_body}</pre>
+            <div style={{ display: 'grid', gap: 3 }}>
+              <span style={{ color: row.link_confidence === 'exact' ? 'var(--success)' : row.link_confidence === 'inferred' ? 'var(--accent)' : 'var(--text-muted)', fontWeight: 700 }}>{row.link_confidence}</span>
+              {row.linked_agent_name && <span style={{ color: 'var(--text-faint)' }}>{row.linked_agent_name}</span>}
+              {row.link_diagnostics && <span style={{ color: 'var(--text-faint)', overflowWrap: 'anywhere' }}>{row.link_diagnostics}</span>}
+            </div>
+            <span style={{ color: row.author_authorized ? 'var(--text)' : 'var(--text-danger)', overflowWrap: 'anywhere' }}>{row.author_login}</span>
+          </article>
+        ))}
+        {!loading && rows.length === 0 && (
+          <div style={{ padding: '1rem', color: 'var(--text-muted)', fontSize: '0.85rem' }}>No matching feedback events.</div>
+        )}
+      </section>
+    </main>
+  )
+}

--- a/internal/ui/src/components/DashboardShell.tsx
+++ b/internal/ui/src/components/DashboardShell.tsx
@@ -17,6 +17,7 @@ const links = [
   { href: '/skills/', label: 'Skills', group: 'Knowledge' },
   { href: '/guardrails/', label: 'Guardrails', group: 'Knowledge' },
   { href: '/memory/', label: 'Memory', group: 'Knowledge' },
+  { href: '/improvements/', label: 'Improvements', group: 'Knowledge' },
   { href: '/workspaces/', label: 'Workspaces', group: 'Config' },
   { href: '/repos/', label: 'Repos', group: 'Config' },
   { href: '/config/', label: 'Config', group: 'Config' },

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -622,7 +622,7 @@ type feedbackCapture struct {
 }
 
 func (h *Handler) captureFeedback(repo fleet.Repo, in feedbackCapture) {
-	if !containsAIImprovementTag(in.Body) {
+	if !containsImproveCommand(in.Body) {
 		if in.Edited {
 			h.ignoreFeedback(repo, in)
 		}
@@ -660,7 +660,7 @@ func (h *Handler) captureFeedback(repo fleet.Repo, in feedbackCapture) {
 		IssueNumber:      in.IssueNumber,
 		PRNumber:         in.PRNumber,
 		RawBody:          in.Body,
-		Tag:              "#ai_improvement",
+		Tag:              store.FeedbackTag,
 		FilePath:         in.FilePath,
 		Line:             in.Line,
 		Side:             in.Side,
@@ -717,7 +717,7 @@ func (h *Handler) ignoreFeedback(repo fleet.Repo, in feedbackCapture) {
 		IssueNumber:      in.IssueNumber,
 		PRNumber:         in.PRNumber,
 		RawBody:          in.Body,
-		Tag:              "#ai_improvement",
+		Tag:              store.FeedbackTag,
 		FilePath:         in.FilePath,
 		Line:             in.Line,
 		Side:             in.Side,
@@ -740,11 +740,11 @@ func (h *Handler) ignoreFeedback(repo fleet.Repo, in feedbackCapture) {
 			Str("workspace", fleet.NormalizeWorkspaceID(repo.WorkspaceID)).
 			Str("repo", repo.Name).
 			Str("source_type", in.SourceType).
-			Msg("webhook: ignored self-improvement feedback after tag removal")
+			Msg("webhook: ignored self-improvement feedback after marker removal")
 	}
 }
 
-func containsAIImprovementTag(body string) bool {
+func containsImproveCommand(body string) bool {
 	inCode := false
 	for _, line := range strings.Split(body, "\n") {
 		if strings.HasPrefix(strings.TrimSpace(line), "```") {
@@ -754,9 +754,11 @@ func containsAIImprovementTag(body string) bool {
 		if inCode {
 			continue
 		}
-		for _, field := range strings.Fields(line) {
-			field = strings.Trim(field, ".,;:!?)]}")
-			if field == "#ai_improvement" {
+		fields := strings.Fields(line)
+		for i := 0; i+1 < len(fields); i++ {
+			command := strings.Trim(fields[i], ".,;:!?([{")
+			action := strings.Trim(fields[i+1], ".,;:!?)]}")
+			if command == "/agents" && action == "improve" {
 				return true
 			}
 		}

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/eloylp/agents/internal/config"
 	"github.com/eloylp/agents/internal/fleet"
+	"github.com/eloylp/agents/internal/observe"
 	"github.com/eloylp/agents/internal/store"
 	"github.com/eloylp/agents/internal/workflow"
 )
@@ -32,19 +33,23 @@ type Handler struct {
 	delivery *DeliveryStore
 	channels *workflow.DataChannels
 	store    *store.Store
+	observe  *observe.Store
 	httpCfg  config.HTTPConfig
+	self     config.SelfImprovementConfig
 	logger   zerolog.Logger
 }
 
 // NewHandler constructs a Handler. delivery, channels, store, and httpCfg
 // are required; logger may be the daemon's root logger (the handler
 // scopes a sub-logger via the standard component label).
-func NewHandler(delivery *DeliveryStore, channels *workflow.DataChannels, st *store.Store, httpCfg config.HTTPConfig, logger zerolog.Logger) *Handler {
+func NewHandler(delivery *DeliveryStore, channels *workflow.DataChannels, st *store.Store, obs *observe.Store, httpCfg config.HTTPConfig, self config.SelfImprovementConfig, logger zerolog.Logger) *Handler {
 	return &Handler{
 		delivery: delivery,
 		channels: channels,
 		store:    st,
+		observe:  obs,
 		httpCfg:  httpCfg,
+		self:     self,
 		logger:   logger.With().Str("component", "webhook").Logger(),
 	}
 }
@@ -185,12 +190,25 @@ type webhookPullRequest struct {
 }
 
 type webhookComment struct {
-	Body string `json:"body"`
+	ID        int64     `json:"id"`
+	HTMLURL   string    `json:"html_url"`
+	Body      string    `json:"body"`
+	Path      string    `json:"path"`
+	Line      int       `json:"line"`
+	Side      string    `json:"side"`
+	DiffHunk  string    `json:"diff_hunk"`
+	CommitID  string    `json:"commit_id"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 type webhookReview struct {
-	Body  string `json:"body"`
-	State string `json:"state"`
+	ID        int64     `json:"id"`
+	HTMLURL   string    `json:"html_url"`
+	Body      string    `json:"body"`
+	State     string    `json:"state"`
+	CommitID  string    `json:"commit_id"`
+	Submitted time.Time `json:"submitted_at"`
 }
 
 // ─── event-type handlers ──────────────────────────────────────────────────────
@@ -356,7 +374,8 @@ func (h *Handler) handlePullRequestEvent(ctx context.Context, w http.ResponseWri
 }
 
 // handleIssueCommentEvent handles X-GitHub-Event: issue_comment.
-// Only "created" actions are forwarded as "issue_comment.created".
+// "created" actions are forwarded as "issue_comment.created"; "edited" can
+// refresh stored self-improvement feedback but does not enqueue agent work.
 func (h *Handler) handleIssueCommentEvent(ctx context.Context, w http.ResponseWriter, body []byte, deliveryID string) {
 
 	var payload struct {
@@ -375,7 +394,7 @@ func (h *Handler) handleIssueCommentEvent(ctx context.Context, w http.ResponseWr
 		w.WriteHeader(http.StatusAccepted)
 		return
 	}
-	if payload.Action != "created" {
+	if payload.Action != "created" && payload.Action != "edited" {
 		for _, repo := range repos {
 			h.skipWebhookLog(deliveryID, repo, "issue_comment", payload.Action).
 				Int("number", payload.Issue.Number).
@@ -385,8 +404,39 @@ func (h *Handler) handleIssueCommentEvent(ctx context.Context, w http.ResponseWr
 		return
 	}
 
+	if payload.Action == "edited" {
+		for _, repo := range repos {
+			h.captureFeedback(repo, feedbackCapture{
+				DeliveryID:      deliveryID,
+				SourceType:      "issue_comment",
+				Body:            payload.Comment.Body,
+				SourceURL:       payload.Comment.HTMLURL,
+				AuthorLogin:     payload.Sender.Login,
+				IssueNumber:     payload.Issue.Number,
+				PRNumber:        prNumber(payload.Issue),
+				CommentID:       payload.Comment.ID,
+				GitHubCreatedAt: zeroNil(payload.Comment.CreatedAt),
+				GitHubUpdatedAt: zeroNil(payload.Comment.UpdatedAt),
+			})
+		}
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+
 	events := make([]workflow.Event, 0, len(repos))
 	for _, repo := range repos {
+		h.captureFeedback(repo, feedbackCapture{
+			DeliveryID:      deliveryID,
+			SourceType:      "issue_comment",
+			Body:            payload.Comment.Body,
+			SourceURL:       payload.Comment.HTMLURL,
+			AuthorLogin:     payload.Sender.Login,
+			IssueNumber:     payload.Issue.Number,
+			PRNumber:        prNumber(payload.Issue),
+			CommentID:       payload.Comment.ID,
+			GitHubCreatedAt: zeroNil(payload.Comment.CreatedAt),
+			GitHubUpdatedAt: zeroNil(payload.Comment.UpdatedAt),
+		})
 		events = append(events, workflow.Event{
 			ID:          deliveryID,
 			WorkspaceID: fleet.NormalizeWorkspaceID(repo.WorkspaceID),
@@ -434,6 +484,18 @@ func (h *Handler) handlePullRequestReviewEvent(ctx context.Context, w http.Respo
 
 	events := make([]workflow.Event, 0, len(repos))
 	for _, repo := range repos {
+		h.captureFeedback(repo, feedbackCapture{
+			DeliveryID:      deliveryID,
+			SourceType:      "pull_request_review",
+			Body:            payload.Review.Body,
+			SourceURL:       payload.Review.HTMLURL,
+			AuthorLogin:     payload.Sender.Login,
+			PRNumber:        payload.PullRequest.Number,
+			ReviewID:        payload.Review.ID,
+			CommitSHA:       payload.Review.CommitID,
+			GitHubCreatedAt: zeroNil(payload.Review.Submitted),
+			GitHubUpdatedAt: zeroNil(payload.Review.Submitted),
+		})
 		events = append(events, workflow.Event{
 			ID:          deliveryID,
 			WorkspaceID: fleet.NormalizeWorkspaceID(repo.WorkspaceID),
@@ -451,8 +513,8 @@ func (h *Handler) handlePullRequestReviewEvent(ctx context.Context, w http.Respo
 }
 
 // handlePullRequestReviewCommentEvent handles X-GitHub-Event:
-// pull_request_review_comment. Only "created" actions are forwarded as
-// "pull_request_review_comment.created".
+// pull_request_review_comment. "created" actions are forwarded as
+// "pull_request_review_comment.created"; "edited" can refresh stored feedback.
 func (h *Handler) handlePullRequestReviewCommentEvent(ctx context.Context, w http.ResponseWriter, body []byte, deliveryID string) {
 
 	var payload struct {
@@ -471,7 +533,7 @@ func (h *Handler) handlePullRequestReviewCommentEvent(ctx context.Context, w htt
 		w.WriteHeader(http.StatusAccepted)
 		return
 	}
-	if payload.Action != "created" {
+	if payload.Action != "created" && payload.Action != "edited" {
 		for _, repo := range repos {
 			h.skipWebhookLog(deliveryID, repo, "pull_request_review_comment", payload.Action).
 				Int("number", payload.PullRequest.Number).
@@ -481,8 +543,47 @@ func (h *Handler) handlePullRequestReviewCommentEvent(ctx context.Context, w htt
 		return
 	}
 
+	if payload.Action == "edited" {
+		for _, repo := range repos {
+			h.captureFeedback(repo, feedbackCapture{
+				DeliveryID:      deliveryID,
+				SourceType:      "pull_request_review_comment",
+				Body:            payload.Comment.Body,
+				SourceURL:       payload.Comment.HTMLURL,
+				AuthorLogin:     payload.Sender.Login,
+				PRNumber:        payload.PullRequest.Number,
+				CommentID:       payload.Comment.ID,
+				FilePath:        payload.Comment.Path,
+				Line:            payload.Comment.Line,
+				Side:            payload.Comment.Side,
+				DiffHunk:        payload.Comment.DiffHunk,
+				CommitSHA:       payload.Comment.CommitID,
+				GitHubCreatedAt: zeroNil(payload.Comment.CreatedAt),
+				GitHubUpdatedAt: zeroNil(payload.Comment.UpdatedAt),
+			})
+		}
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+
 	events := make([]workflow.Event, 0, len(repos))
 	for _, repo := range repos {
+		h.captureFeedback(repo, feedbackCapture{
+			DeliveryID:      deliveryID,
+			SourceType:      "pull_request_review_comment",
+			Body:            payload.Comment.Body,
+			SourceURL:       payload.Comment.HTMLURL,
+			AuthorLogin:     payload.Sender.Login,
+			PRNumber:        payload.PullRequest.Number,
+			CommentID:       payload.Comment.ID,
+			FilePath:        payload.Comment.Path,
+			Line:            payload.Comment.Line,
+			Side:            payload.Comment.Side,
+			DiffHunk:        payload.Comment.DiffHunk,
+			CommitSHA:       payload.Comment.CommitID,
+			GitHubCreatedAt: zeroNil(payload.Comment.CreatedAt),
+			GitHubUpdatedAt: zeroNil(payload.Comment.UpdatedAt),
+		})
 		events = append(events, workflow.Event{
 			ID:          deliveryID,
 			WorkspaceID: fleet.NormalizeWorkspaceID(repo.WorkspaceID),
@@ -496,6 +597,174 @@ func (h *Handler) handlePullRequestReviewCommentEvent(ctx context.Context, w htt
 		})
 	}
 	h.enqueueEvents(ctx, w, events, deliveryID)
+}
+
+type feedbackCapture struct {
+	DeliveryID      string
+	SourceType      string
+	Body            string
+	SourceURL       string
+	AuthorLogin     string
+	IssueNumber     int
+	PRNumber        int
+	CommentID       int64
+	ReviewID        int64
+	FilePath        string
+	Line            int
+	Side            string
+	DiffHunk        string
+	CommitSHA       string
+	GitHubCreatedAt *time.Time
+	GitHubUpdatedAt *time.Time
+}
+
+func (h *Handler) captureFeedback(repo fleet.Repo, in feedbackCapture) {
+	if !containsAIImprovementTag(in.Body) {
+		return
+	}
+	authorized := h.feedbackAuthorAllowed(in.AuthorLogin)
+	status := store.FeedbackStatusNew
+	if !authorized {
+		status = store.FeedbackStatusIgnored
+	}
+	owner, name := splitRepo(repo.Name)
+	res := observe.AttributionResolution{Confidence: observe.AttributionUnresolved, Diagnostic: "run attribution resolver unavailable"}
+	if h.observe != nil {
+		res = h.observe.ResolveRunAttribution(observe.AttributionQuery{
+			Body:            in.Body,
+			WorkspaceID:     repo.WorkspaceID,
+			RepoOwner:       owner,
+			RepoName:        name,
+			IssueOrPRNumber: firstNonZero(in.PRNumber, in.IssueNumber),
+			HeadSHA:         in.CommitSHA,
+			At:              feedbackAt(in.GitHubUpdatedAt, in.GitHubCreatedAt),
+		})
+	}
+	input := store.SelfImprovementFeedbackInput{
+		WorkspaceID:      repo.WorkspaceID,
+		RepoOwner:        owner,
+		RepoName:         name,
+		SourceType:       in.SourceType,
+		GitHubCommentID:  in.CommentID,
+		GitHubReviewID:   in.ReviewID,
+		GitHubDeliveryID: in.DeliveryID,
+		SourceURL:        in.SourceURL,
+		AuthorLogin:      in.AuthorLogin,
+		AuthorAuthorized: authorized,
+		IssueNumber:      in.IssueNumber,
+		PRNumber:         in.PRNumber,
+		RawBody:          in.Body,
+		Tag:              "#ai_improvement",
+		FilePath:         in.FilePath,
+		Line:             in.Line,
+		Side:             in.Side,
+		DiffHunk:         in.DiffHunk,
+		CommitSHA:        in.CommitSHA,
+		GitHubCreatedAt:  in.GitHubCreatedAt,
+		GitHubUpdatedAt:  in.GitHubUpdatedAt,
+		LinkConfidence:   res.Confidence,
+		LinkDiagnostics:  res.Diagnostic,
+		Status:           status,
+	}
+	if res.Snapshot != nil {
+		input.LinkedSpanID = res.Snapshot.SpanID
+		input.LinkedEventID = res.Snapshot.EventID
+		input.LinkedAgentID = res.Snapshot.AgentID
+		input.LinkedAgentName = res.Snapshot.AgentName
+		input.LinkedPromptVersionID = res.Snapshot.PromptVersionID
+		input.LinkedSkillVersionIDs = res.Snapshot.SkillVersionIDs
+		input.LinkedGuardrailVersionIDs = res.Snapshot.GuardrailVersionIDs
+	}
+	if _, err := h.store.UpsertSelfImprovementFeedback(input); err != nil {
+		h.logger.Error().Err(err).
+			Str("delivery_id", in.DeliveryID).
+			Str("workspace", fleet.NormalizeWorkspaceID(repo.WorkspaceID)).
+			Str("repo", repo.Name).
+			Str("source_type", in.SourceType).
+			Msg("webhook: store self-improvement feedback")
+		return
+	}
+	h.logger.Info().
+		Str("delivery_id", in.DeliveryID).
+		Str("workspace", fleet.NormalizeWorkspaceID(repo.WorkspaceID)).
+		Str("repo", repo.Name).
+		Str("source_type", in.SourceType).
+		Bool("author_authorized", authorized).
+		Str("link_confidence", res.Confidence).
+		Msg("webhook: stored self-improvement feedback")
+}
+
+func containsAIImprovementTag(body string) bool {
+	inCode := false
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "```") {
+			inCode = !inCode
+			continue
+		}
+		if inCode {
+			continue
+		}
+		for _, field := range strings.Fields(line) {
+			field = strings.Trim(field, ".,;:!?)]}")
+			if field == "#ai_improvement" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (h *Handler) feedbackAuthorAllowed(login string) bool {
+	login = strings.ToLower(strings.TrimSpace(login))
+	if login == "" {
+		return false
+	}
+	for _, allowed := range h.self.FeedbackAuthorAllowlist {
+		if login == strings.ToLower(strings.TrimSpace(allowed)) {
+			return true
+		}
+	}
+	return false
+}
+
+func prNumber(issue webhookIssue) int {
+	if issue.PullRequest == nil {
+		return 0
+	}
+	return issue.Number
+}
+
+func zeroNil(t time.Time) *time.Time {
+	if t.IsZero() {
+		return nil
+	}
+	return &t
+}
+
+func splitRepo(full string) (string, string) {
+	owner, name, ok := strings.Cut(fleet.NormalizeRepoName(full), "/")
+	if !ok {
+		return "", full
+	}
+	return owner, name
+}
+
+func feedbackAt(candidates ...*time.Time) time.Time {
+	for _, candidate := range candidates {
+		if candidate != nil && !candidate.IsZero() {
+			return *candidate
+		}
+	}
+	return time.Time{}
+}
+
+func firstNonZero(xs ...int) int {
+	for _, x := range xs {
+		if x != 0 {
+			return x
+		}
+	}
+	return 0
 }
 
 // handlePushEvent handles X-GitHub-Event: push.

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -409,6 +409,7 @@ func (h *Handler) handleIssueCommentEvent(ctx context.Context, w http.ResponseWr
 			h.captureFeedback(repo, feedbackCapture{
 				DeliveryID:      deliveryID,
 				SourceType:      "issue_comment",
+				Edited:          true,
 				Body:            payload.Comment.Body,
 				SourceURL:       payload.Comment.HTMLURL,
 				AuthorLogin:     payload.Sender.Login,
@@ -548,6 +549,7 @@ func (h *Handler) handlePullRequestReviewCommentEvent(ctx context.Context, w htt
 			h.captureFeedback(repo, feedbackCapture{
 				DeliveryID:      deliveryID,
 				SourceType:      "pull_request_review_comment",
+				Edited:          true,
 				Body:            payload.Comment.Body,
 				SourceURL:       payload.Comment.HTMLURL,
 				AuthorLogin:     payload.Sender.Login,
@@ -602,6 +604,7 @@ func (h *Handler) handlePullRequestReviewCommentEvent(ctx context.Context, w htt
 type feedbackCapture struct {
 	DeliveryID      string
 	SourceType      string
+	Edited          bool
 	Body            string
 	SourceURL       string
 	AuthorLogin     string
@@ -620,6 +623,9 @@ type feedbackCapture struct {
 
 func (h *Handler) captureFeedback(repo fleet.Repo, in feedbackCapture) {
 	if !containsAIImprovementTag(in.Body) {
+		if in.Edited {
+			h.ignoreFeedback(repo, in)
+		}
 		return
 	}
 	authorized := h.feedbackAuthorAllowed(in.AuthorLogin)
@@ -692,6 +698,50 @@ func (h *Handler) captureFeedback(repo fleet.Repo, in feedbackCapture) {
 		Bool("author_authorized", authorized).
 		Str("link_confidence", res.Confidence).
 		Msg("webhook: stored self-improvement feedback")
+}
+
+func (h *Handler) ignoreFeedback(repo fleet.Repo, in feedbackCapture) {
+	owner, name := splitRepo(repo.Name)
+	authorized := h.feedbackAuthorAllowed(in.AuthorLogin)
+	ignored, err := h.store.IgnoreSelfImprovementFeedback(store.SelfImprovementFeedbackInput{
+		WorkspaceID:      repo.WorkspaceID,
+		RepoOwner:        owner,
+		RepoName:         name,
+		SourceType:       in.SourceType,
+		GitHubCommentID:  in.CommentID,
+		GitHubReviewID:   in.ReviewID,
+		GitHubDeliveryID: in.DeliveryID,
+		SourceURL:        in.SourceURL,
+		AuthorLogin:      in.AuthorLogin,
+		AuthorAuthorized: authorized,
+		IssueNumber:      in.IssueNumber,
+		PRNumber:         in.PRNumber,
+		RawBody:          in.Body,
+		Tag:              "#ai_improvement",
+		FilePath:         in.FilePath,
+		Line:             in.Line,
+		Side:             in.Side,
+		DiffHunk:         in.DiffHunk,
+		CommitSHA:        in.CommitSHA,
+		GitHubUpdatedAt:  in.GitHubUpdatedAt,
+	})
+	if err != nil {
+		h.logger.Error().Err(err).
+			Str("delivery_id", in.DeliveryID).
+			Str("workspace", fleet.NormalizeWorkspaceID(repo.WorkspaceID)).
+			Str("repo", repo.Name).
+			Str("source_type", in.SourceType).
+			Msg("webhook: ignore self-improvement feedback")
+		return
+	}
+	if ignored {
+		h.logger.Info().
+			Str("delivery_id", in.DeliveryID).
+			Str("workspace", fleet.NormalizeWorkspaceID(repo.WorkspaceID)).
+			Str("repo", repo.Name).
+			Str("source_type", in.SourceType).
+			Msg("webhook: ignored self-improvement feedback after tag removal")
+	}
 }
 
 func containsAIImprovementTag(body string) bool {

--- a/internal/webhook/handler_test.go
+++ b/internal/webhook/handler_test.go
@@ -231,7 +231,7 @@ func TestIssueCommentAIImprovementFeedbackStoredForAllowlistedAuthor(t *testing.
 	)
 	body := []byte(`{
 		"action":"created",
-		"comment":{"id":123,"html_url":"https://github.com/owner/repo/issues/7#issuecomment-123","body":"Please remember this #ai_improvement","created_at":"2026-05-30T10:00:00Z","updated_at":"2026-05-30T10:00:00Z"},
+		"comment":{"id":123,"html_url":"https://github.com/owner/repo/issues/7#issuecomment-123","body":"Please remember this /agents improve","created_at":"2026-05-30T10:00:00Z","updated_at":"2026-05-30T10:00:00Z"},
 		"issue":{"number":7},
 		"repository":{"full_name":"owner/repo"},
 		"sender":{"login":"maintainer"}
@@ -283,7 +283,7 @@ func TestAIImprovementFeedbackUnauthorizedAuthorIsIgnored(t *testing.T) {
 	)
 	body := []byte(`{
 		"action":"created",
-		"comment":{"id":124,"body":"Please remember this #ai_improvement"},
+		"comment":{"id":124,"body":"Please remember this /agents improve"},
 		"issue":{"number":7},
 		"repository":{"full_name":"owner/repo"},
 		"sender":{"login":"drive-by"}
@@ -328,7 +328,7 @@ func TestEditedIssueCommentWithoutAIImprovementTagIgnoresExistingFeedback(t *tes
 	)
 	created := []byte(`{
 		"action":"created",
-		"comment":{"id":125,"body":"Please remember this #ai_improvement"},
+		"comment":{"id":125,"body":"Please remember this /agents improve"},
 		"issue":{"number":7},
 		"repository":{"full_name":"owner/repo"},
 		"sender":{"login":"maintainer"}
@@ -360,13 +360,16 @@ func TestEditedIssueCommentWithoutAIImprovementTagIgnoresExistingFeedback(t *tes
 	}
 }
 
-func TestAIImprovementTagIgnoresFencedCodeBlocks(t *testing.T) {
+func TestImproveCommandIgnoresFencedCodeBlocks(t *testing.T) {
 	t.Parallel()
-	body := "```text\n#ai_improvement\n```\noutside"
-	if containsAIImprovementTag(body) {
-		t.Fatalf("tag inside fenced code block should be ignored")
+	body := "```text\n/agents improve\n```\noutside"
+	if containsImproveCommand(body) {
+		t.Fatalf("command inside fenced code block should be ignored")
 	}
-	if !containsAIImprovementTag("outside #ai_improvement.") {
-		t.Fatalf("tag outside code block should be detected")
+	if !containsImproveCommand("outside /agents improve.") {
+		t.Fatalf("command outside code block should be detected")
+	}
+	if containsImproveCommand("outside /agents analyze") {
+		t.Fatalf("different slash command should not be detected")
 	}
 }

--- a/internal/webhook/handler_test.go
+++ b/internal/webhook/handler_test.go
@@ -68,7 +68,7 @@ func TestPushEventCarriesRepoWorkspace(t *testing.T) {
 	}
 
 	dc := workflow.NewDataChannels(1, st)
-	h := NewHandler(NewDeliveryStore(10*time.Minute), dc, st, config.HTTPConfig{}, zerolog.Nop())
+	h := NewHandler(NewDeliveryStore(10*time.Minute), dc, st, nil, config.HTTPConfig{}, config.SelfImprovementConfig{}, zerolog.Nop())
 	body := []byte(`{
 		"ref":"refs/heads/main",
 		"after":"0123456789012345678901234567890123456789",
@@ -120,7 +120,7 @@ func TestWebhookRepoPrefersEnabledWorkspaceOverDisabledDefault(t *testing.T) {
 	}
 
 	dc := workflow.NewDataChannels(1, st)
-	h := NewHandler(NewDeliveryStore(10*time.Minute), dc, st, config.HTTPConfig{}, zerolog.Nop())
+	h := NewHandler(NewDeliveryStore(10*time.Minute), dc, st, nil, config.HTTPConfig{}, config.SelfImprovementConfig{}, zerolog.Nop())
 	body := []byte(`{
 		"action":"created",
 		"comment":{"body":"continue"},
@@ -170,7 +170,7 @@ func TestWebhookFansOutToEveryEnabledWorkspaceRepo(t *testing.T) {
 	}
 
 	dc := workflow.NewDataChannels(2, st)
-	h := NewHandler(NewDeliveryStore(10*time.Minute), dc, st, config.HTTPConfig{}, zerolog.Nop())
+	h := NewHandler(NewDeliveryStore(10*time.Minute), dc, st, nil, config.HTTPConfig{}, config.SelfImprovementConfig{}, zerolog.Nop())
 	body := []byte(`{
 		"action":"created",
 		"comment":{"body":"continue"},
@@ -201,5 +201,116 @@ func TestWebhookFansOutToEveryEnabledWorkspaceRepo(t *testing.T) {
 		if !got[workspaceID] {
 			t.Fatalf("missing queued event for workspace %q; got %+v", workspaceID, got)
 		}
+	}
+}
+
+func TestIssueCommentAIImprovementFeedbackStoredForAllowlistedAuthor(t *testing.T) {
+	t.Parallel()
+	db, err := store.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	st := store.New(db)
+	t.Cleanup(func() { st.Close() })
+	if _, err := store.UpsertWorkspace(db, fleet.Workspace{ID: "team-a", Name: "Team A"}); err != nil {
+		t.Fatalf("seed workspace: %v", err)
+	}
+	if err := st.UpsertRepo(fleet.Repo{WorkspaceID: "team-a", Name: "owner/repo", Enabled: true}); err != nil {
+		t.Fatalf("seed repo: %v", err)
+	}
+
+	dc := workflow.NewDataChannels(1, st)
+	h := NewHandler(
+		NewDeliveryStore(10*time.Minute),
+		dc,
+		st,
+		nil,
+		config.HTTPConfig{},
+		config.SelfImprovementConfig{FeedbackAuthorAllowlist: []string{"maintainer"}},
+		zerolog.Nop(),
+	)
+	body := []byte(`{
+		"action":"created",
+		"comment":{"id":123,"html_url":"https://github.com/owner/repo/issues/7#issuecomment-123","body":"Please remember this #ai_improvement","created_at":"2026-05-30T10:00:00Z","updated_at":"2026-05-30T10:00:00Z"},
+		"issue":{"number":7},
+		"repository":{"full_name":"owner/repo"},
+		"sender":{"login":"maintainer"}
+	}`)
+	w := httptest.NewRecorder()
+
+	h.handleIssueCommentEvent(context.Background(), w, body, "delivery-1")
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusAccepted)
+	}
+	rows, err := st.ListSelfImprovementFeedback("team-a", "new", 10)
+	if err != nil {
+		t.Fatalf("list feedback: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("feedback count = %d, want 1", len(rows))
+	}
+	got := rows[0]
+	if got.SourceType != "issue_comment" || got.GitHubCommentID != 123 || !got.AuthorAuthorized || got.Status != "new" {
+		t.Fatalf("feedback = %+v, want authorized new issue comment 123", got)
+	}
+	if got.IssueNumber != 7 || got.PRNumber != 0 || got.LinkConfidence != "unresolved" {
+		t.Fatalf("feedback context = %+v, want issue #7 unresolved", got)
+	}
+}
+
+func TestAIImprovementFeedbackUnauthorizedAuthorIsIgnored(t *testing.T) {
+	t.Parallel()
+	db, err := store.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	st := store.New(db)
+	t.Cleanup(func() { st.Close() })
+	if err := st.UpsertRepo(fleet.Repo{Name: "owner/repo", Enabled: true}); err != nil {
+		t.Fatalf("seed repo: %v", err)
+	}
+
+	dc := workflow.NewDataChannels(1, st)
+	h := NewHandler(
+		NewDeliveryStore(10*time.Minute),
+		dc,
+		st,
+		nil,
+		config.HTTPConfig{},
+		config.SelfImprovementConfig{FeedbackAuthorAllowlist: []string{"maintainer"}},
+		zerolog.Nop(),
+	)
+	body := []byte(`{
+		"action":"created",
+		"comment":{"id":124,"body":"Please remember this #ai_improvement"},
+		"issue":{"number":7},
+		"repository":{"full_name":"owner/repo"},
+		"sender":{"login":"drive-by"}
+	}`)
+	w := httptest.NewRecorder()
+
+	h.handleIssueCommentEvent(context.Background(), w, body, "delivery-1")
+
+	rows, err := st.ListSelfImprovementFeedback("", "", 10)
+	if err != nil {
+		t.Fatalf("list feedback: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("feedback count = %d, want 1", len(rows))
+	}
+	if rows[0].AuthorAuthorized || rows[0].Status != "ignored" {
+		t.Fatalf("feedback = %+v, want unauthorized ignored", rows[0])
+	}
+}
+
+func TestAIImprovementTagIgnoresFencedCodeBlocks(t *testing.T) {
+	t.Parallel()
+	body := "```text\n#ai_improvement\n```\noutside"
+	if containsAIImprovementTag(body) {
+		t.Fatalf("tag inside fenced code block should be ignored")
+	}
+	if !containsAIImprovementTag("outside #ai_improvement.") {
+		t.Fatalf("tag outside code block should be detected")
 	}
 }

--- a/internal/webhook/handler_test.go
+++ b/internal/webhook/handler_test.go
@@ -304,6 +304,62 @@ func TestAIImprovementFeedbackUnauthorizedAuthorIsIgnored(t *testing.T) {
 	}
 }
 
+func TestEditedIssueCommentWithoutAIImprovementTagIgnoresExistingFeedback(t *testing.T) {
+	t.Parallel()
+	db, err := store.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	st := store.New(db)
+	t.Cleanup(func() { st.Close() })
+	if err := st.UpsertRepo(fleet.Repo{Name: "owner/repo", Enabled: true}); err != nil {
+		t.Fatalf("seed repo: %v", err)
+	}
+
+	dc := workflow.NewDataChannels(1, st)
+	h := NewHandler(
+		NewDeliveryStore(10*time.Minute),
+		dc,
+		st,
+		nil,
+		config.HTTPConfig{},
+		config.SelfImprovementConfig{FeedbackAuthorAllowlist: []string{"maintainer"}},
+		zerolog.Nop(),
+	)
+	created := []byte(`{
+		"action":"created",
+		"comment":{"id":125,"body":"Please remember this #ai_improvement"},
+		"issue":{"number":7},
+		"repository":{"full_name":"owner/repo"},
+		"sender":{"login":"maintainer"}
+	}`)
+	h.handleIssueCommentEvent(context.Background(), httptest.NewRecorder(), created, "delivery-1")
+
+	edited := []byte(`{
+		"action":"edited",
+		"comment":{"id":125,"body":"Please disregard this"},
+		"issue":{"number":7},
+		"repository":{"full_name":"owner/repo"},
+		"sender":{"login":"maintainer"}
+	}`)
+	w := httptest.NewRecorder()
+	h.handleIssueCommentEvent(context.Background(), w, edited, "delivery-2")
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusAccepted)
+	}
+	rows, err := st.ListSelfImprovementFeedback("", "", 10)
+	if err != nil {
+		t.Fatalf("list feedback: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("feedback count = %d, want 1", len(rows))
+	}
+	if rows[0].Status != store.FeedbackStatusIgnored || rows[0].RawBody != "Please disregard this" {
+		t.Fatalf("feedback = %+v, want ignored row with edited body", rows[0])
+	}
+}
+
 func TestAIImprovementTagIgnoresFencedCodeBlocks(t *testing.T) {
 	t.Parallel()
 	body := "```text\n#ai_improvement\n```\noutside"


### PR DESCRIPTION
<!-- agents-run: {"workspace":"default","span_id":"1aa9637ecb01030d","agent_id":"agent_0fb82d1fe34e45408bd2fee153f7003d"} -->

## Summary
- add durable workspace-scoped `/agents improve` feedback storage with deterministic webhook ingestion, author allowlist handling, dedupe/update semantics, and run attribution snapshots
- preserve processed feedback status on idempotent redelivery, and mark existing feedback ignored when edited comments remove the marker
- expose feedback evidence through REST, MCP, docs, and a new Improvements dashboard page

Closes #662

## Verification
- `go test ./internal/store -run 'TestSelfImprovementFeedback|TestIgnoreSelfImprovementFeedback'`\n- `go test ./internal/webhook -run 'TestIssueCommentAIImprovementFeedbackStoredForAllowlistedAuthor|TestAIImprovementFeedbackUnauthorizedAuthorIsIgnored|TestEditedIssueCommentWithoutAIImprovementTagIgnoresExistingFeedback|TestImproveCommandIgnoresFencedCodeBlocks'`\n- `go test ./internal/mcp -run TestToolListImprovementFeedback`\n- `go test ./internal/store ./internal/webhook ./internal/mcp`\n- `go test -race ./internal/store ./internal/webhook ./internal/mcp -run 'TestSelfImprovementFeedback|TestIgnoreSelfImprovementFeedback|TestIssueCommentAIImprovementFeedbackStoredForAllowlistedAuthor|TestAIImprovementFeedbackUnauthorizedAuthorIsIgnored|TestEditedIssueCommentWithoutAIImprovementTagIgnoresExistingFeedback|TestImproveCommandIgnoresFencedCodeBlocks|TestToolListImprovementFeedback'`\n- `go test ./...`\n- `git diff --check`\n\nEarlier in this PR before the review updates:\n- `npm ci`\n- `npm run build`\n- `npm test`\n\nNote: `npm ci` reported the existing Next.js 14.2.29 advisory and npm audit findings; no dependency changes were made.