### PR TITLE
Fix run attribution artifact timestamp scanning

### DIFF
--- a/internal/store/run_attribution_artifacts.go
+++ b/internal/store/run_attribution_artifacts.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"database/sql"
 	"fmt"
 	"strings"
 	"time"
@@ -229,15 +230,43 @@ type runAttributionArtifactScanner interface {
 
 func scanRunAttributionArtifact(row runAttributionArtifactScanner) (RunAttributionArtifact, error) {
 	var a RunAttributionArtifact
+	var githubCreatedAt, githubUpdatedAt, observedAt sql.NullString
 	err := row.Scan(
 		&a.ID, &a.WorkspaceID, &a.RepoOwner, &a.RepoName, &a.IssueOrPRNumber,
 		&a.SourceType, &a.GitHubCommentID, &a.GitHubReviewID, &a.GitHubReviewCommentID,
 		&a.GitHubParentCommentID, &a.GitHubDeliveryID, &a.SourceURL, &a.AuthorLogin,
 		&a.FilePath, &a.Line, &a.Side, &a.CommitSHA, &a.SpanID, &a.MetadataJSON,
-		&a.GitHubCreatedAt, &a.GitHubUpdatedAt, &a.ObservedAt,
+		&githubCreatedAt, &githubUpdatedAt, &observedAt,
 	)
 	if err != nil {
 		return RunAttributionArtifact{}, fmt.Errorf("scan run attribution artifact: %w", err)
 	}
+	a.GitHubCreatedAt = parseRunAttributionArtifactTimePtr(githubCreatedAt)
+	a.GitHubUpdatedAt = parseRunAttributionArtifactTimePtr(githubUpdatedAt)
+	if t := parseRunAttributionArtifactTimePtr(observedAt); t != nil {
+		a.ObservedAt = *t
+	}
 	return a, nil
+}
+
+func parseRunAttributionArtifactTimePtr(ns sql.NullString) *time.Time {
+	value := strings.TrimSpace(ns.String)
+	if !ns.Valid || value == "" {
+		return nil
+	}
+	for _, layout := range []string{
+		time.RFC3339Nano,
+		time.RFC3339,
+		time.DateTime,
+		"2006-01-02 15:04:05 -0700 MST",
+		"2006-01-02 15:04:05.999999999 -0700 MST",
+		"2006-01-02 15:04:05 -0700 -0700",
+		"2006-01-02 15:04:05.999999999 -0700 -0700",
+	} {
+		if t, err := time.Parse(layout, value); err == nil {
+			u := t.UTC()
+			return &u
+		}
+	}
+	return nil
 }

--- a/internal/store/run_attribution_artifacts_test.go
+++ b/internal/store/run_attribution_artifacts_test.go
@@ -132,3 +132,37 @@ func TestRunAttributionArtifactUpsertAndLookups(t *testing.T) {
 		t.Fatalf("review id lookup matched a review comment row, want false")
 	}
 }
+
+func TestRunAttributionArtifactLookupParsesLiveTimestampText(t *testing.T) {
+	t.Parallel()
+	st := store.New(openTestDB(t))
+	t.Cleanup(func() { st.Close() })
+
+	_, err := st.DB().Exec(`
+		INSERT INTO run_attribution_artifacts (
+			workspace_id, repo_owner, repo_name, issue_or_pr_number,
+			source_type, commit_sha, span_id, metadata_json,
+			github_created_at, github_updated_at, observed_at
+		) VALUES (?,?,?,?,?,?,?,?,?,?,?)`,
+		"self-improvement-demo", "eloylp", "test-acme-repo", 0,
+		"commit", "82170ee3de01de12873a0e4dad3ebbc96759166f", "50cc824e1d7faf8d", `{"span_id":"50cc824e1d7faf8d"}`,
+		"2026-06-18 13:06:18 +0200 +0200", "2026-06-18 13:06:18 +0200 +0200", "2026-06-18 11:06:20",
+	)
+	if err != nil {
+		t.Fatalf("insert live-shaped artifact: %v", err)
+	}
+
+	got, ok := st.RunAttributionArtifactByCommitSHA("self-improvement-demo", "eloylp", "test-acme-repo", "82170ee3de01de12873a0e4dad3ebbc96759166f")
+	if !ok {
+		t.Fatalf("lookup ok = false, want true")
+	}
+	if got.SpanID != "50cc824e1d7faf8d" {
+		t.Fatalf("SpanID = %q, want 50cc824e1d7faf8d", got.SpanID)
+	}
+	if got.GitHubCreatedAt == nil {
+		t.Fatalf("GitHubCreatedAt = nil, want parsed time")
+	}
+	if got.ObservedAt.IsZero() {
+		t.Fatalf("ObservedAt is zero, want parsed time")
+	}
+}


### PR DESCRIPTION
## Summary

- Scan run attribution artifact timestamp columns as text instead of directly into time.Time.
- Parse the timestamp formats seen in live SQLite rows, including Go time.String fixed-zone values such as `2026-06-18 13:06:18 +0200 +0200`.
- Add a regression test that inserts a live-shaped commit artifact row and verifies commit-SHA lookup succeeds.

## Why

The `/agents improve` replay showed feedback rows had the right PR review comment context and commit SHA, and the database had the matching commit artifact. The resolver still reported `commented commit has no signed agent attribution` because the artifact lookup helper silently returned false when scanning timestamp text failed.

## Tests

- `GOCACHE=/tmp/go-build-agents go test ./internal/store ./internal/observe ./internal/webhook`
