### PR TITLE
fix: prefer scoped skill catalog refs

### DIFF
--- a/internal/daemon/config/config.go
+++ b/internal/daemon/config/config.go
@@ -439,6 +439,9 @@ func (h *Handler) ExportYAML() ([]byte, error) {
 		idx := ensureWorkspace(a.WorkspaceID)
 		a.WorkspaceID = ""
 		a.PromptID = ""
+		if a.PromptScope == fleet.GlobalCatalogScope {
+			a.PromptScope = ""
+		}
 		workspaces[idx].Agents = append(workspaces[idx].Agents, a)
 	}
 	for _, r := range cfg.Repos {

--- a/internal/daemon/config/config.go
+++ b/internal/daemon/config/config.go
@@ -390,29 +390,6 @@ func (h *Handler) ExportYAML() ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("list token budgets: %w", err)
 	}
-	for i := range cfg.Prompts {
-		versions, err := store.ListPromptVersionSnapshots(h.store.DB(), cfg.Prompts[i].ID)
-		if err != nil {
-			return nil, fmt.Errorf("list prompt %s versions: %w", cfg.Prompts[i].ID, err)
-		}
-		cfg.Prompts[i].Versions = scrubCatalogVersionAssetIDs(versions)
-	}
-	for id, skill := range cfg.Skills {
-		versions, err := store.ListSkillVersionSnapshots(h.store.DB(), id)
-		if err != nil {
-			return nil, fmt.Errorf("list skill %s versions: %w", id, err)
-		}
-		skill.Versions = scrubCatalogVersionAssetIDs(versions)
-		cfg.Skills[id] = skill
-	}
-	for i := range cfg.Guardrails {
-		versions, err := store.ListGuardrailVersionSnapshots(h.store.DB(), cfg.Guardrails[i].ID)
-		if err != nil {
-			return nil, fmt.Errorf("list guardrail %s versions: %w", cfg.Guardrails[i].ID, err)
-		}
-		cfg.Guardrails[i].Versions = scrubCatalogVersionAssetIDs(versions)
-	}
-
 	workspaces := make([]workspaceYAML, 0, len(cfg.Workspaces))
 	byWorkspace := make(map[string]int, len(cfg.Workspaces))
 	for _, w := range cfg.Workspaces {
@@ -477,13 +454,6 @@ func (h *Handler) ExportYAML() ([]byte, error) {
 		return nil, fmt.Errorf("marshal yaml: %w", err)
 	}
 	return b, nil
-}
-
-func scrubCatalogVersionAssetIDs(versions []fleet.CatalogVersion) []fleet.CatalogVersion {
-	for i := range versions {
-		versions[i].AssetID = ""
-	}
-	return versions
 }
 
 // HandleImport serves POST /import, accepts a YAML body in the same format

--- a/internal/daemon/crud_test.go
+++ b/internal/daemon/crud_test.go
@@ -2541,12 +2541,12 @@ workspaces:
 	if exported.Code != http.StatusOK {
 		t.Fatalf("export versioned catalog: got %d, %s", exported.Code, exported.Body.String())
 	}
