### PR TITLE
feat: resolve diff feedback via commit attribution

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -44,7 +44,7 @@ The `/runners` REST surface, the matching MCP tools (`list_runners`, `delete_run
 
 ## Event rules
 
-- **`push` scope:** only branch pushes fire the event. Tag pushes, branch deletions, and pushes to non-`refs/heads/` refs are silently dropped. The agent receives the branch ref and the resulting head SHA. There is no PR number in the context.
+- **`push` scope:** only branch pushes fire the event. Tag pushes, branch deletions, and pushes to non-`refs/heads/` refs are silently dropped. The agent receives the branch ref and the resulting head SHA. There is no PR number in the context. Commit messages in the payload are also scanned for signed `Agents-Attribution` trailers so later diff-line `/agents improve` feedback can resolve through the commented commit SHA.
 - `issues.*` events that originate from a PR-backed GitHub issue are dropped; the corresponding `pull_request.*` event covers them instead.
 - `pull_request.labeled` events on draft PRs are dropped at the webhook boundary. Use `events: ["pull_request.ready_for_review"]` to act when a draft is marked ready.
 - Unknown event kinds are rejected at config load time with a clear error listing the supported set.

--- a/docs/run-attribution.md
+++ b/docs/run-attribution.md
@@ -57,6 +57,8 @@ Each resolution also reports a `mode` describing how the span was found:
 
 - `direct`: signed hidden comment in the feedback body.
 - `commit_trailer`: `Agents-Attribution:` commit trailer in the same body.
+- `commit_artifact`: push webhook captured a signed `Agents-Attribution`
+  trailer for the commit SHA GitHub attached to a diff-line review comment.
 - `artifact_comment`: the comment itself was stored as a signed artifact.
 - `artifact_parent_comment`: parent comment via `in_reply_to_id` is a signed artifact.
 - `artifact_review`: owning PR review via `pull_request_review_id` is a signed artifact.
@@ -66,23 +68,30 @@ Each resolution also reports a `mode` describing how the span was found:
 
 ## Artifact reverse-index
 
-Every incoming `issue_comment`, `pull_request_review`, and
-`pull_request_review_comment` webhook delivery is scanned for valid signed agent
-metadata, regardless of whether it contains `/agents improve`. Valid artifacts
-are stored in the `run_attribution_artifacts` table as a narrow reverse index:
-GitHub object identity (comment id, review id, review comment id) → span id.
+Every incoming `issue_comment`, `pull_request_review`,
+`pull_request_review_comment`, and `push` webhook delivery is scanned for valid
+signed agent metadata, regardless of whether it contains `/agents improve`.
+Valid artifacts are stored in the `run_attribution_artifacts` table as a narrow
+reverse index: GitHub object identity (comment id, review id, review comment id,
+or commit SHA) → span id.
 
 When a maintainer posts an `/agents improve` inline PR review comment:
-1. The daemon checks the comment's own `id` for a stored artifact (in case the
-   agent commented exactly on this line).
+1. The daemon checks the review comment's `commit_id` for a stored signed commit
+   artifact captured from a prior push webhook.
 2. If not found, it walks the `in_reply_to_id` chain to find the parent agent
-   comment.
+   inline comment.
 3. It then checks `pull_request_review_id` to see if the owning PR review
    carried signed metadata.
-4. As a conservative fallback, it looks for artifacts on the same PR/file/commit
+4. It checks the comment's own `id` for a stored artifact.
+5. As a conservative fallback, it looks for artifacts on the same PR/file/commit
    that have exactly one candidate.
-5. Only if none of the above succeeds does it fall back to time-window inference,
+6. Only if none of the above succeeds does it fall back to time-window inference,
    which never attributes feedback to internal analyst agent runs.
+
+If a diff-line review comment references a commit SHA but no signed commit
+artifact exists, attribution remains unresolved with a diagnostic that the
+commented commit has no signed agent attribution, unless stronger parent or
+review ancestry resolves first.
 
 Copied signed metadata from another repo, PR, or instance is rejected. If
 multiple artifact candidates exist for the same PR context without stronger

--- a/docs/self-improvement-feedback.md
+++ b/docs/self-improvement-feedback.md
@@ -70,14 +70,16 @@ to paste attribution metadata. The daemon walks GitHub artifact ownership to
 resolve attribution automatically:
 
 1. Direct signed metadata in the `/agents improve` body.
-2. Artifact lookup for the comment itself (if the agent posted on that line).
+2. For diff-line review comments, the GitHub `commit_id` resolves through a
+   signed commit artifact captured from a push webhook.
 3. Parent comment via `in_reply_to_id` — resolves when you reply to an agent
    inline comment.
 4. Owning PR review via `pull_request_review_id` — resolves when the agent
    submitted the review body with signed metadata.
-5. Conservative PR/file/commit context lookup — only when a single artifact
+5. Artifact lookup for the comment itself.
+6. Conservative PR/file/commit context lookup — only when a single artifact
    candidate matches.
-6. Time-window inference as a last resort, with internal analyst runs excluded.
+7. Time-window inference as a last resort, with internal analyst runs excluded.
 
 Exact attribution comes from the public `agents-run` hidden metadata or
 `Agents-Attribution` commit trailers that agents copy from the daemon-rendered
@@ -88,6 +90,12 @@ and ignored for exact attribution. The daemon stores a reverse index
 (`run_attribution_artifacts`) of every signed GitHub artifact it observes, so
 it can resolve ancestry across comment threads even when the human comment does
 not carry metadata.
+
+Push webhooks also scan commit messages for signed `Agents-Attribution`
+trailers. For inline feedback on a PR diff, this lets the daemon map the
+commented commit SHA back to the exact run that authored the code under review.
+Unsigned or untracked commits stay unresolved with an explicit diagnostic rather
+than falling through to a loose code-ownership guess.
 
 Authorized feedback is still stored when attribution is inferred or unresolved,
 but the analyst does not receive untrusted span, agent, prompt, skill, or

--- a/internal/ai/prompt.go
+++ b/internal/ai/prompt.go
@@ -186,8 +186,9 @@ func renderRuntimeContext(ctx PromptContext) string {
 		fmt.Fprintf(&b, "Run attribution metadata: %s\n", ctx.RunAttributionComment)
 		b.WriteString("When you create or update a GitHub pull request body or GitHub comment for this run, include that exact hidden HTML comment in the content when feasible.\n")
 		if ctx.RunAttributionCommitTrailer != "" {
-			fmt.Fprintf(&b, "For commits authored for this run, add this exact commit trailer: `%s`.\n", ctx.RunAttributionCommitTrailer)
+			fmt.Fprintf(&b, "For commits authored for this run, you must add this exact commit trailer without editing it: `%s`.\n", ctx.RunAttributionCommitTrailer)
 		}
+		b.WriteString("The daemon will not rewrite commits or write to GitHub directly to add attribution metadata.\n")
 		b.WriteString("For human readability, commits may also include trailers `Agents-Run: <span_id>` and `Agents-Agent: <agent_name>` using the values in the metadata.\n")
 	}
 	if len(ctx.Payload) > 0 {

--- a/internal/ai/prompt_test.go
+++ b/internal/ai/prompt_test.go
@@ -144,7 +144,8 @@ func TestRenderAgentPromptIncludesRunAttributionContract(t *testing.T) {
 	for _, want := range []string{
 		"Run attribution metadata: " + comment,
 		"include that exact hidden HTML comment",
-		"For commits authored for this run, add this exact commit trailer: `" + trailer + "`",
+		"For commits authored for this run, you must add this exact commit trailer without editing it: `" + trailer + "`",
+		"The daemon will not rewrite commits or write to GitHub directly to add attribution metadata.",
 		"Agents-Run: <span_id>",
 		"Agents-Agent: <agent_name>",
 	} {

--- a/internal/observe/attribution.go
+++ b/internal/observe/attribution.go
@@ -74,6 +74,7 @@ const (
 	AttributionModeArtifactParent    = "artifact_parent_comment"
 	AttributionModeArtifactReview    = "artifact_review"
 	AttributionModeArtifactPRContext = "artifact_pr_context"
+	AttributionModeCommitArtifact    = "commit_artifact"
 	AttributionModeCommitTrailer     = "commit_trailer"
 	AttributionModeInferred          = "inferred"
 	AttributionModeUnresolved        = "unresolved"
@@ -127,12 +128,12 @@ func (s *Store) resolveArtifactAttribution(workspaceID string, q AttributionQuer
 		return AttributionResolution{}, false
 	}
 
-	// Step 2: For pull_request_review_comment – check if the current comment
-	// itself has a stored artifact (i.e., it carried signed metadata).
-	if q.ReviewCommentID > 0 {
-		if a, ok := s.store.RunAttributionArtifactByReviewCommentID(workspaceID, owner, name, q.ReviewCommentID); ok {
-			return s.artifactResolution(a, AttributionModeArtifactComment)
+	var missingCommitArtifact bool
+	if q.ReviewCommentID > 0 && strings.TrimSpace(q.HeadSHA) != "" {
+		if a, ok := s.store.RunAttributionArtifactByCommitSHA(workspaceID, owner, name, q.HeadSHA); ok {
+			return s.artifactResolution(a, AttributionModeCommitArtifact)
 		}
+		missingCommitArtifact = true
 	}
 
 	// Step 3: Parent review comment lookup via in_reply_to_id.
@@ -161,6 +162,24 @@ func (s *Store) resolveArtifactAttribution(workspaceID string, q AttributionQuer
 		if a, ok := s.store.RunAttributionArtifactByCommentID(workspaceID, owner, name, "issue_comment", q.CommentID); ok {
 			return s.artifactResolution(a, AttributionModeArtifactComment)
 		}
+	}
+
+	// Step 6a: Direct PR review comment artifact lookup. This comes after
+	// commit/parent/review ownership because a human diff-line feedback comment
+	// may carry its own metadata while still targeting unsigned agent-authored
+	// code; code ownership should win.
+	if q.ReviewCommentID > 0 {
+		if a, ok := s.store.RunAttributionArtifactByReviewCommentID(workspaceID, owner, name, q.ReviewCommentID); ok {
+			return s.artifactResolution(a, AttributionModeArtifactComment)
+		}
+	}
+
+	if missingCommitArtifact {
+		return AttributionResolution{
+			Confidence: AttributionUnresolved,
+			Mode:       AttributionModeCommitArtifact,
+			Diagnostic: "commented commit has no signed agent attribution",
+		}, true
 	}
 
 	// Step 7: Conservative PR/thread context lookup – only if it yields exactly

--- a/internal/observe/attribution_artifacts_test.go
+++ b/internal/observe/attribution_artifacts_test.go
@@ -206,6 +206,82 @@ func TestCaptureArtifactResolvedViaReviewID(t *testing.T) {
 	}
 }
 
+func TestCaptureCommitArtifactResolvesReviewCommentCommitID(t *testing.T) {
+	t.Parallel()
+	s := testDB(t)
+	s.WithAttributionVerifier(observe.AttributionVerifierConfig{
+		SigningSecret: "secret",
+		InstanceID:    "prod",
+	})
+	at := time.Date(2026, 1, 10, 12, 0, 0, 0, time.UTC)
+	seedSpan(t, s, "span-commit", "default", "owner/repo", "coder", 90, at)
+
+	attr := workflow.RunAttribution{
+		WorkspaceID: "default",
+		RepoOwner:   "owner",
+		RepoName:    "repo",
+		SpanID:      "span-commit",
+		AgentName:   "coder",
+	}
+	commitMessage := "fix http handler\n\n" + attr.CommitAttributionTrailer("secret", "prod")
+	s.CaptureArtifact(observe.RunAttributionArtifactInput{
+		WorkspaceID:     "default",
+		RepoOwner:       "owner",
+		RepoName:        "repo",
+		SourceType:      "commit",
+		CommitSHA:       "abc123",
+		AuthorLogin:     "coder",
+		SourceURL:       "https://github.com/owner/repo/commit/abc123",
+		GitHubUpdatedAt: &at,
+	}, "", commitMessage)
+
+	got := s.ResolveRunAttribution(observe.AttributionQuery{
+		WorkspaceID:     "default",
+		RepoOwner:       "owner",
+		RepoName:        "repo",
+		IssueOrPRNumber: 90,
+		ReviewCommentID: 700,
+		HeadSHA:         "abc123",
+		Body:            "/agents improve http handlers should be per method",
+	})
+	if got.Confidence != observe.AttributionExact {
+		t.Fatalf("Confidence = %q, want exact; diagnostic: %s", got.Confidence, got.Diagnostic)
+	}
+	if got.Mode != observe.AttributionModeCommitArtifact {
+		t.Fatalf("Mode = %q, want %q", got.Mode, observe.AttributionModeCommitArtifact)
+	}
+	if got.Snapshot == nil || got.Snapshot.SpanID != "span-commit" {
+		t.Fatalf("Snapshot.SpanID want span-commit, got %v", got.Snapshot)
+	}
+}
+
+func TestReviewCommentUnsignedCommitReturnsClearDiagnostic(t *testing.T) {
+	t.Parallel()
+	s := testDB(t)
+	at := time.Date(2026, 1, 10, 12, 0, 0, 0, time.UTC)
+	seedSpan(t, s, "span-inferred", "default", "owner/repo", "coder", 91, at)
+
+	got := s.ResolveRunAttribution(observe.AttributionQuery{
+		WorkspaceID:     "default",
+		RepoOwner:       "owner",
+		RepoName:        "repo",
+		IssueOrPRNumber: 91,
+		ReviewCommentID: 701,
+		HeadSHA:         "unsigned123",
+		At:              at.Add(time.Second),
+		Body:            "/agents improve this diff line",
+	})
+	if got.Confidence != observe.AttributionUnresolved {
+		t.Fatalf("Confidence = %q, want unresolved", got.Confidence)
+	}
+	if got.Mode != observe.AttributionModeCommitArtifact {
+		t.Fatalf("Mode = %q, want %q", got.Mode, observe.AttributionModeCommitArtifact)
+	}
+	if got.Diagnostic != "commented commit has no signed agent attribution" {
+		t.Fatalf("Diagnostic = %q, want unsigned commit diagnostic", got.Diagnostic)
+	}
+}
+
 // TestCaptureArtifactRejectsWrongRepoMetadata verifies that signed metadata
 // from a different repo is rejected and not stored as an authoritative artifact.
 func TestCaptureArtifactRejectsWrongRepoMetadata(t *testing.T) {

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -53,6 +53,16 @@ func migrate(db *sql.DB) error {
 			return fmt.Errorf("store: read migration %s: %w", name, err)
 		}
 
+		if strings.Contains(string(data), "-- agents:migration-no-transaction") {
+			if _, err := db.Exec(string(data)); err != nil {
+				return fmt.Errorf("store: apply migration %s: %w", name, err)
+			}
+			if _, err := db.Exec("INSERT INTO schema_migrations(name) VALUES(?)", name); err != nil {
+				return fmt.Errorf("store: record migration %s: %w", name, err)
+			}
+			continue
+		}
+
 		tx, err := db.Begin()
 		if err != nil {
 			return fmt.Errorf("store: begin migration %s: %w", name, err)

--- a/internal/store/migrations/057_commit_attribution_feedback_ancestry.sql
+++ b/internal/store/migrations/057_commit_attribution_feedback_ancestry.sql
@@ -13,3 +13,7 @@ ALTER TABLE self_improvement_feedback
 
 ALTER TABLE self_improvement_feedback
     ADD COLUMN github_pull_request_review_id INTEGER NOT NULL DEFAULT 0;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_self_improvement_feedback_review_comment
+    ON self_improvement_feedback(workspace_id, source_type, github_review_comment_id, tag)
+    WHERE github_review_comment_id > 0;

--- a/internal/store/migrations/057_commit_attribution_feedback_ancestry.sql
+++ b/internal/store/migrations/057_commit_attribution_feedback_ancestry.sql
@@ -1,0 +1,15 @@
+-- 057_commit_attribution_feedback_ancestry: direct commit attribution lookups
+-- and full PR review comment ancestry for self-improvement feedback.
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_run_attribution_artifacts_commit
+    ON run_attribution_artifacts(workspace_id, repo_owner, repo_name, commit_sha)
+    WHERE source_type = 'commit' AND commit_sha <> '';
+
+ALTER TABLE self_improvement_feedback
+    ADD COLUMN github_review_comment_id INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE self_improvement_feedback
+    ADD COLUMN github_parent_comment_id INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE self_improvement_feedback
+    ADD COLUMN github_pull_request_review_id INTEGER NOT NULL DEFAULT 0;

--- a/internal/store/migrations/058_self_improvement_feedback_identity_indexes.sql
+++ b/internal/store/migrations/058_self_improvement_feedback_identity_indexes.sql
@@ -1,6 +1,7 @@
 -- 058_self_improvement_feedback_identity_indexes: keep feedback identity
 -- columns orthogonal by replacing the legacy table-level unique constraint
 -- with source-specific partial indexes.
+-- agents:migration-no-transaction
 
 PRAGMA foreign_keys = OFF;
 PRAGMA legacy_alter_table = ON;
@@ -76,16 +77,6 @@ SELECT
 FROM self_improvement_feedback_legacy_identity_058;
 
 DROP TABLE self_improvement_feedback_legacy_identity_058;
-
-PRAGMA writable_schema = ON;
-
-UPDATE sqlite_schema
-SET sql = replace(sql, 'self_improvement_feedback_legacy_identity_058', 'self_improvement_feedback')
-WHERE type = 'table'
-  AND sql LIKE '%self_improvement_feedback_legacy_identity_058%';
-
-PRAGMA writable_schema = OFF;
-PRAGMA schema_version = 58;
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_self_improvement_feedback_legacy_identity
     ON self_improvement_feedback(workspace_id, source_type, github_comment_id, github_review_id, tag)

--- a/internal/store/migrations/058_self_improvement_feedback_identity_indexes.sql
+++ b/internal/store/migrations/058_self_improvement_feedback_identity_indexes.sql
@@ -1,0 +1,106 @@
+-- 058_self_improvement_feedback_identity_indexes: keep feedback identity
+-- columns orthogonal by replacing the legacy table-level unique constraint
+-- with source-specific partial indexes.
+
+PRAGMA foreign_keys = OFF;
+PRAGMA legacy_alter_table = ON;
+
+DROP INDEX IF EXISTS idx_self_improvement_feedback_workspace_status;
+DROP INDEX IF EXISTS idx_self_improvement_feedback_repo;
+DROP INDEX IF EXISTS idx_self_improvement_feedback_review_comment;
+
+ALTER TABLE self_improvement_feedback
+RENAME TO self_improvement_feedback_legacy_identity_058;
+
+CREATE TABLE self_improvement_feedback (
+    id                           INTEGER PRIMARY KEY AUTOINCREMENT,
+    workspace_id                 TEXT NOT NULL DEFAULT 'default',
+    repo_owner                   TEXT NOT NULL,
+    repo_name                    TEXT NOT NULL,
+    source_type                  TEXT NOT NULL,
+    github_comment_id            INTEGER NOT NULL DEFAULT 0,
+    github_review_id             INTEGER NOT NULL DEFAULT 0,
+    github_delivery_id           TEXT NOT NULL DEFAULT '',
+    source_url                   TEXT NOT NULL DEFAULT '',
+    author_login                 TEXT NOT NULL DEFAULT '',
+    author_authorized            INTEGER NOT NULL DEFAULT 0,
+    issue_number                 INTEGER NOT NULL DEFAULT 0,
+    pr_number                    INTEGER NOT NULL DEFAULT 0,
+    raw_body                     TEXT NOT NULL DEFAULT '',
+    tag                          TEXT NOT NULL DEFAULT '/agents improve',
+    file_path                    TEXT NOT NULL DEFAULT '',
+    line                         INTEGER NOT NULL DEFAULT 0,
+    side                         TEXT NOT NULL DEFAULT '',
+    diff_hunk                    TEXT NOT NULL DEFAULT '',
+    commit_sha                   TEXT NOT NULL DEFAULT '',
+    github_created_at            TIMESTAMP NULL,
+    github_updated_at            TIMESTAMP NULL,
+    ingested_at                  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    linked_span_id               TEXT NOT NULL DEFAULT '',
+    linked_event_id              TEXT NOT NULL DEFAULT '',
+    linked_agent_id              TEXT NOT NULL DEFAULT '',
+    linked_agent_name            TEXT NOT NULL DEFAULT '',
+    linked_prompt_version_id     TEXT NOT NULL DEFAULT '',
+    linked_skill_version_ids     TEXT NOT NULL DEFAULT '',
+    linked_guardrail_version_ids TEXT NOT NULL DEFAULT '',
+    link_confidence              TEXT NOT NULL DEFAULT 'unresolved',
+    link_diagnostics             TEXT NOT NULL DEFAULT '',
+    status                       TEXT NOT NULL DEFAULT 'new',
+    github_review_comment_id     INTEGER NOT NULL DEFAULT 0,
+    github_parent_comment_id     INTEGER NOT NULL DEFAULT 0,
+    github_pull_request_review_id INTEGER NOT NULL DEFAULT 0
+);
+
+INSERT INTO self_improvement_feedback (
+    id, workspace_id, repo_owner, repo_name, source_type, github_comment_id,
+    github_review_id, github_delivery_id, source_url, author_login,
+    author_authorized, issue_number, pr_number, raw_body, tag, file_path,
+    line, side, diff_hunk, commit_sha, github_created_at, github_updated_at,
+    ingested_at, linked_span_id, linked_event_id, linked_agent_id,
+    linked_agent_name, linked_prompt_version_id, linked_skill_version_ids,
+    linked_guardrail_version_ids, link_confidence, link_diagnostics, status,
+    github_review_comment_id, github_parent_comment_id, github_pull_request_review_id
+)
+SELECT
+    id, workspace_id, repo_owner, repo_name, source_type,
+    CASE WHEN source_type = 'pull_request_review_comment' THEN 0 ELSE github_comment_id END,
+    CASE WHEN source_type = 'pull_request_review_comment' AND github_review_id = github_review_comment_id THEN 0 ELSE github_review_id END,
+    github_delivery_id, source_url, author_login, author_authorized,
+    issue_number, pr_number, raw_body, tag, file_path, line, side, diff_hunk,
+    commit_sha, github_created_at, github_updated_at, ingested_at,
+    linked_span_id, linked_event_id, linked_agent_id, linked_agent_name,
+    linked_prompt_version_id, linked_skill_version_ids,
+    linked_guardrail_version_ids, link_confidence, link_diagnostics, status,
+    github_review_comment_id, github_parent_comment_id,
+    github_pull_request_review_id
+FROM self_improvement_feedback_legacy_identity_058;
+
+DROP TABLE self_improvement_feedback_legacy_identity_058;
+
+PRAGMA writable_schema = ON;
+
+UPDATE sqlite_schema
+SET sql = replace(sql, 'self_improvement_feedback_legacy_identity_058', 'self_improvement_feedback')
+WHERE type = 'table'
+  AND sql LIKE '%self_improvement_feedback_legacy_identity_058%';
+
+PRAGMA writable_schema = OFF;
+PRAGMA schema_version = 58;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_self_improvement_feedback_legacy_identity
+    ON self_improvement_feedback(workspace_id, source_type, github_comment_id, github_review_id, tag)
+    WHERE github_review_comment_id = 0;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_self_improvement_feedback_review_comment
+    ON self_improvement_feedback(workspace_id, source_type, github_review_comment_id, tag)
+    WHERE github_review_comment_id > 0;
+
+CREATE INDEX IF NOT EXISTS idx_self_improvement_feedback_workspace_status
+    ON self_improvement_feedback(workspace_id, status, ingested_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_self_improvement_feedback_repo
+    ON self_improvement_feedback(workspace_id, repo_owner, repo_name, pr_number, issue_number);
+
+PRAGMA foreign_key_check;
+PRAGMA legacy_alter_table = OFF;
+PRAGMA foreign_keys = ON;

--- a/internal/store/run_attribution_artifacts.go
+++ b/internal/store/run_attribution_artifacts.go
@@ -16,7 +16,7 @@ type RunAttributionArtifactInput struct {
 	RepoName              string
 	IssueOrPRNumber       int
 	SourceType            string // "issue_comment", "pull_request_review", "pull_request_review_comment", "commit"
-	GitHubCommentID       int64  // issue_comment or pull_request_review_comment id
+	GitHubCommentID       int64  // issue_comment id
 	GitHubReviewID        int64  // pull_request_review id
 	GitHubReviewCommentID int64  // pull_request_review_comment id (distinguished from CommentID)
 	GitHubParentCommentID int64  // in_reply_to_id from PR review comment

--- a/internal/store/run_attribution_artifacts.go
+++ b/internal/store/run_attribution_artifacts.go
@@ -15,7 +15,7 @@ type RunAttributionArtifactInput struct {
 	RepoOwner             string
 	RepoName              string
 	IssueOrPRNumber       int
-	SourceType            string // "issue_comment", "pull_request_review", "pull_request_review_comment"
+	SourceType            string // "issue_comment", "pull_request_review", "pull_request_review_comment", "commit"
 	GitHubCommentID       int64  // issue_comment or pull_request_review_comment id
 	GitHubReviewID        int64  // pull_request_review id
 	GitHubReviewCommentID int64  // pull_request_review_comment id (distinguished from CommentID)
@@ -73,6 +73,10 @@ func (s *Store) RunAttributionArtifactByReviewCommentID(workspaceID, repoOwner, 
 
 func (s *Store) RunAttributionArtifactByReviewID(workspaceID, repoOwner, repoName string, reviewID int64) (RunAttributionArtifact, bool) {
 	return RunAttributionArtifactByReviewID(s.db, workspaceID, repoOwner, repoName, reviewID)
+}
+
+func (s *Store) RunAttributionArtifactByCommitSHA(workspaceID, repoOwner, repoName, commitSHA string) (RunAttributionArtifact, bool) {
+	return RunAttributionArtifactByCommitSHA(s.db, workspaceID, repoOwner, repoName, commitSHA)
 }
 
 func (s *Store) RunAttributionArtifactsByPRContext(workspaceID, repoOwner, repoName string, prNumber int, filePath, commitSHA string) []RunAttributionArtifact {
@@ -151,6 +155,27 @@ func RunAttributionArtifactByReviewID(db querier, workspaceID, repoOwner, repoNa
 		WHERE workspace_id=? AND repo_owner=? AND repo_name=? AND github_review_id=? AND github_review_comment_id=0
 		LIMIT 1`,
 		fleet.NormalizeWorkspaceID(workspaceID), strings.TrimSpace(repoOwner), strings.TrimSpace(repoName), reviewID,
+	)
+	a, err := scanRunAttributionArtifact(row)
+	if err != nil {
+		return RunAttributionArtifact{}, false
+	}
+	return a, true
+}
+
+// RunAttributionArtifactByCommitSHA looks up a signed commit artifact by the
+// commit SHA GitHub reports for a diff-line review comment.
+func RunAttributionArtifactByCommitSHA(db querier, workspaceID, repoOwner, repoName, commitSHA string) (RunAttributionArtifact, bool) {
+	commitSHA = strings.TrimSpace(commitSHA)
+	if db == nil || commitSHA == "" {
+		return RunAttributionArtifact{}, false
+	}
+	row := db.QueryRow(
+		runAttributionArtifactSelect+`
+		FROM run_attribution_artifacts
+		WHERE workspace_id=? AND repo_owner=? AND repo_name=? AND source_type='commit' AND commit_sha=?
+		LIMIT 1`,
+		fleet.NormalizeWorkspaceID(workspaceID), strings.TrimSpace(repoOwner), strings.TrimSpace(repoName), commitSHA,
 	)
 	a, err := scanRunAttributionArtifact(row)
 	if err != nil {

--- a/internal/store/run_attribution_artifacts_test.go
+++ b/internal/store/run_attribution_artifacts_test.go
@@ -60,6 +60,14 @@ func TestRunAttributionArtifactUpsertAndLookups(t *testing.T) {
 			GitHubCommentID: 3001,
 			SpanID:          "span-issue",
 		},
+		{
+			WorkspaceID: "default",
+			RepoOwner:   "owner",
+			RepoName:    "repo",
+			SourceType:  "commit",
+			CommitSHA:   "def456",
+			SpanID:      "span-commit",
+		},
 	}
 	for _, in := range inputs {
 		if err := st.UpsertRunAttributionArtifact(in); err != nil {
@@ -95,6 +103,13 @@ func TestRunAttributionArtifactUpsertAndLookups(t *testing.T) {
 				return st.RunAttributionArtifactByCommentID("default", "owner", "repo", "issue_comment", 3001)
 			},
 			want: "span-issue",
+		},
+		{
+			name: "commit sha",
+			lookup: func() (store.RunAttributionArtifact, bool) {
+				return st.RunAttributionArtifactByCommitSHA("default", "owner", "repo", "def456")
+			},
+			want: "span-commit",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/store/self_improvement.go
+++ b/internal/store/self_improvement.go
@@ -29,6 +29,9 @@ type SelfImprovementFeedback struct {
 	SourceType                string     `json:"source_type"`
 	GitHubCommentID           int64      `json:"github_comment_id,omitempty"`
 	GitHubReviewID            int64      `json:"github_review_id,omitempty"`
+	GitHubReviewCommentID     int64      `json:"github_review_comment_id,omitempty"`
+	GitHubParentCommentID     int64      `json:"github_parent_comment_id,omitempty"`
+	GitHubPullRequestReviewID int64      `json:"github_pull_request_review_id,omitempty"`
 	GitHubDeliveryID          string     `json:"github_delivery_id,omitempty"`
 	SourceURL                 string     `json:"source_url"`
 	AuthorLogin               string     `json:"author_login"`
@@ -64,6 +67,9 @@ type SelfImprovementFeedbackInput struct {
 	SourceType                string
 	GitHubCommentID           int64
 	GitHubReviewID            int64
+	GitHubReviewCommentID     int64
+	GitHubParentCommentID     int64
+	GitHubPullRequestReviewID int64
 	GitHubDeliveryID          string
 	SourceURL                 string
 	AuthorLogin               string
@@ -203,13 +209,17 @@ func UpsertSelfImprovementFeedback(db *sql.DB, in SelfImprovementFeedbackInput) 
 	_, err := db.Exec(
 		`INSERT INTO self_improvement_feedback (
 			workspace_id, repo_owner, repo_name, source_type, github_comment_id, github_review_id,
+			github_review_comment_id, github_parent_comment_id, github_pull_request_review_id,
 			github_delivery_id, source_url, author_login, author_authorized, issue_number, pr_number,
 			raw_body, tag, file_path, line, side, diff_hunk, commit_sha, github_created_at,
 			github_updated_at, linked_span_id, linked_event_id, linked_agent_id, linked_agent_name,
 			linked_prompt_version_id, linked_skill_version_ids, linked_guardrail_version_ids,
 			link_confidence, link_diagnostics, status
-		) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+		) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
 		ON CONFLICT(workspace_id, source_type, github_comment_id, github_review_id, tag) DO UPDATE SET
+			github_review_comment_id=excluded.github_review_comment_id,
+			github_parent_comment_id=excluded.github_parent_comment_id,
+			github_pull_request_review_id=excluded.github_pull_request_review_id,
 			github_delivery_id=excluded.github_delivery_id,
 			source_url=excluded.source_url,
 			author_login=excluded.author_login,
@@ -238,7 +248,8 @@ func UpsertSelfImprovementFeedback(db *sql.DB, in SelfImprovementFeedbackInput) 
 				ELSE self_improvement_feedback.status
 			END`,
 		workspaceID, strings.TrimSpace(in.RepoOwner), strings.TrimSpace(in.RepoName), strings.TrimSpace(in.SourceType),
-		in.GitHubCommentID, in.GitHubReviewID, strings.TrimSpace(in.GitHubDeliveryID), strings.TrimSpace(in.SourceURL),
+		in.GitHubCommentID, in.GitHubReviewID, in.GitHubReviewCommentID, in.GitHubParentCommentID,
+		in.GitHubPullRequestReviewID, strings.TrimSpace(in.GitHubDeliveryID), strings.TrimSpace(in.SourceURL),
 		strings.TrimSpace(in.AuthorLogin), boolInt(in.AuthorAuthorized), in.IssueNumber, in.PRNumber, in.RawBody, tag,
 		strings.TrimSpace(in.FilePath), in.Line, strings.TrimSpace(in.Side), in.DiffHunk, strings.TrimSpace(in.CommitSHA),
 		in.GitHubCreatedAt, in.GitHubUpdatedAt, strings.TrimSpace(in.LinkedSpanID), strings.TrimSpace(in.LinkedEventID),
@@ -251,6 +262,7 @@ func UpsertSelfImprovementFeedback(db *sql.DB, in SelfImprovementFeedbackInput) 
 	}
 	row := db.QueryRow(
 		`SELECT id, workspace_id, repo_owner, repo_name, source_type, github_comment_id, github_review_id,
+			github_review_comment_id, github_parent_comment_id, github_pull_request_review_id,
 			github_delivery_id, source_url, author_login, author_authorized, issue_number, pr_number,
 			raw_body, tag, file_path, line, side, diff_hunk, commit_sha, github_created_at,
 			github_updated_at, ingested_at, linked_span_id, linked_event_id, linked_agent_id,
@@ -271,6 +283,9 @@ func IgnoreSelfImprovementFeedback(db *sql.DB, in SelfImprovementFeedbackInput) 
 	}
 	res, err := db.Exec(
 		`UPDATE self_improvement_feedback SET
+			github_review_comment_id=?,
+			github_parent_comment_id=?,
+			github_pull_request_review_id=?,
 			github_delivery_id=?,
 			source_url=?,
 			author_login=?,
@@ -286,6 +301,7 @@ func IgnoreSelfImprovementFeedback(db *sql.DB, in SelfImprovementFeedbackInput) 
 			github_updated_at=?,
 			status=?
 		WHERE workspace_id=? AND source_type=? AND github_comment_id=? AND github_review_id=? AND tag=?`,
+		in.GitHubReviewCommentID, in.GitHubParentCommentID, in.GitHubPullRequestReviewID,
 		strings.TrimSpace(in.GitHubDeliveryID), strings.TrimSpace(in.SourceURL), strings.TrimSpace(in.AuthorLogin),
 		boolInt(in.AuthorAuthorized), in.IssueNumber, in.PRNumber, in.RawBody, strings.TrimSpace(in.FilePath),
 		in.Line, strings.TrimSpace(in.Side), in.DiffHunk, strings.TrimSpace(in.CommitSHA), in.GitHubUpdatedAt,
@@ -316,6 +332,7 @@ func ListSelfImprovementFeedback(db *sql.DB, workspace, status string, limit int
 	case allWorkspaces && status == "":
 		rows, err = db.Query(
 			`SELECT id, workspace_id, repo_owner, repo_name, source_type, github_comment_id, github_review_id,
+				github_review_comment_id, github_parent_comment_id, github_pull_request_review_id,
 				github_delivery_id, source_url, author_login, author_authorized, issue_number, pr_number,
 				raw_body, tag, file_path, line, side, diff_hunk, commit_sha, github_created_at,
 				github_updated_at, ingested_at, linked_span_id, linked_event_id, linked_agent_id,
@@ -328,6 +345,7 @@ func ListSelfImprovementFeedback(db *sql.DB, workspace, status string, limit int
 	case allWorkspaces:
 		rows, err = db.Query(
 			`SELECT id, workspace_id, repo_owner, repo_name, source_type, github_comment_id, github_review_id,
+				github_review_comment_id, github_parent_comment_id, github_pull_request_review_id,
 				github_delivery_id, source_url, author_login, author_authorized, issue_number, pr_number,
 				raw_body, tag, file_path, line, side, diff_hunk, commit_sha, github_created_at,
 				github_updated_at, ingested_at, linked_span_id, linked_event_id, linked_agent_id,
@@ -341,6 +359,7 @@ func ListSelfImprovementFeedback(db *sql.DB, workspace, status string, limit int
 	case status == "":
 		rows, err = db.Query(
 			`SELECT id, workspace_id, repo_owner, repo_name, source_type, github_comment_id, github_review_id,
+				github_review_comment_id, github_parent_comment_id, github_pull_request_review_id,
 				github_delivery_id, source_url, author_login, author_authorized, issue_number, pr_number,
 				raw_body, tag, file_path, line, side, diff_hunk, commit_sha, github_created_at,
 				github_updated_at, ingested_at, linked_span_id, linked_event_id, linked_agent_id,
@@ -354,6 +373,7 @@ func ListSelfImprovementFeedback(db *sql.DB, workspace, status string, limit int
 	default:
 		rows, err = db.Query(
 			`SELECT id, workspace_id, repo_owner, repo_name, source_type, github_comment_id, github_review_id,
+				github_review_comment_id, github_parent_comment_id, github_pull_request_review_id,
 				github_delivery_id, source_url, author_login, author_authorized, issue_number, pr_number,
 				raw_body, tag, file_path, line, side, diff_hunk, commit_sha, github_created_at,
 				github_updated_at, ingested_at, linked_span_id, linked_event_id, linked_agent_id,
@@ -383,6 +403,7 @@ func ListSelfImprovementFeedback(db *sql.DB, workspace, status string, limit int
 func GetSelfImprovementFeedback(db *sql.DB, id int64) (SelfImprovementFeedback, error) {
 	row := db.QueryRow(
 		`SELECT id, workspace_id, repo_owner, repo_name, source_type, github_comment_id, github_review_id,
+			github_review_comment_id, github_parent_comment_id, github_pull_request_review_id,
 			github_delivery_id, source_url, author_login, author_authorized, issue_number, pr_number,
 			raw_body, tag, file_path, line, side, diff_hunk, commit_sha, github_created_at,
 			github_updated_at, ingested_at, linked_span_id, linked_event_id, linked_agent_id,
@@ -674,6 +695,7 @@ func scanSelfImprovementFeedback(row selfImprovementScanner) (SelfImprovementFee
 	var skillIDs, guardrailIDs string
 	if err := row.Scan(
 		&ev.ID, &ev.WorkspaceID, &ev.RepoOwner, &ev.RepoName, &ev.SourceType, &ev.GitHubCommentID, &ev.GitHubReviewID,
+		&ev.GitHubReviewCommentID, &ev.GitHubParentCommentID, &ev.GitHubPullRequestReviewID,
 		&ev.GitHubDeliveryID, &ev.SourceURL, &ev.AuthorLogin, &authorized, &ev.IssueNumber, &ev.PRNumber,
 		&ev.RawBody, &ev.Tag, &ev.FilePath, &ev.Line, &ev.Side, &ev.DiffHunk, &ev.CommitSHA, &ev.GitHubCreatedAt,
 		&ev.GitHubUpdatedAt, &ev.IngestedAt, &ev.LinkedSpanID, &ev.LinkedEventID, &ev.LinkedAgentID,
@@ -695,6 +717,7 @@ func recommendationSelectSQL() string {
 		r.proposed_patch, r.proposed_new_body, r.analyzer_prompt_ref,
 		r.analyzer_prompt_version_id, r.structured_output, r.error, r.decision_reason, r.created_at, r.updated_at,
 		f.id, f.workspace_id, f.repo_owner, f.repo_name, f.source_type, f.github_comment_id, f.github_review_id,
+		f.github_review_comment_id, f.github_parent_comment_id, f.github_pull_request_review_id,
 		f.github_delivery_id, f.source_url, f.author_login, f.author_authorized, f.issue_number, f.pr_number,
 		f.raw_body, f.tag, f.file_path, f.line, f.side, f.diff_hunk, f.commit_sha, f.github_created_at,
 		f.github_updated_at, f.ingested_at, f.linked_span_id, f.linked_event_id, f.linked_agent_id,
@@ -721,7 +744,9 @@ func scanSelfImprovementRecommendation(row selfImprovementScanner, includeFeedba
 		&rec.ProposedPatch, &rec.ProposedNewBody, &rec.AnalyzerPromptRef,
 		&rec.AnalyzerPromptVersionID, &structured, &rec.Error, &rec.DecisionReason, &rec.CreatedAt, &rec.UpdatedAt,
 		&feedback.ID, &feedback.WorkspaceID, &feedback.RepoOwner, &feedback.RepoName, &feedback.SourceType,
-		&feedback.GitHubCommentID, &feedback.GitHubReviewID, &feedback.GitHubDeliveryID, &feedback.SourceURL,
+		&feedback.GitHubCommentID, &feedback.GitHubReviewID, &feedback.GitHubReviewCommentID,
+		&feedback.GitHubParentCommentID, &feedback.GitHubPullRequestReviewID,
+		&feedback.GitHubDeliveryID, &feedback.SourceURL,
 		&feedback.AuthorLogin, &authorized, &feedback.IssueNumber, &feedback.PRNumber, &feedback.RawBody,
 		&feedback.Tag, &feedback.FilePath, &feedback.Line, &feedback.Side, &feedback.DiffHunk,
 		&feedback.CommitSHA, &feedback.GitHubCreatedAt, &feedback.GitHubUpdatedAt, &feedback.IngestedAt,

--- a/internal/store/self_improvement.go
+++ b/internal/store/self_improvement.go
@@ -206,15 +206,12 @@ func UpsertSelfImprovementFeedback(db *sql.DB, in SelfImprovementFeedbackInput) 
 	if confidence == "" {
 		confidence = "unresolved"
 	}
-	in.GitHubCommentID, in.GitHubReviewID = feedbackLegacyIdentity(in)
 	if in.SourceType == "pull_request_review_comment" && in.GitHubReviewCommentID > 0 {
-		updated, err := updateSelfImprovementFeedbackByReviewCommentID(db, workspaceID, tag, in, status, confidence)
+		err := upsertSelfImprovementFeedbackByReviewCommentID(db, workspaceID, tag, in, status, confidence)
 		if err != nil {
 			return SelfImprovementFeedback{}, err
 		}
-		if updated {
-			return getSelfImprovementFeedbackByReviewCommentID(db, workspaceID, strings.TrimSpace(in.SourceType), in.GitHubReviewCommentID, tag)
-		}
+		return getSelfImprovementFeedbackByReviewCommentID(db, workspaceID, strings.TrimSpace(in.SourceType), in.GitHubReviewCommentID, tag)
 	}
 	_, err := db.Exec(
 		`INSERT INTO self_improvement_feedback (
@@ -226,7 +223,7 @@ func UpsertSelfImprovementFeedback(db *sql.DB, in SelfImprovementFeedbackInput) 
 			linked_prompt_version_id, linked_skill_version_ids, linked_guardrail_version_ids,
 			link_confidence, link_diagnostics, status
 		) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
-		ON CONFLICT(workspace_id, source_type, github_comment_id, github_review_id, tag) DO UPDATE SET
+		ON CONFLICT(workspace_id, source_type, github_comment_id, github_review_id, tag) WHERE github_review_comment_id = 0 DO UPDATE SET
 			github_review_comment_id=excluded.github_review_comment_id,
 			github_parent_comment_id=excluded.github_parent_comment_id,
 			github_pull_request_review_id=excluded.github_pull_request_review_id,
@@ -285,59 +282,62 @@ func UpsertSelfImprovementFeedback(db *sql.DB, in SelfImprovementFeedbackInput) 
 	return scanSelfImprovementFeedback(row)
 }
 
-func updateSelfImprovementFeedbackByReviewCommentID(db *sql.DB, workspaceID, tag string, in SelfImprovementFeedbackInput, status, confidence string) (bool, error) {
-	res, err := db.Exec(
-		`UPDATE self_improvement_feedback SET
-			github_comment_id=?,
-			github_review_id=?,
-			github_parent_comment_id=?,
-			github_pull_request_review_id=?,
-			github_delivery_id=?,
-			source_url=?,
-			author_login=?,
-			author_authorized=?,
-			issue_number=?,
-			pr_number=?,
-			raw_body=?,
-			file_path=?,
-			line=?,
-			side=?,
-			diff_hunk=?,
-			commit_sha=?,
-			github_updated_at=?,
-			linked_span_id=?,
-			linked_event_id=?,
-			linked_agent_id=?,
-			linked_agent_name=?,
-			linked_prompt_version_id=?,
-			linked_skill_version_ids=?,
-			linked_guardrail_version_ids=?,
-			link_confidence=?,
-			link_diagnostics=?,
+func upsertSelfImprovementFeedbackByReviewCommentID(db *sql.DB, workspaceID, tag string, in SelfImprovementFeedbackInput, status, confidence string) error {
+	_, err := db.Exec(
+		`INSERT INTO self_improvement_feedback (
+			workspace_id, repo_owner, repo_name, source_type, github_comment_id, github_review_id,
+			github_review_comment_id, github_parent_comment_id, github_pull_request_review_id,
+			github_delivery_id, source_url, author_login, author_authorized, issue_number, pr_number,
+			raw_body, tag, file_path, line, side, diff_hunk, commit_sha, github_created_at,
+			github_updated_at, linked_span_id, linked_event_id, linked_agent_id, linked_agent_name,
+			linked_prompt_version_id, linked_skill_version_ids, linked_guardrail_version_ids,
+			link_confidence, link_diagnostics, status
+		) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+		ON CONFLICT(workspace_id, source_type, github_review_comment_id, tag) WHERE github_review_comment_id > 0 DO UPDATE SET
+			repo_owner=excluded.repo_owner,
+			repo_name=excluded.repo_name,
+			github_comment_id=0,
+			github_review_id=0,
+			github_parent_comment_id=excluded.github_parent_comment_id,
+			github_pull_request_review_id=excluded.github_pull_request_review_id,
+			github_delivery_id=excluded.github_delivery_id,
+			source_url=excluded.source_url,
+			author_login=excluded.author_login,
+			author_authorized=excluded.author_authorized,
+			issue_number=excluded.issue_number,
+			pr_number=excluded.pr_number,
+			raw_body=excluded.raw_body,
+			file_path=excluded.file_path,
+			line=excluded.line,
+			side=excluded.side,
+			diff_hunk=excluded.diff_hunk,
+			commit_sha=excluded.commit_sha,
+			github_updated_at=excluded.github_updated_at,
+			linked_span_id=excluded.linked_span_id,
+			linked_event_id=excluded.linked_event_id,
+			linked_agent_id=excluded.linked_agent_id,
+			linked_agent_name=excluded.linked_agent_name,
+			linked_prompt_version_id=excluded.linked_prompt_version_id,
+			linked_skill_version_ids=excluded.linked_skill_version_ids,
+			linked_guardrail_version_ids=excluded.linked_guardrail_version_ids,
+			link_confidence=excluded.link_confidence,
+			link_diagnostics=excluded.link_diagnostics,
 			status=CASE
-				WHEN ? = 'ignored' THEN ?
-				WHEN raw_body <> ? THEN ?
-				ELSE status
-			END
-		WHERE workspace_id=? AND source_type=? AND github_review_comment_id=? AND tag=?`,
-		in.GitHubCommentID, in.GitHubReviewID, in.GitHubParentCommentID, in.GitHubPullRequestReviewID,
+				WHEN excluded.status = 'ignored' THEN excluded.status
+				WHEN self_improvement_feedback.raw_body <> excluded.raw_body THEN excluded.status
+				ELSE self_improvement_feedback.status
+			END`,
+		workspaceID, strings.TrimSpace(in.RepoOwner), strings.TrimSpace(in.RepoName), strings.TrimSpace(in.SourceType),
+		0, 0, in.GitHubReviewCommentID, in.GitHubParentCommentID, in.GitHubPullRequestReviewID,
 		strings.TrimSpace(in.GitHubDeliveryID), strings.TrimSpace(in.SourceURL), strings.TrimSpace(in.AuthorLogin),
-		boolInt(in.AuthorAuthorized), in.IssueNumber, in.PRNumber, in.RawBody, strings.TrimSpace(in.FilePath),
-		in.Line, strings.TrimSpace(in.Side), in.DiffHunk, strings.TrimSpace(in.CommitSHA), in.GitHubUpdatedAt,
-		strings.TrimSpace(in.LinkedSpanID), strings.TrimSpace(in.LinkedEventID), strings.TrimSpace(in.LinkedAgentID),
-		strings.TrimSpace(in.LinkedAgentName), strings.TrimSpace(in.LinkedPromptVersionID),
+		boolInt(in.AuthorAuthorized), in.IssueNumber, in.PRNumber, in.RawBody, tag, strings.TrimSpace(in.FilePath),
+		in.Line, strings.TrimSpace(in.Side), in.DiffHunk, strings.TrimSpace(in.CommitSHA), in.GitHubCreatedAt,
+		in.GitHubUpdatedAt, strings.TrimSpace(in.LinkedSpanID), strings.TrimSpace(in.LinkedEventID),
+		strings.TrimSpace(in.LinkedAgentID), strings.TrimSpace(in.LinkedAgentName), strings.TrimSpace(in.LinkedPromptVersionID),
 		strings.Join(in.LinkedSkillVersionIDs, ","), strings.Join(in.LinkedGuardrailVersionIDs, ","), confidence,
-		strings.TrimSpace(in.LinkDiagnostics), status, status, in.RawBody, status,
-		workspaceID, strings.TrimSpace(in.SourceType), in.GitHubReviewCommentID, tag,
+		strings.TrimSpace(in.LinkDiagnostics), status,
 	)
-	if err != nil {
-		return false, err
-	}
-	affected, err := res.RowsAffected()
-	if err != nil {
-		return false, err
-	}
-	return affected > 0, nil
+	return err
 }
 
 func getSelfImprovementFeedbackByReviewCommentID(db *sql.DB, workspaceID, sourceType string, reviewCommentID int64, tag string) (SelfImprovementFeedback, error) {
@@ -356,20 +356,12 @@ func getSelfImprovementFeedbackByReviewCommentID(db *sql.DB, workspaceID, source
 	return scanSelfImprovementFeedback(row)
 }
 
-func feedbackLegacyIdentity(in SelfImprovementFeedbackInput) (commentID, reviewID int64) {
-	if in.SourceType == "pull_request_review_comment" {
-		return 0, in.GitHubReviewCommentID
-	}
-	return in.GitHubCommentID, in.GitHubReviewID
-}
-
 func IgnoreSelfImprovementFeedback(db *sql.DB, in SelfImprovementFeedbackInput) (bool, error) {
 	workspaceID := fleet.NormalizeWorkspaceID(in.WorkspaceID)
 	tag := strings.TrimSpace(in.Tag)
 	if tag == "" {
 		tag = FeedbackTag
 	}
-	in.GitHubCommentID, in.GitHubReviewID = feedbackLegacyIdentity(in)
 	if in.SourceType == "pull_request_review_comment" && in.GitHubReviewCommentID > 0 {
 		res, err := db.Exec(
 			`UPDATE self_improvement_feedback SET
@@ -831,17 +823,7 @@ func scanSelfImprovementFeedback(row selfImprovementScanner) (SelfImprovementFee
 	ev.AuthorAuthorized = authorized == 1
 	ev.LinkedSkillVersionIDs = splitCSV(skillIDs)
 	ev.LinkedGuardrailVersionIDs = splitCSV(guardrailIDs)
-	normalizeFeedbackIdentity(&ev)
 	return ev, nil
-}
-
-func normalizeFeedbackIdentity(ev *SelfImprovementFeedback) {
-	if ev.SourceType == "pull_request_review_comment" {
-		ev.GitHubCommentID = 0
-		if ev.GitHubReviewID == ev.GitHubReviewCommentID {
-			ev.GitHubReviewID = 0
-		}
-	}
 }
 
 func recommendationSelectSQL() string {
@@ -899,7 +881,6 @@ func scanSelfImprovementRecommendation(row selfImprovementScanner, includeFeedba
 	feedback.AuthorAuthorized = authorized == 1
 	feedback.LinkedSkillVersionIDs = splitCSV(skillIDs)
 	feedback.LinkedGuardrailVersionIDs = splitCSV(guardrailIDs)
-	normalizeFeedbackIdentity(&feedback)
 	if includeFeedback {
 		rec.Feedback = &feedback
 	}

--- a/internal/store/self_improvement.go
+++ b/internal/store/self_improvement.go
@@ -206,6 +206,16 @@ func UpsertSelfImprovementFeedback(db *sql.DB, in SelfImprovementFeedbackInput) 
 	if confidence == "" {
 		confidence = "unresolved"
 	}
+	in.GitHubCommentID, in.GitHubReviewID = feedbackLegacyIdentity(in)
+	if in.SourceType == "pull_request_review_comment" && in.GitHubReviewCommentID > 0 {
+		updated, err := updateSelfImprovementFeedbackByReviewCommentID(db, workspaceID, tag, in, status, confidence)
+		if err != nil {
+			return SelfImprovementFeedback{}, err
+		}
+		if updated {
+			return getSelfImprovementFeedbackByReviewCommentID(db, workspaceID, strings.TrimSpace(in.SourceType), in.GitHubReviewCommentID, tag)
+		}
+	}
 	_, err := db.Exec(
 		`INSERT INTO self_improvement_feedback (
 			workspace_id, repo_owner, repo_name, source_type, github_comment_id, github_review_id,
@@ -275,11 +285,125 @@ func UpsertSelfImprovementFeedback(db *sql.DB, in SelfImprovementFeedbackInput) 
 	return scanSelfImprovementFeedback(row)
 }
 
+func updateSelfImprovementFeedbackByReviewCommentID(db *sql.DB, workspaceID, tag string, in SelfImprovementFeedbackInput, status, confidence string) (bool, error) {
+	res, err := db.Exec(
+		`UPDATE self_improvement_feedback SET
+			github_comment_id=?,
+			github_review_id=?,
+			github_parent_comment_id=?,
+			github_pull_request_review_id=?,
+			github_delivery_id=?,
+			source_url=?,
+			author_login=?,
+			author_authorized=?,
+			issue_number=?,
+			pr_number=?,
+			raw_body=?,
+			file_path=?,
+			line=?,
+			side=?,
+			diff_hunk=?,
+			commit_sha=?,
+			github_updated_at=?,
+			linked_span_id=?,
+			linked_event_id=?,
+			linked_agent_id=?,
+			linked_agent_name=?,
+			linked_prompt_version_id=?,
+			linked_skill_version_ids=?,
+			linked_guardrail_version_ids=?,
+			link_confidence=?,
+			link_diagnostics=?,
+			status=CASE
+				WHEN ? = 'ignored' THEN ?
+				WHEN raw_body <> ? THEN ?
+				ELSE status
+			END
+		WHERE workspace_id=? AND source_type=? AND github_review_comment_id=? AND tag=?`,
+		in.GitHubCommentID, in.GitHubReviewID, in.GitHubParentCommentID, in.GitHubPullRequestReviewID,
+		strings.TrimSpace(in.GitHubDeliveryID), strings.TrimSpace(in.SourceURL), strings.TrimSpace(in.AuthorLogin),
+		boolInt(in.AuthorAuthorized), in.IssueNumber, in.PRNumber, in.RawBody, strings.TrimSpace(in.FilePath),
+		in.Line, strings.TrimSpace(in.Side), in.DiffHunk, strings.TrimSpace(in.CommitSHA), in.GitHubUpdatedAt,
+		strings.TrimSpace(in.LinkedSpanID), strings.TrimSpace(in.LinkedEventID), strings.TrimSpace(in.LinkedAgentID),
+		strings.TrimSpace(in.LinkedAgentName), strings.TrimSpace(in.LinkedPromptVersionID),
+		strings.Join(in.LinkedSkillVersionIDs, ","), strings.Join(in.LinkedGuardrailVersionIDs, ","), confidence,
+		strings.TrimSpace(in.LinkDiagnostics), status, status, in.RawBody, status,
+		workspaceID, strings.TrimSpace(in.SourceType), in.GitHubReviewCommentID, tag,
+	)
+	if err != nil {
+		return false, err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return affected > 0, nil
+}
+
+func getSelfImprovementFeedbackByReviewCommentID(db *sql.DB, workspaceID, sourceType string, reviewCommentID int64, tag string) (SelfImprovementFeedback, error) {
+	row := db.QueryRow(
+		`SELECT id, workspace_id, repo_owner, repo_name, source_type, github_comment_id, github_review_id,
+			github_review_comment_id, github_parent_comment_id, github_pull_request_review_id,
+			github_delivery_id, source_url, author_login, author_authorized, issue_number, pr_number,
+			raw_body, tag, file_path, line, side, diff_hunk, commit_sha, github_created_at,
+			github_updated_at, ingested_at, linked_span_id, linked_event_id, linked_agent_id,
+			linked_agent_name, linked_prompt_version_id, linked_skill_version_ids,
+			linked_guardrail_version_ids, link_confidence, link_diagnostics, status
+		FROM self_improvement_feedback
+		WHERE workspace_id=? AND source_type=? AND github_review_comment_id=? AND tag=?`,
+		workspaceID, sourceType, reviewCommentID, tag,
+	)
+	return scanSelfImprovementFeedback(row)
+}
+
+func feedbackLegacyIdentity(in SelfImprovementFeedbackInput) (commentID, reviewID int64) {
+	if in.SourceType == "pull_request_review_comment" {
+		return 0, in.GitHubReviewCommentID
+	}
+	return in.GitHubCommentID, in.GitHubReviewID
+}
+
 func IgnoreSelfImprovementFeedback(db *sql.DB, in SelfImprovementFeedbackInput) (bool, error) {
 	workspaceID := fleet.NormalizeWorkspaceID(in.WorkspaceID)
 	tag := strings.TrimSpace(in.Tag)
 	if tag == "" {
 		tag = FeedbackTag
+	}
+	in.GitHubCommentID, in.GitHubReviewID = feedbackLegacyIdentity(in)
+	if in.SourceType == "pull_request_review_comment" && in.GitHubReviewCommentID > 0 {
+		res, err := db.Exec(
+			`UPDATE self_improvement_feedback SET
+				github_parent_comment_id=?,
+				github_pull_request_review_id=?,
+				github_delivery_id=?,
+				source_url=?,
+				author_login=?,
+				author_authorized=?,
+				issue_number=?,
+				pr_number=?,
+				raw_body=?,
+				file_path=?,
+				line=?,
+				side=?,
+				diff_hunk=?,
+				commit_sha=?,
+				github_updated_at=?,
+				status=?
+			WHERE workspace_id=? AND source_type=? AND github_review_comment_id=? AND tag=?`,
+			in.GitHubParentCommentID, in.GitHubPullRequestReviewID, strings.TrimSpace(in.GitHubDeliveryID),
+			strings.TrimSpace(in.SourceURL), strings.TrimSpace(in.AuthorLogin), boolInt(in.AuthorAuthorized),
+			in.IssueNumber, in.PRNumber, in.RawBody, strings.TrimSpace(in.FilePath), in.Line, strings.TrimSpace(in.Side),
+			in.DiffHunk, strings.TrimSpace(in.CommitSHA), in.GitHubUpdatedAt, FeedbackStatusIgnored,
+			workspaceID, strings.TrimSpace(in.SourceType), in.GitHubReviewCommentID, tag,
+		)
+		if err != nil {
+			return false, err
+		}
+		affected, err := res.RowsAffected()
+		if err != nil {
+			return false, err
+		}
+		return affected > 0, nil
 	}
 	res, err := db.Exec(
 		`UPDATE self_improvement_feedback SET
@@ -707,7 +831,17 @@ func scanSelfImprovementFeedback(row selfImprovementScanner) (SelfImprovementFee
 	ev.AuthorAuthorized = authorized == 1
 	ev.LinkedSkillVersionIDs = splitCSV(skillIDs)
 	ev.LinkedGuardrailVersionIDs = splitCSV(guardrailIDs)
+	normalizeFeedbackIdentity(&ev)
 	return ev, nil
+}
+
+func normalizeFeedbackIdentity(ev *SelfImprovementFeedback) {
+	if ev.SourceType == "pull_request_review_comment" {
+		ev.GitHubCommentID = 0
+		if ev.GitHubReviewID == ev.GitHubReviewCommentID {
+			ev.GitHubReviewID = 0
+		}
+	}
 }
 
 func recommendationSelectSQL() string {
@@ -765,6 +899,7 @@ func scanSelfImprovementRecommendation(row selfImprovementScanner, includeFeedba
 	feedback.AuthorAuthorized = authorized == 1
 	feedback.LinkedSkillVersionIDs = splitCSV(skillIDs)
 	feedback.LinkedGuardrailVersionIDs = splitCSV(guardrailIDs)
+	normalizeFeedbackIdentity(&feedback)
 	if includeFeedback {
 		rec.Feedback = &feedback
 	}

--- a/internal/store/self_improvement_migration_test.go
+++ b/internal/store/self_improvement_migration_test.go
@@ -131,6 +131,73 @@ func TestSelfImprovementLegacyFieldsRemovedOnFreshStore(t *testing.T) {
 	}
 }
 
+func TestSelfImprovementFeedbackIdentityMigrationPreservesRecommendations(t *testing.T) {
+	t.Parallel()
+
+	db, err := Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	st := New(db)
+	t.Cleanup(func() { st.Close() })
+
+	feedback, err := st.UpsertSelfImprovementFeedback(SelfImprovementFeedbackInput{
+		WorkspaceID:      fleet.DefaultWorkspaceID,
+		RepoOwner:        "owner",
+		RepoName:         "repo",
+		SourceType:       "issue_comment",
+		GitHubCommentID:  58,
+		SourceURL:        "https://github.com/owner/repo/issues/1#issuecomment-58",
+		AuthorLogin:      "maintainer",
+		AuthorAuthorized: true,
+		IssueNumber:      1,
+		RawBody:          "preserve recommendation during feedback identity migration",
+		Tag:              FeedbackTag,
+		LinkConfidence:   "exact",
+	})
+	if err != nil {
+		t.Fatalf("seed feedback: %v", err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO self_improvement_recommendations (
+			id, workspace_id, feedback_event_id, type, status, confidence, risk,
+			finding, normalized_lesson, rationale, evidence_feedback_ids,
+			evidence_source_urls, attribution_confidence, structured_output
+		) VALUES (?, ?, ?, 'catalog_patch', 'recommended', 'medium', 'low',
+			'finding', 'lesson', 'rationale', ?, 'https://github.com/owner/repo/issues/1#issuecomment-58',
+			'exact', '{}'
+		)
+	`, "rec_identity_migration", fleet.DefaultWorkspaceID, feedback.ID, feedback.ID); err != nil {
+		t.Fatalf("seed recommendation: %v", err)
+	}
+	if _, err := db.Exec(`DELETE FROM schema_migrations WHERE name = '058_self_improvement_feedback_identity_indexes.sql'`); err != nil {
+		t.Fatalf("unmark identity migration: %v", err)
+	}
+
+	if err := migrate(db); err != nil {
+		t.Fatalf("rerun identity migration: %v", err)
+	}
+
+	var gotFeedbackID int64
+	if err := db.QueryRow(`SELECT feedback_event_id FROM self_improvement_recommendations WHERE id = 'rec_identity_migration'`).Scan(&gotFeedbackID); err != nil {
+		t.Fatalf("read recommendation feedback id: %v", err)
+	}
+	if gotFeedbackID != feedback.ID {
+		t.Fatalf("feedback_event_id = %d, want %d", gotFeedbackID, feedback.ID)
+	}
+	rows, err := db.Query(`PRAGMA foreign_key_check`)
+	if err != nil {
+		t.Fatalf("foreign_key_check: %v", err)
+	}
+	defer rows.Close()
+	if rows.Next() {
+		t.Fatal("foreign_key_check reported violations")
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate foreign_key_check: %v", err)
+	}
+}
+
 func TestAcceptedRecommendationCleanupMigration(t *testing.T) {
 	t.Parallel()
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -150,7 +150,6 @@ func TestSelfImprovementFeedbackUpsertAndList(t *testing.T) {
 		RepoOwner:                 "owner",
 		RepoName:                  "repo",
 		SourceType:                "pull_request_review_comment",
-		GitHubCommentID:           123,
 		GitHubReviewCommentID:     123,
 		GitHubParentCommentID:     99,
 		GitHubPullRequestReviewID: 456,
@@ -182,7 +181,6 @@ func TestSelfImprovementFeedbackUpsertAndList(t *testing.T) {
 		RepoOwner:                 "owner",
 		RepoName:                  "repo",
 		SourceType:                "pull_request_review_comment",
-		GitHubCommentID:           123,
 		GitHubReviewCommentID:     123,
 		GitHubParentCommentID:     99,
 		GitHubPullRequestReviewID: 456,
@@ -211,8 +209,64 @@ func TestSelfImprovementFeedbackUpsertAndList(t *testing.T) {
 	if got.LinkedSpanID != "" || got.LinkConfidence != "unresolved" {
 		t.Fatalf("updated attribution = %+v, want unresolved with no linked span", got)
 	}
+	if got.GitHubCommentID != 0 {
+		t.Fatalf("github_comment_id = %d, want 0 for pull_request_review_comment", got.GitHubCommentID)
+	}
 	if got.GitHubReviewCommentID != 123 || got.GitHubParentCommentID != 99 || got.GitHubPullRequestReviewID != 456 {
 		t.Fatalf("feedback ancestry = (%d,%d,%d), want (123,99,456)", got.GitHubReviewCommentID, got.GitHubParentCommentID, got.GitHubPullRequestReviewID)
+	}
+}
+
+func TestSelfImprovementReviewCommentFeedbackUsesReviewCommentIdentity(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	st := store.New(db)
+	t.Cleanup(func() { st.Close() })
+
+	for _, reviewCommentID := range []int64{123, 124} {
+		if _, err := st.UpsertSelfImprovementFeedback(store.SelfImprovementFeedbackInput{
+			WorkspaceID:               "team-a",
+			RepoOwner:                 "owner",
+			RepoName:                  "repo",
+			SourceType:                "pull_request_review_comment",
+			GitHubReviewCommentID:     reviewCommentID,
+			GitHubPullRequestReviewID: 456,
+			GitHubDeliveryID:          "delivery",
+			AuthorLogin:               "maintainer",
+			AuthorAuthorized:          true,
+			PRNumber:                  7,
+			RawBody:                   "first /agents improve",
+		}); err != nil {
+			t.Fatalf("insert review comment %d: %v", reviewCommentID, err)
+		}
+	}
+
+	if _, err := st.UpsertSelfImprovementFeedback(store.SelfImprovementFeedbackInput{
+		WorkspaceID:               "team-a",
+		RepoOwner:                 "owner",
+		RepoName:                  "repo",
+		SourceType:                "pull_request_review_comment",
+		GitHubReviewCommentID:     123,
+		GitHubPullRequestReviewID: 456,
+		GitHubDeliveryID:          "delivery-2",
+		AuthorLogin:               "maintainer",
+		AuthorAuthorized:          true,
+		PRNumber:                  7,
+		RawBody:                   "edited /agents improve",
+	}); err != nil {
+		t.Fatalf("redeliver review comment: %v", err)
+	}
+	rows, err := st.ListSelfImprovementFeedback("team-a", "", 10)
+	if err != nil {
+		t.Fatalf("list feedback: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("feedback rows = %d, want 2", len(rows))
+	}
+	for _, row := range rows {
+		if row.GitHubCommentID != 0 {
+			t.Fatalf("row %d github_comment_id = %d, want 0", row.ID, row.GitHubCommentID)
+		}
 	}
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -149,8 +149,11 @@ func TestSelfImprovementFeedbackUpsertAndList(t *testing.T) {
 		WorkspaceID:               "team-a",
 		RepoOwner:                 "owner",
 		RepoName:                  "repo",
-		SourceType:                "issue_comment",
+		SourceType:                "pull_request_review_comment",
 		GitHubCommentID:           123,
+		GitHubReviewCommentID:     123,
+		GitHubParentCommentID:     99,
+		GitHubPullRequestReviewID: 456,
 		GitHubDeliveryID:          "delivery-1",
 		SourceURL:                 "https://github.com/owner/repo/issues/7#issuecomment-123",
 		AuthorLogin:               "maintainer",
@@ -175,18 +178,21 @@ func TestSelfImprovementFeedbackUpsertAndList(t *testing.T) {
 	}
 
 	if _, err := st.UpsertSelfImprovementFeedback(store.SelfImprovementFeedbackInput{
-		WorkspaceID:      "team-a",
-		RepoOwner:        "owner",
-		RepoName:         "repo",
-		SourceType:       "issue_comment",
-		GitHubCommentID:  123,
-		GitHubDeliveryID: "delivery-2",
-		AuthorLogin:      "maintainer",
-		AuthorAuthorized: true,
-		IssueNumber:      7,
-		RawBody:          "edited /agents improve",
-		LinkConfidence:   "unresolved",
-		LinkDiagnostics:  "no matching run attribution snapshot",
+		WorkspaceID:               "team-a",
+		RepoOwner:                 "owner",
+		RepoName:                  "repo",
+		SourceType:                "pull_request_review_comment",
+		GitHubCommentID:           123,
+		GitHubReviewCommentID:     123,
+		GitHubParentCommentID:     99,
+		GitHubPullRequestReviewID: 456,
+		GitHubDeliveryID:          "delivery-2",
+		AuthorLogin:               "maintainer",
+		AuthorAuthorized:          true,
+		IssueNumber:               7,
+		RawBody:                   "edited /agents improve",
+		LinkConfidence:            "unresolved",
+		LinkDiagnostics:           "no matching run attribution snapshot",
 	}); err != nil {
 		t.Fatalf("update feedback: %v", err)
 	}
@@ -204,6 +210,9 @@ func TestSelfImprovementFeedbackUpsertAndList(t *testing.T) {
 	}
 	if got.LinkedSpanID != "" || got.LinkConfidence != "unresolved" {
 		t.Fatalf("updated attribution = %+v, want unresolved with no linked span", got)
+	}
+	if got.GitHubReviewCommentID != 123 || got.GitHubParentCommentID != 99 || got.GitHubPullRequestReviewID != 456 {
+		t.Fatalf("feedback ancestry = (%d,%d,%d), want (123,99,456)", got.GitHubReviewCommentID, got.GitHubParentCommentID, got.GitHubPullRequestReviewID)
 	}
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -267,6 +267,47 @@ func TestSelfImprovementReviewCommentFeedbackUsesReviewCommentIdentity(t *testin
 		if row.GitHubCommentID != 0 {
 			t.Fatalf("row %d github_comment_id = %d, want 0", row.ID, row.GitHubCommentID)
 		}
+		if row.GitHubReviewID != 0 {
+			t.Fatalf("row %d github_review_id = %d, want 0", row.ID, row.GitHubReviewID)
+		}
+	}
+
+	dbRows, err := db.Query(`
+		SELECT github_comment_id, github_review_id, github_review_comment_id, github_pull_request_review_id, raw_body
+		FROM self_improvement_feedback
+		WHERE workspace_id=? AND source_type=?
+		ORDER BY github_review_comment_id`, "team-a", "pull_request_review_comment")
+	if err != nil {
+		t.Fatalf("query stored feedback rows: %v", err)
+	}
+	defer dbRows.Close()
+	wantBodies := map[int64]string{
+		123: "edited /agents improve",
+		124: "first /agents improve",
+	}
+	seen := 0
+	for dbRows.Next() {
+		var commentID, reviewID, reviewCommentID, pullRequestReviewID int64
+		var rawBody string
+		if err := dbRows.Scan(&commentID, &reviewID, &reviewCommentID, &pullRequestReviewID, &rawBody); err != nil {
+			t.Fatalf("scan stored feedback row: %v", err)
+		}
+		if commentID != 0 || reviewID != 0 {
+			t.Fatalf("stored identity for review comment %d = comment %d review %d, want both 0", reviewCommentID, commentID, reviewID)
+		}
+		if pullRequestReviewID != 456 {
+			t.Fatalf("stored pull_request_review_id for review comment %d = %d, want 456", reviewCommentID, pullRequestReviewID)
+		}
+		if want := wantBodies[reviewCommentID]; rawBody != want {
+			t.Fatalf("stored raw_body for review comment %d = %q, want %q", reviewCommentID, rawBody, want)
+		}
+		seen++
+	}
+	if err := dbRows.Err(); err != nil {
+		t.Fatalf("iterate stored feedback rows: %v", err)
+	}
+	if seen != 2 {
+		t.Fatalf("stored feedback rows = %d, want 2", seen)
 	}
 }
 

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -213,6 +213,13 @@ type webhookReview struct {
 	Submitted time.Time `json:"submitted_at"`
 }
 
+type webhookCommit struct {
+	ID        string    `json:"id"`
+	Message   string    `json:"message"`
+	URL       string    `json:"url"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
 // ─── event-type handlers ──────────────────────────────────────────────────────
 
 // handleIssuesEvent handles X-GitHub-Event: issues.
@@ -714,30 +721,33 @@ func (h *Handler) captureFeedback(repo fleet.Repo, in feedbackCapture) (store.Se
 		})
 	}
 	input := store.SelfImprovementFeedbackInput{
-		WorkspaceID:      repo.WorkspaceID,
-		RepoOwner:        owner,
-		RepoName:         name,
-		SourceType:       in.SourceType,
-		GitHubCommentID:  in.CommentID,
-		GitHubReviewID:   in.ReviewID,
-		GitHubDeliveryID: in.DeliveryID,
-		SourceURL:        in.SourceURL,
-		AuthorLogin:      in.AuthorLogin,
-		AuthorAuthorized: authorized,
-		IssueNumber:      in.IssueNumber,
-		PRNumber:         in.PRNumber,
-		RawBody:          in.Body,
-		Tag:              store.FeedbackTag,
-		FilePath:         in.FilePath,
-		Line:             in.Line,
-		Side:             in.Side,
-		DiffHunk:         in.DiffHunk,
-		CommitSHA:        in.CommitSHA,
-		GitHubCreatedAt:  in.GitHubCreatedAt,
-		GitHubUpdatedAt:  in.GitHubUpdatedAt,
-		LinkConfidence:   res.Confidence,
-		LinkDiagnostics:  res.Diagnostic,
-		Status:           status,
+		WorkspaceID:               repo.WorkspaceID,
+		RepoOwner:                 owner,
+		RepoName:                  name,
+		SourceType:                in.SourceType,
+		GitHubCommentID:           in.CommentID,
+		GitHubReviewID:            in.ReviewID,
+		GitHubReviewCommentID:     in.ReviewCommentID,
+		GitHubParentCommentID:     in.InReplyToID,
+		GitHubPullRequestReviewID: in.PullRequestReviewID,
+		GitHubDeliveryID:          in.DeliveryID,
+		SourceURL:                 in.SourceURL,
+		AuthorLogin:               in.AuthorLogin,
+		AuthorAuthorized:          authorized,
+		IssueNumber:               in.IssueNumber,
+		PRNumber:                  in.PRNumber,
+		RawBody:                   in.Body,
+		Tag:                       store.FeedbackTag,
+		FilePath:                  in.FilePath,
+		Line:                      in.Line,
+		Side:                      in.Side,
+		DiffHunk:                  in.DiffHunk,
+		CommitSHA:                 in.CommitSHA,
+		GitHubCreatedAt:           in.GitHubCreatedAt,
+		GitHubUpdatedAt:           in.GitHubUpdatedAt,
+		LinkConfidence:            res.Confidence,
+		LinkDiagnostics:           res.Diagnostic,
+		Status:                    status,
 	}
 	if res.Snapshot != nil {
 		input.LinkedSpanID = res.Snapshot.SpanID
@@ -801,26 +811,29 @@ func (h *Handler) ignoreFeedback(repo fleet.Repo, in feedbackCapture) {
 	owner, name := splitRepo(repo.Name)
 	authorized := h.feedbackAuthorAllowed(in.AuthorLogin)
 	ignored, err := h.store.IgnoreSelfImprovementFeedback(store.SelfImprovementFeedbackInput{
-		WorkspaceID:      repo.WorkspaceID,
-		RepoOwner:        owner,
-		RepoName:         name,
-		SourceType:       in.SourceType,
-		GitHubCommentID:  in.CommentID,
-		GitHubReviewID:   in.ReviewID,
-		GitHubDeliveryID: in.DeliveryID,
-		SourceURL:        in.SourceURL,
-		AuthorLogin:      in.AuthorLogin,
-		AuthorAuthorized: authorized,
-		IssueNumber:      in.IssueNumber,
-		PRNumber:         in.PRNumber,
-		RawBody:          in.Body,
-		Tag:              store.FeedbackTag,
-		FilePath:         in.FilePath,
-		Line:             in.Line,
-		Side:             in.Side,
-		DiffHunk:         in.DiffHunk,
-		CommitSHA:        in.CommitSHA,
-		GitHubUpdatedAt:  in.GitHubUpdatedAt,
+		WorkspaceID:               repo.WorkspaceID,
+		RepoOwner:                 owner,
+		RepoName:                  name,
+		SourceType:                in.SourceType,
+		GitHubCommentID:           in.CommentID,
+		GitHubReviewID:            in.ReviewID,
+		GitHubReviewCommentID:     in.ReviewCommentID,
+		GitHubParentCommentID:     in.InReplyToID,
+		GitHubPullRequestReviewID: in.PullRequestReviewID,
+		GitHubDeliveryID:          in.DeliveryID,
+		SourceURL:                 in.SourceURL,
+		AuthorLogin:               in.AuthorLogin,
+		AuthorAuthorized:          authorized,
+		IssueNumber:               in.IssueNumber,
+		PRNumber:                  in.PRNumber,
+		RawBody:                   in.Body,
+		Tag:                       store.FeedbackTag,
+		FilePath:                  in.FilePath,
+		Line:                      in.Line,
+		Side:                      in.Side,
+		DiffHunk:                  in.DiffHunk,
+		CommitSHA:                 in.CommitSHA,
+		GitHubUpdatedAt:           in.GitHubUpdatedAt,
 	})
 	if err != nil {
 		h.logger.Error().Err(err).
@@ -922,6 +935,7 @@ func (h *Handler) handlePushEvent(ctx context.Context, w http.ResponseWriter, bo
 	var payload struct {
 		Ref        string            `json:"ref"`
 		After      string            `json:"after"`
+		Commits    []webhookCommit   `json:"commits"`
 		Repository webhookRepository `json:"repository"`
 		Sender     webhookSender     `json:"sender"`
 	}
@@ -952,6 +966,18 @@ func (h *Handler) handlePushEvent(ctx context.Context, w http.ResponseWriter, bo
 
 	events := make([]workflow.Event, 0, len(repos))
 	for _, repo := range repos {
+		owner, name := splitRepo(repo.Name)
+		for _, commit := range payload.Commits {
+			h.captureArtifact(repo, owner, name, observe.RunAttributionArtifactInput{
+				SourceType:       "commit",
+				GitHubDeliveryID: deliveryID,
+				SourceURL:        commit.URL,
+				AuthorLogin:      payload.Sender.Login,
+				CommitSHA:        commit.ID,
+				GitHubCreatedAt:  zeroNil(commit.Timestamp),
+				GitHubUpdatedAt:  zeroNil(commit.Timestamp),
+			}, "", commit.Message)
+		}
 		events = append(events, workflow.Event{
 			ID:          deliveryID,
 			WorkspaceID: fleet.NormalizeWorkspaceID(repo.WorkspaceID),

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -592,7 +592,6 @@ func (h *Handler) handlePullRequestReviewCommentEvent(ctx context.Context, w htt
 				SourceURL:           payload.Comment.HTMLURL,
 				AuthorLogin:         payload.Sender.Login,
 				PRNumber:            payload.PullRequest.Number,
-				CommentID:           payload.Comment.ID,
 				ReviewCommentID:     payload.Comment.ID,
 				InReplyToID:         payload.Comment.InReplyToID,
 				PullRequestReviewID: payload.Comment.PullRequestReviewID,
@@ -615,7 +614,6 @@ func (h *Handler) handlePullRequestReviewCommentEvent(ctx context.Context, w htt
 		h.captureArtifact(repo, owner, name, observe.RunAttributionArtifactInput{
 			IssueOrPRNumber:       payload.PullRequest.Number,
 			SourceType:            "pull_request_review_comment",
-			GitHubCommentID:       payload.Comment.ID,
 			GitHubReviewID:        payload.Comment.PullRequestReviewID,
 			GitHubReviewCommentID: payload.Comment.ID,
 			GitHubParentCommentID: payload.Comment.InReplyToID,
@@ -636,7 +634,6 @@ func (h *Handler) handlePullRequestReviewCommentEvent(ctx context.Context, w htt
 			SourceURL:           payload.Comment.HTMLURL,
 			AuthorLogin:         payload.Sender.Login,
 			PRNumber:            payload.PullRequest.Number,
-			CommentID:           payload.Comment.ID,
 			ReviewCommentID:     payload.Comment.ID,
 			InReplyToID:         payload.Comment.InReplyToID,
 			PullRequestReviewID: payload.Comment.PullRequestReviewID,

--- a/internal/webhook/handler_test.go
+++ b/internal/webhook/handler_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/eloylp/agents/internal/config"
 	"github.com/eloylp/agents/internal/fleet"
+	"github.com/eloylp/agents/internal/observe"
 	"github.com/eloylp/agents/internal/store"
 	"github.com/eloylp/agents/internal/workflow"
 )
@@ -48,6 +49,9 @@ func TestPushEventCarriesRepoWorkspace(t *testing.T) {
 	st := store.New(db)
 	t.Cleanup(func() { st.Close() })
 
+	if _, err := store.UpsertWorkspace(db, fleet.Workspace{ID: "team-a", Name: "Team A"}); err != nil {
+		t.Fatalf("seed workspace: %v", err)
+	}
 	repo := fleet.Repo{
 		WorkspaceID: "team-a",
 		Name:        "owner/repo",
@@ -89,6 +93,80 @@ func TestPushEventCarriesRepoWorkspace(t *testing.T) {
 		}
 	case <-time.After(100 * time.Millisecond):
 		t.Fatal("timed out waiting for queued event")
+	}
+}
+
+func TestPushEventCapturesCommitAttributionArtifact(t *testing.T) {
+	t.Parallel()
+	db, err := store.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	st := store.New(db)
+	t.Cleanup(func() { st.Close() })
+
+	if _, err := store.UpsertWorkspace(db, fleet.Workspace{ID: "team-a", Name: "Team A"}); err != nil {
+		t.Fatalf("seed workspace: %v", err)
+	}
+	repo := fleet.Repo{
+		WorkspaceID: "team-a",
+		Name:        "owner/repo",
+		Enabled:     true,
+	}
+	if err := st.UpsertRepo(repo); err != nil {
+		t.Fatalf("seed repo: %v", err)
+	}
+
+	obs := observe.NewStore(db)
+	obs.WithAttributionVerifier(observe.AttributionVerifierConfig{
+		SigningSecret: "secret",
+		InstanceID:    "prod",
+	})
+	obs.RecordSpan(workflow.SpanInput{
+		SpanID:      "span-commit",
+		WorkspaceID: "team-a",
+		Agent:       "coder",
+		Backend:     "claude",
+		Repo:        "owner/repo",
+		StartedAt:   time.Date(2026, 1, 10, 12, 0, 0, 0, time.UTC),
+		Status:      "success",
+	})
+	attr := workflow.RunAttribution{
+		WorkspaceID: "team-a",
+		RepoOwner:   "owner",
+		RepoName:    "repo",
+		SpanID:      "span-commit",
+		AgentName:   "coder",
+	}
+	trailer := attr.CommitAttributionTrailer("secret", "prod")
+
+	dc := workflow.NewDataChannels(1, st)
+	h := NewHandler(NewDeliveryStore(10*time.Minute), dc, st, obs, config.HTTPConfig{}, config.SelfImprovementConfig{}, zerolog.Nop())
+	body := []byte(`{
+		"ref":"refs/heads/main",
+		"after":"abc123",
+		"commits":[{
+			"id":"abc123",
+			"message":"fix handler\n\n` + trailer + `",
+			"url":"https://github.com/owner/repo/commit/abc123",
+			"timestamp":"2026-01-10T12:00:00Z"
+		}],
+		"repository":{"full_name":"owner/repo"},
+		"sender":{"login":"coder"}
+	}`)
+	w := httptest.NewRecorder()
+
+	h.handlePushEvent(context.Background(), w, body, "delivery-commit")
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusAccepted)
+	}
+	got, ok := st.RunAttributionArtifactByCommitSHA("team-a", "owner", "repo", "abc123")
+	if !ok {
+		t.Fatalf("commit artifact lookup ok = false, want true")
+	}
+	if got.SpanID != "span-commit" {
+		t.Fatalf("SpanID = %q, want span-commit", got.SpanID)
 	}
 }
 


### PR DESCRIPTION
## Summary

- capture signed `Agents-Attribution` trailers from push commit messages as commit attribution artifacts
- resolve PR diff-line `/agents improve` feedback through the commented commit SHA before ancestry fallbacks
- persist PR review comment ancestry fields on feedback rows and document the new resolver mode

## Verification

- `go test ./internal/store ./internal/observe ./internal/webhook ./internal/workflow`
- `go test ./...`
- `go test ./internal/store -run "TestRunAttributionArtifactUpsertAndLookups|TestSelfImprovementFeedbackUpsertAndList" -race`
- `go test ./internal/store ./internal/observe ./internal/webhook -race` timed out in existing store auth migration/bcrypt tests after observe and webhook passed under race; no race report was emitted.

Closes #696

<!-- agents-run: {"v":1,"instance_id":"ts-lonestar","workspace":"default","repo":"eloylp/agents","span_id":"2ac77a42276b77f1","agent_id":"agent_0fb82d1fe34e45408bd2fee153f7003d","agent_name":"coder","sig":"0d08v9dVqUaduvYdqKPqbpYrq5aQjGazOReVGseGTkc"} -->