### PR TITLE
feat: create catalog proposals from recommendations

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -55,6 +55,8 @@ The `/run` body is `{"agent": "<name>", "repo": "owner/repo"}`. It returns `202 
 | `POST` | `/improvements/feedback/{id}/analyze` | Manually create or refresh the recommendation for one feedback event. |
 | `POST` | `/improvements/recommendations/{id}/status` | Update recommendation status (`accepted`, `rejected`, `deferred`, `duplicate`, etc.). |
 | `POST` | `/improvements/recommendations/{id}/clarification` | Replace the recommendation's editable maintainer clarification and enqueue a fresh `agents.improvement` analysis run. Body: `{ "body": "...", "author": "optional" }`. |
+| `GET` | `/improvements/recommendations/{id}/proposal` | Catalog proposal versions linked to a recommendation. |
+| `POST` | `/improvements/recommendations/{id}/proposal` | Create an inert catalog proposal version from an accepted recommendation. Does not publish or affect runtime composition. |
 | `GET` | `/config` | Current fleet config snapshot |
 
 ## Self-Improvement Feedback
@@ -63,7 +65,7 @@ GitHub `issue_comment`, `pull_request_review`, and `pull_request_review_comment`
 
 Feedback events preserve the raw comment, source URL, repo/issue/PR/file context, delivery ids, author authorization, and any run attribution resolved from public hidden metadata or repo/PR/SHA/time context.
 
-Authorized new feedback creates one durable recommendation linked back to the feedback event and source URL. Recommendations preserve attribution confidence, expose review status transitions, and remain inert: accepting one does not publish catalog versions or mutate prompts, skills, guardrails, agents, or dispatch wiring.
+Authorized new feedback creates one durable recommendation linked back to the feedback event and source URL. Recommendations preserve attribution confidence and expose review status transitions. Accepted recommendations with concrete prompt, skill, or guardrail targets can create `state=proposal` catalog versions with `source_type=feedback_recommendation`, but proposals remain inert until a human publishes them through the catalog versioning path. Non-convertible recommendations remain design records and do not mutate prompts, skills, guardrails, agents, or dispatch wiring.
 
 Configure trusted authors at startup with `AGENTS_SELF_IMPROVEMENT_FEEDBACK_AUTHOR_ALLOWLIST=maintainer-login,agents-bot`.
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -98,6 +98,9 @@ For agent lifecycle changes, use `create_agent` when adding a new agent or inten
 | `analyze_improvement_feedback` | Manually create or refresh the recommendation for one feedback event. |
 | `update_improvement_recommendation_status` | Accept, reject, defer, mark duplicate, or otherwise update recommendation status without publishing catalog changes. |
 | `clarify_improvement_recommendation` | Replace the editable maintainer clarification for a recommendation and enqueue a fresh self-improvement analysis run. |
+| `create_improvement_proposal` | Create an inert catalog proposal version from an accepted recommendation. |
+| `get_improvement_proposal` | Fetch proposal versions linked to one recommendation. |
+| `list_improvement_recommendations_with_proposals` | List recommendations that already have linked proposal versions. |
 | `list_traces` | Recent agent run spans with timing, summary, and token usage (`input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_write_tokens`, `prompt_size`). The composed prompt body is fetched separately via the `/traces/{span_id}/prompt` REST endpoint, not an MCP tool, since it can be many KB. |
 | `get_trace` | Full dispatch chain by root event ID. |
 | `get_trace_steps` | Tool-loop transcript for one span. |

--- a/docs/self-improvement-feedback.md
+++ b/docs/self-improvement-feedback.md
@@ -40,11 +40,27 @@ hard safety contract remains enforced by code: feedback is evidence, not a
 command; the analyzer never auto-applies, publishes, or mutates agents,
 guardrails, prompts, skills, or dispatch wiring.
 
+Accepted recommendations with concrete prompt, skill, or guardrail targets can
+be turned into inert catalog proposal versions from **Improvements**, through
+`POST /improvements/recommendations/{id}/proposal`, or through the MCP
+`create_improvement_proposal` tool. Proposal creation records
+`state=proposal`, `source_type=feedback_recommendation`, the recommendation id
+as `source_ref`, the current target version as `base_version_id`, and the
+recommendation rationale as changelog metadata.
+
+There are two separate human gates: first accept the recommendation, then
+review and publish the catalog proposal version. Proposal versions do not affect
+runtime prompt composition until explicitly published through the normal catalog
+versioning path. Non-convertible recommendation types, such as broad design
+recommendations, split-agent work, dispatch-wiring changes, `needs_more_context`,
+or `no_action`, remain review records and do not mutate fleet state.
+
 Inspect the workflow in the dashboard under **Improvements**, through
-`GET /improvements/feedback` and `GET /improvements/recommendations`, or through
-the MCP `list_improvement_feedback` and `list_improvement_recommendations`
-tools. Accepted recommendations remain inert until a later proposal step turns
-them into catalog proposal versions for separate human publishing.
+`GET /improvements/feedback`, `GET /improvements/recommendations`, and
+`GET /improvements/recommendations/{id}/proposal`, or through the MCP
+`list_improvement_feedback`, `list_improvement_recommendations`,
+`get_improvement_proposal`, and
+`list_improvement_recommendations_with_proposals` tools.
 
 When a recommendation needs more input, the dashboard's **Clarify** action lets
 an operator edit one clarification field while seeing the original feedback,

--- a/internal/daemon/observe/observe.go
+++ b/internal/daemon/observe/observe.go
@@ -89,6 +89,8 @@ func (h *Handler) RegisterRoutes(r *mux.Router, withTimeout func(http.Handler) h
 	r.Handle("/improvements/recommendations/{id}", withTimeout(http.HandlerFunc(h.HandleImprovementRecommendation))).Methods(http.MethodGet)
 	r.Handle("/improvements/recommendations/{id}/status", withTimeout(http.HandlerFunc(h.HandleUpdateImprovementRecommendationStatus))).Methods(http.MethodPost, http.MethodPatch)
 	r.Handle("/improvements/recommendations/{id}/clarification", withTimeout(http.HandlerFunc(h.HandleClarifyImprovementRecommendation))).Methods(http.MethodPost, http.MethodPatch)
+	r.Handle("/improvements/recommendations/{id}/proposal", withTimeout(http.HandlerFunc(h.HandleCreateImprovementProposal))).Methods(http.MethodPost)
+	r.Handle("/improvements/recommendations/{id}/proposal", withTimeout(http.HandlerFunc(h.HandleImprovementProposal))).Methods(http.MethodGet)
 	r.Handle("/improvements/feedback/{id:[0-9]+}/analyze", withTimeout(http.HandlerFunc(h.HandleAnalyzeImprovementFeedback))).Methods(http.MethodPost)
 }
 
@@ -273,6 +275,29 @@ func (h *Handler) HandleClarifyImprovementRecommendation(w http.ResponseWriter, 
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(rec)
+}
+
+func (h *Handler) HandleCreateImprovementProposal(w http.ResponseWriter, r *http.Request) {
+	proposal, err := h.store.CreateSelfImprovementProposal(mux.Vars(r)["id"])
+	if err != nil {
+		h.writeStoreError(w, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(proposal)
+}
+
+func (h *Handler) HandleImprovementProposal(w http.ResponseWriter, r *http.Request) {
+	proposals, err := h.store.ListSelfImprovementProposals(mux.Vars(r)["id"])
+	if err != nil {
+		h.writeStoreError(w, err)
+		return
+	}
+	if proposals == nil {
+		proposals = []store.SelfImprovementProposal{}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(proposals)
 }
 
 func clarificationImprovementEvent(rec store.SelfImprovementRecommendation) workflow.Event {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -273,6 +273,35 @@ func registerTools(srv *server.MCPServer, deps Deps) {
 			toolClarifyImprovementRecommendation(deps),
 		)
 		srv.AddTool(
+			mcpgo.NewTool("create_improvement_proposal",
+				mcpgo.WithDescription("Create an inert catalog proposal version from an accepted self-improvement recommendation. This does not publish or affect runtime prompt composition."),
+				mcpgo.WithString("recommendation_id",
+					mcpgo.Required(),
+					mcpgo.Description("Accepted recommendation id."),
+				),
+			),
+			toolCreateImprovementProposal(deps),
+		)
+		srv.AddTool(
+			mcpgo.NewTool("get_improvement_proposal",
+				mcpgo.WithDescription("Fetch catalog proposal versions linked to a self-improvement recommendation."),
+				mcpgo.WithString("recommendation_id",
+					mcpgo.Required(),
+					mcpgo.Description("Recommendation id."),
+				),
+			),
+			toolGetImprovementProposal(deps),
+		)
+		srv.AddTool(
+			mcpgo.NewTool("list_improvement_recommendations_with_proposals",
+				mcpgo.WithDescription("List self-improvement recommendations that already have linked catalog proposal versions."),
+				mcpgo.WithString("workspace",
+					mcpgo.Description("Optional workspace id or display name. Defaults to default."),
+				),
+			),
+			toolListImprovementRecommendationsWithProposals(deps),
+		)
+		srv.AddTool(
 			mcpgo.NewTool("list_traces",
 				mcpgo.WithDescription("List recent agent run spans for one workspace. Ordered newest→oldest, capped at 200. Each span records backend, repo, status, duration, and summary. Omitted workspace defaults to default."),
 				mcpgo.WithString("workspace",

--- a/internal/mcp/tools_observe.go
+++ b/internal/mcp/tools_observe.go
@@ -196,6 +196,45 @@ func mcpFirstNonZero(values ...int) int {
 	return 0
 }
 
+func toolCreateImprovementProposal(deps Deps) server.ToolHandlerFunc {
+	return func(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		id, ok := trimmedString(req, "recommendation_id")
+		if !ok {
+			return mcpgo.NewToolResultError("recommendation_id is required"), nil
+		}
+		proposal, err := deps.Store.CreateSelfImprovementProposal(id)
+		if err != nil {
+			return mcpgo.NewToolResultErrorFromErr("create improvement proposal", err), nil
+		}
+		return jsonResult(proposal)
+	}
+}
+
+func toolGetImprovementProposal(deps Deps) server.ToolHandlerFunc {
+	return func(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		id, ok := trimmedString(req, "recommendation_id")
+		if !ok {
+			return mcpgo.NewToolResultError("recommendation_id is required"), nil
+		}
+		proposals, err := deps.Store.ListSelfImprovementProposals(id)
+		if err != nil {
+			return mcpgo.NewToolResultErrorFromErr("get improvement proposal", err), nil
+		}
+		return jsonResult(nilSafe(proposals))
+	}
+}
+
+func toolListImprovementRecommendationsWithProposals(deps Deps) server.ToolHandlerFunc {
+	return func(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		workspace, _ := trimmedStringOptional(req, "workspace")
+		rows, err := deps.Store.ListSelfImprovementRecommendationsWithProposals(workspace, 100)
+		if err != nil {
+			return mcpgo.NewToolResultErrorFromErr("list improvement recommendations with proposals", err), nil
+		}
+		return jsonResult(nilSafe(rows))
+	}
+}
+
 // toolListTraces returns the 200 most recent spans verbatim. The Span JSON
 // shape already matches GET /traces so clients can parse both surfaces with
 // the same decoder.

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -226,6 +226,112 @@ func textOf(t *testing.T, res *mcpgo.CallToolResult) string {
 	return tc.Text
 }
 
+func TestToolImprovementProposalLifecycle(t *testing.T) {
+	t.Parallel()
+	deps := testFixture(t)
+	prompt, err := deps.Store.UpsertPrompt(fleet.Prompt{Name: "proposal-target", Description: "target desc", Content: "body v1"})
+	if err != nil {
+		t.Fatalf("seed prompt: %v", err)
+	}
+	feedback, err := deps.Store.UpsertSelfImprovementFeedback(store.SelfImprovementFeedbackInput{
+		WorkspaceID:      fleet.DefaultWorkspaceID,
+		RepoOwner:        "owner",
+		RepoName:         "one",
+		SourceType:       "issue_comment",
+		GitHubCommentID:  669001,
+		SourceURL:        "https://github.com/owner/one/issues/1#issuecomment-1",
+		AuthorLogin:      "maintainer",
+		AuthorAuthorized: true,
+		IssueNumber:      1,
+		RawBody:          "Please improve this prompt /agents improve",
+		Tag:              store.FeedbackTag,
+		LinkConfidence:   "exact",
+		Status:           store.FeedbackStatusNew,
+	})
+	if err != nil {
+		t.Fatalf("seed feedback: %v", err)
+	}
+	rec, err := deps.Store.UpsertSelfImprovementRecommendation(store.SelfImprovementRecommendationInput{
+		WorkspaceID:           fleet.DefaultWorkspaceID,
+		FeedbackEventID:       feedback.ID,
+		Type:                  "prompt_guidance",
+		Status:                store.RecommendationStatusAccepted,
+		Finding:               "tighten prompt guidance",
+		NormalizedLesson:      "Keep guidance concrete.",
+		Rationale:             "Feedback asked for a concrete prompt update.",
+		TargetAssetType:       "prompt",
+		TargetAssetID:         prompt.ID,
+		TargetBaseVersionID:   prompt.VersionID,
+		ProposedNewBody:       "body v2",
+		AnalyzerPromptRef:     "prompt_self-improvement-analyst",
+		StructuredOutput:      map[string]any{"status": "recommended"},
+		AttributionConfidence: "exact",
+	})
+	if err != nil {
+		t.Fatalf("seed recommendation: %v", err)
+	}
+
+	createReq := mcpgo.CallToolRequest{}
+	createReq.Params.Arguments = map[string]any{"recommendation_id": rec.ID}
+	res, err := toolCreateImprovementProposal(deps)(context.Background(), createReq)
+	if err != nil {
+		t.Fatalf("create proposal: %v", err)
+	}
+	var proposal map[string]any
+	decodeText(t, res, &proposal)
+	version, ok := proposal["version"].(map[string]any)
+	if !ok {
+		t.Fatalf("proposal version missing: %+v", proposal)
+	}
+	if proposal["recommendation_id"] != rec.ID || proposal["target_asset_type"] != "prompt" || proposal["target_asset_id"] != prompt.ID {
+		t.Fatalf("proposal linkage = %+v, want rec %s prompt %s", proposal, rec.ID, prompt.ID)
+	}
+	if version["state"] != "proposal" || version["source_type"] != "feedback_recommendation" || version["source_ref"] != rec.ID {
+		t.Fatalf("proposal version metadata = %+v, want inert recommendation proposal", version)
+	}
+	if version["base_version_id"] != prompt.VersionID {
+		t.Fatalf("proposal version base = %+v, want %s", version, prompt.VersionID)
+	}
+
+	getReq := mcpgo.CallToolRequest{}
+	getReq.Params.Arguments = map[string]any{"recommendation_id": rec.ID}
+	res, err = toolGetImprovementProposal(deps)(context.Background(), getReq)
+	if err != nil {
+		t.Fatalf("get proposal: %v", err)
+	}
+	var proposals []map[string]any
+	decodeText(t, res, &proposals)
+	if len(proposals) != 1 {
+		t.Fatalf("proposals len = %d, want 1: %+v", len(proposals), proposals)
+	}
+	base, ok := proposals[0]["base_version"].(map[string]any)
+	if !ok {
+		t.Fatalf("proposal base version missing: %+v", proposals[0])
+	}
+	if base["id"] != prompt.VersionID || base["content"] != "body v1" {
+		t.Fatalf("proposal base version = %+v, want %s body v1", base, prompt.VersionID)
+	}
+	fetchedVersion, ok := proposals[0]["version"].(map[string]any)
+	if !ok {
+		t.Fatalf("proposal version missing from fetched proposal: %+v", proposals[0])
+	}
+	if fetchedVersion["content"] != "body v2" {
+		t.Fatalf("fetched proposal version = %+v, want body v2", fetchedVersion)
+	}
+
+	listReq := mcpgo.CallToolRequest{}
+	listReq.Params.Arguments = map[string]any{"workspace": fleet.DefaultWorkspaceID}
+	res, err = toolListImprovementRecommendationsWithProposals(deps)(context.Background(), listReq)
+	if err != nil {
+		t.Fatalf("list recommendations with proposals: %v", err)
+	}
+	var linked []map[string]any
+	decodeText(t, res, &linked)
+	if len(linked) != 1 || linked[0]["id"] != rec.ID {
+		t.Fatalf("linked recommendations = %+v, want %s", linked, rec.ID)
+	}
+}
+
 func TestToolListAgents(t *testing.T) {
 	t.Parallel()
 	deps := testFixture(t)

--- a/internal/store/self_improvement.go
+++ b/internal/store/self_improvement.go
@@ -780,14 +780,14 @@ func ListSelfImprovementProposals(db *sql.DB, id string) ([]SelfImprovementPropo
 		return nil, &ErrValidation{Msg: "recommendation id is required"}
 	}
 	rows, err := db.Query(`
