### PR TITLE
docs: synchronize current behavior notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,7 @@ When making common classes of changes, update all of these at once:
 | Agent prompt contract | Prompts in SQLite (edit via UI or CRUD API), runner parser in `internal/ai/cmdrunner.go`, `internal/ai/types.go`, `internal/ai/response-schema.json`, AGENTS.md runner-contract section, tests |
 | Memory contract | `internal/workflow/engine.go` (memory load/persist around runs), `internal/store/memory*.go` (SQLite path), agent prompts "Memory hygiene" sections, `internal/ai/types.go` |
 | Dispatch semantics | `internal/workflow/dispatch.go` (runtime), `internal/config/config.go` (load-time validation), agent response schema in `internal/ai/types.go`, README dispatch section, all prompt "Response format" sections, tests on both paths |
-| SQLite store schema | `internal/store/migrations/`, `internal/store/open.go`, `internal/store/snapshot_*.go`, `internal/store/*s.go` concept files, the per-domain handlers under `internal/daemon/{fleet,repos,config,queue}`, tests |
+| SQLite store schema | `internal/store/migrations/`, `internal/store/open.go`, `internal/store/snapshot_*.go`, `internal/store/*s.go` concept files, the per-domain handlers under `internal/daemon/{fleet,repos,config,runners}`, tests |
 | Proxy translation behavior | `internal/anthropic_proxy/{types,translate,handler}.go`, unit tests for the affected shape, `docs/local-models.md` if user-visible |
 | Token budget schema (`token_budgets` table) | `internal/store/migrations/`, `internal/store/budgets.go`, `internal/store/facade.go`, `internal/daemon/config/budgets.go`, `internal/daemon/config/config.go` (export/import), `internal/mcp/tools_budgets.go`, docs |
 | Anything in the README | Also check `CLAUDE.md`, `AGENTS.md`, `config.example.yaml`, these four should stay in sync |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ internal/
   mcp/                      # MCP server exposing fleet-management tools at /mcp
   ui/                       # Embedded Next.js web dashboard (served at /ui/)
   logging/                  # zerolog setup
-docs/                       # Long-form docs: configuration, events, dispatch, API, docker, local-models, security
+docs/                       # Long-form docs: quickstart, configuration, events, dispatch, API, local-models, security
 ```
 
 ## Config Model

--- a/docs/api.md
+++ b/docs/api.md
@@ -53,7 +53,7 @@ The `/run` body is `{"agent": "<name>", "repo": "owner/repo"}`. It returns `202 
 | `GET` | `/improvements/recommendations` | Review-only proposal candidates. Global by default; query params: optional `workspace`, optional proposal candidate `status`. |
 | `GET` | `/improvements/recommendations/{id}` | One proposal candidate with linked feedback evidence. |
 | `POST` | `/improvements/feedback/{id}/analyze` | Manually create or refresh the proposal candidate for one feedback event. |
-| `POST` | `/improvements/recommendations/{id}/status` | Reject a proposal candidate. Rejected decisions are terminal. Body: `{ "status": "rejected", "reason": "optional" }`. |
+| `POST/PATCH` | `/improvements/recommendations/{id}/status` | Reject a proposal candidate. Rejected decisions are terminal. Body: `{ "status": "rejected", "reason": "optional" }`. |
 | `POST/PATCH` | `/improvements/recommendations/{id}/clarification` | Replace the proposal candidate's editable maintainer clarification and enqueue a fresh `agents.improvement` analysis run. Also retries failed clarification runs with the stored/latest clarification body. Body: `{ "body": "...", "author": "optional" }`. |
 | `GET` | `/improvements/recommendations/{id}/proposal-bundle` | Editable proposal bundle attached to a ready proposal candidate. Returns `{}` when no bundle exists. |
 | `PATCH` | `/improvements/proposal-bundles/{id}/items/{item_id}` | Edit one pending proposal bundle item before publishing. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -208,7 +208,7 @@ workspaces:
         enabled: true
         use:
           - agent: coder
-            labels: ["ai:ready"]
+            labels: ["ai ready"]
     token_budgets:
       - scope_kind: workspace+agent
         agent: coder
@@ -285,7 +285,7 @@ Each `use` entry binds one agent to one trigger. An agent can appear multiple ti
 
 ### Label architecture
 
