### PR TITLE
[codex] Reuse modal shell for improvement dialogs

### DIFF
--- a/internal/ui/src/app/improvements/page.tsx
+++ b/internal/ui/src/app/improvements/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { type CSSProperties, type ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
 import MarkdownEditor from '@/components/MarkdownEditor'
+import Modal from '@/components/Modal'
 import { formatDateTime } from '@/lib/datetime'
 import { withWorkspace } from '@/lib/workspace'
 
@@ -1038,16 +1039,16 @@ export default function ImprovementsPage() {
       )}
 
       {reviewingProposal && (
-        <div role="dialog" aria-modal="true" style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.48)', display: 'grid', placeItems: 'center', zIndex: 1200, padding: '1rem' }}>
-          <section style={{ width: 'min(1100px, 100%)', maxHeight: 'min(860px, 94vh)', overflow: 'auto', background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 8, boxShadow: '0 18px 48px rgba(0,0,0,0.35)' }}>
-            <header style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem', alignItems: 'start', padding: '1rem', borderBottom: '1px solid var(--border-subtle)' }}>
-              <div>
-                <h2 style={{ color: 'var(--text-heading)', fontSize: '1rem', marginBottom: 4 }}>Review proposal</h2>
-                <div style={{ color: 'var(--text-muted)', fontSize: '0.8rem' }}>{reviewingProposal.id} · {reviewingProposal.status}</div>
-              </div>
-              <button onClick={() => setReviewingProposal(null)} style={{ border: '1px solid var(--border)', background: 'var(--bg-input)', color: 'var(--text)', borderRadius: 6, padding: '6px 9px' }}>Close</button>
-            </header>
-            <div style={{ display: 'grid', gap: '1rem', padding: '1rem' }}>
+        <Modal
+          title="Review proposal"
+          subtitle={`${reviewingProposal.id} · ${reviewingProposal.status}`}
+          onClose={() => setReviewingProposal(null)}
+          maxWidth="1100px"
+          maxHeight="min(860px, 94vh)"
+          overlayBackground="rgba(0,0,0,0.48)"
+          align="center"
+        >
+            <div style={{ display: 'grid', gap: '1rem' }}>
               <section style={{ display: 'grid', gap: 6 }}>
                 <strong style={{ color: 'var(--text-heading)' }}>{reviewingProposal.finding}</strong>
                 <span style={{ color: 'var(--text)' }}>{reviewingProposal.rationale}</span>
@@ -1234,21 +1235,21 @@ export default function ImprovementsPage() {
                 </section>
               )}
             </div>
-          </section>
-        </div>
+        </Modal>
       )}
 
       {clarifying && (
-        <div role="dialog" aria-modal="true" style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.42)', display: 'grid', placeItems: 'center', zIndex: 1300, padding: '1rem' }}>
-          <section style={{ width: 'min(920px, 100%)', maxHeight: 'min(760px, 92vh)', overflow: 'auto', background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 8, boxShadow: '0 18px 48px rgba(0,0,0,0.35)' }}>
-            <header style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem', alignItems: 'start', padding: '1rem', borderBottom: '1px solid var(--border-subtle)' }}>
-              <div>
-                <h2 style={{ color: 'var(--text-heading)', fontSize: '1rem', marginBottom: 4 }}>Clarify proposal</h2>
-                <div style={{ color: 'var(--text-muted)', fontSize: '0.8rem' }}>#{clarifying.feedback_event_id} · {clarifying.id} · {clarifying.status}</div>
-              </div>
-              <button onClick={() => setClarifying(null)} style={{ border: '1px solid var(--border)', background: 'var(--bg-input)', color: 'var(--text)', borderRadius: 6, padding: '6px 9px' }}>Close</button>
-            </header>
-            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 320px), 1fr))', gap: '1rem', padding: '1rem' }}>
+        <Modal
+          title="Clarify proposal"
+          subtitle={`#${clarifying.feedback_event_id} · ${clarifying.id} · ${clarifying.status}`}
+          onClose={() => setClarifying(null)}
+          maxWidth="920px"
+          maxHeight="min(760px, 92vh)"
+          zIndex={1300}
+          overlayBackground="rgba(0,0,0,0.42)"
+          align="center"
+        >
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 320px), 1fr))', gap: '1rem' }}>
               <div style={{ display: 'grid', gap: '0.85rem' }}>
                 <section style={{ display: 'grid', gap: 6 }}>
                   <h3 style={{ color: 'var(--text-heading)', fontSize: '0.82rem' }}>Proposal</h3>