-		SELECT 'prompt', p.ref, pv.id, pv.prompt_id, pv.version_number, pv.state, pv.description, pv.content,
+		SELECT 'prompt', p.ref, pv.id, pv.prompt_id, pv.version_number, pv.state, pv.description, pv.content, 0, 0,
 		       pv.source_type, pv.source_ref, pv.author, pv.changelog, COALESCE(pv.base_version_id, ''),
 		       pv.body_hash, pv.created_at, COALESCE(pv.published_at, '')
 		FROM prompt_versions pv
 		JOIN prompts p ON p.id = pv.prompt_id
 		WHERE pv.source_type='feedback_recommendation' AND pv.source_ref=?
 		UNION ALL
-		SELECT 'skill', s.ref, sv.id, sv.skill_id, sv.version_number, sv.state, '', sv.prompt,
+		SELECT 'skill', s.ref, sv.id, sv.skill_id, sv.version_number, sv.state, '', sv.prompt, 0, 0,
 		       sv.source_type, sv.source_ref, sv.author, sv.changelog, COALESCE(sv.base_version_id, ''),
 		       sv.body_hash, sv.created_at, COALESCE(sv.published_at, '')
 		FROM skill_versions sv
@@ -795,6 +795,7 @@ func ListSelfImprovementProposals(db *sql.DB, id string) ([]SelfImprovementPropo
 		WHERE sv.source_type='feedback_recommendation' AND sv.source_ref=?
 		UNION ALL
 		SELECT 'guardrail', g.ref, gv.id, gv.guardrail_id, gv.version_number, gv.state, gv.description, gv.content,
+		       gv.enabled, gv.position,
 		       gv.source_type, gv.source_ref, gv.author, gv.changelog, COALESCE(gv.base_version_id, ''),
 		       gv.body_hash, gv.created_at, COALESCE(gv.published_at, '')
 		FROM guardrail_versions gv
@@ -807,11 +808,12 @@ func ListSelfImprovementProposals(db *sql.DB, id string) ([]SelfImprovementPropo
 	var out []SelfImprovementProposal
 	for rows.Next() {
 		var proposal SelfImprovementProposal
+		var enabled int
 		proposal.RecommendationID = id
 		if err := rows.Scan(
 			&proposal.TargetAssetType, &proposal.TargetAssetID, &proposal.Version.ID, &proposal.Version.AssetID,
 			&proposal.Version.Version, &proposal.Version.State, &proposal.Version.Description, &proposal.Version.Content,
-			&proposal.Version.SourceType, &proposal.Version.SourceRef, &proposal.Version.Author, &proposal.Version.Changelog,
+			&enabled, &proposal.Version.Position, &proposal.Version.SourceType, &proposal.Version.SourceRef, &proposal.Version.Author, &proposal.Version.Changelog,
 			&proposal.Version.BaseVersionID, &proposal.Version.BodyHash, &proposal.Version.CreatedAt, &proposal.Version.PublishedAt,
 		); err != nil {
 			return nil, fmt.Errorf("store: scan self-improvement proposal: %w", err)
@@ -819,6 +821,9 @@ func ListSelfImprovementProposals(db *sql.DB, id string) ([]SelfImprovementPropo
 		if proposal.TargetAssetType == "skill" {
 			proposal.Version.Prompt = proposal.Version.Content
 			proposal.Version.Content = ""
+		}
+		if proposal.TargetAssetType == "guardrail" {
+			proposal.Version.Enabled = enabled != 0
 		}
 		proposal.BaseVersionID = proposal.Version.BaseVersionID
 		out = append(out, proposal)
@@ -1095,7 +1100,7 @@ func recommendationProposalChangelog(rec SelfImprovementRecommendation) string {
 
 func ensureRecommendationBaseVersion(rec SelfImprovementRecommendation, currentVersionID string) error {
 	if rec.TargetBaseVersionID == "" {
-		return nil
+		return &ErrValidation{Msg: "recommendation base version is required; re-analyze feedback before creating a proposal"}
 	}
 	if rec.TargetBaseVersionID != currentVersionID {
 		return &ErrValidation{Msg: "recommendation base version is stale; re-analyze feedback before creating a proposal"}

--- a/internal/store/self_improvement.go
+++ b/internal/store/self_improvement.go
@@ -136,6 +136,15 @@ type SelfImprovementClarification struct {
 	UpdatedAt        string `json:"updated_at"`
 }
 
+type SelfImprovementProposal struct {
+	RecommendationID string                `json:"recommendation_id"`
+	TargetAssetType  string                `json:"target_asset_type"`
+	TargetAssetID    string                `json:"target_asset_id"`
+	BaseVersionID    string                `json:"base_version_id,omitempty"`
+	BaseVersion      *fleet.CatalogVersion `json:"base_version,omitempty"`
+	Version          fleet.CatalogVersion  `json:"version"`
+}
+
 type SelfImprovementRecommendationInput struct {
 	WorkspaceID             string
 	FeedbackEventID         int64
@@ -195,6 +204,18 @@ func (s *Store) UpdateSelfImprovementRecommendationStatus(id, status string) (Se
 
 func (s *Store) UpsertSelfImprovementClarification(recommendationID, author, body string) (SelfImprovementRecommendation, error) {
 	return UpsertSelfImprovementClarification(s.db, recommendationID, author, body)
+}
+
+func (s *Store) CreateSelfImprovementProposal(id string) (SelfImprovementProposal, error) {
+	return CreateSelfImprovementProposal(s.db, id)
+}
+
+func (s *Store) ListSelfImprovementProposals(id string) ([]SelfImprovementProposal, error) {
+	return ListSelfImprovementProposals(s.db, id)
+}
+
+func (s *Store) ListSelfImprovementRecommendationsWithProposals(workspace string, limit int) ([]SelfImprovementRecommendation, error) {
+	return ListSelfImprovementRecommendationsWithProposals(s.db, workspace, limit)
 }
 
 func (s *Store) MarkSelfImprovementFeedbackFailed(id int64, cause string) error {
@@ -647,6 +668,252 @@ func UpdateSelfImprovementRecommendationStatus(db *sql.DB, id, status string) (S
 	return GetSelfImprovementRecommendation(db, id)
 }
 
+func CreateSelfImprovementProposal(db *sql.DB, id string) (SelfImprovementProposal, error) {
+	rec, err := GetSelfImprovementRecommendation(db, id)
+	if err != nil {
+		return SelfImprovementProposal{}, err
+	}
+	if rec.Status != RecommendationStatusAccepted {
+		return SelfImprovementProposal{}, &ErrValidation{Msg: "recommendation must be accepted before creating a proposal"}
+	}
+	if nonConvertibleRecommendationType(rec.Type) {
+		return SelfImprovementProposal{}, &ErrValidation{Msg: fmt.Sprintf("recommendation type %q is not proposal-convertible", rec.Type)}
+	}
+	if existing, err := ListSelfImprovementProposals(db, rec.ID); err != nil {
+		return SelfImprovementProposal{}, err
+	} else if len(existing) > 0 {
+		return existing[0], nil
+	}
+	targetType := strings.TrimSpace(rec.TargetAssetType)
+	targetID := strings.TrimSpace(rec.TargetAssetID)
+	if targetID == "" {
+		return SelfImprovementProposal{}, &ErrValidation{Msg: "recommendation has no target catalog asset"}
+	}
+	if strings.TrimSpace(rec.ProposedNewBody) == "" {
+		return SelfImprovementProposal{}, &ErrValidation{Msg: "recommendation has no proposed catalog body"}
+	}
+	meta := fleet.CatalogVersionMetadata{
+		State:      "proposal",
+		SourceType: "feedback_recommendation",
+		SourceRef:  rec.ID,
+		Author:     "agents-assistant",
+		Changelog:  recommendationProposalChangelog(rec),
+	}
+	var version fleet.CatalogVersion
+	switch targetType {
+	case "prompt":
+		prompt, err := ReadPrompt(db, targetID)
+		if err != nil {
+			return SelfImprovementProposal{}, err
+		}
+		if err := ensureRecommendationBaseVersion(rec, prompt.VersionID); err != nil {
+			return SelfImprovementProposal{}, err
+		}
+		tx, err := db.Begin()
+		if err != nil {
+			return SelfImprovementProposal{}, fmt.Errorf("store: create self-improvement proposal: begin: %w", err)
+		}
+		defer tx.Rollback()
+		version, err = CreatePromptDraftTx(tx, prompt.ID, prompt.Description, rec.ProposedNewBody, meta)
+		if err != nil {
+			return SelfImprovementProposal{}, err
+		}
+		if err := tx.Commit(); err != nil {
+			return SelfImprovementProposal{}, fmt.Errorf("store: create self-improvement proposal: commit: %w", err)
+		}
+	case "skill":
+		skill, err := readSkill(db, targetID)
+		if err != nil {
+			return SelfImprovementProposal{}, err
+		}
+		if err := ensureRecommendationBaseVersion(rec, skill.VersionID); err != nil {
+			return SelfImprovementProposal{}, err
+		}
+		tx, err := db.Begin()
+		if err != nil {
+			return SelfImprovementProposal{}, fmt.Errorf("store: create self-improvement proposal: begin: %w", err)
+		}
+		defer tx.Rollback()
+		version, err = CreateSkillDraftTx(tx, skill.ID, rec.ProposedNewBody, meta)
+		if err != nil {
+			return SelfImprovementProposal{}, err
+		}
+		if err := tx.Commit(); err != nil {
+			return SelfImprovementProposal{}, fmt.Errorf("store: create self-improvement proposal: commit: %w", err)
+		}
+	case "guardrail":
+		guardrail, err := GetGuardrail(db, targetID)
+		if err != nil {
+			return SelfImprovementProposal{}, err
+		}
+		if err := ensureRecommendationBaseVersion(rec, guardrail.VersionID); err != nil {
+			return SelfImprovementProposal{}, err
+		}
+		guardrail.Content = rec.ProposedNewBody
+		tx, err := db.Begin()
+		if err != nil {
+			return SelfImprovementProposal{}, fmt.Errorf("store: create self-improvement proposal: begin: %w", err)
+		}
+		defer tx.Rollback()
+		version, err = CreateGuardrailDraftTx(tx, guardrail.ID, guardrail, meta)
+		if err != nil {
+			return SelfImprovementProposal{}, err
+		}
+		if err := tx.Commit(); err != nil {
+			return SelfImprovementProposal{}, fmt.Errorf("store: create self-improvement proposal: commit: %w", err)
+		}
+	default:
+		return SelfImprovementProposal{}, &ErrValidation{Msg: fmt.Sprintf("recommendation target type %q is not proposal-convertible", targetType)}
+	}
+	return SelfImprovementProposal{
+		RecommendationID: rec.ID,
+		TargetAssetType:  targetType,
+		TargetAssetID:    targetID,
+		BaseVersionID:    version.BaseVersionID,
+		Version:          version,
+	}, nil
+}
+
+func ListSelfImprovementProposals(db *sql.DB, id string) ([]SelfImprovementProposal, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil, &ErrValidation{Msg: "recommendation id is required"}
+	}
+	rows, err := db.Query(`
+		SELECT 'prompt', p.ref, pv.id, pv.prompt_id, pv.version_number, pv.state, pv.description, pv.content,
+		       pv.source_type, pv.source_ref, pv.author, pv.changelog, COALESCE(pv.base_version_id, ''),
+		       pv.body_hash, pv.created_at, COALESCE(pv.published_at, '')
+		FROM prompt_versions pv
+		JOIN prompts p ON p.id = pv.prompt_id
+		WHERE pv.source_type='feedback_recommendation' AND pv.source_ref=?
+		UNION ALL
+		SELECT 'skill', s.ref, sv.id, sv.skill_id, sv.version_number, sv.state, '', sv.prompt,
+		       sv.source_type, sv.source_ref, sv.author, sv.changelog, COALESCE(sv.base_version_id, ''),
+		       sv.body_hash, sv.created_at, COALESCE(sv.published_at, '')
+		FROM skill_versions sv
+		JOIN skills s ON s.id = sv.skill_id
+		WHERE sv.source_type='feedback_recommendation' AND sv.source_ref=?
+		UNION ALL
+		SELECT 'guardrail', g.ref, gv.id, gv.guardrail_id, gv.version_number, gv.state, gv.description, gv.content,
+		       gv.source_type, gv.source_ref, gv.author, gv.changelog, COALESCE(gv.base_version_id, ''),
+		       gv.body_hash, gv.created_at, COALESCE(gv.published_at, '')
+		FROM guardrail_versions gv
+		JOIN guardrails g ON g.id = gv.guardrail_id
+		WHERE gv.source_type='feedback_recommendation' AND gv.source_ref=?
+		ORDER BY created_at DESC`, id, id, id)
+	if err != nil {
+		return nil, fmt.Errorf("store: list self-improvement proposals: %w", err)
+	}
+	var out []SelfImprovementProposal
+	for rows.Next() {
+		var proposal SelfImprovementProposal
+		proposal.RecommendationID = id
+		if err := rows.Scan(
+			&proposal.TargetAssetType, &proposal.TargetAssetID, &proposal.Version.ID, &proposal.Version.AssetID,
+			&proposal.Version.Version, &proposal.Version.State, &proposal.Version.Description, &proposal.Version.Content,
+			&proposal.Version.SourceType, &proposal.Version.SourceRef, &proposal.Version.Author, &proposal.Version.Changelog,
+			&proposal.Version.BaseVersionID, &proposal.Version.BodyHash, &proposal.Version.CreatedAt, &proposal.Version.PublishedAt,
+		); err != nil {
+			return nil, fmt.Errorf("store: scan self-improvement proposal: %w", err)
+		}
+		if proposal.TargetAssetType == "skill" {
+			proposal.Version.Prompt = proposal.Version.Content
+			proposal.Version.Content = ""
+		}
+		proposal.BaseVersionID = proposal.Version.BaseVersionID
+		out = append(out, proposal)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return nil, err
+	}
+	if err := rows.Close(); err != nil {
+		return nil, fmt.Errorf("store: close self-improvement proposals: %w", err)
+	}
+	for i := range out {
+		if out[i].BaseVersionID == "" {
+			continue
+		}
+		base, err := readSelfImprovementProposalBaseVersion(db, out[i].TargetAssetType, out[i].BaseVersionID)
+		if err != nil {
+			return nil, err
+		}
+		out[i].BaseVersion = &base
+	}
+	return out, nil
+}
+
+func readSelfImprovementProposalBaseVersion(q querier, targetType, versionID string) (fleet.CatalogVersion, error) {
+	var version fleet.CatalogVersion
+	var err error
+	switch targetType {
+	case "prompt":
+		err = q.QueryRow(`
+			SELECT id, prompt_id, version_number, state, description, content, source_type, source_ref, author, changelog,
+			       COALESCE(base_version_id, ''), body_hash, created_at, COALESCE(published_at, '')
+			FROM prompt_versions
+			WHERE id=?`, versionID).
+			Scan(&version.ID, &version.AssetID, &version.Version, &version.State, &version.Description, &version.Content,
+				&version.SourceType, &version.SourceRef, &version.Author, &version.Changelog,
+				&version.BaseVersionID, &version.BodyHash, &version.CreatedAt, &version.PublishedAt)
+	case "skill":
+		err = q.QueryRow(`
+			SELECT id, skill_id, version_number, state, prompt, source_type, source_ref, author, changelog,
+			       COALESCE(base_version_id, ''), body_hash, created_at, COALESCE(published_at, '')
+			FROM skill_versions
+			WHERE id=?`, versionID).
+			Scan(&version.ID, &version.AssetID, &version.Version, &version.State, &version.Prompt,
+				&version.SourceType, &version.SourceRef, &version.Author, &version.Changelog,
+				&version.BaseVersionID, &version.BodyHash, &version.CreatedAt, &version.PublishedAt)
+	case "guardrail":
+		var enabled int
+		err = q.QueryRow(`
+			SELECT id, guardrail_id, version_number, state, description, content, enabled, position, source_type, source_ref,
+			       author, changelog, COALESCE(base_version_id, ''), body_hash, created_at, COALESCE(published_at, '')
+			FROM guardrail_versions
+			WHERE id=?`, versionID).
+			Scan(&version.ID, &version.AssetID, &version.Version, &version.State, &version.Description, &version.Content,
+				&enabled, &version.Position, &version.SourceType, &version.SourceRef,
+				&version.Author, &version.Changelog, &version.BaseVersionID, &version.BodyHash, &version.CreatedAt, &version.PublishedAt)
+		version.Enabled = enabled != 0
+	default:
+		return fleet.CatalogVersion{}, &ErrValidation{Msg: fmt.Sprintf("recommendation target type %q is not proposal-convertible", targetType)}
+	}
+	if err != nil {
+		return fleet.CatalogVersion{}, versionReadErr(targetType, versionID, err)
+	}
+	return version, nil
+}
+
+func ListSelfImprovementRecommendationsWithProposals(db *sql.DB, workspace string, limit int) ([]SelfImprovementRecommendation, error) {
+	if limit <= 0 || limit > 500 {
+		limit = 100
+	}
+	workspaceID := fleet.NormalizeWorkspaceID(workspace)
+	rows, err := db.Query(recommendationSelectSQL()+`
+		WHERE r.workspace_id=? AND EXISTS (
+			SELECT 1 FROM prompt_versions pv WHERE pv.source_type='feedback_recommendation' AND pv.source_ref=r.id
+			UNION ALL
+			SELECT 1 FROM skill_versions sv WHERE sv.source_type='feedback_recommendation' AND sv.source_ref=r.id
+			UNION ALL
+			SELECT 1 FROM guardrail_versions gv WHERE gv.source_type='feedback_recommendation' AND gv.source_ref=r.id
+		)
+		ORDER BY r.updated_at DESC, r.id DESC LIMIT ?`, workspaceID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []SelfImprovementRecommendation
+	for rows.Next() {
+		rec, err := scanSelfImprovementRecommendation(rows, false)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, rec)
+	}
+	return out, rows.Err()
+}
+
 func MarkSelfImprovementFeedbackFailed(db *sql.DB, id int64, cause string) error {
 	if id <= 0 {
 		return &ErrValidation{Msg: "feedback id is required"}
@@ -814,6 +1081,57 @@ func splitInt64CSV(s string) []int64 {
 		}
 	}
 	return out
+}
+
+func recommendationProposalChangelog(rec SelfImprovementRecommendation) string {
+	for _, value := range []string{rec.NormalizedLesson, rec.Rationale, rec.Finding} {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			return value
+		}
+	}
+	return "Self-improvement recommendation " + rec.ID
+}
+
+func ensureRecommendationBaseVersion(rec SelfImprovementRecommendation, currentVersionID string) error {
+	if rec.TargetBaseVersionID == "" {
+		return nil
+	}
+	if rec.TargetBaseVersionID != currentVersionID {
+		return &ErrValidation{Msg: "recommendation base version is stale; re-analyze feedback before creating a proposal"}
+	}
+	return nil
+}
+
+func nonConvertibleRecommendationType(typ string) bool {
+	switch strings.TrimSpace(typ) {
+	case "needs_more_context", "no_action", "split_agent", "change_dispatch_wiring":
+		return true
+	default:
+		return false
+	}
+}
+
+func readSkill(db *sql.DB, ref string) (fleet.Skill, error) {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return fleet.Skill{}, &ErrValidation{Msg: "skill id is required"}
+	}
+	var skill fleet.Skill
+	err := db.QueryRow(`
+		SELECT s.ref, COALESCE(s.workspace_id, ''), COALESCE(s.repo, ''), s.name, s.prompt,
+		       COALESCE(sv.id, ''), COALESCE(sv.version_number, 0)
+		FROM skills s
+		LEFT JOIN skill_versions sv ON sv.id = s.current_version_id
+		WHERE s.id=? OR s.ref=?`, ref, ref).
+		Scan(&skill.ID, &skill.WorkspaceID, &skill.Repo, &skill.Name, &skill.Prompt, &skill.VersionID, &skill.Version)
+	if errors.Is(err, sql.ErrNoRows) {
+		return fleet.Skill{}, &ErrNotFound{Msg: fmt.Sprintf("skill %q not found", ref)}
+	}
+	if err != nil {
+		return fleet.Skill{}, fmt.Errorf("store: read skill %s: %w", ref, err)
+	}
+	return skill, nil
 }
 
 func validRecommendationStatus(status string) bool {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -514,6 +514,85 @@ func TestCreateSelfImprovementProposalRejectsUnsafeStatesAndTargets(t *testing.T
 	if _, err := store.CreateSelfImprovementProposal(db, accepted.ID); err == nil || !strings.Contains(err.Error(), "not proposal-convertible") {
 		t.Fatalf("CreateSelfImprovementProposal error = %v, want non-convertible validation", err)
 	}
+
+	prompt, err := store.UpsertPrompt(db, fleet.Prompt{Name: "missing-base-proposal-target", Description: "target desc", Content: "body v1"})
+	if err != nil {
+		t.Fatalf("UpsertPrompt: %v", err)
+	}
+	missingBase, err := store.UpsertSelfImprovementRecommendation(db, store.SelfImprovementRecommendationInput{
+		WorkspaceID:           "team-a",
+		FeedbackEventID:       feedback.ID,
+		Type:                  "prompt_guidance",
+		Status:                store.RecommendationStatusAccepted,
+		Finding:               "tighten prompt guidance",
+		TargetAssetType:       "prompt",
+		TargetAssetID:         prompt.ID,
+		ProposedNewBody:       "body v2",
+		AttributionConfidence: "exact",
+	})
+	if err != nil {
+		t.Fatalf("UpsertSelfImprovementRecommendation missing base: %v", err)
+	}
+	if _, err := store.CreateSelfImprovementProposal(db, missingBase.ID); err == nil || !strings.Contains(err.Error(), "base version is required") {
+		t.Fatalf("CreateSelfImprovementProposal error = %v, want missing base version validation", err)
+	}
+}
+
+func TestCreateSelfImprovementProposalListsGuardrailMetadata(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	if _, err := store.UpsertWorkspace(db, fleet.Workspace{ID: "team-a", Name: "Team A"}); err != nil {
+		t.Fatalf("seed workspace: %v", err)
+	}
+	if err := store.UpsertGuardrail(db, fleet.Guardrail{
+		Name:        "proposal-guardrail-metadata",
+		Description: "guardrail desc",
+		Content:     "guardrail v1",
+		Enabled:     true,
+		Position:    11,
+	}); err != nil {
+		t.Fatalf("UpsertGuardrail: %v", err)
+	}
+	guardrail, err := store.GetGuardrail(db, "proposal-guardrail-metadata")
+	if err != nil {
+		t.Fatalf("GetGuardrail: %v", err)
+	}
+	feedback, err := storableFeedback(db, "team-a")
+	if err != nil {
+		t.Fatalf("storableFeedback: %v", err)
+	}
+	rec, err := store.UpsertSelfImprovementRecommendation(db, store.SelfImprovementRecommendationInput{
+		WorkspaceID:           "team-a",
+		FeedbackEventID:       feedback.ID,
+		Type:                  "guardrail_guidance",
+		Status:                store.RecommendationStatusAccepted,
+		Finding:               "tighten guardrail guidance",
+		TargetAssetType:       "guardrail",
+		TargetAssetID:         guardrail.ID,
+		TargetBaseVersionID:   guardrail.VersionID,
+		ProposedNewBody:       "guardrail v2",
+		AttributionConfidence: "exact",
+	})
+	if err != nil {
+		t.Fatalf("UpsertSelfImprovementRecommendation: %v", err)
+	}
+
+	if _, err := store.CreateSelfImprovementProposal(db, rec.ID); err != nil {
+		t.Fatalf("CreateSelfImprovementProposal: %v", err)
+	}
+	listed, err := store.ListSelfImprovementProposals(db, rec.ID)
+	if err != nil {
+		t.Fatalf("ListSelfImprovementProposals: %v", err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("proposals len = %d, want 1", len(listed))
+	}
+	if !listed[0].Version.Enabled || listed[0].Version.Position != 11 {
+		t.Fatalf("proposal guardrail metadata = enabled %v position %d, want enabled true position 11", listed[0].Version.Enabled, listed[0].Version.Position)
+	}
+	if listed[0].BaseVersion == nil || !listed[0].BaseVersion.Enabled || listed[0].BaseVersion.Position != 11 {
+		t.Fatalf("base guardrail metadata = %+v, want enabled true position 11", listed[0].BaseVersion)
+	}
 }
 
 func storableFeedback(db *sql.DB, workspace string) (store.SelfImprovementFeedback, error) {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -398,6 +398,142 @@ func TestSelfImprovementRecommendationLifecycle(t *testing.T) {
 	}
 }
 
+func TestCreateSelfImprovementProposalFromAcceptedRecommendation(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	if _, err := store.UpsertWorkspace(db, fleet.Workspace{ID: "team-a", Name: "Team A"}); err != nil {
+		t.Fatalf("seed workspace: %v", err)
+	}
+	prompt, err := store.UpsertPrompt(db, fleet.Prompt{Name: "proposal-target", Description: "target desc", Content: "body v1"})
+	if err != nil {
+		t.Fatalf("UpsertPrompt: %v", err)
+	}
+	feedback, err := storableFeedback(db, "team-a")
+	if err != nil {
+		t.Fatalf("storableFeedback: %v", err)
+	}
+	rec, err := store.UpsertSelfImprovementRecommendation(db, store.SelfImprovementRecommendationInput{
+		WorkspaceID:           "team-a",
+		FeedbackEventID:       feedback.ID,
+		Type:                  "prompt_guidance",
+		Status:                store.RecommendationStatusAccepted,
+		Finding:               "tighten prompt guidance",
+		NormalizedLesson:      "Keep guidance concrete.",
+		Rationale:             "Feedback asked for a concrete prompt update.",
+		TargetAssetType:       "prompt",
+		TargetAssetID:         prompt.ID,
+		TargetBaseVersionID:   prompt.VersionID,
+		ProposedNewBody:       "body v2",
+		AnalyzerPromptRef:     "prompt_self-improvement-analyst",
+		StructuredOutput:      map[string]any{"status": "recommended"},
+		AttributionConfidence: "exact",
+	})
+	if err != nil {
+		t.Fatalf("UpsertSelfImprovementRecommendation: %v", err)
+	}
+
+	proposal, err := store.CreateSelfImprovementProposal(db, rec.ID)
+	if err != nil {
+		t.Fatalf("CreateSelfImprovementProposal: %v", err)
+	}
+	if proposal.Version.State != "proposal" || proposal.Version.SourceType != "feedback_recommendation" ||
+		proposal.Version.SourceRef != rec.ID || proposal.Version.Author != "agents-assistant" {
+		t.Fatalf("proposal metadata = %+v, want inert feedback recommendation proposal", proposal.Version)
+	}
+	if proposal.Version.BaseVersionID != prompt.VersionID {
+		t.Fatalf("proposal base = %q, want %q", proposal.Version.BaseVersionID, prompt.VersionID)
+	}
+	listed, err := store.ListSelfImprovementProposals(db, rec.ID)
+	if err != nil {
+		t.Fatalf("ListSelfImprovementProposals: %v", err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("proposals len = %d, want 1", len(listed))
+	}
+	if listed[0].BaseVersion == nil || listed[0].BaseVersion.ID != prompt.VersionID || listed[0].BaseVersion.Content != "body v1" {
+		t.Fatalf("proposal base version = %+v, want prompt version %q with body v1", listed[0].BaseVersion, prompt.VersionID)
+	}
+	if listed[0].Version.Content != "body v2" {
+		t.Fatalf("proposal version content = %q, want body v2", listed[0].Version.Content)
+	}
+	current, err := store.ReadPrompt(db, prompt.ID)
+	if err != nil {
+		t.Fatalf("ReadPrompt: %v", err)
+	}
+	if current.Content != "body v1" || current.VersionID != prompt.VersionID {
+		t.Fatalf("current prompt = id %q body %q, want published version unchanged", current.VersionID, current.Content)
+	}
+	second, err := store.CreateSelfImprovementProposal(db, rec.ID)
+	if err != nil {
+		t.Fatalf("CreateSelfImprovementProposal second call: %v", err)
+	}
+	if second.Version.ID != proposal.Version.ID {
+		t.Fatalf("second proposal id = %q, want existing %q", second.Version.ID, proposal.Version.ID)
+	}
+	linked, err := store.ListSelfImprovementRecommendationsWithProposals(db, "team-a", 10)
+	if err != nil {
+		t.Fatalf("ListSelfImprovementRecommendationsWithProposals: %v", err)
+	}
+	if len(linked) != 1 || linked[0].ID != rec.ID {
+		t.Fatalf("linked recommendations = %+v, want %s", linked, rec.ID)
+	}
+}
+
+func TestCreateSelfImprovementProposalRejectsUnsafeStatesAndTargets(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	if _, err := store.UpsertWorkspace(db, fleet.Workspace{ID: "team-a", Name: "Team A"}); err != nil {
+		t.Fatalf("seed workspace: %v", err)
+	}
+	feedback, err := storableFeedback(db, "team-a")
+	if err != nil {
+		t.Fatalf("storableFeedback: %v", err)
+	}
+	rec, err := store.UpsertSelfImprovementRecommendation(db, store.SelfImprovementRecommendationInput{
+		WorkspaceID:           "team-a",
+		FeedbackEventID:       feedback.ID,
+		Type:                  "needs_more_context",
+		Status:                store.RecommendationStatusRecommended,
+		Finding:               "not accepted",
+		TargetAssetType:       "prompt",
+		TargetAssetID:         "prompt_missing",
+		TargetBaseVersionID:   "promptver_missing",
+		ProposedNewBody:       "body",
+		AttributionConfidence: "unresolved",
+	})
+	if err != nil {
+		t.Fatalf("UpsertSelfImprovementRecommendation: %v", err)
+	}
+	if _, err := store.CreateSelfImprovementProposal(db, rec.ID); err == nil || !strings.Contains(err.Error(), "must be accepted") {
+		t.Fatalf("CreateSelfImprovementProposal error = %v, want accepted-state validation", err)
+	}
+	accepted, err := store.UpdateSelfImprovementRecommendationStatus(db, rec.ID, store.RecommendationStatusAccepted)
+	if err != nil {
+		t.Fatalf("UpdateSelfImprovementRecommendationStatus: %v", err)
+	}
+	if _, err := store.CreateSelfImprovementProposal(db, accepted.ID); err == nil || !strings.Contains(err.Error(), "not proposal-convertible") {
+		t.Fatalf("CreateSelfImprovementProposal error = %v, want non-convertible validation", err)
+	}
+}
+
+func storableFeedback(db *sql.DB, workspace string) (store.SelfImprovementFeedback, error) {
+	return store.UpsertSelfImprovementFeedback(db, store.SelfImprovementFeedbackInput{
+		WorkspaceID:      workspace,
+		RepoOwner:        "acme",
+		RepoName:         "repo",
+		SourceType:       "issue_comment",
+		GitHubCommentID:  time.Now().UnixNano(),
+		SourceURL:        "https://github.com/acme/repo/issues/1#issuecomment-1",
+		AuthorLogin:      "maintainer",
+		AuthorAuthorized: true,
+		IssueNumber:      1,
+		RawBody:          "Please improve this prompt /agents improve",
+		Tag:              store.FeedbackTag,
+		LinkConfidence:   "exact",
+		Status:           store.FeedbackStatusNew,
+	})
+}
+
 // TestGuardrailsSeed verifies that migrations 010, 012, 013, and 016 created
 // the generic guardrails table and seeded the built-in rows with content
 // equal to default_content (so a "Reset to default" from the unedited

--- a/internal/ui/src/app/improvements/page.test.tsx
+++ b/internal/ui/src/app/improvements/page.test.tsx
@@ -1,0 +1,117 @@
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import ImprovementsPage from './page'
+
+describe('<ImprovementsPage />', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    window.localStorage.clear()
+  })
+
+  it('renders proposal review metadata and diff for accepted catalog recommendations', async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url === '/workspaces') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([{ id: 'default', name: 'Default' }]) } as Response)
+      }
+      if (url === '/improvements/feedback?workspace=default') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) } as Response)
+      }
+      if (url === '/improvements/recommendations?workspace=default') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([
+            {
+              id: 'rec-1',
+              feedback_event_id: 7,
+              type: 'prompt_guidance',
+              status: 'accepted',
+              confidence: 'high',
+              risk: 'low',
+              finding: 'Tighten prompt',
+              normalized_lesson: 'Use concrete language.',
+              rationale: 'The linked review asked for sharper guidance.',
+              attribution_confidence: 'exact',
+              target_asset_type: 'prompt',
+              target_base_version_id: 'promptver-1',
+              proposed_new_body: 'new body',
+              updated_at: '2026-06-01T18:00:00Z',
+              feedback: {
+                id: 7,
+                workspace: 'default',
+                repo_owner: 'acme',
+                repo_name: 'repo',
+                source_type: 'issue_comment',
+                source_url: 'https://example.test/feedback',
+                author_login: 'maintainer',
+                author_authorized: true,
+                raw_body: 'please improve this',
+                link_confidence: 'exact',
+                status: 'processed',
+                ingested_at: '2026-06-01T17:00:00Z',
+              },
+            },
+            {
+              id: 'rec-2',
+              feedback_event_id: 8,
+              type: 'split_agent',
+              status: 'accepted',
+              confidence: 'medium',
+              risk: 'medium',
+              finding: 'Split broad agent',
+              normalized_lesson: 'Separate concerns.',
+              rationale: 'This is design work, not a catalog body edit.',
+              attribution_confidence: 'inferred',
+              updated_at: '2026-06-01T18:05:00Z',
+            },
+          ]),
+        } as Response)
+      }
+      if (url === '/improvements/recommendations/rec-1/proposal') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([
+            {
+              recommendation_id: 'rec-1',
+              target_asset_type: 'prompt',
+              target_asset_id: 'prompt-a',
+              base_version_id: 'promptver-1',
+              base_version: { id: 'promptver-1', version: 1, state: 'published', description: 'desc', content: 'old body' },
+              version: {
+                id: 'promptver-2',
+                version: 2,
+                state: 'proposal',
+                description: 'desc',
+                content: 'new body',
+                source_type: 'feedback_recommendation',
+                source_ref: 'rec-1',
+                author: 'agents-assistant',
+                changelog: 'The linked review asked for sharper guidance.',
+                base_version_id: 'promptver-1',
+              },
+            },
+          ]),
+        } as Response)
+      }
+      if (url === '/improvements/recommendations/rec-2/proposal') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) } as Response)
+      }
+      return Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve([]) } as Response)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<ImprovementsPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'recommendations' }))
+
+    expect(await screen.findByText('Target prompt/prompt-a')).toBeInTheDocument()
+    expect(screen.getByText('Base v1')).toBeInTheDocument()
+    expect(screen.getByText('Proposal v2')).toBeInTheDocument()
+    expect(screen.getByText('State proposal')).toBeInTheDocument()
+    expect(screen.getByText('Source feedback_recommendation rec-1')).toBeInTheDocument()
+    expect(screen.getByText('Design recommendation only in v1.')).toBeInTheDocument()
+    const diff = screen.getByLabelText('Proposal diff for rec-1')
+    expect(within(diff).getByText('-old body')).toBeInTheDocument()
+    expect(within(diff).getByText('+new body')).toBeInTheDocument()
+  })
+})