-	for _, want := range []string{"versions:", "id: promptver_one", "id: skillver_two", "id: guardrailver_one"} {
+	for _, want := range []string{"content: current prompt", "prompt: current skill", "content: current guardrail"} {
 		if !strings.Contains(exported.Body.String(), want) {
 			t.Fatalf("export missing %q: %s", want, exported.Body.String())
 		}
 	}
-	for _, forbidden := range []string{"prompt_version_id:", "guardrail_version_id:", "imported-skill@"} {
+	for _, forbidden := range []string{"versions:", "base_version_id:", "prompt_version_id:", "guardrail_version_id:", "imported-skill@"} {
 		if strings.Contains(exported.Body.String(), forbidden) {
 			t.Fatalf("export contains removed live pin field %q: %s", forbidden, exported.Body.String())
 		}

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -39,9 +39,13 @@ func fixtureConfig() *config.Config {
 			"testing":  {Prompt: "write good tests"},
 			"security": {Prompt: "audit inputs"},
 		},
+		Prompts: []fleet.Prompt{
+			{Name: "coder", Content: "code"},
+			{Name: "reviewer", Content: "review"},
+		},
 		Agents: []fleet.Agent{
-			{Name: "coder", Backend: "claude", Skills: []string{"testing"}, Description: "writes code", AllowDispatch: true},
-			{Name: "reviewer", Backend: "claude", AllowDispatch: true, Description: "reviews code"},
+			{Name: "coder", Backend: "claude", Skills: []string{"testing"}, PromptRef: "coder", Description: "writes code", AllowDispatch: true},
+			{Name: "reviewer", Backend: "claude", PromptRef: "reviewer", AllowDispatch: true, Description: "reviews code"},
 		},
 		Repos: []fleet.Repo{
 			{Name: "owner/one", Enabled: true, Use: []fleet.Binding{

--- a/internal/store/agents.go
+++ b/internal/store/agents.go
@@ -104,7 +104,7 @@ func resolveAgentSkillRefs(tx *sql.Tx, a fleet.Agent, workspaceID, scopeType str
 		if err != nil {
 			return nil, fmt.Errorf("store import: agent %s skill %q: %w", a.Name, raw, err)
 		}
-		id, err := resolveVisibleCatalogRef(tx, "skills", ref, workspaceID, repo)
+		id, err := resolveVisibleCatalogRef(tx, "skills", "skill", "skill id", ref, workspaceID, repo, catalogScopeRepo)
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
 				if skill, ok, readErr := readSkillScopeByID(tx, ref); readErr != nil {

--- a/internal/store/catalog_resolution.go
+++ b/internal/store/catalog_resolution.go
@@ -193,31 +193,35 @@ func catalogCandidatesInScope(q querier, table, selector, workspaceID, repo stri
 		SELECT id, ref, name, COALESCE(workspace_id, ''), COALESCE(repo, '')
 		FROM ` + table + `
 		WHERE (id = ? OR ref = ? OR name = ?)
-		  AND workspace_id IS ?
-		  AND repo IS ?`
-	var workspaceArg, repoArg any
+		  AND workspace_id ` + catalogScopePredicate(workspaceID) + `
+		  AND repo ` + catalogScopePredicate(repo)
+	args := []any{selector, selector, selector}
 	if workspaceID != "" {
-		query = strings.Replace(query, "workspace_id IS ?", "workspace_id = ?", 1)
-		workspaceArg = workspaceID
+		args = append(args, workspaceID)
 	}
 	if repo != "" {
-		query = strings.Replace(query, "repo IS ?", "repo = ?", 1)
-		repoArg = repo
+		args = append(args, repo)
 	}
 	if mode == catalogScopeWorkspace {
 		query = `
 		SELECT id, ref, name, COALESCE(workspace_id, ''), ''
 		FROM ` + table + `
 		WHERE (id = ? OR ref = ? OR name = ?)
-		  AND workspace_id IS ?`
-		workspaceArg = nil
+		  AND workspace_id ` + catalogScopePredicate(workspaceID)
+		args = []any{selector, selector, selector}
 		if workspaceID != "" {
-			query = strings.Replace(query, "workspace_id IS ?", "workspace_id = ?", 1)
-			workspaceArg = workspaceID
+			args = append(args, workspaceID)
 		}
-		return scanCatalogCandidates(q, query, selector, selector, selector, workspaceArg)
+		return scanCatalogCandidates(q, query, args...)
 	}
-	return scanCatalogCandidates(q, query, selector, selector, selector, workspaceArg, repoArg)
+	return scanCatalogCandidates(q, query, args...)
+}
+
+func catalogScopePredicate(value string) string {
+	if value == "" {
+		return "IS NULL"
+	}
+	return "= ?"
 }
 
 func scanCatalogCandidates(q querier, query string, args ...any) ([]catalogCandidate, error) {

--- a/internal/store/catalog_resolution.go
+++ b/internal/store/catalog_resolution.go
@@ -170,7 +170,7 @@ func resolveVisibleCatalogRef(q querier, table, ref, workspaceID, repo string) (
 		}
 		return "", sql.ErrNoRows
 	}
-	if exactID != "" && exactName != ref {
+	if exactID != "" && (exactName != ref || isGeneratedCatalogRef(table, ref)) {
 		return exactID, nil
 	}
 	if ambiguous {
@@ -178,6 +178,10 @@ func resolveVisibleCatalogRef(q querier, table, ref, workspaceID, repo string) (
 		return "", fmt.Errorf("ambiguous %s %q in workspace %q; use %s id", label, ref, workspaceID, label)
 	}
 	return bestID, nil
+}
+
+func isGeneratedCatalogRef(table, ref string) bool {
+	return strings.HasPrefix(ref, strings.TrimSuffix(table, "s")+"_")
 }
 
 func resolveVisibleCatalogExactRef(q querier, table, ref, workspaceID, repo string) (string, string, error) {

--- a/internal/store/catalog_resolution.go
+++ b/internal/store/catalog_resolution.go
@@ -4,7 +4,6 @@ import (
 	"crypto/rand"
 	"database/sql"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -114,14 +113,59 @@ func ensureCatalogScope(tx *sql.Tx, kind, workspaceID, repo string) error {
 }
 
 func resolveVisibleCatalogRef(q querier, table, ref, workspaceID, repo string) (string, error) {
-	id, err := resolveVisibleCatalogID(q, table, ref, workspaceID, repo)
-	if err == nil {
-		return id, nil
-	}
-	if !errors.Is(err, sql.ErrNoRows) {
+	workspaceID = fleet.NormalizeWorkspaceID(workspaceID)
+	repo = fleet.NormalizeRepoName(repo)
+	rows, err := q.Query(`
+		SELECT id,
+			CASE
+				WHEN workspace_id IS NULL THEN 0
+				WHEN repo IS NULL THEN 1
+				ELSE 2
+			END AS specificity
+		FROM `+table+`
+		WHERE (id = ? OR ref = ? OR name = ?)
+		  AND (
+			(workspace_id IS NULL AND repo IS NULL)
+			OR (workspace_id = ? AND repo IS NULL)
+			OR (? <> '' AND workspace_id = ? AND repo = ?)
+		  )
+		ORDER BY specificity DESC, id`,
+		ref, ref, ref, workspaceID, repo, workspaceID, repo,
+	)
+	if err != nil {
 		return "", err
 	}
-	return resolveVisibleCatalogName(q, table, strings.TrimSuffix(table, "s"), strings.TrimSuffix(table, "s")+" id", ref, workspaceID, repo)
+	defer rows.Close()
+
+	var bestID string
+	bestSpecificity := -1
+	ambiguous := false
+	for rows.Next() {
+		var id string
+		var specificity int
+		if err := rows.Scan(&id, &specificity); err != nil {
+			return "", err
+		}
+		if bestSpecificity == -1 {
+			bestID = id
+			bestSpecificity = specificity
+			continue
+		}
+		if specificity == bestSpecificity && id != bestID {
+			ambiguous = true
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
+	if bestSpecificity == -1 {
+		return "", sql.ErrNoRows
+	}
+	if ambiguous {
+		label := strings.TrimSuffix(table, "s")
+		return "", fmt.Errorf("ambiguous %s %q in workspace %q; use %s id", label, ref, workspaceID, label)
+	}
+	return bestID, nil
 }
 
 func resolveVisibleCatalogID(q querier, table, id, workspaceID, repo string) (string, error) {

--- a/internal/store/catalog_resolution.go
+++ b/internal/store/catalog_resolution.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"database/sql"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -115,6 +116,11 @@ func ensureCatalogScope(tx *sql.Tx, kind, workspaceID, repo string) error {
 func resolveVisibleCatalogRef(q querier, table, ref, workspaceID, repo string) (string, error) {
 	workspaceID = fleet.NormalizeWorkspaceID(workspaceID)
 	repo = fleet.NormalizeRepoName(repo)
+
+	exactID, exactName, err := resolveVisibleCatalogExactRef(q, table, ref, workspaceID, repo)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return "", err
+	}
 	rows, err := q.Query(`
 		SELECT id,
 			CASE
@@ -123,14 +129,14 @@ func resolveVisibleCatalogRef(q querier, table, ref, workspaceID, repo string) (
 				ELSE 2
 			END AS specificity
 		FROM `+table+`
-		WHERE (id = ? OR ref = ? OR name = ?)
+		WHERE name = ?
 		  AND (
 			(workspace_id IS NULL AND repo IS NULL)
 			OR (workspace_id = ? AND repo IS NULL)
 			OR (? <> '' AND workspace_id = ? AND repo = ?)
 		  )
 		ORDER BY specificity DESC, id`,
-		ref, ref, ref, workspaceID, repo, workspaceID, repo,
+		ref, workspaceID, repo, workspaceID, repo,
 	)
 	if err != nil {
 		return "", err
@@ -159,13 +165,43 @@ func resolveVisibleCatalogRef(q querier, table, ref, workspaceID, repo string) (
 		return "", err
 	}
 	if bestSpecificity == -1 {
+		if exactID != "" {
+			return exactID, nil
+		}
 		return "", sql.ErrNoRows
+	}
+	if exactID != "" && exactName != ref {
+		return exactID, nil
 	}
 	if ambiguous {
 		label := strings.TrimSuffix(table, "s")
 		return "", fmt.Errorf("ambiguous %s %q in workspace %q; use %s id", label, ref, workspaceID, label)
 	}
 	return bestID, nil
+}
+
+func resolveVisibleCatalogExactRef(q querier, table, ref, workspaceID, repo string) (string, string, error) {
+	var id, name string
+	err := q.QueryRow(`
+		SELECT id, name
+		FROM `+table+`
+		WHERE (id = ? OR ref = ?)
+		  AND (
+			(workspace_id IS NULL AND repo IS NULL)
+			OR (workspace_id = ? AND repo IS NULL)
+			OR (? <> '' AND workspace_id = ? AND repo = ?)
+		  )
+		ORDER BY
+			CASE
+				WHEN workspace_id IS NULL THEN 0
+				WHEN repo IS NULL THEN 1
+				ELSE 2
+			END DESC,
+			id
+		LIMIT 1`,
+		ref, ref, workspaceID, repo, workspaceID, repo,
+	).Scan(&id, &name)
+	return id, name, err
 }
 
 func resolveVisibleCatalogID(q querier, table, id, workspaceID, repo string) (string, error) {

--- a/internal/store/catalog_resolution.go
+++ b/internal/store/catalog_resolution.go
@@ -42,7 +42,7 @@ func queryCatalogRefByScopeName(q querier, table, workspaceID, repo, name string
 }
 
 func resolveVisiblePromptByName(q querier, name, workspaceID, repo string) (string, error) {
-	return resolveVisibleCatalogName(q, "prompts", "prompt_ref", "prompt_id", name, workspaceID, repo)
+	return resolveVisibleCatalogRef(q, "prompts", "prompt_ref", "prompt_id", name, workspaceID, repo, catalogScopeRepo)
 }
 
 func resolveAgentPromptRef(q querier, name, promptScope, agentWorkspaceID, agentRepo string) (string, error) {
@@ -50,11 +50,7 @@ func resolveAgentPromptRef(q querier, name, promptScope, agentWorkspaceID, agent
 		if !catalogScopeVisibleToAgent(workspaceID, repo, agentWorkspaceID, agentRepo) {
 			return "", sql.ErrNoRows
 		}
-		var id string
-		if err := queryPromptByScopeName(q, workspaceID, repo, name).Scan(&id); err != nil {
-			return "", err
-		}
-		return id, nil
+		return resolveCatalogRefInScope(q, "prompts", "prompt_ref", "prompt_id", name, workspaceID, repo, catalogScopeRepo)
 	}
 	return resolveVisiblePromptByName(q, name, agentWorkspaceID, agentRepo)
 }
@@ -113,99 +109,191 @@ func ensureCatalogScope(tx *sql.Tx, kind, workspaceID, repo string) error {
 	return nil
 }
 
-func resolveVisibleCatalogRef(q querier, table, ref, workspaceID, repo string) (string, error) {
+type catalogScopeMode int
+
+const (
+	catalogScopeWorkspace catalogScopeMode = iota
+	catalogScopeRepo
+)
+
+type catalogCandidate struct {
+	ID          string
+	Ref         string
+	Name        string
+	WorkspaceID string
+	Repo        string
+}
+
+func resolveVisibleCatalogRef(q querier, table, label, idHint, ref, workspaceID, repo string, mode catalogScopeMode) (string, error) {
 	workspaceID = fleet.NormalizeWorkspaceID(workspaceID)
 	repo = fleet.NormalizeRepoName(repo)
-
-	exactID, exactName, err := resolveVisibleCatalogExactRef(q, table, ref, workspaceID, repo)
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		return "", err
+	if mode == catalogScopeWorkspace {
+		repo = ""
 	}
-	rows, err := q.Query(`
-		SELECT id,
-			CASE
-				WHEN workspace_id IS NULL THEN 0
-				WHEN repo IS NULL THEN 1
-				ELSE 2
-			END AS specificity
-		FROM `+table+`
-		WHERE name = ?
-		  AND (
-			(workspace_id IS NULL AND repo IS NULL)
-			OR (workspace_id = ? AND repo IS NULL)
-			OR (? <> '' AND workspace_id = ? AND repo = ?)
-		  )
-		ORDER BY specificity DESC, id`,
-		ref, workspaceID, repo, workspaceID, repo,
-	)
+
+	candidates, err := visibleCatalogCandidates(q, table, ref, workspaceID, repo, mode)
 	if err != nil {
 		return "", err
 	}
-	defer rows.Close()
-
-	var bestID string
-	bestSpecificity := -1
-	ambiguous := false
-	for rows.Next() {
-		var id string
-		var specificity int
-		if err := rows.Scan(&id, &specificity); err != nil {
-			return "", err
-		}
-		if bestSpecificity == -1 {
-			bestID = id
-			bestSpecificity = specificity
-			continue
-		}
-		if specificity == bestSpecificity && id != bestID {
-			ambiguous = true
-		}
+	candidate, err := chooseCatalogCandidate(candidates, ref, workspaceID, repo, mode)
+	if err == nil {
+		return candidate.ID, nil
 	}
-	if err := rows.Err(); err != nil {
+	if errors.Is(err, errAmbiguousCatalogSelector) {
+		return "", ambiguousCatalogError(table, label, idHint, ref, workspaceID)
+	}
+	return "", err
+}
+
+func resolveCatalogRefInScope(q querier, table, label, idHint, ref, workspaceID, repo string, mode catalogScopeMode) (string, error) {
+	workspaceID = fleet.NormalizeWorkspaceID(workspaceID)
+	repo = fleet.NormalizeRepoName(repo)
+	if mode == catalogScopeWorkspace {
+		repo = ""
+	}
+
+	candidates, err := catalogCandidatesInScope(q, table, ref, workspaceID, repo, mode)
+	if err != nil {
 		return "", err
 	}
-	if bestSpecificity == -1 {
-		if exactID != "" {
-			return exactID, nil
-		}
-		return "", sql.ErrNoRows
+	candidate, err := chooseCatalogCandidate(candidates, ref, workspaceID, repo, mode)
+	if err == nil {
+		return candidate.ID, nil
 	}
-	if exactID != "" && (exactName != ref || isGeneratedCatalogRef(table, ref)) {
-		return exactID, nil
+	if errors.Is(err, errAmbiguousCatalogSelector) {
+		return "", ambiguousCatalogError(table, label, idHint, ref, workspaceID)
 	}
-	if ambiguous {
-		label := strings.TrimSuffix(table, "s")
-		return "", fmt.Errorf("ambiguous %s %q in workspace %q; use %s id", label, ref, workspaceID, label)
-	}
-	return bestID, nil
+	return "", err
 }
 
-func isGeneratedCatalogRef(table, ref string) bool {
-	return strings.HasPrefix(ref, strings.TrimSuffix(table, "s")+"_")
-}
-
-func resolveVisibleCatalogExactRef(q querier, table, ref, workspaceID, repo string) (string, string, error) {
-	var id, name string
-	err := q.QueryRow(`
-		SELECT id, name
-		FROM `+table+`
-		WHERE (id = ? OR ref = ?)
+func visibleCatalogCandidates(q querier, table, selector, workspaceID, repo string, mode catalogScopeMode) ([]catalogCandidate, error) {
+	query := `
+		SELECT id, ref, name, COALESCE(workspace_id, ''), COALESCE(repo, '')
+		FROM ` + table + `
+		WHERE (id = ? OR ref = ? OR name = ?)
 		  AND (
 			(workspace_id IS NULL AND repo IS NULL)
 			OR (workspace_id = ? AND repo IS NULL)
 			OR (? <> '' AND workspace_id = ? AND repo = ?)
-		  )
-		ORDER BY
-			CASE
-				WHEN workspace_id IS NULL THEN 0
-				WHEN repo IS NULL THEN 1
-				ELSE 2
-			END DESC,
-			id
-		LIMIT 1`,
-		ref, ref, workspaceID, repo, workspaceID, repo,
-	).Scan(&id, &name)
-	return id, name, err
+		  )`
+	args := []any{selector, selector, selector, workspaceID, repo, workspaceID, repo}
+	if mode == catalogScopeWorkspace {
+		query = `
+		SELECT id, ref, name, COALESCE(workspace_id, ''), ''
+		FROM ` + table + `
+		WHERE (id = ? OR ref = ? OR name = ?)
+		  AND (workspace_id IS NULL OR workspace_id = ?)`
+		args = []any{selector, selector, selector, workspaceID}
+	}
+	return scanCatalogCandidates(q, query, args...)
+}
+
+func catalogCandidatesInScope(q querier, table, selector, workspaceID, repo string, mode catalogScopeMode) ([]catalogCandidate, error) {
+	query := `
+		SELECT id, ref, name, COALESCE(workspace_id, ''), COALESCE(repo, '')
+		FROM ` + table + `
+		WHERE (id = ? OR ref = ? OR name = ?)
+		  AND workspace_id IS ?
+		  AND repo IS ?`
+	var workspaceArg, repoArg any
+	if workspaceID != "" {
+		query = strings.Replace(query, "workspace_id IS ?", "workspace_id = ?", 1)
+		workspaceArg = workspaceID
+	}
+	if repo != "" {
+		query = strings.Replace(query, "repo IS ?", "repo = ?", 1)
+		repoArg = repo
+	}
+	if mode == catalogScopeWorkspace {
+		query = `
+		SELECT id, ref, name, COALESCE(workspace_id, ''), ''
+		FROM ` + table + `
+		WHERE (id = ? OR ref = ? OR name = ?)
+		  AND workspace_id IS ?`
+		workspaceArg = nil
+		if workspaceID != "" {
+			query = strings.Replace(query, "workspace_id IS ?", "workspace_id = ?", 1)
+			workspaceArg = workspaceID
+		}
+		return scanCatalogCandidates(q, query, selector, selector, selector, workspaceArg)
+	}
+	return scanCatalogCandidates(q, query, selector, selector, selector, workspaceArg, repoArg)
+}
+
+func scanCatalogCandidates(q querier, query string, args ...any) ([]catalogCandidate, error) {
+	rows, err := q.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var candidates []catalogCandidate
+	for rows.Next() {
+		var c catalogCandidate
+		if err := rows.Scan(&c.ID, &c.Ref, &c.Name, &c.WorkspaceID, &c.Repo); err != nil {
+			return nil, err
+		}
+		candidates = append(candidates, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return candidates, nil
+}
+
+var errAmbiguousCatalogSelector = errors.New("ambiguous catalog selector")
+
+func chooseCatalogCandidate(candidates []catalogCandidate, selector, workspaceID, repo string, mode catalogScopeMode) (catalogCandidate, error) {
+	for _, c := range candidates {
+		if c.ID == selector || c.Ref == selector {
+			return c, nil
+		}
+	}
+
+	var best catalogCandidate
+	bestSpecificity := -1
+	ambiguous := false
+	for _, c := range candidates {
+		if c.Name != selector {
+			continue
+		}
+		specificity := catalogSpecificity(c, mode)
+		if specificity > bestSpecificity {
+			best = c
+			bestSpecificity = specificity
+			ambiguous = false
+			continue
+		}
+		if specificity == bestSpecificity && c.ID != best.ID {
+			ambiguous = true
+		}
+	}
+	if bestSpecificity == -1 {
+		return catalogCandidate{}, sql.ErrNoRows
+	}
+	if ambiguous {
+		return catalogCandidate{}, errAmbiguousCatalogSelector
+	}
+	return best, nil
+}
+
+func catalogSpecificity(c catalogCandidate, mode catalogScopeMode) int {
+	if c.WorkspaceID == "" {
+		return 0
+	}
+	if mode == catalogScopeRepo && c.Repo != "" {
+		return 2
+	}
+	return 1
+}
+
+func ambiguousCatalogError(table, label, idHint, selector, workspaceID string) error {
+	if label == "" {
+		label = strings.TrimSuffix(table, "s")
+	}
+	if idHint == "" {
+		idHint = strings.TrimSuffix(table, "s") + " id"
+	}
+	return fmt.Errorf("ambiguous %s %q in workspace %q; use %s", label, selector, workspaceID, idHint)
 }
 
 func resolveVisibleCatalogID(q querier, table, id, workspaceID, repo string) (string, error) {

--- a/internal/store/catalog_versions.go
+++ b/internal/store/catalog_versions.go
@@ -743,20 +743,45 @@ func promptInternalID(q querier, ref string) (string, error) {
 
 func skillInternalID(q querier, ref string) (string, error) {
 	ref = fleet.NormalizeSkillName(ref)
-	var id string
-	if err := q.QueryRow("SELECT id FROM skills WHERE id=? OR ref=? OR name=?", ref, ref, ref).Scan(&id); err != nil {
-		return "", catalogReadErr("skill", ref, err)
-	}
-	return id, nil
+	return catalogInternalID(q, "skills", "skill", ref)
 }
 
 func guardrailInternalID(q querier, ref string) (string, error) {
 	ref = fleet.NormalizeGuardrailName(ref)
+	return catalogInternalID(q, "guardrails", "guardrail", ref)
+}
+
+func catalogInternalID(q querier, table, kind, ref string) (string, error) {
 	var id string
-	if err := q.QueryRow("SELECT id FROM guardrails WHERE id=? OR ref=? OR name=?", ref, ref, ref).Scan(&id); err != nil {
-		return "", catalogReadErr("guardrail", ref, err)
+	if err := q.QueryRow("SELECT id FROM "+table+" WHERE id=? OR ref=?", ref, ref).Scan(&id); err == nil {
+		return id, nil
+	} else if err != sql.ErrNoRows {
+		return "", catalogReadErr(kind, ref, err)
 	}
-	return id, nil
+
+	rows, err := q.Query("SELECT id FROM "+table+" WHERE name=?", ref)
+	if err != nil {
+		return "", catalogReadErr(kind, ref, err)
+	}
+	defer rows.Close()
+	var matches []string
+	for rows.Next() {
+		if err := rows.Scan(&id); err != nil {
+			return "", catalogReadErr(kind, ref, err)
+		}
+		matches = append(matches, id)
+	}
+	if err := rows.Err(); err != nil {
+		return "", catalogReadErr(kind, ref, err)
+	}
+	switch len(matches) {
+	case 0:
+		return "", catalogReadErr(kind, ref, sql.ErrNoRows)
+	case 1:
+		return matches[0], nil
+	default:
+		return "", &ErrValidation{Msg: fmt.Sprintf("%s selector %q is ambiguous", kind, ref)}
+	}
 }
 
 func catalogReadErr(kind, ref string, err error) error {

--- a/internal/store/crud_test.go
+++ b/internal/store/crud_test.go
@@ -572,6 +572,77 @@ func TestCreatePublishedCatalogVersionsRecordSourceMetadata(t *testing.T) {
 	}
 }
 
+func TestCatalogVersionSnapshotsUseExactRefBeforeDisplayName(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	t.Cleanup(func() { _ = tx.Rollback() })
+	cfg := &config.Config{
+		Skills: map[string]fleet.Skill{
+			"skill_global_policy": {
+				Name:   "skill_global_policy",
+				Prompt: "global skill body",
+			},
+			"skill_workspace_policy": {
+				WorkspaceID: "default",
+				Name:        "skill_global_policy",
+				Prompt:      "workspace skill body",
+			},
+		},
+		Guardrails: []fleet.Guardrail{
+			{
+				ID:          "guardrail_global_policy",
+				Name:        "guardrail-global-policy",
+				Description: "global guardrail",
+				Content:     "global guardrail body",
+				Enabled:     true,
+				Position:    10,
+			},
+			{
+				ID:          "guardrail_workspace_policy",
+				WorkspaceID: "default",
+				Name:        "guardrail-global-policy",
+				Description: "workspace guardrail",
+				Content:     "workspace guardrail body",
+				Enabled:     true,
+				Position:    20,
+			},
+		},
+	}
+	if err := store.ImportConfigTx(tx, cfg, nil); err != nil {
+		t.Fatalf("import config: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	versions, err := store.ListSkillVersionSnapshots(db, "skill_global_policy")
+	if err != nil {
+		t.Fatalf("list skill versions: %v", err)
+	}
+	if got, want := len(versions), 1; got != want {
+		t.Fatalf("versions len = %d, want %d: %+v", got, want, versions)
+	}
+	if got, want := versions[0].Prompt, "global skill body"; got != want {
+		t.Fatalf("version prompt = %q, want %q", got, want)
+	}
+
+	guardrailVersions, err := store.ListGuardrailVersionSnapshots(db, "guardrail_global_policy")
+	if err != nil {
+		t.Fatalf("list guardrail versions: %v", err)
+	}
+	if got, want := len(guardrailVersions), 1; got != want {
+		t.Fatalf("guardrail versions len = %d, want %d: %+v", got, want, guardrailVersions)
+	}
+	if got, want := guardrailVersions[0].Content, "global guardrail body"; got != want {
+		t.Fatalf("guardrail version content = %q, want %q", got, want)
+	}
+}
+
 func TestCreatePublishedCatalogVersionRejectsInvalidMetadata(t *testing.T) {
 	t.Parallel()
 	db := openTestDB(t)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/eloylp/agents/internal/ai"
 	"github.com/eloylp/agents/internal/config"
 	"github.com/eloylp/agents/internal/fleet"
 	"github.com/eloylp/agents/internal/store"
@@ -2048,7 +2049,7 @@ func TestAgentSkillDisplayNamePrefersRepoOverWorkspaceAndGlobal(t *testing.T) {
 	}
 }
 
-func TestAgentSkillDisplayNameBeatsLessSpecificRef(t *testing.T) {
+func TestAgentSkillExactRefBeatsMoreSpecificDisplayName(t *testing.T) {
 	t.Parallel()
 	db := openTestDB(t)
 
@@ -2070,8 +2071,118 @@ func TestAgentSkillDisplayNameBeatsLessSpecificRef(t *testing.T) {
 	if idx < 0 {
 		t.Fatal("team-a coder agent not found after load")
 	}
-	if !slices.Contains(out.Agents[idx].Skills, "skill_team_go_api") {
-		t.Fatalf("coder skills = %v, want workspace-scoped skill ref", out.Agents[idx].Skills)
+	if !slices.Contains(out.Agents[idx].Skills, "go-api") {
+		t.Fatalf("coder skills = %v, want exact skill ref", out.Agents[idx].Skills)
+	}
+	if slices.Contains(out.Agents[idx].Skills, "skill_team_go_api") {
+		t.Fatalf("coder skills = %v, unexpectedly selected display-name collision", out.Agents[idx].Skills)
+	}
+}
+
+func TestAgentPromptRefExactIDBeatsMoreSpecificDisplayName(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+
+	cfg := minimalCfg()
+	cfg.Workspaces = append(cfg.Workspaces, fleet.Workspace{ID: "team-a", Name: "Team A"})
+	cfg.Prompts = []fleet.Prompt{
+		{ID: "prompt_global_shared", Name: "shared", Content: "global prompt"},
+		{ID: "prompt_team_collision", WorkspaceID: "team-a", Name: "prompt_global_shared", Content: "team collision prompt"},
+	}
+	cfg.Agents[0].WorkspaceID = "team-a"
+	cfg.Agents[0].PromptRef = "prompt_global_shared"
+	cfg.Agents[1].WorkspaceID = "team-a"
+	cfg.Repos[0].WorkspaceID = "team-a"
+	if err := store.Import(db, cfg); err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	out, err := store.Load(db)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	idx := slices.IndexFunc(out.Agents, func(a fleet.Agent) bool { return a.WorkspaceID == "team-a" && a.Name == "coder" })
+	if idx < 0 {
+		t.Fatal("team-a coder agent not found after load")
+	}
+	if out.Agents[idx].PromptRef != "shared" {
+		t.Fatalf("resolved prompt ref = %q, want shared", out.Agents[idx].PromptRef)
+	}
+	promptIdx := slices.IndexFunc(out.Prompts, func(p fleet.Prompt) bool { return p.ID == "prompt_global_shared" })
+	if promptIdx < 0 || out.Prompts[promptIdx].Content != "global prompt" {
+		t.Fatalf("selected prompt = %+v, want global prompt", out.Prompts)
+	}
+}
+
+func TestAgentPromptDisplayNamePrefersRepoOverWorkspaceAndGlobal(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+
+	cfg := minimalCfg()
+	cfg.Prompts = []fleet.Prompt{
+		{ID: "prompt_global_shared", Name: "shared", Content: "global prompt"},
+		{ID: "prompt_team_shared", WorkspaceID: "default", Name: "shared", Content: "workspace prompt"},
+		{ID: "prompt_repo_shared", WorkspaceID: "default", Repo: "owner/repo", Name: "shared", Content: "repo prompt"},
+	}
+	cfg.Agents[0].ScopeType = "repo"
+	cfg.Agents[0].ScopeRepo = "owner/repo"
+	cfg.Agents[0].PromptRef = "shared"
+	if err := store.Import(db, cfg); err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	out, err := store.Load(db)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	idx := slices.IndexFunc(out.Prompts, func(p fleet.Prompt) bool { return p.ID == "prompt_repo_shared" })
+	if idx < 0 || out.Prompts[idx].Content != "repo prompt" {
+		t.Fatalf("prompts = %+v, want repo prompt selected in catalog", out.Prompts)
+	}
+	agentIdx := slices.IndexFunc(out.Agents, func(a fleet.Agent) bool { return a.Name == "coder" })
+	if agentIdx < 0 || out.Agents[agentIdx].PromptRef != "shared" || out.Agents[agentIdx].PromptScope != "default/owner/repo" {
+		t.Fatalf("agent prompt = (%q, %q), want shared/default/owner/repo",
+			out.Agents[agentIdx].PromptRef, out.Agents[agentIdx].PromptScope)
+	}
+}
+
+func TestRuntimePromptUsesResolvedScopedCatalogBodies(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+
+	cfg := minimalCfg()
+	cfg.Prompts = []fleet.Prompt{
+		{ID: "prompt_global_shared", Name: "shared", Content: "global prompt"},
+		{ID: "prompt_repo_shared", WorkspaceID: "default", Repo: "owner/repo", Name: "shared", Content: "repo prompt"},
+	}
+	cfg.Skills["skill_global_shared"] = fleet.Skill{Name: "shared", Prompt: "global skill"}
+	cfg.Skills["skill_repo_shared"] = fleet.Skill{WorkspaceID: "default", Repo: "owner/repo", Name: "shared", Prompt: "repo skill"}
+	cfg.Agents[0].ScopeType = "repo"
+	cfg.Agents[0].ScopeRepo = "owner/repo"
+	cfg.Agents[0].PromptRef = "shared"
+	cfg.Agents[0].Skills = []string{"shared"}
+	if err := store.Import(db, cfg); err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	out, err := store.Load(db)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	agentIdx := slices.IndexFunc(out.Agents, func(a fleet.Agent) bool { return a.Name == "coder" })
+	if agentIdx < 0 {
+		t.Fatal("coder agent not found after load")
+	}
+	promptIdx := slices.IndexFunc(out.Prompts, func(p fleet.Prompt) bool { return p.ID == "prompt_repo_shared" })
+	if promptIdx < 0 {
+		t.Fatal("repo prompt not found after load")
+	}
+	rendered, err := ai.RenderAgentPrompt(out.Agents[agentIdx], out.Prompts[promptIdx].Content, out.Skills, nil, ai.PromptContext{})
+	if err != nil {
+		t.Fatalf("RenderAgentPrompt: %v", err)
+	}
+	if !strings.Contains(rendered.System, "repo skill") || !strings.Contains(rendered.System, "repo prompt") {
+		t.Fatalf("rendered system = %q, want resolved repo skill and prompt", rendered.System)
+	}
+	if strings.Contains(rendered.System, "global skill") || strings.Contains(rendered.System, "global prompt") {
+		t.Fatalf("rendered system = %q, unexpectedly used global catalog body", rendered.System)
 	}
 }
 
@@ -2110,6 +2221,41 @@ func TestWorkspaceGuardrailReferenceCanUseVisibleDisplayName(t *testing.T) {
 	}
 	if guardrails[0].ID != "guardrail_team_policy" || guardrails[0].Name != "team-policy" {
 		t.Fatalf("guardrail = %+v, want scoped team policy", guardrails[0])
+	}
+}
+
+func TestWorkspaceGuardrailExactRefBeatsWorkspaceDisplayName(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+
+	cfg := minimalCfg()
+	cfg.Workspaces = []fleet.Workspace{{
+		ID:   "team-a",
+		Name: "Team A",
+		Guardrails: []fleet.WorkspaceGuardrailRef{{
+			GuardrailName: "guardrail_global_policy",
+			Enabled:       true,
+		}},
+	}}
+	cfg.Guardrails = []fleet.Guardrail{
+		{ID: "guardrail_global_policy", Name: "global-policy", Content: "Global policy.", Enabled: true},
+		{ID: "guardrail_team_collision", WorkspaceID: "team-a", Name: "guardrail_global_policy", Content: "Team collision.", Enabled: true},
+	}
+	cfg.Agents[0].WorkspaceID = "team-a"
+	cfg.Agents[1].WorkspaceID = "team-a"
+	cfg.Repos[0].WorkspaceID = "team-a"
+	if err := store.Import(db, cfg); err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	guardrails, err := store.ReadWorkspacePromptGuardrails(db, "team-a")
+	if err != nil {
+		t.Fatalf("ReadWorkspacePromptGuardrails: %v", err)
+	}
+	if len(guardrails) != 1 {
+		t.Fatalf("guardrails len = %d, want 1: %+v", len(guardrails), guardrails)
+	}
+	if guardrails[0].ID != "guardrail_global_policy" || guardrails[0].Content != "Global policy." {
+		t.Fatalf("guardrail = %+v, want exact global policy", guardrails[0])
 	}
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1985,6 +1985,42 @@ func TestAgentSkillStableRefBeatsMoreSpecificDisplayName(t *testing.T) {
 	}
 }
 
+func TestAgentSkillGeneratedRefBeatsMoreSpecificDefaultDisplayName(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+
+	cfg := minimalCfg()
+	cfg.Skills["skill_global_shared"] = fleet.Skill{
+		Prompt: "Global shared guidance.",
+	}
+	cfg.Skills["skill_team_collision"] = fleet.Skill{
+		WorkspaceID: "team-a",
+		Name:        "skill_global_shared",
+		Prompt:      "Team collision guidance.",
+	}
+	cfg.Agents[0].WorkspaceID = "team-a"
+	cfg.Agents[0].Skills = append(cfg.Agents[0].Skills, "skill_global_shared")
+	cfg.Agents[1].WorkspaceID = "team-a"
+	cfg.Repos[0].WorkspaceID = "team-a"
+	if err := store.ImportAll(db, cfg.Agents, cfg.Repos, cfg.Skills, cfg.Daemon.AIBackends, nil, nil); err != nil {
+		t.Fatalf("ImportAll: %v", err)
+	}
+	out, err := store.Load(db)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	idx := slices.IndexFunc(out.Agents, func(a fleet.Agent) bool { return a.WorkspaceID == "team-a" && a.Name == "coder" })
+	if idx < 0 {
+		t.Fatal("team-a coder agent not found after load")
+	}
+	if !slices.Contains(out.Agents[idx].Skills, "skill_global_shared") {
+		t.Fatalf("coder skills = %v, want exact generated skill ref", out.Agents[idx].Skills)
+	}
+	if slices.Contains(out.Agents[idx].Skills, "skill_team_collision") {
+		t.Fatalf("coder skills = %v, unexpectedly selected display-name collision", out.Agents[idx].Skills)
+	}
+}
+
 func TestAgentSkillDisplayNamePrefersRepoOverWorkspaceAndGlobal(t *testing.T) {
 	t.Parallel()
 	db := openTestDB(t)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1911,7 +1911,7 @@ func TestAgentSkillDisplayNameResolvesToStableScopedID(t *testing.T) {
 	}
 }
 
-func TestAgentSkillDisplayNameRejectsAmbiguousVisibleName(t *testing.T) {
+func TestAgentSkillDisplayNamePrefersMostSpecificVisibleName(t *testing.T) {
 	t.Parallel()
 	db := openTestDB(t)
 
@@ -1929,12 +1929,76 @@ func TestAgentSkillDisplayNameRejectsAmbiguousVisibleName(t *testing.T) {
 	cfg.Agents[0].Skills = append(cfg.Agents[0].Skills, "shared")
 	cfg.Agents[1].WorkspaceID = "team-a"
 	cfg.Repos[0].WorkspaceID = "team-a"
-	err := store.ImportAll(db, cfg.Agents, cfg.Repos, cfg.Skills, cfg.Daemon.AIBackends, nil, nil)
-	if err == nil {
-		t.Fatal("ImportAll succeeded, want ambiguous skill validation error")
+	if err := store.ImportAll(db, cfg.Agents, cfg.Repos, cfg.Skills, cfg.Daemon.AIBackends, nil, nil); err != nil {
+		t.Fatalf("ImportAll: %v", err)
 	}
-	if !strings.Contains(err.Error(), `ambiguous skill "shared" in workspace "team-a"; use skill id`) {
-		t.Fatalf("error = %v, want ambiguous skill validation", err)
+	out, err := store.Load(db)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	idx := slices.IndexFunc(out.Agents, func(a fleet.Agent) bool { return a.WorkspaceID == "team-a" && a.Name == "coder" })
+	if idx < 0 {
+		t.Fatal("team-a coder agent not found after load")
+	}
+	if !slices.Contains(out.Agents[idx].Skills, "skill_team_shared") {
+		t.Fatalf("coder skills = %v, want workspace-scoped skill ref", out.Agents[idx].Skills)
+	}
+	if slices.Contains(out.Agents[idx].Skills, "skill_global_shared") {
+		t.Fatalf("coder skills = %v, unexpectedly selected global skill", out.Agents[idx].Skills)
+	}
+}
+
+func TestAgentSkillDisplayNamePrefersRepoOverWorkspaceAndGlobal(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+
+	cfg := minimalCfg()
+	cfg.Skills["skill_global_shared"] = fleet.Skill{Name: "shared", Prompt: "Global shared guidance."}
+	cfg.Skills["skill_team_shared"] = fleet.Skill{WorkspaceID: "default", Name: "shared", Prompt: "Team shared guidance."}
+	cfg.Skills["skill_repo_shared"] = fleet.Skill{WorkspaceID: "default", Repo: "owner/repo", Name: "shared", Prompt: "Repo shared guidance."}
+	cfg.Agents[0].ScopeType = "repo"
+	cfg.Agents[0].ScopeRepo = "owner/repo"
+	cfg.Agents[0].Skills = append(cfg.Agents[0].Skills, "shared")
+	if err := store.ImportAll(db, cfg.Agents, cfg.Repos, cfg.Skills, cfg.Daemon.AIBackends, nil, nil); err != nil {
+		t.Fatalf("ImportAll: %v", err)
+	}
+	out, err := store.Load(db)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	idx := slices.IndexFunc(out.Agents, func(a fleet.Agent) bool { return a.WorkspaceID == "default" && a.Name == "coder" })
+	if idx < 0 {
+		t.Fatal("default coder agent not found after load")
+	}
+	if !slices.Contains(out.Agents[idx].Skills, "skill_repo_shared") {
+		t.Fatalf("coder skills = %v, want repo-scoped skill ref", out.Agents[idx].Skills)
+	}
+}
+
+func TestAgentSkillDisplayNameBeatsLessSpecificRef(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+
+	cfg := minimalCfg()
+	cfg.Skills["go-api"] = fleet.Skill{Name: "go-api", Prompt: "Global guidance."}
+	cfg.Skills["skill_team_go_api"] = fleet.Skill{WorkspaceID: "team-a", Name: "go-api", Prompt: "Workspace guidance."}
+	cfg.Agents[0].WorkspaceID = "team-a"
+	cfg.Agents[0].Skills = append(cfg.Agents[0].Skills, "go-api")
+	cfg.Agents[1].WorkspaceID = "team-a"
+	cfg.Repos[0].WorkspaceID = "team-a"
+	if err := store.ImportAll(db, cfg.Agents, cfg.Repos, cfg.Skills, cfg.Daemon.AIBackends, nil, nil); err != nil {
+		t.Fatalf("ImportAll: %v", err)
+	}
+	out, err := store.Load(db)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	idx := slices.IndexFunc(out.Agents, func(a fleet.Agent) bool { return a.WorkspaceID == "team-a" && a.Name == "coder" })
+	if idx < 0 {
+		t.Fatal("team-a coder agent not found after load")
+	}
+	if !slices.Contains(out.Agents[idx].Skills, "skill_team_go_api") {
+		t.Fatalf("coder skills = %v, want workspace-scoped skill ref", out.Agents[idx].Skills)
 	}
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1663,7 +1663,7 @@ func TestAgentPromptRefMustExistWithoutInlinePrompt(t *testing.T) {
 	}
 }
 
-func TestAgentPromptRefRejectsAmbiguousVisiblePromptName(t *testing.T) {
+func TestAgentPromptRefDisplayNamePrefersMostSpecificVisibleName(t *testing.T) {
 	t.Parallel()
 	db := openTestDB(t)
 
@@ -1678,12 +1678,20 @@ func TestAgentPromptRefRejectsAmbiguousVisiblePromptName(t *testing.T) {
 	cfg.Agents[0].PromptRef = "shared"
 	cfg.Agents[1].WorkspaceID = "team-a"
 	cfg.Repos[0].WorkspaceID = "team-a"
-	err := store.Import(db, cfg)
-	if err == nil {
-		t.Fatal("Import succeeded, want ambiguous prompt_ref error")
+	if err := store.Import(db, cfg); err != nil {
+		t.Fatalf("Import: %v", err)
 	}
-	if !strings.Contains(err.Error(), `ambiguous prompt_ref "shared" in workspace "team-a"; use prompt_id`) {
-		t.Fatalf("error = %v, want ambiguous prompt_ref validation", err)
+	out, err := store.Load(db)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	idx := slices.IndexFunc(out.Agents, func(a fleet.Agent) bool { return a.WorkspaceID == "team-a" && a.Name == "coder" })
+	if idx < 0 {
+		t.Fatal("team-a coder agent not found after load")
+	}
+	if out.Agents[idx].PromptRef != "shared" || out.Agents[idx].PromptScope != "team-a" {
+		t.Fatalf("resolved prompt = (%q, %q), want shared/team-a",
+			out.Agents[idx].PromptRef, out.Agents[idx].PromptScope)
 	}
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1948,6 +1948,43 @@ func TestAgentSkillDisplayNamePrefersMostSpecificVisibleName(t *testing.T) {
 	}
 }
 
+func TestAgentSkillStableRefBeatsMoreSpecificDisplayName(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+
+	cfg := minimalCfg()
+	cfg.Skills["skill_global_shared"] = fleet.Skill{
+		Name:   "shared",
+		Prompt: "Global shared guidance.",
+	}
+	cfg.Skills["skill_team_collision"] = fleet.Skill{
+		WorkspaceID: "team-a",
+		Name:        "skill_global_shared",
+		Prompt:      "Team collision guidance.",
+	}
+	cfg.Agents[0].WorkspaceID = "team-a"
+	cfg.Agents[0].Skills = append(cfg.Agents[0].Skills, "skill_global_shared")
+	cfg.Agents[1].WorkspaceID = "team-a"
+	cfg.Repos[0].WorkspaceID = "team-a"
+	if err := store.ImportAll(db, cfg.Agents, cfg.Repos, cfg.Skills, cfg.Daemon.AIBackends, nil, nil); err != nil {
+		t.Fatalf("ImportAll: %v", err)
+	}
+	out, err := store.Load(db)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	idx := slices.IndexFunc(out.Agents, func(a fleet.Agent) bool { return a.WorkspaceID == "team-a" && a.Name == "coder" })
+	if idx < 0 {
+		t.Fatal("team-a coder agent not found after load")
+	}
+	if !slices.Contains(out.Agents[idx].Skills, "skill_global_shared") {
+		t.Fatalf("coder skills = %v, want exact stable skill ref", out.Agents[idx].Skills)
+	}
+	if slices.Contains(out.Agents[idx].Skills, "skill_team_collision") {
+		t.Fatalf("coder skills = %v, unexpectedly selected display-name collision", out.Agents[idx].Skills)
+	}
+}
+
 func TestAgentSkillDisplayNamePrefersRepoOverWorkspaceAndGlobal(t *testing.T) {
 	t.Parallel()
 	db := openTestDB(t)

--- a/internal/store/workspaces_import_load.go
+++ b/internal/store/workspaces_import_load.go
@@ -138,48 +138,7 @@ func replaceWorkspaceGuardrailsTx(tx *sql.Tx, workspaceID string, refs []fleet.W
 func resolveWorkspaceGuardrailRef(q querier, workspaceID, ref string) (string, error) {
 	ref = fleet.NormalizeGuardrailName(ref)
 	workspaceID = fleet.NormalizeWorkspaceID(workspaceID)
-	rows, err := q.Query(`
-		SELECT id, ref, name
-		FROM guardrails
-		WHERE (id = ? OR ref = ? OR name = ?)
-		  AND (workspace_id IS NULL OR workspace_id = ?)
-		ORDER BY
-			CASE WHEN id = ? OR ref = ? THEN 0 ELSE 1 END,
-			CASE WHEN workspace_id IS NULL THEN 0 ELSE 1 END`,
-		ref, ref, ref, workspaceID, ref, ref,
-	)
-	if err != nil {
-		return "", err
-	}
-	defer rows.Close()
-	type match struct {
-		id    string
-		ref   string
-		name  string
-		exact bool
-	}
-	var matches []match
-	for rows.Next() {
-		var m match
-		if err := rows.Scan(&m.id, &m.ref, &m.name); err != nil {
-			return "", err
-		}
-		m.exact = m.id == ref || m.ref == ref
-		matches = append(matches, m)
-	}
-	if err := rows.Err(); err != nil {
-		return "", err
-	}
-	if len(matches) == 0 {
-		return "", sql.ErrNoRows
-	}
-	if matches[0].exact {
-		return matches[0].id, nil
-	}
-	if len(matches) > 1 {
-		return "", fmt.Errorf("ambiguous guardrail %q in workspace %q; use guardrail id", ref, workspaceID)
-	}
-	return matches[0].id, nil
+	return resolveVisibleCatalogRef(q, "guardrails", "guardrail", "guardrail id", ref, workspaceID, "", catalogScopeWorkspace)
 }
 
 func importReferencedWorkspaces(tx *sql.Tx, agents []fleet.Agent, repos []fleet.Repo) error {


### PR DESCRIPTION
## Summary

- resolve agent skill refs across visible id, public ref, and display-name matches in one scoped query
- prefer the most specific visible skill scope: repo > workspace > global
- add regressions for workspace/global name collisions, repo-specific precedence, and a workspace display name shadowed by a global ref

## Verification

- go test ./internal/store
- go test ./...

Closes #699

<!-- agents-run: {"v":1,"instance_id":"ts-lonestar","workspace":"default","repo":"eloylp/agents","span_id":"6371ae57a9d964e3","agent_id":"agent_0fb82d1fe34e45408bd2fee153f7003d","agent_name":"coder","sig":"MRYofAfiU3qmcZeIJt1n8aKEblM90jRiKvzF70Bf458"} -->
