### PR TITLE
fix: make improvement analyst schema strict

### DIFF
--- a/internal/workflow/self_improvement.go
+++ b/internal/workflow/self_improvement.go
@@ -45,26 +45,26 @@ const selfImprovementRecommendationSchema = `{
         "properties": {
           "operation": {"type": "string"},
           "asset_type": {"type": "string"},
-          "asset_id": {"type": "string"},
-          "base_version_id": {"type": "string"},
-          "proposed_ref": {"type": "string"},
-          "proposed_name": {"type": "string"},
-          "proposed_scope": {"type": "string"},
+          "asset_id": {"type": ["string", "null"]},
+          "base_version_id": {"type": ["string", "null"]},
+          "proposed_ref": {"type": ["string", "null"]},
+          "proposed_name": {"type": ["string", "null"]},
+          "proposed_scope": {"type": ["string", "null"]},
           "proposed_body": {"type": "string"},
-          "proposed_description": {"type": "string"},
-          "proposed_enabled": {"type": "boolean"},
-          "proposed_position": {"type": "integer"},
-          "duplicate_risk": {"type": "string"},
-          "rationale": {"type": "string"}
+          "proposed_description": {"type": ["string", "null"]},
+          "proposed_enabled": {"type": ["boolean", "null"]},
+          "proposed_position": {"type": ["integer", "null"]},
+          "duplicate_risk": {"type": ["string", "null"]},
+          "rationale": {"type": ["string", "null"]}
         },
-        "required": ["operation", "asset_type", "proposed_body"],
+        "required": ["operation", "asset_type", "asset_id", "base_version_id", "proposed_ref", "proposed_name", "proposed_scope", "proposed_body", "proposed_description", "proposed_enabled", "proposed_position", "duplicate_risk", "rationale"],
         "additionalProperties": false
       }
     },
     "suggested_rollout_scope": {"type": "string"},
     "no_auto_apply_confirmed": {"type": "boolean"}
   },
-  "required": ["type", "status", "confidence", "risk", "finding", "normalized_lesson", "rationale", "evidence_feedback_ids", "evidence_source_urls", "attribution_confidence", "target_asset_type", "target_asset_id", "target_base_version_id", "proposed_patch", "proposed_new_body", "suggested_rollout_scope", "no_auto_apply_confirmed"],
+  "required": ["type", "status", "confidence", "risk", "finding", "normalized_lesson", "rationale", "evidence_feedback_ids", "evidence_source_urls", "attribution_confidence", "target_asset_type", "target_asset_id", "target_base_version_id", "proposed_patch", "proposed_new_body", "changes", "suggested_rollout_scope", "no_auto_apply_confirmed"],
   "additionalProperties": false
 }`
 

--- a/internal/workflow/self_improvement_test.go
+++ b/internal/workflow/self_improvement_test.go
@@ -229,6 +229,50 @@ func TestSelfImprovementBackendUsesRuntimeAnalystSettings(t *testing.T) {
 	}
 }
 
+func TestSelfImprovementRecommendationSchemaIsStrict(t *testing.T) {
+	t.Parallel()
+
+	var schema map[string]any
+	if err := json.Unmarshal([]byte(selfImprovementRecommendationSchema), &schema); err != nil {
+		t.Fatalf("schema json: %v", err)
+	}
+	assertStrictObjectSchema(t, "root", schema)
+}
+
+func assertStrictObjectSchema(t *testing.T, path string, schema map[string]any) {
+	t.Helper()
+	properties, _ := schema["properties"].(map[string]any)
+	if len(properties) > 0 {
+		requiredItems, ok := schema["required"].([]any)
+		if !ok {
+			t.Fatalf("%s: object with properties must declare required array", path)
+		}
+		required := make(map[string]struct{}, len(requiredItems))
+		for _, item := range requiredItems {
+			name, ok := item.(string)
+			if !ok {
+				t.Fatalf("%s: required item %v is not a string", path, item)
+			}
+			required[name] = struct{}{}
+		}
+		for name := range properties {
+			if _, ok := required[name]; !ok {
+				t.Fatalf("%s: property %q is missing from required", path, name)
+			}
+		}
+	}
+	for name, raw := range properties {
+		child, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		assertStrictObjectSchema(t, path+"."+name, child)
+		if items, ok := child["items"].(map[string]any); ok {
+			assertStrictObjectSchema(t, path+"."+name+"[]", items)
+		}
+	}
+}
+
 func renderedPayloadBlock(t *testing.T, user, key string) string {
 	t.Helper()
 	prefix := key + ":\n"


### PR DESCRIPTION
## Summary
- make the self-improvement analyst structured-output schema strict for Codex/OpenAI response_format validation
- require all object properties while making optional bundle item fields nullable
- add a recursive test that fails if an object schema property is missing from required

## Why
The live /agents improve test now reaches internal-catalog-analyst, but Codex rejects the current schema with invalid_json_schema because changes.items.required does not include every property.

## Tests
- GOCACHE=/tmp/go-build-agents go test ./internal/workflow
- GOCACHE=/tmp/go-build-agents go test ./...