### PR TITLE
fix: preserve improvement analyst runner flow

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -49,11 +49,11 @@ The `/run` body is `{"agent": "<name>", "repo": "owner/repo"}`. It returns `202 
 | `GET` | `/dispatches` | Dispatch dedup store contents + counters |
 | `GET` | `/memory/{agent}/{repo}` | Raw agent memory markdown. `{repo}` uses `owner_repo` format (underscore-separated) |
 | `GET` | `/memory/stream` | Memory file change notifications (SSE) |
-| `GET` | `/improvements/feedback` | Stored `/agents improve` feedback events. Query params: `workspace`, optional `status` (`new`, `ignored`, etc.). |
-| `GET` | `/improvements/recommendations` | Review-only self-improvement recommendations. Query params: `workspace`, optional recommendation `status`. |
+| `GET` | `/improvements/feedback` | Stored `/agents improve` feedback events. Global by default; query params: optional `workspace`, optional `status` (`new`, `ignored`, etc.). |
+| `GET` | `/improvements/recommendations` | Review-only self-improvement recommendations. Global by default; query params: optional `workspace`, optional recommendation `status`. |
 | `GET` | `/improvements/recommendations/{id}` | One recommendation with linked feedback evidence. |
 | `POST` | `/improvements/feedback/{id}/analyze` | Manually create or refresh the recommendation for one feedback event. |
-| `POST` | `/improvements/recommendations/{id}/status` | Update recommendation status (`accepted`, `rejected`, `deferred`, `duplicate`, etc.). |
+| `POST` | `/improvements/recommendations/{id}/status` | Accept or reject a recommendation. Accepted/rejected decisions are terminal. |
 | `POST` | `/improvements/recommendations/{id}/clarification` | Replace the recommendation's editable maintainer clarification and enqueue a fresh `agents.improvement` analysis run. Body: `{ "body": "...", "author": "optional" }`. |
 | `GET` | `/improvements/recommendations/{id}/proposal` | Catalog proposal versions linked to a recommendation. |
 | `POST` | `/improvements/recommendations/{id}/proposal` | Create an inert catalog proposal version from an accepted recommendation. Does not publish or affect runtime composition. |

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -92,11 +92,11 @@ For agent lifecycle changes, use `create_agent` when adding a new agent or inten
 | Tool | Description |
 |---|---|
 | `list_events` | Recent events with optional `since` filter. |
-| `list_improvement_feedback` | Stored `/agents improve` feedback evidence for a workspace, optionally filtered by status. |
+| `list_improvement_feedback` | Stored `/agents improve` feedback evidence from the global inbox, optionally narrowed by workspace/status. |
 | `list_improvement_recommendations` | Review-only self-improvement recommendations, optionally filtered by status. |
 | `get_improvement_recommendation` | Fetch one recommendation with linked feedback evidence. |
 | `analyze_improvement_feedback` | Manually create or refresh the recommendation for one feedback event. |
-| `update_improvement_recommendation_status` | Accept, reject, defer, mark duplicate, or otherwise update recommendation status without publishing catalog changes. |
+| `update_improvement_recommendation_status` | Accept or reject a recommendation as a terminal decision without publishing catalog changes. |
 | `clarify_improvement_recommendation` | Replace the editable maintainer clarification for a recommendation and enqueue a fresh self-improvement analysis run. |
 | `create_improvement_proposal` | Create an inert catalog proposal version from an accepted recommendation. |
 | `get_improvement_proposal` | Fetch proposal versions linked to one recommendation. |

--- a/docs/self-improvement-feedback.md
+++ b/docs/self-improvement-feedback.md
@@ -3,7 +3,7 @@
 The daemon can capture maintainer review lessons from GitHub comments marked
 with `/agents improve`, turn authorized feedback into a durable recommendation,
 and present that recommendation for human review. The flow stays gated:
-recommendations can be accepted, rejected, deferred, or marked duplicate, but
+recommendations can be accepted or rejected as terminal human decisions, but
 they do not publish catalog changes or mutate runtime behavior.
 
 Supported webhook sources:
@@ -87,6 +87,10 @@ through the MCP `list_improvement_feedback`,
 `discard_improvement_proposal_bundle`,
 `list_improvement_recommendations_with_proposals`, and
 `list_improvement_recommendations_with_bundles` tools.
+
+Improvement listings are global by default. The stored rows still retain
+`workspace_id` as attribution and catalog-scope provenance, and API clients may
+pass `workspace` to narrow diagnostic views.
 
 Single-target proposals are for simple one-asset edits. Reactive multi-asset
 bundles are feedback-driven and keep coordinated changes together. Proactive

--- a/internal/daemon/observe/observe.go
+++ b/internal/daemon/observe/observe.go
@@ -175,8 +175,7 @@ func (h *Handler) HandleEvents(w http.ResponseWriter, r *http.Request) {
 // tagged feedback events that later recommendation runs consume.
 func (h *Handler) HandleImprovementFeedback(w http.ResponseWriter, r *http.Request) {
 	limit := 100
-	workspaceID := fleet.NormalizeWorkspaceID(r.URL.Query().Get("workspace"))
-	rows, err := h.store.ListSelfImprovementFeedback(workspaceID, r.URL.Query().Get("status"), limit)
+	rows, err := h.store.ListSelfImprovementFeedback(improvementWorkspaceFilter(r), r.URL.Query().Get("status"), limit)
 	if err != nil {
 		h.logger.Error().Err(err).Msg("list self-improvement feedback")
 		http.Error(w, "internal error", http.StatusInternalServerError)
@@ -192,7 +191,7 @@ func (h *Handler) HandleImprovementFeedback(w http.ResponseWriter, r *http.Reque
 // HandleImprovementRecommendations serves GET /improvements/recommendations,
 // the durable review inbox generated from stored feedback evidence.
 func (h *Handler) HandleImprovementRecommendations(w http.ResponseWriter, r *http.Request) {
-	rows, err := h.improve.ListRecommendations(fleet.NormalizeWorkspaceID(r.URL.Query().Get("workspace")), r.URL.Query().Get("status"), 100)
+	rows, err := h.improve.ListRecommendations(improvementWorkspaceFilter(r), r.URL.Query().Get("status"), 100)
 	if err != nil {
 		h.logger.Error().Err(err).Msg("list self-improvement recommendations")
 		http.Error(w, "internal error", http.StatusInternalServerError)
@@ -203,6 +202,13 @@ func (h *Handler) HandleImprovementRecommendations(w http.ResponseWriter, r *htt
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(rows)
+}
+
+func improvementWorkspaceFilter(r *http.Request) string {
+	if _, ok := r.URL.Query()["workspace"]; !ok {
+		return store.SelfImprovementAllWorkspaces
+	}
+	return fleet.NormalizeWorkspaceID(r.URL.Query().Get("workspace"))
 }
 
 func (h *Handler) HandleImprovementRecommendation(w http.ResponseWriter, r *http.Request) {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -199,9 +199,9 @@ func registerTools(srv *server.MCPServer, deps Deps) {
 		)
 		srv.AddTool(
 			mcpgo.NewTool("list_improvement_feedback",
-				mcpgo.WithDescription("List stored /agents improve feedback events for one workspace. These are raw evidence records used by self-improvement recommendations."),
+				mcpgo.WithDescription("List stored /agents improve feedback events. These are raw evidence records used by self-improvement recommendations. Omitted workspace lists the global inbox."),
 				mcpgo.WithString("workspace",
-					mcpgo.Description("Optional workspace id or display name. Defaults to default."),
+					mcpgo.Description("Optional workspace id or display name to narrow the global inbox."),
 				),
 				mcpgo.WithString("status",
 					mcpgo.Description("Optional status filter such as new or ignored."),
@@ -211,12 +211,12 @@ func registerTools(srv *server.MCPServer, deps Deps) {
 		)
 		srv.AddTool(
 			mcpgo.NewTool("list_improvement_recommendations",
-				mcpgo.WithDescription("List durable self-improvement recommendation records for one workspace. Recommendations are review-only and never publish catalog changes."),
+				mcpgo.WithDescription("List durable self-improvement recommendation records. Recommendations are review-only and never publish catalog changes. Omitted workspace lists the global inbox."),
 				mcpgo.WithString("workspace",
-					mcpgo.Description("Optional workspace id or display name. Defaults to default."),
+					mcpgo.Description("Optional workspace id or display name to narrow the global inbox."),
 				),
 				mcpgo.WithString("status",
-					mcpgo.Description("Optional status filter such as recommended, needs_user_input, accepted, rejected, deferred, duplicate, or failed."),
+					mcpgo.Description("Optional status filter such as recommended, needs_user_input, accepted, rejected, or failed."),
 				),
 			),
 			toolListImprovementRecommendations(deps),
@@ -243,14 +243,14 @@ func registerTools(srv *server.MCPServer, deps Deps) {
 		)
 		srv.AddTool(
 			mcpgo.NewTool("update_improvement_recommendation_status",
-				mcpgo.WithDescription("Accept, reject, defer, mark duplicate, or otherwise update one self-improvement recommendation status. This never publishes or applies catalog changes."),
+				mcpgo.WithDescription("Accept or reject one self-improvement recommendation. Accepted and rejected are terminal decisions; this never publishes or applies catalog changes."),
 				mcpgo.WithString("id",
 					mcpgo.Required(),
 					mcpgo.Description("Recommendation id."),
 				),
 				mcpgo.WithString("status",
 					mcpgo.Required(),
-					mcpgo.Description("New status: recommended, needs_user_input, accepted, rejected, deferred, duplicate, or failed."),
+					mcpgo.Description("New terminal decision: accepted or rejected."),
 				),
 			),
 			toolUpdateImprovementRecommendationStatus(deps),
@@ -296,7 +296,7 @@ func registerTools(srv *server.MCPServer, deps Deps) {
 			mcpgo.NewTool("list_improvement_recommendations_with_proposals",
 				mcpgo.WithDescription("List self-improvement recommendations that already have linked catalog proposal versions."),
 				mcpgo.WithString("workspace",
-					mcpgo.Description("Optional workspace id or display name. Defaults to default."),
+					mcpgo.Description("Optional workspace id or display name to narrow the global inbox."),
 				),
 			),
 			toolListImprovementRecommendationsWithProposals(deps),
@@ -367,7 +367,7 @@ func registerTools(srv *server.MCPServer, deps Deps) {
 		srv.AddTool(
 			mcpgo.NewTool("list_improvement_recommendations_with_bundles",
 				mcpgo.WithDescription("List self-improvement recommendations that already have linked proposal bundles."),
-				mcpgo.WithString("workspace", mcpgo.Description("Optional workspace id or display name. Defaults to default.")),
+				mcpgo.WithString("workspace", mcpgo.Description("Optional workspace id or display name to narrow the global inbox.")),
 			),
 			toolListImprovementRecommendationsWithBundles(deps),
 		)

--- a/internal/mcp/tools_observe.go
+++ b/internal/mcp/tools_observe.go
@@ -14,6 +14,7 @@ import (
 	"github.com/eloylp/agents/internal/ai"
 	"github.com/eloylp/agents/internal/fleet"
 	"github.com/eloylp/agents/internal/selfimprovement"
+	"github.com/eloylp/agents/internal/store"
 	"github.com/eloylp/agents/internal/workflow"
 )
 
@@ -59,7 +60,10 @@ func toolListEvents(deps Deps) server.ToolHandlerFunc {
 
 func toolListImprovementFeedback(deps Deps) server.ToolHandlerFunc {
 	return func(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
-		workspace, _ := trimmedStringOptional(req, "workspace")
+		workspace, ok := trimmedStringOptional(req, "workspace")
+		if !ok {
+			workspace = store.SelfImprovementAllWorkspaces
+		}
 		status, _ := trimmedStringOptional(req, "status")
 		rows, err := deps.Store.ListSelfImprovementFeedback(workspace, status, 100)
 		if err != nil {
@@ -71,7 +75,10 @@ func toolListImprovementFeedback(deps Deps) server.ToolHandlerFunc {
 
 func toolListImprovementRecommendations(deps Deps) server.ToolHandlerFunc {
 	return func(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
-		workspace, _ := trimmedStringOptional(req, "workspace")
+		workspace, ok := trimmedStringOptional(req, "workspace")
+		if !ok {
+			workspace = store.SelfImprovementAllWorkspaces
+		}
 		status, _ := trimmedStringOptional(req, "status")
 		rows, err := deps.Improvements.ListRecommendations(workspace, status, 100)
 		if err != nil {
@@ -226,7 +233,10 @@ func toolGetImprovementProposal(deps Deps) server.ToolHandlerFunc {
 
 func toolListImprovementRecommendationsWithProposals(deps Deps) server.ToolHandlerFunc {
 	return func(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
-		workspace, _ := trimmedStringOptional(req, "workspace")
+		workspace, ok := trimmedStringOptional(req, "workspace")
+		if !ok {
+			workspace = store.SelfImprovementAllWorkspaces
+		}
 		rows, err := deps.Improvements.ListRecommendationsWithProposals(workspace, 100)
 		if err != nil {
 			return mcpgo.NewToolResultErrorFromErr("list improvement recommendations with proposals", err), nil
@@ -388,7 +398,10 @@ func toolDiscardImprovementProposalBundle(deps Deps) server.ToolHandlerFunc {
 
 func toolListImprovementRecommendationsWithBundles(deps Deps) server.ToolHandlerFunc {
 	return func(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
-		workspace, _ := trimmedStringOptional(req, "workspace")
+		workspace, ok := trimmedStringOptional(req, "workspace")
+		if !ok {
+			workspace = store.SelfImprovementAllWorkspaces
+		}
 		rows, err := deps.Improvements.ListRecommendationsWithBundles(workspace, 100)
 		if err != nil {
 			return mcpgo.NewToolResultErrorFromErr("list improvement recommendations with bundles", err), nil

--- a/internal/selfimprovement/recommendations.go
+++ b/internal/selfimprovement/recommendations.go
@@ -1,6 +1,7 @@
 package selfimprovement
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -13,8 +14,6 @@ const (
 	RecommendationStatusNeedsUserInput = "needs_user_input"
 	RecommendationStatusAccepted       = "accepted"
 	RecommendationStatusRejected       = "rejected"
-	RecommendationStatusDeferred       = "deferred"
-	RecommendationStatusDuplicate      = "duplicate"
 	RecommendationStatusFailed         = "failed"
 )
 
@@ -164,6 +163,21 @@ func (s *Service) RecordRecommendation(in SelfImprovementRecommendationInput) (S
 	in.Risk = defaultString(in.Risk, "low")
 	in.AttributionConfidence = defaultString(in.AttributionConfidence, "unresolved")
 	in.AnalyzerPromptRef = defaultString(in.AnalyzerPromptRef, "prompt_self-improvement-analyst")
+	if existing, err := s.store.GetSelfImprovementRecommendationByFeedback(in.WorkspaceID, in.FeedbackEventID); err == nil {
+		if terminalRecommendationStatus(existing.Status) {
+			if err := s.store.Transact(func(tx *store.Tx) error {
+				return store.UpdateSelfImprovementFeedbackStatusRow(tx, in.FeedbackEventID, store.FeedbackStatusAnalyzed)
+			}); err != nil {
+				return SelfImprovementRecommendation{}, err
+			}
+			return recommendationFromRow(existing), nil
+		}
+	} else {
+		var nf *store.ErrNotFound
+		if !errors.As(err, &nf) {
+			return SelfImprovementRecommendation{}, err
+		}
+	}
 	if err := s.store.Transact(func(tx *store.Tx) error {
 		if err := store.UpsertSelfImprovementRecommendationRow(tx, recommendationInputRow(in)); err != nil {
 			return err
@@ -178,8 +192,18 @@ func (s *Service) RecordRecommendation(in SelfImprovementRecommendationInput) (S
 
 func (s *Service) UpdateRecommendationStatus(id, status string) (SelfImprovementRecommendation, error) {
 	status = strings.TrimSpace(status)
-	if !validRecommendationStatus(status) {
-		return SelfImprovementRecommendation{}, &store.ErrValidation{Msg: fmt.Sprintf("unsupported recommendation status %q", status)}
+	if !validHumanRecommendationStatus(status) {
+		return SelfImprovementRecommendation{}, &store.ErrValidation{Msg: fmt.Sprintf("unsupported recommendation decision %q", status)}
+	}
+	current, err := s.GetRecommendation(id)
+	if err != nil {
+		return SelfImprovementRecommendation{}, err
+	}
+	if terminalRecommendationStatus(current.Status) {
+		if current.Status == status {
+			return current, nil
+		}
+		return SelfImprovementRecommendation{}, &store.ErrValidation{Msg: fmt.Sprintf("recommendation %q is already %s and cannot be changed", id, current.Status)}
 	}
 	if err := s.store.Transact(func(tx *store.Tx) error {
 		return store.UpdateSelfImprovementRecommendationStatusRow(tx, id, status)
@@ -198,8 +222,12 @@ func (s *Service) UpsertClarification(recommendationID, author, body string) (Se
 	if body == "" {
 		return SelfImprovementRecommendation{}, &store.ErrValidation{Msg: "clarification body is required"}
 	}
-	if _, err := s.store.GetSelfImprovementRecommendation(recommendationID); err != nil {
+	rec, err := s.GetRecommendation(recommendationID)
+	if err != nil {
 		return SelfImprovementRecommendation{}, err
+	}
+	if terminalRecommendationStatus(rec.Status) {
+		return SelfImprovementRecommendation{}, &store.ErrValidation{Msg: fmt.Sprintf("recommendation %q is already %s and cannot be clarified", recommendationID, rec.Status)}
 	}
 	if err := s.store.Transact(func(tx *store.Tx) error {
 		if err := store.UpsertSelfImprovementClarificationRow(tx, recommendationID, author, body); err != nil {
@@ -369,7 +397,25 @@ func recommendationTarget(feedback store.SelfImprovementFeedback) (assetType, as
 
 func validRecommendationStatus(status string) bool {
 	switch strings.TrimSpace(status) {
-	case RecommendationStatusRecommended, RecommendationStatusNeedsUserInput, RecommendationStatusAccepted, RecommendationStatusRejected, RecommendationStatusDeferred, RecommendationStatusDuplicate, RecommendationStatusFailed:
+	case RecommendationStatusRecommended, RecommendationStatusNeedsUserInput, RecommendationStatusAccepted, RecommendationStatusRejected, RecommendationStatusFailed:
+		return true
+	default:
+		return false
+	}
+}
+
+func validHumanRecommendationStatus(status string) bool {
+	switch strings.TrimSpace(status) {
+	case RecommendationStatusAccepted, RecommendationStatusRejected:
+		return true
+	default:
+		return false
+	}
+}
+
+func terminalRecommendationStatus(status string) bool {
+	switch strings.TrimSpace(status) {
+	case RecommendationStatusAccepted, RecommendationStatusRejected:
 		return true
 	default:
 		return false

--- a/internal/selfimprovement/service_test.go
+++ b/internal/selfimprovement/service_test.go
@@ -71,6 +71,17 @@ func TestRecommendationLifecycleOwnedByService(t *testing.T) {
 		t.Fatalf("analyzed feedback = %+v, want feedback %d", rows, feedback.ID)
 	}
 
+	clarified, err := svc.UpsertClarification(rec.ID, "dashboard", "Apply this only to reviewer guidance.")
+	if err != nil {
+		t.Fatalf("UpsertClarification: %v", err)
+	}
+	if clarified.Status != RecommendationStatusNeedsUserInput {
+		t.Fatalf("clarified status = %q, want needs_user_input", clarified.Status)
+	}
+	if clarified.Clarification == nil || clarified.Clarification.Body != "Apply this only to reviewer guidance." {
+		t.Fatalf("clarification = %+v, want stored body", clarified.Clarification)
+	}
+
 	accepted, err := svc.UpdateRecommendationStatus(rec.ID, RecommendationStatusAccepted)
 	if err != nil {
 		t.Fatalf("UpdateRecommendationStatus: %v", err)
@@ -81,16 +92,11 @@ func TestRecommendationLifecycleOwnedByService(t *testing.T) {
 	if _, err := svc.UpdateRecommendationStatus(rec.ID, "unknown"); err == nil {
 		t.Fatal("UpdateRecommendationStatus unknown status succeeded, want validation error")
 	}
-
-	clarified, err := svc.UpsertClarification(rec.ID, "dashboard", "Apply this only to reviewer guidance.")
-	if err != nil {
-		t.Fatalf("UpsertClarification: %v", err)
+	if _, err := svc.UpdateRecommendationStatus(rec.ID, RecommendationStatusRejected); err == nil {
+		t.Fatal("UpdateRecommendationStatus changed accepted recommendation, want validation error")
 	}
-	if clarified.Status != RecommendationStatusNeedsUserInput {
-		t.Fatalf("clarified status = %q, want needs_user_input", clarified.Status)
-	}
-	if clarified.Clarification == nil || clarified.Clarification.Body != "Apply this only to reviewer guidance." {
-		t.Fatalf("clarification = %+v, want stored body", clarified.Clarification)
+	if _, err := svc.UpsertClarification(rec.ID, "dashboard", "Re-open this decision."); err == nil {
+		t.Fatal("UpsertClarification on terminal recommendation succeeded, want validation error")
 	}
 }
 
@@ -284,9 +290,10 @@ func TestCreateProposalRejectsUnsafeStatesAndTargets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("UpsertPrompt: %v", err)
 	}
+	missingBaseFeedback := seedFeedback(t, st, "team-a", 683104)
 	missingBase, err := svc.RecordRecommendation(SelfImprovementRecommendationInput{
 		WorkspaceID:           "team-a",
-		FeedbackEventID:       feedback.ID,
+		FeedbackEventID:       missingBaseFeedback.ID,
 		Type:                  "prompt_guidance",
 		Status:                RecommendationStatusAccepted,
 		Finding:               "tighten prompt guidance",

--- a/internal/store/self_improvement.go
+++ b/internal/store/self_improvement.go
@@ -17,6 +17,8 @@ const (
 	FeedbackStatusAnalyzed = "analyzed"
 	FeedbackStatusFailed   = "failed"
 	FeedbackTag            = "/agents improve"
+
+	SelfImprovementAllWorkspaces = "*"
 )
 
 type SelfImprovementFeedback struct {
@@ -321,13 +323,40 @@ func ListSelfImprovementFeedback(db *sql.DB, workspace, status string, limit int
 	if limit <= 0 || limit > 500 {
 		limit = 100
 	}
+	allWorkspaces := selfImprovementAllWorkspaces(workspace)
 	workspaceID := fleet.NormalizeWorkspaceID(workspace)
 	status = strings.TrimSpace(status)
 	var (
 		rows *sql.Rows
 		err  error
 	)
-	if status == "" {
+	switch {
+	case allWorkspaces && status == "":
+		rows, err = db.Query(
+			`SELECT id, workspace_id, repo_owner, repo_name, source_type, github_comment_id, github_review_id,
+				github_delivery_id, source_url, author_login, author_authorized, issue_number, pr_number,
+				raw_body, tag, file_path, line, side, diff_hunk, commit_sha, github_created_at,
+				github_updated_at, ingested_at, linked_span_id, linked_event_id, linked_agent_id,
+				linked_agent_name, linked_prompt_version_id, linked_skill_version_ids,
+				linked_guardrail_version_ids, link_confidence, link_diagnostics, status
+			FROM self_improvement_feedback
+			ORDER BY ingested_at DESC, id DESC LIMIT ?`,
+			limit,
+		)
+	case allWorkspaces:
+		rows, err = db.Query(
+			`SELECT id, workspace_id, repo_owner, repo_name, source_type, github_comment_id, github_review_id,
+				github_delivery_id, source_url, author_login, author_authorized, issue_number, pr_number,
+				raw_body, tag, file_path, line, side, diff_hunk, commit_sha, github_created_at,
+				github_updated_at, ingested_at, linked_span_id, linked_event_id, linked_agent_id,
+				linked_agent_name, linked_prompt_version_id, linked_skill_version_ids,
+				linked_guardrail_version_ids, link_confidence, link_diagnostics, status
+			FROM self_improvement_feedback
+			WHERE status=?
+			ORDER BY ingested_at DESC, id DESC LIMIT ?`,
+			status, limit,
+		)
+	case status == "":
 		rows, err = db.Query(
 			`SELECT id, workspace_id, repo_owner, repo_name, source_type, github_comment_id, github_review_id,
 				github_delivery_id, source_url, author_login, author_authorized, issue_number, pr_number,
