### PR TITLE
[codex] Tidy skill list labels

### DIFF
--- a/internal/ui/src/app/skills/page.test.tsx
+++ b/internal/ui/src/app/skills/page.test.tsx
@@ -20,7 +20,7 @@ describe('<SkillsPage />', () => {
     vi.unstubAllGlobals()
   })
 
-  it('shows stable skill ids next to display names', async () => {
+  it('keeps long stable skill ids in tooltips instead of row labels', async () => {
     const fetchMock = vi.fn((input: RequestInfo | URL) => {
       const url = String(input)
       if (url === '/skills') {
@@ -53,14 +53,16 @@ describe('<SkillsPage />', () => {
 
     render(<SkillsPage />)
 
-    expect(await screen.findByText('go-api · go api boundaries')).toBeInTheDocument()
+    expect(await screen.findByText('go api boundaries')).toBeInTheDocument()
     expect(screen.getByText('testing')).toBeInTheDocument()
+    expect(screen.queryByText('go-api · go api boundaries')).not.toBeInTheDocument()
+    expect(screen.getByText('go api boundaries')).toHaveAttribute('title', 'go api boundaries · go-api')
 
-    const goAPI = screen.getByText('go-api · go api boundaries').closest('div')
+    const goAPI = screen.getByText('go api boundaries').closest('div')
     if (!goAPI) throw new Error('go-api skill row not found')
     fireEvent.click(within(goAPI.parentElement?.parentElement ?? goAPI).getByRole('button', { name: 'Edit' }))
 
-    expect(await screen.findByText('Edit, go-api · go api boundaries')).toBeInTheDocument()
+    expect(await screen.findByText('Edit, go api boundaries')).toBeInTheDocument()
     expect(screen.getByText('Stable id')).toBeInTheDocument()
     expect(screen.getByText('go-api')).toBeInTheDocument()
     expect(screen.getByTestId('catalog-versions')).toHaveTextContent('versions for go-api')

--- a/internal/ui/src/app/skills/page.tsx
+++ b/internal/ui/src/app/skills/page.tsx
@@ -44,10 +44,15 @@ function stableSkillID(skill: Skill) {
 }
 
 function skillDisplayLabel(skill: Skill) {
+  const name = (skill.name || '').trim()
+  return name || stableSkillID(skill)
+}
+
+function skillIdentityTooltip(skill: Skill) {
   const id = stableSkillID(skill)
   const name = (skill.name || '').trim()
   if (!id || id === name) return name || id
-  return `${id} · ${name}`
+  return `${name} · ${id}`
 }
 
 function SkillForm({
@@ -302,6 +307,12 @@ export default function SkillsPage() {
     return 'Global'
   }
 
+  const shortScopeLabel = (sk: Skill) => {
+    if (sk.repo) return 'Repo'
+    if (sk.workspace_id) return 'Workspace'
+    return 'Global'
+  }
+
   const visibleSkills = skills.filter(sk => {
     const type = scopeType(sk)
     if (filterScope !== 'all' && type !== filterScope) return false
@@ -382,9 +393,17 @@ export default function SkillsPage() {
           <Card key={stableSkillID(sk) || sk.name}>
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '1rem' }}>
               <div style={{ flex: 1, minWidth: 0 }}>
-                <div style={{ fontWeight: 700, color: 'var(--text-heading)', marginBottom: '0.2rem', overflowWrap: 'anywhere' }}>{skillDisplayLabel(sk)}</div>
-                <div style={{ color: 'var(--text-muted)', fontSize: '0.72rem', marginBottom: '0.35rem' }}>
-                  {scopeLabel(sk)}{sk.version ? ` · v${sk.version}` : ''}
+                <div
+                  title={skillIdentityTooltip(sk)}
+                  style={{ fontWeight: 700, color: 'var(--text-heading)', marginBottom: '0.2rem', overflowWrap: 'anywhere' }}
+                >
+                  {skillDisplayLabel(sk)}
+                </div>
+                <div
+                  title={scopeLabel(sk)}
+                  style={{ color: 'var(--text-muted)', fontSize: '0.72rem', marginBottom: '0.35rem' }}
+                >
+                  {shortScopeLabel(sk)}{sk.version ? ` · v${sk.version}` : ''}
                 </div>
                 <pre style={{
                   fontSize: '0.78rem', color: 'var(--text-faint)', background: 'var(--bg)',


### PR DESCRIPTION
## Summary

- Show skill display names in the Skills list instead of long stable refs.
- Move stable ids and full scope strings into row tooltips so they remain inspectable without crowding the UI.
- Update the Skills page component test for the new label behavior.

## Validation

- npm test -- src/app/skills/page.test.tsx