-Labels are plain strings matched against each binding's `labels` list. There is **no magic format**; you choose the labels. Convention across the example config is `ai:review:<agent-name>`, but any string works.
+Labels are plain strings matched against each binding's `labels` list. There is **no magic format**; you choose the labels. The autonomous fleet examples use `ai ready` for maintainer-approved implementation work and `ai:review:<agent-name>` for reviewer routing, but any string works.
 
 ```yaml
 repos:

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -104,7 +104,7 @@ For agent lifecycle changes, use `create_agent` when adding a new agent or inten
 | `link_improvement_proposal_bundle_item` | Resolve one create-new item as already covered by an existing catalog asset, without attaching that asset to agents. |
 | `publish_improvement_proposal_bundle` | Atomically publish accepted bundle items into catalog versions. |
 | `discard_improvement_proposal_bundle` | Discard a pending proposal bundle. |
-| `list_traces` | Recent agent run spans with timing, summary, and token usage (`input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_write_tokens`, `prompt_size`). The composed prompt body is fetched separately via the `/traces/{span_id}/prompt` REST endpoint, not an MCP tool, since it can be many KB. |
+| `list_traces` | Recent agent run spans with timing, summary, and token usage (`input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_write_tokens`, `prompt_size`). The composed prompt body is intentionally not included in listings; fetch it separately with `get_trace_prompt` or `GET /traces/{span_id}/prompt` when needed. |
 | `get_trace` | Full dispatch chain by root event ID. |
 | `get_trace_steps` | Tool-loop transcript for one span. |
 | `get_trace_prompt` | Composed prompt the daemon sent to the AI CLI for one span (gzipped on disk; decompressed on the fly). The "what did the agent see" debug artefact. Errors when no prompt is recorded (pre-009-migration spans). |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -10,7 +10,7 @@ The daemon dispatches AI CLIs (`claude`, `codex`) with sandbox-bypass flags so a
 curl -fsSL https://raw.githubusercontent.com/eloylp/agents/main/scripts/quickstart.sh | bash
 ```
 
-The script will download the docker-compose file and help you configure the .env file in an interactive way. Note that at least codex or claude should be configured for the agent runs. It ends up bringing up 
+The script downloads the Compose file, walks through `.env` creation, and starts the daemon. Configure at least one backend credential path (Claude or Codex) before expecting agent runs to succeed.
 
 This requires Bash, `curl`, Docker, and Docker Compose v2.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -26,6 +26,13 @@ Verify the daemon is healthy:
 curl -s http://localhost:8080/status | jq
 ```
 
+Configure each GitHub repository webhook to send **all events** to
+`https://<your-daemon-host>/webhooks/github` with the generated
+`GITHUB_WEBHOOK_SECRET`. Label-triggered agents only need labeled issue/PR
+events to start, but observability and self-improvement attribution depend on
+the surrounding GitHub event stream, including `push`, `pull_request`,
+`pull_request_review`, `pull_request_review_comment`, and `issue_comment`.
+
 ## Credential reference
 
 The quickstart script writes credentials to `.env`. Production runs are env-driven: credentials are injected into each short-lived runner container and are not exported through UI, REST, MCP, or fleet YAML.

--- a/docs/run-attribution.md
+++ b/docs/run-attribution.md
@@ -102,6 +102,8 @@ metadata is logged and ignored for exact attribution. Authorized feedback can
 still be captured, but untrusted span, agent, prompt, skill, or guardrail fields
 are not passed through as exact attribution.
 
-Catalog version ids are nullable on deployments that do not yet have immutable
-catalog versioning. Once versioned prompts, skills, and guardrails are available,
-the same snapshot fields should carry exact version ids.
+Catalog version ids are nullable because older spans and some unresolved
+contexts may not have an exact prompt, skill, or guardrail version. For current
+runs, the daemon records the catalog version ids available at prompt
+composition time so self-improvement analysis can inspect the exact catalog
+content the agent saw instead of the latest mutable display names.

--- a/docs/self-improvement-feedback.md
+++ b/docs/self-improvement-feedback.md
@@ -45,6 +45,12 @@ Supported webhook sources:
 - pull request review comments
 - pull request reviews
 
+For setup, configure the GitHub webhook to send all events to the daemon, not
+only the comment or review event that contains `/agents improve`. Attribution
+resolution uses surrounding context such as push commits, pull request updates,
+PR review submissions, review comments, and issue comments to connect feedback
+back to signed agent artifacts.
+
 The marker match is exact and case-sensitive. Fenced code blocks are ignored so
 examples do not create feedback records accidentally.
 


### PR DESCRIPTION
## Summary

- align docs with current route/tool behavior for self-improvement status updates and trace prompt access
- fix current fleet label examples and package/doc references
- clarify quickstart setup text and current run-attribution catalog-version behavior

## Verification

- go test ./...

Closes #694

<!-- agents-run: {"v":1,"instance_id":"ts-lonestar","workspace":"default","repo":"eloylp/agents","span_id":"24c34d9012dae386","agent_id":"agent_0fb82d1fe34e45408bd2fee153f7003d","agent_name":"coder","sig":"opsRKAbGmukmBxO7yftmapEfdSLQ-2IhVV0jvIono-k"} -->