@@ -1289,27 +1290,23 @@ export default function ImprovementsPage() {
                 {clarifying.clarification && <InfoRow label="Last clarified" value={formatDateTime(clarifying.clarification.updated_at)} />}
               </aside>
             </div>
-          </section>
-        </div>
+        </Modal>
       )}
 
       {bundleDecision && (
-        <div role="dialog" aria-modal="true" style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.42)', display: 'grid', placeItems: 'center', zIndex: 1200, padding: '1rem' }}>
-          <section style={{ width: 'min(620px, 100%)', maxHeight: 'min(620px, 92vh)', overflow: 'auto', background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 8, boxShadow: '0 18px 48px rgba(0,0,0,0.35)' }}>
-            <header style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem', alignItems: 'start', padding: '1rem', borderBottom: '1px solid var(--border-subtle)' }}>
-              <div>
-                <h2 style={{ color: 'var(--text-heading)', fontSize: '1rem', marginBottom: 4 }}>
-                  {bundleDecision.kind === 'reject'
-                    ? bundleDecision.closesProposal ? 'Reject proposal' : 'Reject bundle item'
-                    : 'Use existing asset'}
-                </h2>
-                <div style={{ color: 'var(--text-muted)', fontSize: '0.8rem' }}>{bundleDecision.assetLabel}</div>
-              </div>
-              {bundleDecision.kind === 'link' && (
-                <button onClick={() => setBundleDecision(null)} style={{ border: '1px solid var(--border)', background: 'var(--bg-input)', color: 'var(--text)', borderRadius: 6, padding: '6px 9px' }}>Close</button>
-              )}
-            </header>
-            <div style={{ display: 'grid', gap: '0.85rem', padding: '1rem' }}>
+        <Modal
+          title={bundleDecision.kind === 'reject'
+            ? bundleDecision.closesProposal ? 'Reject proposal' : 'Reject bundle item'
+            : 'Use existing asset'}
+          subtitle={bundleDecision.assetLabel}
+          onClose={() => setBundleDecision(null)}
+          maxWidth="620px"
+          maxHeight="min(620px, 92vh)"
+          overlayBackground="rgba(0,0,0,0.42)"
+          align="center"
+          showHeaderClose={bundleDecision.kind === 'link'}
+        >
+            <div style={{ display: 'grid', gap: '0.85rem' }}>
               {bundleDecision.kind === 'reject' && bundleDecision.closesProposal && (
                 <p style={{ color: 'var(--text-muted)', fontSize: '0.84rem', lineHeight: 1.45, margin: 0 }}>
                   This is the only item in the bundle, so rejecting it will close the whole proposal. The decision is terminal.
@@ -1362,20 +1359,21 @@ export default function ImprovementsPage() {
                 </button>
               </div>
             </div>
-          </section>
-        </div>
+        </Modal>
       )}
 
       {rejectingRecommendation && (
-        <div role="dialog" aria-modal="true" style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.42)', display: 'grid', placeItems: 'center', zIndex: 1210, padding: '1rem' }}>
-          <section style={{ width: 'min(560px, 100%)', background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 8, boxShadow: '0 18px 48px rgba(0,0,0,0.35)' }}>
-            <header style={{ padding: '1rem', borderBottom: '1px solid var(--border-subtle)' }}>
-              <h2 style={{ color: 'var(--text-heading)', fontSize: '1rem', marginBottom: 4 }}>Reject proposal</h2>
-              <p style={{ color: 'var(--text-muted)', fontSize: '0.84rem', lineHeight: 1.45, margin: 0 }}>
-                Rejecting this proposal is a terminal decision. You can optionally record why.
-              </p>
-            </header>
-            <div style={{ display: 'grid', gap: '0.85rem', padding: '1rem' }}>
+        <Modal
+          title="Reject proposal"
+          subtitle="Rejecting this proposal is a terminal decision. You can optionally record why."
+          onClose={() => setRejectingRecommendation(null)}
+          maxWidth="560px"
+          zIndex={1210}
+          overlayBackground="rgba(0,0,0,0.42)"
+          align="center"
+          showHeaderClose={false}
+        >
+            <div style={{ display: 'grid', gap: '0.85rem' }}>
               <label style={{ display: 'grid', gap: 5, color: 'var(--text-muted)', fontSize: '0.78rem' }}>
                 Reason
                 <textarea
@@ -1392,25 +1390,25 @@ export default function ImprovementsPage() {
                 <button disabled={recommendationRejectSaving} onClick={submitRecommendationReject} style={{ padding: '7px 10px', border: '1px solid var(--accent)', background: 'var(--bg-active)', color: 'var(--text)', borderRadius: 6, opacity: recommendationRejectSaving ? 0.6 : 1 }}>{recommendationRejectSaving ? 'Rejecting...' : 'Reject Proposal'}</button>
               </div>
             </div>
-          </section>
-        </div>
+        </Modal>
       )}
 
       {confirming && (
-        <div role="dialog" aria-modal="true" style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.42)', display: 'grid', placeItems: 'center', zIndex: 1210, padding: '1rem' }}>
-          <section style={{ width: 'min(520px, 100%)', background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 8, boxShadow: '0 18px 48px rgba(0,0,0,0.35)' }}>
-            <header style={{ padding: '1rem', borderBottom: '1px solid var(--border-subtle)' }}>
-              <div>
-                <h2 style={{ color: 'var(--text-heading)', fontSize: '1rem', marginBottom: 4 }}>{confirming.title}</h2>
-                <p style={{ color: 'var(--text-muted)', fontSize: '0.84rem', lineHeight: 1.45, margin: 0 }}>{confirming.body}</p>
-              </div>
-            </header>
-            <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', padding: '1rem', flexWrap: 'wrap' }}>
+        <Modal
+          title={confirming.title}
+          subtitle={confirming.body}
+          onClose={() => setConfirming(null)}
+          maxWidth="520px"
+          zIndex={1210}
+          overlayBackground="rgba(0,0,0,0.42)"
+          align="center"
+          showHeaderClose={false}
+        >
+            <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', flexWrap: 'wrap' }}>
               <button onClick={() => setConfirming(null)} style={{ padding: '7px 10px', border: '1px solid var(--border)', background: 'var(--bg-input)', color: 'var(--text)', borderRadius: 6 }}>Cancel</button>
               <button disabled={confirmSaving} onClick={submitConfirmation} style={{ padding: '7px 10px', border: '1px solid var(--accent)', background: 'var(--bg-active)', color: 'var(--text)', borderRadius: 6, opacity: confirmSaving ? 0.6 : 1 }}>{confirmSaving ? 'Working...' : confirming.confirmLabel}</button>
             </div>
-          </section>
-        </div>
+        </Modal>
       )}
 
     </main>

--- a/internal/ui/src/components/FullscreenModal.tsx
+++ b/internal/ui/src/components/FullscreenModal.tsx
@@ -31,7 +31,8 @@ export default function FullscreenModal({ title, onClose, children }: Fullscreen
             onClick={onClose}
             style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '1.2rem', color: 'var(--text-faint)', lineHeight: 1 }}
             aria-label="Close"
