### PR TITLE
fix: drop malformed review feedback during migration

### DIFF
--- a/internal/store/migrations/058_self_improvement_feedback_identity_indexes.sql
+++ b/internal/store/migrations/058_self_improvement_feedback_identity_indexes.sql
@@ -78,6 +78,10 @@ FROM self_improvement_feedback_legacy_identity_058;
 
 DROP TABLE self_improvement_feedback_legacy_identity_058;
 
+DELETE FROM self_improvement_feedback
+WHERE source_type = 'pull_request_review_comment'
+  AND github_review_comment_id = 0;
+
 CREATE UNIQUE INDEX IF NOT EXISTS idx_self_improvement_feedback_legacy_identity
     ON self_improvement_feedback(workspace_id, source_type, github_comment_id, github_review_id, tag)
     WHERE github_review_comment_id = 0;

--- a/internal/store/self_improvement_migration_test.go
+++ b/internal/store/self_improvement_migration_test.go
@@ -198,6 +198,73 @@ func TestSelfImprovementFeedbackIdentityMigrationPreservesRecommendations(t *tes
 	}
 }
 
+func TestSelfImprovementFeedbackIdentityMigrationDeletesLegacyReviewCommentsWithoutIDs(t *testing.T) {
+	t.Parallel()
+
+	db, err := Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	st := New(db)
+	t.Cleanup(func() { st.Close() })
+
+	if _, err := db.Exec(`DROP INDEX IF EXISTS idx_self_improvement_feedback_legacy_identity`); err != nil {
+		t.Fatalf("drop legacy identity index: %v", err)
+	}
+	if _, err := db.Exec(`DROP INDEX IF EXISTS idx_self_improvement_feedback_review_comment`); err != nil {
+		t.Fatalf("drop review comment identity index: %v", err)
+	}
+	for _, body := range []string{
+		"first legacy review comment without identity",
+		"second legacy review comment without identity",
+	} {
+		if _, err := db.Exec(`
+			INSERT INTO self_improvement_feedback (
+				workspace_id, repo_owner, repo_name, source_type, raw_body, tag,
+				source_url, author_login, author_authorized, pr_number,
+				github_comment_id, github_review_id, github_review_comment_id
+			) VALUES (?, 'eloylp', 'test-acme-repo', 'pull_request_review_comment', ?, ?,
+				'https://github.com/eloylp/test-acme-repo/pull/1#discussion_r0',
+				'maintainer', 1, 1, 0, 0, 0
+			)
+		`, "self-improvement-demo", body, FeedbackTag); err != nil {
+			t.Fatalf("seed legacy review comment feedback: %v", err)
+		}
+	}
+	if _, err := db.Exec(`DELETE FROM schema_migrations WHERE name = '058_self_improvement_feedback_identity_indexes.sql'`); err != nil {
+		t.Fatalf("unmark identity migration: %v", err)
+	}
+
+	if err := migrate(db); err != nil {
+		t.Fatalf("rerun identity migration: %v", err)
+	}
+
+	var count int
+	if err := db.QueryRow(`
+		SELECT COUNT(*)
+		FROM self_improvement_feedback
+		WHERE workspace_id = 'self-improvement-demo'
+		  AND source_type = 'pull_request_review_comment'
+		  AND github_review_comment_id = 0
+	`).Scan(&count); err != nil {
+		t.Fatalf("count legacy review comments: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("legacy review comment count = %d, want 0", count)
+	}
+	rows, err := db.Query(`PRAGMA foreign_key_check`)
+	if err != nil {
+		t.Fatalf("foreign_key_check: %v", err)
+	}
+	defer rows.Close()
+	if rows.Next() {
+		t.Fatal("foreign_key_check reported violations")
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate foreign_key_check: %v", err)
+	}
+}
+
 func TestAcceptedRecommendationCleanupMigration(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- delete legacy pull_request_review_comment feedback rows that have no GitHub review-comment identity during migration 058
- keep the identity indexes strict and complete after migration
- add a regression test for rerunning migration 058 with production-shaped malformed review feedback rows

## Why
The live daemon failed booting on migration 058 because historical PR review-comment feedback rows had github_comment_id=0, github_review_id=0, and github_review_comment_id=0. Those rows cannot be uniquely identified, so migration 058 now discards them instead of preserving an invalid identity shape.

## Tests
- GOCACHE=/tmp/go-build-agents go test ./internal/store -run 'TestSelfImprovementFeedbackIdentityMigration' -count=1
- GOCACHE=/tmp/go-build-agents go test ./internal/store ./internal/webhook ./internal/workflow