@@ -340,7 +369,7 @@ func ListSelfImprovementFeedback(db *sql.DB, workspace, status string, limit int
 			ORDER BY ingested_at DESC, id DESC LIMIT ?`,
 			workspaceID, limit,
 		)
-	} else {
+	default:
 		rows, err = db.Query(
 			`SELECT id, workspace_id, repo_owner, repo_name, source_type, github_comment_id, github_review_id,
 				github_delivery_id, source_url, author_login, author_authorized, issue_number, pr_number,
@@ -445,13 +474,19 @@ func ListSelfImprovementRecommendations(db *sql.DB, workspace, status string, li
 	if limit <= 0 || limit > 500 {
 		limit = 100
 	}
+	allWorkspaces := selfImprovementAllWorkspaces(workspace)
 	workspaceID := fleet.NormalizeWorkspaceID(workspace)
 	status = strings.TrimSpace(status)
 	var rows *sql.Rows
 	var err error
-	if status == "" {
+	switch {
+	case allWorkspaces && status == "":
+		rows, err = db.Query(recommendationSelectSQL()+` ORDER BY r.updated_at DESC, r.id DESC LIMIT ?`, limit)
+	case allWorkspaces:
+		rows, err = db.Query(recommendationSelectSQL()+` WHERE r.status=? ORDER BY r.updated_at DESC, r.id DESC LIMIT ?`, status, limit)
+	case status == "":
 		rows, err = db.Query(recommendationSelectSQL()+` WHERE r.workspace_id=? ORDER BY r.updated_at DESC, r.id DESC LIMIT ?`, workspaceID, limit)
-	} else {
+	default:
 		rows, err = db.Query(recommendationSelectSQL()+` WHERE r.workspace_id=? AND r.status=? ORDER BY r.updated_at DESC, r.id DESC LIMIT ?`, workspaceID, status, limit)
 	}
 	if err != nil {
@@ -662,16 +697,29 @@ func ListSelfImprovementRecommendationsWithProposals(db *sql.DB, workspace strin
 	if limit <= 0 || limit > 500 {
 		limit = 100
 	}
+	allWorkspaces := selfImprovementAllWorkspaces(workspace)
 	workspaceID := fleet.NormalizeWorkspaceID(workspace)
-	rows, err := db.Query(recommendationSelectSQL()+`
-		WHERE r.workspace_id=? AND EXISTS (
+	where := `WHERE EXISTS (
 			SELECT 1 FROM prompt_versions pv WHERE pv.source_type='feedback_recommendation' AND pv.source_ref=r.id
 			UNION ALL
 			SELECT 1 FROM skill_versions sv WHERE sv.source_type='feedback_recommendation' AND sv.source_ref=r.id
 			UNION ALL
 			SELECT 1 FROM guardrail_versions gv WHERE gv.source_type='feedback_recommendation' AND gv.source_ref=r.id
-		)
-		ORDER BY r.updated_at DESC, r.id DESC LIMIT ?`, workspaceID, limit)
+		)`
+	args := []any{limit}
+	if !allWorkspaces {
+		where = `WHERE r.workspace_id=? AND EXISTS (
+			SELECT 1 FROM prompt_versions pv WHERE pv.source_type='feedback_recommendation' AND pv.source_ref=r.id
+			UNION ALL
+			SELECT 1 FROM skill_versions sv WHERE sv.source_type='feedback_recommendation' AND sv.source_ref=r.id
+			UNION ALL
+			SELECT 1 FROM guardrail_versions gv WHERE gv.source_type='feedback_recommendation' AND gv.source_ref=r.id
+		)`
+		args = []any{workspaceID, limit}
+	}
+	rows, err := db.Query(recommendationSelectSQL()+`
+		`+where+`
+		ORDER BY r.updated_at DESC, r.id DESC LIMIT ?`, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -713,7 +761,11 @@ func MarkSelfImprovementFeedbackFailed(db *sql.DB, id int64, cause string) error
 
 func getSelfImprovementRecommendationByFeedback(db *sql.DB, workspaceID string, feedbackID int64) (SelfImprovementRecommendationRow, error) {
 	row := db.QueryRow(recommendationSelectSQL()+` WHERE r.workspace_id=? AND r.feedback_event_id=?`, workspaceID, feedbackID)
-	return scanSelfImprovementRecommendation(row, true)
+	rec, err := scanSelfImprovementRecommendation(row, true)
+	if errors.Is(err, sql.ErrNoRows) {
+		return SelfImprovementRecommendationRow{}, &ErrNotFound{Msg: fmt.Sprintf("recommendation for feedback %d not found", feedbackID)}
+	}
+	return rec, err
 }
 
 type selfImprovementScanner interface {
@@ -821,6 +873,10 @@ func splitCSV(s string) []string {
 		}
 	}
 	return out
+}
+
+func selfImprovementAllWorkspaces(workspace string) bool {
+	return strings.TrimSpace(workspace) == SelfImprovementAllWorkspaces
 }
 
 func trimStrings(values []string) []string {

--- a/internal/ui/src/app/improvements/page.test.tsx
+++ b/internal/ui/src/app/improvements/page.test.tsx
@@ -14,10 +14,10 @@ describe('<ImprovementsPage />', () => {
       if (url === '/workspaces') {
         return Promise.resolve({ ok: true, json: () => Promise.resolve([{ id: 'default', name: 'Default' }]) } as Response)
       }
-      if (url === '/improvements/feedback?workspace=default') {
+      if (url === '/improvements/feedback') {
         return Promise.resolve({ ok: true, json: () => Promise.resolve([]) } as Response)
       }
-      if (url === '/improvements/recommendations?workspace=default') {
+      if (url === '/improvements/recommendations') {
         return Promise.resolve({
           ok: true,
           json: () => Promise.resolve([
@@ -121,10 +121,10 @@ describe('<ImprovementsPage />', () => {
       if (url === '/workspaces') {
         return Promise.resolve({ ok: true, json: () => Promise.resolve([{ id: 'default', name: 'Default' }]) } as Response)
       }
-      if (url === '/improvements/feedback?workspace=default') {
+      if (url === '/improvements/feedback') {
         return Promise.resolve({ ok: true, json: () => Promise.resolve([]) } as Response)
       }
-      if (url === '/improvements/recommendations?workspace=default') {
+      if (url === '/improvements/recommendations') {
         return Promise.resolve({
           ok: true,
           json: () => Promise.resolve([
@@ -276,5 +276,98 @@ describe('<ImprovementsPage />', () => {
       '/improvements/proposal-bundles/bundle-1/items/item-skill/link-existing',
       expect.objectContaining({ method: 'POST', body: JSON.stringify({ asset_id: 'existing-skill', reason: 'Already covered' }) }),
     ))
+  })
+
+  it('links a published create-new skill to the attributed agent', async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url === '/improvements/feedback') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) } as Response)
+      }
+      if (url === '/improvements/recommendations') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([
+            {
+              id: 'rec-skill',
+              workspace: 'team-a',
+              feedback_event_id: 10,
+              type: 'catalog_patch_bundle',
+              status: 'accepted',
+              confidence: 'high',
+              risk: 'low',
+              finding: 'Create Go API skill',
+              normalized_lesson: 'Use per-method handlers.',
+              rationale: 'The maintainer asked for a reusable skill.',
+              attribution_confidence: 'exact',
+              updated_at: '2026-06-01T18:20:00Z',
+              feedback: {
+                id: 10,
+                workspace: 'team-a',
+                repo_owner: 'acme',
+                repo_name: 'repo',
+                source_type: 'pull_request_review_comment',
+                source_url: 'https://example.test/review',
+                author_login: 'maintainer',
+                author_authorized: true,
+                raw_body: '/agents improve add go-api',
+                link_confidence: 'exact',
+                linked_agent_name: 'coder',
+                status: 'analyzed',
+                ingested_at: '2026-06-01T18:15:00Z',
+              },
+            },
+          ]),
+        } as Response)
+      }
+      if (url === '/improvements/recommendations/rec-skill/proposal') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) } as Response)
+      }
+      if (url === '/improvements/recommendations/rec-skill/proposal-bundle') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            id: 'bundle-skill',
+            recommendation_id: 'rec-skill',
+            status: 'published',
+            items: [
+              {
+                id: 'item-go-api',
+                operation: 'create_new',
+                asset_type: 'skill',
+                proposed_ref: 'go-api',
+                proposed_name: 'Go API',
+                proposed_scope: 'workspace',
+                proposed_body: 'Use one handler per HTTP method.',
+                analyst_proposed_body: 'Use one handler per HTTP method.',
+                decision: 'published',
+                published_version_id: 'skillver-go-api-1',
+              },
+            ],
+          }),
+        } as Response)
+      }
+      if (url === '/agents/coder?workspace=team-a' && (!init || init.method === undefined)) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ name: 'coder', skills: ['testing'] }) } as Response)
+      }
+      if (url === '/agents/coder?workspace=team-a' && init?.method === 'PATCH') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ name: 'coder', skills: ['testing', 'go-api'] }) } as Response)
+      }
+      return Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve([]) } as Response)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    render(<ImprovementsPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'recommendations' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Add go-api to coder' }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
+      '/agents/coder?workspace=team-a',
+      expect.objectContaining({
+        method: 'PATCH',
+        body: JSON.stringify({ skills: ['testing', 'go-api'] }),
+      }),
+    ))
+    expect(await screen.findByText('Linked go-api to coder.')).toBeInTheDocument()
   })
 })