-          >x</button>
+            title="Close"
+          >×</button>
         </div>
         <div style={{ flex: 1, minHeight: 0, padding: '1rem 1.25rem', overflow: 'auto' }}>
           {children}

--- a/internal/ui/src/components/LiveTraceModal.tsx
+++ b/internal/ui/src/components/LiveTraceModal.tsx
@@ -94,11 +94,16 @@ export default function LiveTraceModal({ span, onClose }: { span: LiveTraceSpan;
               span <code>{span.id}</code> · {status === 'live' ? 'streaming' : status === 'ended' ? 'run completed' : status === 'error' ? 'disconnected' : 'connecting'} · {entries.length} event{entries.length !== 1 ? 's' : ''}
             </div>
           </div>
-          <button onClick={onClose} style={{
-            background: 'var(--bg-input)', border: '1px solid var(--border)',
-            color: 'var(--text)', padding: '4px 12px', borderRadius: '4px',
-            cursor: 'pointer', fontSize: '0.85rem',
-          }}>Close</button>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            title="Close"
+            style={{
+              background: 'none', border: 'none', color: 'var(--text-faint)',
+              width: 28, height: 28, borderRadius: 4, cursor: 'pointer',
+              fontSize: '1.25rem', lineHeight: 1,
+            }}
+          >×</button>
         </div>
         <div
           ref={scrollRef}

--- a/internal/ui/src/components/Modal.tsx
+++ b/internal/ui/src/components/Modal.tsx
@@ -1,34 +1,59 @@
 import React from 'react'
 
 interface ModalProps {
-  title: string
+  title: React.ReactNode
+  subtitle?: React.ReactNode
   onClose: () => void
   children: React.ReactNode
   maxWidth?: number | string
+  maxHeight?: number | string
+  zIndex?: number
+  overlayBackground?: string
+  align?: 'start' | 'center'
+  showHeaderClose?: boolean
 }
 
-export default function Modal({ title, onClose, children, maxWidth = '600px' }: ModalProps) {
+export default function Modal({
+  title,
+  subtitle,
+  onClose,
+  children,
+  maxWidth = '600px',
+  maxHeight,
+  zIndex = 1200,
+  overlayBackground = 'var(--bg-modal-overlay)',
+  align = 'start',
+  showHeaderClose = true,
+}: ModalProps) {
   return (
     <div
+      role="dialog"
+      aria-modal="true"
       style={{
-        position: 'fixed', inset: 0, background: 'var(--bg-modal-overlay)',
-        display: 'flex', alignItems: 'flex-start', justifyContent: 'center',
-        zIndex: 1200, padding: '2rem 1rem', overflowY: 'auto',
+        position: 'fixed', inset: 0, background: overlayBackground,
+        display: 'flex', alignItems: align === 'center' ? 'center' : 'flex-start', justifyContent: 'center',
+        zIndex, padding: align === 'center' ? '1rem' : '2rem 1rem', overflowY: 'auto',
       }}
       onClick={e => { if (e.target === e.currentTarget) onClose() }}
     >
       <div style={{
         background: 'var(--bg-card)', borderRadius: '10px', border: '1px solid var(--border)',
         boxShadow: '0 8px 32px rgba(0,0,0,0.2)', width: '100%', maxWidth,
-        padding: '1.5rem',
+        maxHeight, overflow: maxHeight ? 'auto' : undefined, padding: '1.5rem',
       }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1.25rem' }}>
-          <h2 style={{ fontSize: '1.1rem', fontWeight: 700, color: 'var(--text-heading)' }}>{title}</h2>
-          <button
-            onClick={onClose}
-            style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '1.2rem', color: 'var(--text-faint)', lineHeight: 1 }}
-            aria-label="Close"
-          >x</button>
+          <div>
+            <h2 style={{ fontSize: '1.1rem', fontWeight: 700, color: 'var(--text-heading)' }}>{title}</h2>
+            {subtitle && <div style={{ color: 'var(--text-muted)', fontSize: '0.8rem', marginTop: 4 }}>{subtitle}</div>}
+          </div>
+          {showHeaderClose && (
+            <button
+              onClick={onClose}
+              style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '1.2rem', color: 'var(--text-faint)', lineHeight: 1 }}
+              aria-label="Close"
+              title="Close"
+            >×</button>
+          )}
         </div>
         {children}
       </div>


### PR DESCRIPTION
## Summary

- Extend the shared Modal component with optional subtitle, sizing, z-index, alignment, overlay, and header-close controls.
- Migrate Improvements dialogs from hand-rolled modal shells to the shared Modal component.
- Use icon-only top-right close controls for shared, fullscreen, and live trace modal headers while preserving footer Close actions.

## Validation

- npm test -- src/app/improvements/page.test.tsx src/app/skills/page.test.tsx