--- a/internal/ui/src/app/improvements/page.tsx
+++ b/internal/ui/src/app/improvements/page.tsx
@@ -56,12 +56,97 @@ interface Recommendation {
   clarification?: Clarification
 }
 
+interface CatalogVersion {
+  id: string
+  asset_id?: string
+  version: number
+  state: string
+  description?: string
+  content?: string
+  prompt?: string
+  enabled?: boolean
+  position?: number
+  source_type?: string
+  source_ref?: string
+  author?: string
+  changelog?: string
+  base_version_id?: string
+  body_hash?: string
+  created_at?: string
+  published_at?: string
+}
+
+interface ImprovementProposal {
+  recommendation_id: string
+  target_asset_type: string
+  target_asset_id: string
+  base_version_id?: string
+  base_version?: CatalogVersion
+  version: CatalogVersion
+}
+
 type Tab = 'inbox' | 'recommendations' | 'history'
+
+const nonConvertibleTypes = ['needs_more_context', 'no_action', 'split_agent', 'change_dispatch_wiring']
+
+function versionBody(type: string, version?: CatalogVersion) {
+  if (!version) return ''
+  if (type === 'skill') return version.prompt || ''
+  if (type === 'guardrail') {
+    return [
+      version.description ? `description: ${version.description}` : '',
+      version.content || '',
+      `enabled: ${version.enabled ? 'true' : 'false'}`,
+      `position: ${version.position ?? 0}`,
+    ].filter(Boolean).join('\n')
+  }
+  return [version.description, version.content].filter(Boolean).join('\n\n')
+}
+
+function diffLines(oldText: string, newText: string) {
+  const oldLines = oldText.split('\n')
+  const newLines = newText.split('\n')
+  const lengths = Array.from({ length: oldLines.length + 1 }, () => Array(newLines.length + 1).fill(0) as number[])
+  for (let i = oldLines.length - 1; i >= 0; i -= 1) {
+    for (let j = newLines.length - 1; j >= 0; j -= 1) {
+      lengths[i][j] = oldLines[i] === newLines[j] ? lengths[i + 1][j + 1] + 1 : Math.max(lengths[i + 1][j], lengths[i][j + 1])
+    }
+  }
+  const rows: { kind: 'same' | 'add' | 'del'; text: string }[] = []
+  let i = 0
+  let j = 0
+  while (i < oldLines.length && j < newLines.length) {
+    if (oldLines[i] === newLines[j]) {
+      rows.push({ kind: 'same', text: ` ${oldLines[i]}` })
+      i += 1
+      j += 1
+    } else if (lengths[i + 1][j] >= lengths[i][j + 1]) {
+      rows.push({ kind: 'del', text: `-${oldLines[i]}` })
+      i += 1
+    } else {
+      rows.push({ kind: 'add', text: `+${newLines[j]}` })
+      j += 1
+    }
+  }
+  for (; i < oldLines.length; i += 1) rows.push({ kind: 'del', text: `-${oldLines[i]}` })
+  for (; j < newLines.length; j += 1) rows.push({ kind: 'add', text: `+${newLines[j]}` })
+  return rows
+}
+
+function proposalReadiness(row: Recommendation) {
+  if (row.status !== 'accepted') return 'Accept before creating a proposal.'
+  if (nonConvertibleTypes.includes(row.type)) return 'Design recommendation only in v1.'
+  if (!['prompt', 'skill', 'guardrail'].includes(row.target_asset_type || '')) return 'No proposal-convertible catalog target.'
+  if (!row.target_base_version_id) return 'Missing target base version.'
+  if (!row.proposed_new_body) return 'Missing proposed catalog body.'
+  return ''
+}
 
 export default function ImprovementsPage() {
   const { workspace } = useSelectedWorkspace()
   const [feedback, setFeedback] = useState<FeedbackEvent[]>([])
   const [recommendations, setRecommendations] = useState<Recommendation[]>([])
+  const [proposals, setProposals] = useState<Record<string, ImprovementProposal[]>>({})
   const [tab, setTab] = useState<Tab>('inbox')
   const [status, setStatus] = useState('')
   const [loading, setLoading] = useState(true)
@@ -78,11 +163,22 @@ export default function ImprovementsPage() {
     ])
       .then(([feedbackRows, recommendationRows]) => {
         setFeedback(feedbackRows ?? [])
-        setRecommendations(recommendationRows ?? [])
+        const recs = recommendationRows ?? []
+        setRecommendations(recs)
+        return Promise.all(recs.map((row: Recommendation) =>
+          fetch(`/improvements/recommendations/${encodeURIComponent(row.id)}/proposal`, { cache: 'no-store' })
+            .then(r => r.ok ? r.json() : [])
+            .then(rows => [row.id, rows ?? []] as const)
+        ))
+      })
+      .then(rows => {
+        if (!rows) return
+        setProposals(Object.fromEntries(rows))
       })
       .catch(() => {
         setFeedback([])
         setRecommendations([])
+        setProposals({})
       })
       .finally(() => setLoading(false))
   }