--- a/internal/ui/src/app/improvements/page.tsx
+++ b/internal/ui/src/app/improvements/page.tsx
@@ -1,7 +1,6 @@
 'use client'
 import { useEffect, useMemo, useState } from 'react'
-import WorkspaceSelect from '@/components/WorkspaceSelect'
-import { useSelectedWorkspace, withWorkspace } from '@/lib/workspace'
+import { withWorkspace } from '@/lib/workspace'
 
 interface FeedbackEvent {
   id: number
@@ -37,6 +36,7 @@ interface Clarification {
 
 interface Recommendation {
   id: string
+  workspace?: string
   feedback_event_id: number
   type: string
   status: string
@@ -224,15 +224,17 @@ function bundleItemDraftBody(item: ProposalBundleItem, draft: BundleItemDraft) {
 }
 
 export default function ImprovementsPage() {
-  const { workspace } = useSelectedWorkspace()
   const [feedback, setFeedback] = useState<FeedbackEvent[]>([])
   const [recommendations, setRecommendations] = useState<Recommendation[]>([])
   const [proposals, setProposals] = useState<Record<string, ImprovementProposal[]>>({})
   const [bundles, setBundles] = useState<Record<string, ProposalBundle>>({})
   const [itemDrafts, setItemDrafts] = useState<Record<string, BundleItemDraft>>({})
+  const [collapsedRecommendations, setCollapsedRecommendations] = useState<Set<string>>(new Set())
   const [tab, setTab] = useState<Tab>('inbox')
   const [status, setStatus] = useState('')
   const [loading, setLoading] = useState(true)
+  const [actionMessage, setActionMessage] = useState<string | null>(null)
+  const [linkingSkillItem, setLinkingSkillItem] = useState<string | null>(null)
   const [clarifying, setClarifying] = useState<Recommendation | null>(null)
   const [clarificationBody, setClarificationBody] = useState('')
   const [clarificationSaving, setClarificationSaving] = useState(false)
@@ -243,8 +245,8 @@ export default function ImprovementsPage() {
     setLoading(true)
     const suffix = status ? `?status=${encodeURIComponent(status)}` : ''
     Promise.all([
-      fetch(withWorkspace(`/improvements/feedback${suffix}`, workspace), { cache: 'no-store' }).then(r => r.ok ? r.json() : []),
-      fetch(withWorkspace(`/improvements/recommendations${suffix}`, workspace), { cache: 'no-store' }).then(r => r.ok ? r.json() : []),
+      fetch(`/improvements/feedback${suffix}`, { cache: 'no-store' }).then(r => r.ok ? r.json() : []),
+      fetch(`/improvements/recommendations${suffix}`, { cache: 'no-store' }).then(r => r.ok ? r.json() : []),
     ])
       .then(([feedbackRows, recommendationRows]) => {
         setFeedback(feedbackRows ?? [])
@@ -269,7 +271,7 @@ export default function ImprovementsPage() {
       .finally(() => setLoading(false))
   }
 
-  useEffect(() => { load() }, [workspace, status])
+  useEffect(() => { load() }, [status])
 
   const counts = useMemo(() => recommendations.reduce<Record<string, number>>((acc, row) => {
     acc[row.status] = (acc[row.status] ?? 0) + 1
@@ -401,6 +403,46 @@ export default function ImprovementsPage() {
     if (res.ok) load()
   }
 
+  const skillRefForItem = (item: ProposalBundleItem) => (item.asset_id || item.proposed_ref || '').trim()
+
+  const canLinkPublishedSkill = (row: Recommendation, item: ProposalBundleItem) =>
+    item.asset_type === 'skill' &&
+    item.operation === 'create_new' &&
+    item.decision === 'published' &&
+    skillRefForItem(item) !== '' &&
+    Boolean(row.feedback?.linked_agent_name)
+
+  const linkPublishedSkillToAgent = async (row: Recommendation, item: ProposalBundleItem) => {
+    const agentName = (row.feedback?.linked_agent_name || '').trim()
+    const skillRef = skillRefForItem(item)
+    const targetWorkspace = row.feedback?.workspace || row.workspace || 'default'
+    if (!agentName || !skillRef || linkingSkillItem) return
+    setLinkingSkillItem(item.id)
+    setActionMessage(null)
+    try {
+      const url = withWorkspace(`/agents/${encodeURIComponent(agentName)}`, targetWorkspace)
+      const read = await fetch(url, { cache: 'no-store' })
+      if (!read.ok) throw new Error(`read agent returned HTTP ${read.status}`)
+      const agent = await read.json()
+      const currentSkills = Array.isArray(agent.skills) ? agent.skills : []
+      if (currentSkills.includes(skillRef)) {
+        setActionMessage(`${skillRef} is already linked to ${agentName}.`)
+        return
+      }
+      const write = await fetch(url, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ skills: [...currentSkills, skillRef] }),
+      })
+      if (!write.ok) throw new Error(`update agent returned HTTP ${write.status}`)
+      setActionMessage(`Linked ${skillRef} to ${agentName}.`)
+    } catch (err) {
+      setActionMessage(`Could not link ${skillRef} to ${agentName}: ${(err as Error).message}`)
+    } finally {
+      setLinkingSkillItem(null)
+    }
+  }
+
   const canCreateProposal = (row: Recommendation) =>
     row.status === 'accepted' &&
     ['prompt', 'skill', 'guardrail'].includes(row.target_asset_type || '') &&
@@ -410,6 +452,19 @@ export default function ImprovementsPage() {
   const shownRecommendations = tab === 'inbox'
     ? recommendations.filter(row => row.status === 'recommended' || row.status === 'needs_user_input')
     : recommendations
+
+  const toggleRecommendationCollapsed = (id: string) => {
+    setCollapsedRecommendations(current => {
+      const next = new Set(current)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const setShownRecommendationsCollapsed = (collapsed: boolean) => {
+    setCollapsedRecommendations(collapsed ? new Set(shownRecommendations.map(row => row.id)) : new Set())
+  }
 
   return (
     <main style={{ display: 'grid', gap: '1rem' }}>
@@ -422,18 +477,28 @@ export default function ImprovementsPage() {
           </div>
         </div>
         <div style={{ display: 'flex', gap: '0.75rem', alignItems: 'center', flexWrap: 'wrap' }}>
-          <WorkspaceSelect />
+          {shownRecommendations.length > 0 && (
+            <>
+              <button onClick={() => setShownRecommendationsCollapsed(true)} style={{ padding: '7px 9px', border: '1px solid var(--border)', background: 'var(--bg-input)', color: 'var(--text)', borderRadius: 6 }}>Collapse all</button>
+              <button onClick={() => setShownRecommendationsCollapsed(false)} style={{ padding: '7px 9px', border: '1px solid var(--border)', background: 'var(--bg-input)', color: 'var(--text)', borderRadius: 6 }}>Expand all</button>
+            </>
+          )}
           <select value={status} onChange={e => setStatus(e.target.value)} style={{ background: 'var(--bg-input)', border: '1px solid var(--border)', color: 'var(--text)', padding: '7px 9px' }}>
             <option value="">All statuses</option>
             <option value="recommended">Recommended</option>
             <option value="needs_user_input">Needs input</option>
             <option value="accepted">Accepted</option>
             <option value="rejected">Rejected</option>
-            <option value="deferred">Deferred</option>
-            <option value="duplicate">Duplicate</option>
           </select>
         </div>
       </section>
+
+      {actionMessage && (
+        <section style={{ background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 6, padding: '0.75rem 0.85rem', color: 'var(--text)', fontSize: '0.84rem', display: 'flex', justifyContent: 'space-between', gap: '1rem', alignItems: 'center' }}>
+          <span>{actionMessage}</span>
+          <button onClick={() => setActionMessage(null)} style={{ padding: '5px 8px', border: '1px solid var(--border)', background: 'var(--bg-input)', color: 'var(--text)', borderRadius: 6 }}>Dismiss</button>
+        </section>
+      )}
 
       <nav style={{ display: 'flex', gap: 8 }}>
         {(['inbox', 'recommendations', 'history'] as Tab[]).map(next => (
@@ -454,16 +519,18 @@ export default function ImprovementsPage() {
             const proposal = proposals[row.id]?.[0]
             const readiness = proposalReadiness(row)
             const diff = proposal ? diffLines(versionBody(proposal.target_asset_type, proposal.base_version), versionBody(proposal.target_asset_type, proposal.version)) : []
+            const isCollapsed = collapsedRecommendations.has(row.id)
+            const terminalDecision = row.status === 'accepted' || row.status === 'rejected'
             return (
             <article key={row.id} style={{ display: 'grid', gridTemplateColumns: '130px 92px 1fr 150px 190px', gap: '0.75rem', padding: '0.75rem 0.8rem', borderBottom: '1px solid var(--border-subtle)', fontSize: '0.8rem', alignItems: 'start' }}>
               <time style={{ color: 'var(--text-faint)' }}>{new Date(row.updated_at).toLocaleString()}</time>
               <span style={{ color: row.status === 'recommended' ? 'var(--success)' : 'var(--text-muted)', fontWeight: 700 }}>{row.status}</span>
               <div style={{ display: 'grid', gap: 6 }}>
                 <strong style={{ color: 'var(--text-heading)' }}>{row.finding}</strong>
-                <span style={{ color: 'var(--text)' }}>{row.rationale}</span>
-                {row.feedback?.source_url && <a href={row.feedback.source_url} target="_blank" rel="noreferrer">{row.feedback.repo_owner}/{row.feedback.repo_name} feedback #{row.feedback_event_id}</a>}
-                {(row.proposed_patch || row.proposed_new_body) && <pre style={{ whiteSpace: 'pre-wrap', overflowWrap: 'anywhere', color: 'var(--text)', fontSize: '0.76rem' }}>{row.proposed_patch || row.proposed_new_body}</pre>}
-                {proposal && (
+                {!isCollapsed && <span style={{ color: 'var(--text)' }}>{row.rationale}</span>}
+                {!isCollapsed && row.feedback?.source_url && <a href={row.feedback.source_url} target="_blank" rel="noreferrer">{row.feedback.repo_owner}/{row.feedback.repo_name} feedback #{row.feedback_event_id}</a>}
+                {!isCollapsed && (row.proposed_patch || row.proposed_new_body) && <pre style={{ whiteSpace: 'pre-wrap', overflowWrap: 'anywhere', color: 'var(--text)', fontSize: '0.76rem' }}>{row.proposed_patch || row.proposed_new_body}</pre>}
+                {!isCollapsed && proposal && (
                   <div style={{ display: 'grid', gap: 8, borderTop: '1px solid var(--border-subtle)', paddingTop: 8 }}>
                     <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: 6, color: 'var(--text-muted)' }}>
                       <span>Recommendation {proposal.recommendation_id}</span>
@@ -484,7 +551,7 @@ export default function ImprovementsPage() {
                     </div>
                   </div>
                 )}
-                {bundles[row.id]?.id && (
+                {!isCollapsed && bundles[row.id]?.id && (
                   <div style={{ display: 'grid', gap: 10, borderTop: '1px solid var(--border-subtle)', paddingTop: 8 }}>
                     <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8, flexWrap: 'wrap', color: 'var(--text-muted)' }}>
                       <span>Bundle {bundles[row.id].id} · {bundles[row.id].status}{bundles[row.id].recommendation_changed ? ' · recommendation changed' : ''}</span>
@@ -545,6 +612,17 @@ export default function ImprovementsPage() {
                               {item.operation === 'create_new' && <button onClick={() => openLinkBundleItem(bundles[row.id].id!, item)} style={{ padding: '5px 7px', border: '1px solid var(--border)', background: 'var(--bg-input)', color: 'var(--text)', borderRadius: 6 }}>Link Existing</button>}
                             </div>
                           )}
+                          {canLinkPublishedSkill(row, item) && (
+                            <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                              <button
+                                disabled={linkingSkillItem === item.id}
+                                onClick={() => linkPublishedSkillToAgent(row, item)}
+                                style={{ padding: '5px 7px', border: '1px solid var(--accent)', background: 'var(--bg-active)', color: 'var(--text)', borderRadius: 6, opacity: linkingSkillItem === item.id ? 0.6 : 1 }}
+                              >
+                                {linkingSkillItem === item.id ? 'Linking...' : `Add ${skillRefForItem(item)} to ${row.feedback?.linked_agent_name}`}
+                              </button>
+                            </div>
+                          )}
                         </section>
                       )
                     })}
@@ -559,12 +637,14 @@ export default function ImprovementsPage() {
                 <span>{row.attribution_confidence}</span>
               </div>
               <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                <button onClick={() => toggleRecommendationCollapsed(row.id)} style={{ padding: '6px 8px', border: '1px solid var(--border)', background: 'var(--bg-input)', color: 'var(--text)', borderRadius: 6 }}>{isCollapsed ? 'Expand' : 'Collapse'}</button>
                 {row.status === 'needs_user_input' && (
                   <button onClick={() => openClarification(row)} style={{ padding: '6px 8px', border: '1px solid var(--border)', background: 'var(--bg-active)', color: 'var(--text)', borderRadius: 6 }}>clarify</button>
                 )}
-                {['accepted', 'rejected', 'deferred', 'duplicate'].map(next => (
+                {!terminalDecision && (['accepted', 'rejected'] as const).map(next => (
                   <button key={next} onClick={() => updateStatus(row.id, next)} style={{ padding: '6px 8px', border: '1px solid var(--border)', background: 'var(--bg-input)', color: 'var(--text)', borderRadius: 6 }}>{next}</button>
                 ))}
+                {terminalDecision && <span style={{ color: 'var(--text-faint)', fontSize: '0.76rem', alignSelf: 'center' }}>Decision locked</span>}
                 {canCreateProposal(row) && !proposals[row.id]?.length && (
                   <button onClick={() => createProposal(row.id)} style={{ padding: '6px 8px', border: '1px solid var(--accent)', background: 'var(--bg-active)', color: 'var(--text)', borderRadius: 6 }}>Create Proposal</button>
                 )}

--- a/internal/workflow/self_improvement.go
+++ b/internal/workflow/self_improvement.go
@@ -149,10 +149,10 @@ type selfImprovementInput struct {
 }
 
 func (e *Engine) AnalyzeSelfImprovementFeedback(ctx context.Context, feedback store.SelfImprovementFeedback) (selfimprovement.SelfImprovementRecommendation, error) {
-	return e.analyzeSelfImprovementFeedback(ctx, feedback, nil, nil)
+	return e.analyzeSelfImprovementFeedback(ctx, feedback, nil, nil, nil)
 }
 
-func (e *Engine) analyzeSelfImprovementFeedback(ctx context.Context, feedback store.SelfImprovementFeedback, prior *selfimprovement.SelfImprovementRecommendation, clarification *selfimprovement.SelfImprovementClarification) (selfimprovement.SelfImprovementRecommendation, error) {
+func (e *Engine) analyzeSelfImprovementFeedback(ctx context.Context, feedback store.SelfImprovementFeedback, prior *selfimprovement.SelfImprovementRecommendation, clarification *selfimprovement.SelfImprovementClarification, queuedEvent *Event) (selfimprovement.SelfImprovementRecommendation, error) {
 	prompt, err := e.store.ReadPrompt(selfImprovementPromptRef)
 	if err != nil {
 		_ = e.store.MarkSelfImprovementFeedbackFailed(feedback.ID, err.Error())
@@ -168,7 +168,7 @@ func (e *Engine) analyzeSelfImprovementFeedback(ctx context.Context, feedback st
 		_ = e.store.MarkSelfImprovementFeedbackFailed(feedback.ID, err.Error())
 		return selfimprovement.SelfImprovementRecommendation{}, err
 	}
-	resp, err := e.runSelfImprovementAnalyst(ctx, feedback, prompt, backendName, backend, model, string(payload))
+	resp, err := e.runSelfImprovementAnalyst(ctx, feedback, prompt, backendName, backend, model, string(payload), queuedEvent)
 	if err != nil {
 		_ = e.store.MarkSelfImprovementFeedbackFailed(feedback.ID, err.Error())
 		return selfimprovement.SelfImprovementRecommendation{}, err
@@ -181,7 +181,7 @@ func (e *Engine) analyzeSelfImprovementFeedback(ctx context.Context, feedback st
 	return selfimprovement.New(e.store).RecordRecommendation(in)
 }
 
-func (e *Engine) runSelfImprovementAnalyst(ctx context.Context, feedback store.SelfImprovementFeedback, prompt fleet.Prompt, backendName string, backend fleet.Backend, model string, payload string) (ai.Response, error) {
+func (e *Engine) runSelfImprovementAnalyst(ctx context.Context, feedback store.SelfImprovementFeedback, prompt fleet.Prompt, backendName string, backend fleet.Backend, model string, payload string, queuedEvent *Event) (ai.Response, error) {
 	allowMemory := false
 	agent := fleet.Agent{
 		WorkspaceID: feedback.WorkspaceID,
@@ -202,25 +202,47 @@ func (e *Engine) runSelfImprovementAnalyst(ctx context.Context, feedback store.S
 	cfg.Daemon.AIBackends[backendName] = backend
 	cfg.Agents = append(cfg.Agents, agent)
 	cfg.Prompts = replacePrompt(cfg.Prompts, prompt)
+	ev := selfImprovementRunEvent(feedback, agent.Name, payload, queuedEvent)
+	return e.runAgentResult(ctx, ev, agent, cfg)
+}
+
+func selfImprovementRunEvent(feedback store.SelfImprovementFeedback, agentName, payload string, queuedEvent *Event) Event {
+	repo := strings.Trim(feedback.RepoOwner+"/"+feedback.RepoName, "/")
 	ev := Event{
 		ID:          fmt.Sprintf("self-improvement-%d", feedback.ID),
 		WorkspaceID: feedback.WorkspaceID,
-		Repo:        RepoRef{FullName: strings.Trim(feedback.RepoOwner+"/"+feedback.RepoName, "/"), Enabled: true},
+		Repo:        RepoRef{FullName: repo, Enabled: true},
 		Kind:        selfImprovementEventKind,
 		Number:      max(feedback.PRNumber, feedback.IssueNumber),
 		Actor:       feedback.AuthorLogin,
-		Payload: map[string]any{
-			"feedback_event_id":   feedback.ID,
-			"analysis_input_json": payload,
-			"structured_schema":   selfImprovementRecommendationSchema,
-			"target_agent":        agent.Name,
-			"source_url":          feedback.SourceURL,
-			"attribution_comment": "stored self-improvement feedback",
-			"no_auto_apply":       true,
-			"requested_output":    "structured self-improvement recommendation JSON",
-		},
 	}
-	return e.runAgentResult(ctx, ev, agent, cfg)
+	if queuedEvent != nil {
+		ev.ID = queuedEvent.ID
+		ev.QueueID = queuedEvent.QueueID
+		ev.EnqueuedAt = queuedEvent.EnqueuedAt
+		ev.WorkspaceID = queuedEvent.WorkspaceID
+		ev.Kind = queuedEvent.Kind
+		if queuedEvent.Repo.FullName != "" {
+			ev.Repo = queuedEvent.Repo
+		}
+		if queuedEvent.Number > 0 {
+			ev.Number = queuedEvent.Number
+		}
+		if queuedEvent.Actor != "" {
+			ev.Actor = queuedEvent.Actor
+		}
+	}
+	ev.Payload = map[string]any{
+		"feedback_event_id":   feedback.ID,
+		"analysis_input_json": payload,
+		"structured_schema":   selfImprovementRecommendationSchema,
+		"target_agent":        agentName,
+		"source_url":          feedback.SourceURL,
+		"attribution_comment": "stored self-improvement feedback",
+		"no_auto_apply":       true,
+		"requested_output":    "structured self-improvement recommendation JSON",
+	}
+	return ev
 }
 
 func replacePrompt(prompts []fleet.Prompt, prompt fleet.Prompt) []fleet.Prompt {
@@ -254,7 +276,7 @@ func (e *Engine) handleSelfImprovementEvent(ctx context.Context, ev Event) error
 		prior = &rec
 		clarification = rec.Clarification
 	}
-	_, err = e.analyzeSelfImprovementFeedback(ctx, feedback, prior, clarification)
+	_, err = e.analyzeSelfImprovementFeedback(ctx, feedback, prior, clarification, &ev)
 	return err
 }
 

--- a/internal/workflow/self_improvement_test.go
+++ b/internal/workflow/self_improvement_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/rs/zerolog"
 
@@ -173,6 +174,40 @@ func TestAnalyzeSelfImprovementFeedbackRunsStructuredAssistant(t *testing.T) {
 	}
 	if len(streamPub.begin) != 1 || len(streamPub.end) != 1 || streamPub.begin[0].Agent != selfImprovementInternalAgentName {
 		t.Fatalf("stream lifecycle begin=%+v end=%+v, want analyst run lifecycle", streamPub.begin, streamPub.end)
+	}
+}
+
+func TestSelfImprovementRunEventPreservesQueuedEventIdentity(t *testing.T) {
+	t.Parallel()
+
+	enqueuedAt := time.Now().Add(-time.Minute)
+	feedback := store.SelfImprovementFeedback{
+		ID:          42,
+		WorkspaceID: "team-a",
+		RepoOwner:   "owner",
+		RepoName:    "repo",
+		PRNumber:    17,
+		AuthorLogin: "maintainer",
+		SourceURL:   "https://github.com/owner/repo/pull/17#discussion_r1",
+	}
+	queued := Event{
+		ID:          "delivery-1:improvement",
+		QueueID:     99,
+		WorkspaceID: "team-a",
+		Repo:        RepoRef{FullName: "owner/repo", Enabled: true},
+		Kind:        selfImprovementEventKind,
+		Number:      17,
+		Actor:       "maintainer",
+		EnqueuedAt:  enqueuedAt,
+	}
+
+	ev := selfImprovementRunEvent(feedback, selfImprovementInternalAgentName, `{"feedback_event_id":42}`, &queued)
+
+	if ev.ID != queued.ID || ev.QueueID != queued.QueueID || !ev.EnqueuedAt.Equal(enqueuedAt) {
+		t.Fatalf("event identity = id %q queue %d enqueued %s, want queued event", ev.ID, ev.QueueID, ev.EnqueuedAt)
+	}
+	if ev.Payload["target_agent"] != selfImprovementInternalAgentName || ev.Payload["structured_schema"] == "" {
+		t.Fatalf("event payload = %+v, want analyst target and schema", ev.Payload)
 	}
 }
 


### PR DESCRIPTION
Summary
- Preserve the queued agents.improvement event identity when running internal-catalog-analyst, so active and completed rows join through the normal runner pipeline.
- Make self-improvement recommendations global by default while keeping workspace_id as provenance, and remove deferred/duplicate decisions from REST/MCP/UI.
- Add terminal accept/reject validation, collapsible recommendation rows, and a post-publish action to link a newly created skill to the attributed agent.

Notes
- No new runner button was added; internal analyst runs use the existing running-row Live action like normal agents.

Tests
- GOCACHE=/tmp/go-build-agents go test ./...
- npm test