@@ -132,6 +228,17 @@ export default function ImprovementsPage() {
     }
   }
 
+  const createProposal = async (id: string) => {
+    const res = await fetch(`/improvements/recommendations/${encodeURIComponent(id)}/proposal`, { method: 'POST' })
+    if (res.ok) load()
+  }
+
+  const canCreateProposal = (row: Recommendation) =>
+    row.status === 'accepted' &&
+    ['prompt', 'skill', 'guardrail'].includes(row.target_asset_type || '') &&
+    Boolean(row.target_base_version_id && row.proposed_new_body) &&
+    !nonConvertibleTypes.includes(row.type)
+
   const shownRecommendations = tab === 'inbox'
     ? recommendations.filter(row => row.status === 'recommended' || row.status === 'needs_user_input')
     : recommendations
@@ -175,7 +282,11 @@ export default function ImprovementsPage() {
             <span>Target</span>
             <span>Actions</span>
           </div>
-          {shownRecommendations.map(row => (
+          {shownRecommendations.map(row => {
+            const proposal = proposals[row.id]?.[0]
+            const readiness = proposalReadiness(row)
+            const diff = proposal ? diffLines(versionBody(proposal.target_asset_type, proposal.base_version), versionBody(proposal.target_asset_type, proposal.version)) : []
+            return (
             <article key={row.id} style={{ display: 'grid', gridTemplateColumns: '130px 92px 1fr 150px 190px', gap: '0.75rem', padding: '0.75rem 0.8rem', borderBottom: '1px solid var(--border-subtle)', fontSize: '0.8rem', alignItems: 'start' }}>
               <time style={{ color: 'var(--text-faint)' }}>{new Date(row.updated_at).toLocaleString()}</time>
               <span style={{ color: row.status === 'recommended' ? 'var(--success)' : 'var(--text-muted)', fontWeight: 700 }}>{row.status}</span>
@@ -184,10 +295,33 @@ export default function ImprovementsPage() {
                 <span style={{ color: 'var(--text)' }}>{row.rationale}</span>
                 {row.feedback?.source_url && <a href={row.feedback.source_url} target="_blank" rel="noreferrer">{row.feedback.repo_owner}/{row.feedback.repo_name} feedback #{row.feedback_event_id}</a>}
                 {(row.proposed_patch || row.proposed_new_body) && <pre style={{ whiteSpace: 'pre-wrap', overflowWrap: 'anywhere', color: 'var(--text)', fontSize: '0.76rem' }}>{row.proposed_patch || row.proposed_new_body}</pre>}
+                {proposal && (
+                  <div style={{ display: 'grid', gap: 8, borderTop: '1px solid var(--border-subtle)', paddingTop: 8 }}>
+                    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: 6, color: 'var(--text-muted)' }}>
+                      <span>Recommendation {proposal.recommendation_id}</span>
+                      <span>Target {proposal.target_asset_type}/{proposal.target_asset_id}</span>
+                      <span>Base v{proposal.base_version?.version ?? proposal.base_version_id}</span>
+                      <span>Proposal v{proposal.version.version}</span>
+                      <span>State {proposal.version.state}</span>
+                      <span>Source {proposal.version.source_type || 'unknown'} {proposal.version.source_ref || ''}</span>
+                    </div>
+                    <pre aria-label={`Proposal diff for ${row.id}`} style={{ margin: 0, whiteSpace: 'pre-wrap', overflowWrap: 'anywhere', maxHeight: 360, overflow: 'auto', background: 'var(--bg)', border: '1px solid var(--border-subtle)', borderRadius: 6, padding: 8, fontSize: '0.76rem', lineHeight: 1.45 }}>
+                      {diff.map((line, i) => (
+                        <span key={`${i}-${line.kind}`} style={{ display: 'block', color: line.kind === 'add' ? 'var(--success)' : line.kind === 'del' ? 'var(--text-danger)' : 'var(--text-muted)' }}>{line.text || ' '}</span>
+                      ))}
+                    </pre>
+                    <div style={{ color: 'var(--text-muted)' }}>
+                      {proposal.version.author && <span>Author {proposal.version.author}. </span>}
+                      {proposal.version.changelog && <span>{proposal.version.changelog}</span>}
+                    </div>
+                  </div>
+                )}
               </div>
               <div style={{ display: 'grid', gap: 3, color: 'var(--text-muted)' }}>
                 <span>{row.type}</span>
                 <span>{row.target_asset_type || 'design review'}</span>
+                {proposal && <span>proposal v{proposal.version.version}</span>}
+                {!proposal && row.status === 'accepted' && readiness && <span>{readiness}</span>}
                 <span>{row.attribution_confidence}</span>
               </div>
               <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
@@ -197,9 +331,12 @@ export default function ImprovementsPage() {
                 {['accepted', 'rejected', 'deferred', 'duplicate'].map(next => (
                   <button key={next} onClick={() => updateStatus(row.id, next)} style={{ padding: '6px 8px', border: '1px solid var(--border)', background: 'var(--bg-input)', color: 'var(--text)', borderRadius: 6 }}>{next}</button>
                 ))}
+                {canCreateProposal(row) && !proposals[row.id]?.length && (
+                  <button onClick={() => createProposal(row.id)} style={{ padding: '6px 8px', border: '1px solid var(--accent)', background: 'var(--bg-active)', color: 'var(--text)', borderRadius: 6 }}>Create Proposal</button>
+                )}
               </div>
             </article>
-          ))}
+          )})}
           {!loading && shownRecommendations.length === 0 && (
             <div style={{ padding: '1rem', color: 'var(--text-muted)', fontSize: '0.85rem' }}>No matching recommendations.</div>
           )}


### PR DESCRIPTION
<!-- agents-run: {"workspace":"default","span_id":"d3e184b9d95c497a","agent_id":"agent_0fb82d1fe34e45408bd2fee153f7003d"} -->

## Summary
- add accepted-recommendation to inert catalog proposal version creation for prompts, skills, and guardrails
- expose proposal creation/lookup through Improvements REST endpoints, MCP tools, and the Improvements UI
- document the two human gates: accept recommendation, then separately publish the proposal

Closes #669

## Verification
- `go test -run 'TestCreateSelfImprovementProposal' ./internal/store`
- `go test ./internal/store ./internal/daemon/observe ./internal/mcp`
- `go test ./...`
- `npm ci` (reports existing Next.js advisory and npm audit findings; no dependency changes)
- `npm test`
- `npm run build`
- `git diff --check`