### PR TITLE
fix: harden SQLite timestamp scans

### DIFF
--- a/internal/observe/attribution.go
+++ b/internal/observe/attribution.go
@@ -577,11 +577,15 @@ func (s *Store) inferRunAttributions(workspaceID string, q AttributionQuery) []A
 		FROM run_attributions
 		WHERE workspace_id=? AND repo_owner=? AND repo_name=? AND issue_or_pr_number=?
 		  AND (?='' OR head_sha=?)
-		  AND created_at BETWEEN ? AND ?
-		ORDER BY created_at DESC`,
+		  AND (
+			created_at BETWEEN ? AND ?
+			OR replace(substr(created_at, 1, 19), 'T', ' ') BETWEEN ? AND ?
+		  )
+		ORDER BY replace(substr(created_at, 1, 19), 'T', ' ') DESC, created_at DESC`,
 		workspaceID, q.RepoOwner, q.RepoName, q.IssueOrPRNumber,
 		strings.TrimSpace(q.HeadSHA), strings.TrimSpace(q.HeadSHA),
 		from.UTC().Format(time.RFC3339Nano), to.UTC().Format(time.RFC3339Nano),
+		from.UTC().Format(time.DateTime), to.UTC().Format(time.DateTime),
 	)
 	if err != nil {
 		return nil

--- a/internal/observe/attribution.go
+++ b/internal/observe/attribution.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/eloylp/agents/internal/fleet"
+	storepkg "github.com/eloylp/agents/internal/store"
 	"github.com/eloylp/agents/internal/workflow"
 )
 
@@ -513,7 +514,7 @@ func (s *Store) recordRunAttribution(in workflow.SpanInput, createdAt time.Time)
 		a.SpanID, a.WorkspaceID, a.RepoOwner, a.RepoName, a.IssueOrPRNumber,
 		a.EventID, a.EventQueueID, a.AgentID, a.AgentName, a.BackendID, a.BackendName,
 		nullString(a.PromptVersionID), a.PromptRef, strings.Join(a.SkillVersionIDs, ","), strings.Join(a.GuardrailVersionIDs, ","),
-		a.HeadSHA, a.Branch, a.CreatedAt,
+		a.HeadSHA, a.Branch, a.CreatedAt.UTC().Format(time.RFC3339Nano),
 	)
 	if err != nil {
 		log.Printf("observe: persist run attribution %s: %v", in.SpanID, err)
@@ -580,7 +581,7 @@ func (s *Store) inferRunAttributions(workspaceID string, q AttributionQuery) []A
 		ORDER BY created_at DESC`,
 		workspaceID, q.RepoOwner, q.RepoName, q.IssueOrPRNumber,
 		strings.TrimSpace(q.HeadSHA), strings.TrimSpace(q.HeadSHA),
-		from, to,
+		from.UTC().Format(time.RFC3339Nano), to.UTC().Format(time.RFC3339Nano),
 	)
 	if err != nil {
 		return nil
@@ -609,15 +610,20 @@ type attributionScanner interface {
 func scanAttribution(row attributionScanner) (AttributionSnapshot, error) {
 	var snap AttributionSnapshot
 	var skills, guardrails string
+	var createdAt storepkg.SQLiteTime
 	err := row.Scan(
 		&snap.WorkspaceID, &snap.RepoOwner, &snap.RepoName, &snap.IssueOrPRNumber,
 		&snap.EventID, &snap.EventQueueID, &snap.SpanID, &snap.AgentID, &snap.AgentName,
 		&snap.BackendID, &snap.BackendName, &snap.PromptVersionID, &snap.PromptRef,
-		&skills, &guardrails, &snap.HeadSHA, &snap.Branch, &snap.CreatedAt,
+		&skills, &guardrails, &snap.HeadSHA, &snap.Branch, &createdAt,
 	)
 	if err != nil {
 		return AttributionSnapshot{}, err
 	}
+	if err := createdAt.Err(); err != nil {
+		return AttributionSnapshot{}, fmt.Errorf("scan attribution created_at: %w", err)
+	}
+	snap.CreatedAt = createdAt.OrZero()
 	snap.SkillVersionIDs = splitList(skills)
 	snap.GuardrailVersionIDs = splitList(guardrails)
 	return snap, nil

--- a/internal/observe/observe.go
+++ b/internal/observe/observe.go
@@ -474,9 +474,14 @@ func (s *Store) ListEventsForWorkspace(workspaceID string, since time.Time) []Ti
 			workspaceID,
 		)
 	} else {
+		sinceTime := since.UTC()
 		rows, err = s.db.Query(
-			`SELECT id, workspace_id, at, repo, kind, number, actor, payload FROM events WHERE workspace_id = ? AND at > ? ORDER BY at ASC LIMIT 500`,
-			workspaceID, since,
+			`SELECT id, workspace_id, at, repo, kind, number, actor, payload
+			FROM events
+			WHERE workspace_id = ?
+			  AND (at > ? OR replace(substr(at, 1, 19), 'T', ' ') > ?)
+			ORDER BY at ASC LIMIT 500`,
+			workspaceID, sinceTime.Format(time.RFC3339Nano), sinceTime.Format(time.DateTime),
 		)
 	}
 	if err != nil {
@@ -488,10 +493,16 @@ func (s *Store) ListEventsForWorkspace(workspaceID string, since time.Time) []Ti
 	for rows.Next() {
 		var te TimestampedEvent
 		var payloadStr string
-		if err := rows.Scan(&te.ID, &te.WorkspaceID, &te.At, &te.Repo, &te.Kind, &te.Number, &te.Actor, &payloadStr); err != nil {
+		var at storepkg.SQLiteTime
+		if err := rows.Scan(&te.ID, &te.WorkspaceID, &at, &te.Repo, &te.Kind, &te.Number, &te.Actor, &payloadStr); err != nil {
 			log.Printf("observe: scan event row: %v", err)
 			continue
 		}
+		if err := at.Err(); err != nil {
+			log.Printf("observe: parse event timestamp: %v", err)
+			continue
+		}
+		te.At = at.OrZero()
 		if payloadStr != "" {
 			_ = json.Unmarshal([]byte(payloadStr), &te.Payload)
 		}
@@ -584,12 +595,13 @@ func scanSpans(rows *sql.Rows) []Span {
 		var sp Span
 		var promptSize, inTok, outTok, cacheR, cacheW sql.NullInt64
 		var promptVersionID, skillVersionIDs, guardrailVersionIDs string
+		var started, finished storepkg.SQLiteTime
 		if err := rows.Scan(
 			&sp.SpanID, &sp.WorkspaceID, &sp.RootEventID, &sp.ParentSpanID,
 			&sp.Agent, &sp.Backend, &sp.Repo, &sp.Number,
 			&sp.EventKind, &sp.InvokedBy, &sp.DispatchDepth,
 			&sp.QueueWaitMs, &sp.ArtifactsCount, &sp.Summary,
-			&sp.StartedAt, &sp.FinishedAt, &sp.DurationMs,
+			&started, &finished, &sp.DurationMs,
 			&sp.Status, &sp.ErrorMsg, &sp.ErrorDetail,
 			&promptSize, &promptVersionID, &skillVersionIDs, &guardrailVersionIDs,
 			&inTok, &outTok, &cacheR, &cacheW,
@@ -597,6 +609,16 @@ func scanSpans(rows *sql.Rows) []Span {
 			log.Printf("observe: scan trace row: %v", err)
 			continue
 		}
+		if err := started.Err(); err != nil {
+			log.Printf("observe: parse trace started_at: %v", err)
+			continue
+		}
+		if err := finished.Err(); err != nil {
+			log.Printf("observe: parse trace finished_at: %v", err)
+			continue
+		}
+		sp.StartedAt = started.OrZero()
+		sp.FinishedAt = finished.OrZero()
 		sp.PromptSize = promptSize.Int64
 		sp.PromptVersionID = promptVersionID
 		sp.SkillVersionIDs = splitCatalogVersionIDs(skillVersionIDs)
@@ -646,9 +668,13 @@ func (s *Store) ListEdgesForWorkspace(workspaceID string) []Edge {
 	for rows.Next() {
 		var from, to, repo, reason string
 		var number int
-		var at time.Time
+		var at storepkg.SQLiteTime
 		if err := rows.Scan(&from, &to, &repo, &number, &reason, &at); err != nil {
 			log.Printf("observe: scan dispatch row: %v", err)
+			continue
+		}
+		if err := at.Err(); err != nil {
+			log.Printf("observe: parse dispatch timestamp: %v", err)
 			continue
 		}
 		key := from + "\x00" + to
@@ -658,7 +684,7 @@ func (s *Store) ListEdgesForWorkspace(workspaceID string) []Edge {
 			edges[key] = e
 		}
 		e.Count++
-		e.Dispatches = append(e.Dispatches, DispatchRecord{At: at, WorkspaceID: workspaceID, Repo: repo, Number: number, Reason: reason})
+		e.Dispatches = append(e.Dispatches, DispatchRecord{At: at.OrZero(), WorkspaceID: workspaceID, Repo: repo, Number: number, Reason: reason})
 	}
 
 	out := make([]Edge, 0, len(edges))
@@ -727,7 +753,7 @@ func (s *Store) RecordEvent(at time.Time, ev workflow.Event) {
 		payload, _ := json.Marshal(te.Payload)
 		_, err := s.db.Exec(
 			`INSERT OR IGNORE INTO events (id, workspace_id, at, repo, kind, number, actor, payload) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-			te.ID, te.WorkspaceID, te.At, te.Repo, te.Kind, te.Number, te.Actor, string(payload),
+			te.ID, te.WorkspaceID, te.At.UTC().Format(time.RFC3339Nano), te.Repo, te.Kind, te.Number, te.Actor, string(payload),
 		)
 		if err != nil {
 			log.Printf("observe: persist event %s: %v", te.ID, err)
@@ -791,7 +817,7 @@ func (s *Store) RecordSpan(in workflow.SpanInput) {
 			sp.Agent, sp.Backend, sp.Repo, sp.Number,
 			sp.EventKind, sp.InvokedBy, sp.DispatchDepth,
 			sp.QueueWaitMs, sp.ArtifactsCount, sp.Summary,
-			sp.StartedAt, sp.FinishedAt, sp.DurationMs,
+			sp.StartedAt.UTC().Format(time.RFC3339Nano), sp.FinishedAt.UTC().Format(time.RFC3339Nano), sp.DurationMs,
 			sp.Status, sp.ErrorMsg, sp.ErrorDetail,
 			promptGz, sp.PromptSize,
 			sp.PromptVersionID, strings.Join(sp.SkillVersionIDs, ","), strings.Join(sp.GuardrailVersionIDs, ","),

--- a/internal/observe/observe_test.go
+++ b/internal/observe/observe_test.go
@@ -933,6 +933,44 @@ func TestResolveRunAttributionInferredAmbiguousAndUnresolved(t *testing.T) {
 	}
 }
 
+func TestResolveRunAttributionInfersLegacySQLiteDatetimeText(t *testing.T) {
+	t.Parallel()
+	db, err := store.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	s := observe.NewStore(db)
+
+	_, err = db.Exec(
+		`INSERT INTO run_attributions (
+			span_id, workspace_id, repo_owner, repo_name, issue_or_pr_number,
+			agent_name, backend_name, head_sha, created_at
+		) VALUES (?,?,?,?,?,?,?,?,?)`,
+		"legacy-span", "default", "owner", "repo", 7,
+		"coder", "codex", "abc", "2026-06-18 12:00:00",
+	)
+	if err != nil {
+		t.Fatalf("insert legacy run attribution: %v", err)
+	}
+
+	got := s.ResolveRunAttribution(observe.AttributionQuery{
+		WorkspaceID: "default", RepoOwner: "owner", RepoName: "repo", IssueOrPRNumber: 7,
+		HeadSHA: "abc",
+		At:      time.Date(2026, 6, 18, 12, 30, 0, 0, time.UTC),
+		Window:  time.Hour,
+	})
+	if got.Confidence != observe.AttributionInferred {
+		t.Fatalf("Confidence = %q, want %q (%s)", got.Confidence, observe.AttributionInferred, got.Diagnostic)
+	}
+	if got.Snapshot == nil || got.Snapshot.SpanID != "legacy-span" {
+		t.Fatalf("Snapshot = %+v, want legacy-span", got.Snapshot)
+	}
+	if got.Snapshot.CreatedAt != time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC) {
+		t.Fatalf("CreatedAt = %v, want parsed legacy timestamp", got.Snapshot.CreatedAt)
+	}
+}
+
 // ─── Store.RecordDispatch ─────────────────────────────────────────────────────
 
 // TestStoreRecordDispatchPersistsToDB verifies that RecordDispatch persists

--- a/internal/store/auth.go
+++ b/internal/store/auth.go
@@ -549,36 +549,46 @@ func randomBytes(n int) ([]byte, error) {
 func scanUser(row rowScanner) (User, error) {
 	var user User
 	var isAdmin int
-	var created, updated, lastLogin, disabled sql.NullString
+	var created, updated, lastLogin, disabled SQLiteTime
 	if err := row.Scan(&user.ID, &user.Username, &created, &updated, &lastLogin, &disabled, &isAdmin); err != nil {
 		return User{}, err
 	}
-	user.CreatedAt = parseDBTime(created)
-	user.UpdatedAt = parseDBTime(updated)
-	user.LastLoginAt = parseDBTimePtr(lastLogin)
-	user.DisabledAt = parseDBTimePtr(disabled)
+	for name, ts := range map[string]SQLiteTime{"created_at": created, "updated_at": updated, "last_login_at": lastLogin, "disabled_at": disabled} {
+		if err := ts.Err(); err != nil {
+			return User{}, fmt.Errorf("auth: scan user %s: %w", name, err)
+		}
+	}
+	user.CreatedAt = created.OrZero()
+	user.UpdatedAt = updated.OrZero()
+	user.LastLoginAt = lastLogin.Ptr()
+	user.DisabledAt = disabled.Ptr()
 	user.IsAdmin = isAdmin != 0
 	return user, nil
 }
 
 func scanAuthToken(row rowScanner) (AuthToken, error) {
 	var tok AuthToken
-	var created, expires, lastUsed, revoked sql.NullString
+	var created, expires, lastUsed, revoked SQLiteTime
 	if err := row.Scan(&tok.ID, &tok.UserID, &tok.Kind, &tok.Name, &tok.Prefix, &created, &expires, &lastUsed, &revoked); err != nil {
 		return AuthToken{}, fmt.Errorf("auth: scan token: %w", err)
 	}
-	tok.CreatedAt = parseDBTime(created)
-	tok.ExpiresAt = parseDBTimePtr(expires)
-	tok.LastUsedAt = parseDBTimePtr(lastUsed)
-	tok.RevokedAt = parseDBTimePtr(revoked)
+	for name, ts := range map[string]SQLiteTime{"created_at": created, "expires_at": expires, "last_used_at": lastUsed, "revoked_at": revoked} {
+		if err := ts.Err(); err != nil {
+			return AuthToken{}, fmt.Errorf("auth: scan token %s: %w", name, err)
+		}
+	}
+	tok.CreatedAt = created.OrZero()
+	tok.ExpiresAt = expires.Ptr()
+	tok.LastUsedAt = lastUsed.Ptr()
+	tok.RevokedAt = revoked.Ptr()
 	return tok, nil
 }
 
 func scanAuthIdentity(row rowScanner) (AuthIdentity, error) {
 	var ident AuthIdentity
 	var isAdmin int
-	var userCreated, userUpdated, lastLogin, disabled sql.NullString
-	var tokCreated, expires, lastUsed, revoked sql.NullString
+	var userCreated, userUpdated, lastLogin, disabled SQLiteTime
+	var tokCreated, expires, lastUsed, revoked SQLiteTime
 	err := row.Scan(
 		&ident.User.ID, &ident.User.Username, &userCreated, &userUpdated, &lastLogin, &disabled, &isAdmin,
 		&ident.Token.ID, &ident.Token.UserID, &ident.Token.Kind, &ident.Token.Name, &ident.Token.Prefix, &tokCreated, &expires, &lastUsed, &revoked,
@@ -586,34 +596,22 @@ func scanAuthIdentity(row rowScanner) (AuthIdentity, error) {
 	if err != nil {
 		return AuthIdentity{}, err
 	}
-	ident.User.CreatedAt = parseDBTime(userCreated)
-	ident.User.UpdatedAt = parseDBTime(userUpdated)
-	ident.User.LastLoginAt = parseDBTimePtr(lastLogin)
-	ident.User.DisabledAt = parseDBTimePtr(disabled)
-	ident.User.IsAdmin = isAdmin != 0
-	ident.Token.CreatedAt = parseDBTime(tokCreated)
-	ident.Token.ExpiresAt = parseDBTimePtr(expires)
-	ident.Token.LastUsedAt = parseDBTimePtr(lastUsed)
-	ident.Token.RevokedAt = parseDBTimePtr(revoked)
-	return ident, nil
-}
-
-func parseDBTime(ns sql.NullString) time.Time {
-	if t := parseDBTimePtr(ns); t != nil {
-		return *t
-	}
-	return time.Time{}
-}
-
-func parseDBTimePtr(ns sql.NullString) *time.Time {
-	if !ns.Valid || ns.String == "" {
-		return nil
-	}
-	for _, layout := range []string{time.RFC3339, "2006-01-02 15:04:05"} {
-		if t, err := time.Parse(layout, ns.String); err == nil {
-			u := t.UTC()
-			return &u
+	for name, ts := range map[string]SQLiteTime{
+		"user.created_at": userCreated, "user.updated_at": userUpdated, "user.last_login_at": lastLogin, "user.disabled_at": disabled,
+		"token.created_at": tokCreated, "token.expires_at": expires, "token.last_used_at": lastUsed, "token.revoked_at": revoked,
+	} {
+		if err := ts.Err(); err != nil {
+			return AuthIdentity{}, fmt.Errorf("auth: scan identity %s: %w", name, err)
 		}
 	}
-	return nil
+	ident.User.CreatedAt = userCreated.OrZero()
+	ident.User.UpdatedAt = userUpdated.OrZero()
+	ident.User.LastLoginAt = lastLogin.Ptr()
+	ident.User.DisabledAt = disabled.Ptr()
+	ident.User.IsAdmin = isAdmin != 0
+	ident.Token.CreatedAt = tokCreated.OrZero()
+	ident.Token.ExpiresAt = expires.Ptr()
+	ident.Token.LastUsedAt = lastUsed.Ptr()
+	ident.Token.RevokedAt = revoked.Ptr()
+	return ident, nil
 }

--- a/internal/store/helpers.go
+++ b/internal/store/helpers.go
@@ -1,5 +1,11 @@
 package store
 
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
 // boolToInt converts a bool to 0/1 for SQLite storage.
 func boolToInt(b bool) int {
 	if b {
@@ -20,4 +26,98 @@ func bindingEnabledInt(enabled *bool) int {
 		return 0
 	}
 	return 1
+}
+
+// SQLiteTime scans SQLite timestamp values without depending on the driver to
+// materialize a particular Go type. SQLite may return TIMESTAMP columns as
+// time.Time, []byte, or text in either RFC3339 or datetime('now') shape.
+type SQLiteTime struct {
+	Time  time.Time
+	Valid bool
+	raw   string
+	err   error
+}
+
+func (t *SQLiteTime) Scan(value any) error {
+	t.Time = time.Time{}
+	t.Valid = false
+	t.raw = ""
+	t.err = nil
+	switch v := value.(type) {
+	case nil:
+		return nil
+	case time.Time:
+		t.Time = v.UTC()
+		t.Valid = true
+		return nil
+	case string:
+		t.raw = strings.TrimSpace(v)
+	case []byte:
+		t.raw = strings.TrimSpace(string(v))
+	default:
+		t.err = fmt.Errorf("unsupported sqlite timestamp type %T", value)
+		return nil
+	}
+	if t.raw == "" {
+		return nil
+	}
+	parsed, err := ParseSQLiteTime(t.raw)
+	if err != nil {
+		t.err = err
+		return nil
+	}
+	t.Time = parsed
+	t.Valid = true
+	return nil
+}
+
+func (t SQLiteTime) Err() error {
+	if t.err == nil {
+		return nil
+	}
+	if t.raw != "" {
+		return fmt.Errorf("parse sqlite timestamp %q: %w", t.raw, t.err)
+	}
+	return t.err
+}
+
+func (t SQLiteTime) OrZero() time.Time {
+	if !t.Valid || t.err != nil {
+		return time.Time{}
+	}
+	return t.Time
+}
+
+func (t SQLiteTime) Ptr() *time.Time {
+	if !t.Valid || t.err != nil {
+		return nil
+	}
+	u := t.Time.UTC()
+	return &u
+}
+
+func ParseSQLiteTime(value string) (time.Time, error) {
+	value = strings.TrimSpace(value)
+	for _, layout := range []string{
+		time.RFC3339Nano,
+		time.RFC3339,
+		time.DateTime,
+		"2006-01-02 15:04:05.999999999",
+		"2006-01-02 15:04:05 -0700 MST",
+		"2006-01-02 15:04:05.999999999 -0700 MST",
+		"2006-01-02 15:04:05 -0700 -0700",
+		"2006-01-02 15:04:05.999999999 -0700 -0700",
+	} {
+		if parsed, err := time.Parse(layout, value); err == nil {
+			return parsed.UTC(), nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("unsupported timestamp format")
+}
+
+func sqliteTimeArg(t *time.Time) any {
+	if t == nil {
+		return nil
+	}
+	return t.UTC().Format(time.RFC3339Nano)
 }

--- a/internal/store/memory_raw.go
+++ b/internal/store/memory_raw.go
@@ -12,7 +12,8 @@ import (
 // ("", false, time.Time{}, nil). An empty content string with found=true
 // means the agent intentionally cleared its memory.
 func ReadMemory(db *sql.DB, workspace, agent, repo string) (string, bool, time.Time, error) {
-	var content, updatedAt string
+	var content string
+	var updatedAt SQLiteTime
 	err := db.QueryRow(
 		"SELECT content, updated_at FROM memory WHERE workspace_id=? AND agent=? AND repo=?", workspace, agent, repo,
 	).Scan(&content, &updatedAt)
@@ -22,14 +23,10 @@ func ReadMemory(db *sql.DB, workspace, agent, repo string) (string, bool, time.T
 	if err != nil {
 		return "", false, time.Time{}, fmt.Errorf("store: read memory %s/%s/%s: %w", workspace, agent, repo, err)
 	}
-	// The modernc.org/sqlite driver returns TIMESTAMP columns as RFC3339 strings
-	// (e.g. "2026-04-21T10:30:00Z"). Parse with time.RFC3339 and fall back to
-	// the bare "YYYY-MM-DD HH:MM:SS" SQLite text format as a safety net.
-	t, parseErr := time.Parse(time.RFC3339, updatedAt)
-	if parseErr != nil {
-		t, _ = time.Parse(time.DateTime, updatedAt)
+	if err := updatedAt.Err(); err != nil {
+		return "", false, time.Time{}, fmt.Errorf("store: read memory %s/%s/%s updated_at: %w", workspace, agent, repo, err)
 	}
-	return content, true, t.UTC(), nil
+	return content, true, updatedAt.OrZero(), nil
 }
 
 // WriteMemory upserts the memory string for (workspace, agent, repo), setting updated_at

--- a/internal/store/run_attribution_artifacts.go
+++ b/internal/store/run_attribution_artifacts.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"database/sql"
 	"fmt"
 	"strings"
 	"time"
@@ -100,7 +99,7 @@ func UpsertRunAttributionArtifact(db sqlExec, in RunAttributionArtifactInput) er
 		in.GitHubParentCommentID, strings.TrimSpace(in.GitHubDeliveryID), strings.TrimSpace(in.SourceURL),
 		strings.TrimSpace(in.AuthorLogin), strings.TrimSpace(in.FilePath), in.Line, strings.TrimSpace(in.Side),
 		strings.TrimSpace(in.CommitSHA), strings.TrimSpace(in.SpanID), in.MetadataJSON,
-		in.GitHubCreatedAt, in.GitHubUpdatedAt,
+		sqliteTimeArg(in.GitHubCreatedAt), sqliteTimeArg(in.GitHubUpdatedAt),
 	)
 	return err
 }
@@ -230,7 +229,7 @@ type runAttributionArtifactScanner interface {
 
 func scanRunAttributionArtifact(row runAttributionArtifactScanner) (RunAttributionArtifact, error) {
 	var a RunAttributionArtifact
-	var githubCreatedAt, githubUpdatedAt, observedAt sql.NullString
+	var githubCreatedAt, githubUpdatedAt, observedAt SQLiteTime
 	err := row.Scan(
 		&a.ID, &a.WorkspaceID, &a.RepoOwner, &a.RepoName, &a.IssueOrPRNumber,
 		&a.SourceType, &a.GitHubCommentID, &a.GitHubReviewID, &a.GitHubReviewCommentID,
@@ -241,32 +240,11 @@ func scanRunAttributionArtifact(row runAttributionArtifactScanner) (RunAttributi
 	if err != nil {
 		return RunAttributionArtifact{}, fmt.Errorf("scan run attribution artifact: %w", err)
 	}
-	a.GitHubCreatedAt = parseRunAttributionArtifactTimePtr(githubCreatedAt)
-	a.GitHubUpdatedAt = parseRunAttributionArtifactTimePtr(githubUpdatedAt)
-	if t := parseRunAttributionArtifactTimePtr(observedAt); t != nil {
-		a.ObservedAt = *t
+	a.GitHubCreatedAt = githubCreatedAt.Ptr()
+	a.GitHubUpdatedAt = githubUpdatedAt.Ptr()
+	if err := observedAt.Err(); err != nil {
+		return RunAttributionArtifact{}, fmt.Errorf("scan run attribution artifact observed_at: %w", err)
 	}
+	a.ObservedAt = observedAt.OrZero()
 	return a, nil
-}
-
-func parseRunAttributionArtifactTimePtr(ns sql.NullString) *time.Time {
-	value := strings.TrimSpace(ns.String)
-	if !ns.Valid || value == "" {
-		return nil
-	}
-	for _, layout := range []string{
-		time.RFC3339Nano,
-		time.RFC3339,
-		time.DateTime,
-		"2006-01-02 15:04:05 -0700 MST",
-		"2006-01-02 15:04:05.999999999 -0700 MST",
-		"2006-01-02 15:04:05 -0700 -0700",
-		"2006-01-02 15:04:05.999999999 -0700 -0700",
-	} {
-		if t, err := time.Parse(layout, value); err == nil {
-			u := t.UTC()
-			return &u
-		}
-	}
-	return nil
 }

--- a/internal/store/runners.go
+++ b/internal/store/runners.go
@@ -328,8 +328,10 @@ func scanRunnerRow(s rowScanner) (RunnerRecord, error) {
 // bound. Returns the number of rows removed.
 func (s *Store) DeleteCompletedEventsBefore(before time.Time) (int64, error) {
 	res, err := s.db.Exec(
-		"DELETE FROM event_queue WHERE completed_at IS NOT NULL AND completed_at < ?",
-		before.UTC().Format(time.RFC3339Nano),
+		`DELETE FROM event_queue
+		WHERE completed_at IS NOT NULL
+		  AND replace(substr(completed_at, 1, 19), 'T', ' ') < ?`,
+		before.UTC().Format(time.DateTime),
 	)
 	if err != nil {
 		return 0, fmt.Errorf("store: prune completed events: %w", err)

--- a/internal/store/runners.go
+++ b/internal/store/runners.go
@@ -256,26 +256,25 @@ func scanRunnerRow(s rowScanner) (RunnerRecord, error) {
 		id              int64
 		workspaceID     string
 		blob            string
-		enq             string
-		started, comple sql.NullString
+		enq             SQLiteTime
+		started, comple SQLiteTime
 	)
 	if err := s.Scan(&id, &workspaceID, &blob, &enq, &started, &comple); err != nil {
 		return RunnerRecord{}, err
 	}
 	rec := RunnerRecord{ID: id, WorkspaceID: fleet.NormalizeWorkspaceID(workspaceID)}
-	if t, err := time.Parse(time.RFC3339Nano, enq); err == nil {
-		rec.EnqueuedAt = t
+	if err := enq.Err(); err != nil {
+		return RunnerRecord{}, fmt.Errorf("store: scan runner enqueued_at: %w", err)
 	}
-	if started.Valid {
-		if t, err := time.Parse(time.RFC3339Nano, started.String); err == nil {
-			rec.StartedAt = &t
-		}
+	if err := started.Err(); err != nil {
+		return RunnerRecord{}, fmt.Errorf("store: scan runner started_at: %w", err)
 	}
-	if comple.Valid {
-		if t, err := time.Parse(time.RFC3339Nano, comple.String); err == nil {
-			rec.CompletedAt = &t
-		}
+	if err := comple.Err(); err != nil {
+		return RunnerRecord{}, fmt.Errorf("store: scan runner completed_at: %w", err)
 	}
+	rec.EnqueuedAt = enq.OrZero()
+	rec.StartedAt = started.Ptr()
+	rec.CompletedAt = comple.Ptr()
 	switch {
 	case rec.CompletedAt != nil:
 		rec.Status = RunnerCompleted

--- a/internal/store/runners_test.go
+++ b/internal/store/runners_test.go
@@ -173,6 +173,73 @@ func TestDeleteCompletedEventsBeforePrunesOnlyCompletedRows(t *testing.T) {
 	}
 }
 
+func TestDeleteCompletedEventsBeforeKeepsSameDayLegacyDatetimeAfterCutoff(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	st := store.New(db)
+
+	cutoff := time.Date(2026, 6, 18, 14, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name      string
+		completed string
+		wantGone  bool
+	}{
+		{
+			name:      "legacy before cutoff",
+			completed: "2026-06-18 13:59:59",
+			wantGone:  true,
+		},
+		{
+			name:      "legacy after cutoff",
+			completed: "2026-06-18 15:00:00",
+			wantGone:  false,
+		},
+		{
+			name:      "rfc3339 before cutoff",
+			completed: "2026-06-18T13:59:59Z",
+			wantGone:  true,
+		},
+		{
+			name:      "rfc3339 after cutoff",
+			completed: "2026-06-18T15:00:00Z",
+			wantGone:  false,
+		},
+	}
+
+	ids := make(map[string]int64, len(cases))
+	for _, tc := range cases {
+		id, err := st.EnqueueEvent(`{"kind":"` + tc.name + `"}`)
+		if err != nil {
+			t.Fatalf("%s: enqueue: %v", tc.name, err)
+		}
+		if _, err := db.Exec("UPDATE event_queue SET completed_at = ? WHERE id = ?", tc.completed, id); err != nil {
+			t.Fatalf("%s: set completed_at: %v", tc.name, err)
+		}
+		ids[tc.name] = id
+	}
+
+	n, err := st.DeleteCompletedEventsBefore(cutoff)
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("rows pruned = %d, want 2", n)
+	}
+
+	for _, tc := range cases {
+		_, err := st.ReadQueuedEvent(ids[tc.name])
+		if tc.wantGone {
+			if !errors.Is(err, store.ErrRunnerNotFound) {
+				t.Fatalf("%s: err = %v, want ErrRunnerNotFound", tc.name, err)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("%s: row missing: %v", tc.name, err)
+		}
+	}
+}
+
 // TestListRunnersReturnsParsedRows seeds three rows in distinct
 // states and asserts the listing decodes status + blob fields.
 func TestListRunnersReturnsParsedRows(t *testing.T) {

--- a/internal/store/self_improvement.go
+++ b/internal/store/self_improvement.go
@@ -259,7 +259,7 @@ func UpsertSelfImprovementFeedback(db *sql.DB, in SelfImprovementFeedbackInput) 
 		in.GitHubPullRequestReviewID, strings.TrimSpace(in.GitHubDeliveryID), strings.TrimSpace(in.SourceURL),
 		strings.TrimSpace(in.AuthorLogin), boolInt(in.AuthorAuthorized), in.IssueNumber, in.PRNumber, in.RawBody, tag,
 		strings.TrimSpace(in.FilePath), in.Line, strings.TrimSpace(in.Side), in.DiffHunk, strings.TrimSpace(in.CommitSHA),
-		in.GitHubCreatedAt, in.GitHubUpdatedAt, strings.TrimSpace(in.LinkedSpanID), strings.TrimSpace(in.LinkedEventID),
+		sqliteTimeArg(in.GitHubCreatedAt), sqliteTimeArg(in.GitHubUpdatedAt), strings.TrimSpace(in.LinkedSpanID), strings.TrimSpace(in.LinkedEventID),
 		strings.TrimSpace(in.LinkedAgentID), strings.TrimSpace(in.LinkedAgentName), strings.TrimSpace(in.LinkedPromptVersionID),
 		strings.Join(in.LinkedSkillVersionIDs, ","), strings.Join(in.LinkedGuardrailVersionIDs, ","), confidence,
 		strings.TrimSpace(in.LinkDiagnostics), status,
@@ -331,8 +331,8 @@ func upsertSelfImprovementFeedbackByReviewCommentID(db *sql.DB, workspaceID, tag
 		0, 0, in.GitHubReviewCommentID, in.GitHubParentCommentID, in.GitHubPullRequestReviewID,
 		strings.TrimSpace(in.GitHubDeliveryID), strings.TrimSpace(in.SourceURL), strings.TrimSpace(in.AuthorLogin),
 		boolInt(in.AuthorAuthorized), in.IssueNumber, in.PRNumber, in.RawBody, tag, strings.TrimSpace(in.FilePath),
-		in.Line, strings.TrimSpace(in.Side), in.DiffHunk, strings.TrimSpace(in.CommitSHA), in.GitHubCreatedAt,
-		in.GitHubUpdatedAt, strings.TrimSpace(in.LinkedSpanID), strings.TrimSpace(in.LinkedEventID),
+		in.Line, strings.TrimSpace(in.Side), in.DiffHunk, strings.TrimSpace(in.CommitSHA), sqliteTimeArg(in.GitHubCreatedAt),
+		sqliteTimeArg(in.GitHubUpdatedAt), strings.TrimSpace(in.LinkedSpanID), strings.TrimSpace(in.LinkedEventID),
 		strings.TrimSpace(in.LinkedAgentID), strings.TrimSpace(in.LinkedAgentName), strings.TrimSpace(in.LinkedPromptVersionID),
 		strings.Join(in.LinkedSkillVersionIDs, ","), strings.Join(in.LinkedGuardrailVersionIDs, ","), confidence,
 		strings.TrimSpace(in.LinkDiagnostics), status,
@@ -385,7 +385,7 @@ func IgnoreSelfImprovementFeedback(db *sql.DB, in SelfImprovementFeedbackInput) 
 			in.GitHubParentCommentID, in.GitHubPullRequestReviewID, strings.TrimSpace(in.GitHubDeliveryID),
 			strings.TrimSpace(in.SourceURL), strings.TrimSpace(in.AuthorLogin), boolInt(in.AuthorAuthorized),
 			in.IssueNumber, in.PRNumber, in.RawBody, strings.TrimSpace(in.FilePath), in.Line, strings.TrimSpace(in.Side),
-			in.DiffHunk, strings.TrimSpace(in.CommitSHA), in.GitHubUpdatedAt, FeedbackStatusIgnored,
+			in.DiffHunk, strings.TrimSpace(in.CommitSHA), sqliteTimeArg(in.GitHubUpdatedAt), FeedbackStatusIgnored,
 			workspaceID, strings.TrimSpace(in.SourceType), in.GitHubReviewCommentID, tag,
 		)
 		if err != nil {
@@ -420,7 +420,7 @@ func IgnoreSelfImprovementFeedback(db *sql.DB, in SelfImprovementFeedbackInput) 
 		in.GitHubReviewCommentID, in.GitHubParentCommentID, in.GitHubPullRequestReviewID,
 		strings.TrimSpace(in.GitHubDeliveryID), strings.TrimSpace(in.SourceURL), strings.TrimSpace(in.AuthorLogin),
 		boolInt(in.AuthorAuthorized), in.IssueNumber, in.PRNumber, in.RawBody, strings.TrimSpace(in.FilePath),
-		in.Line, strings.TrimSpace(in.Side), in.DiffHunk, strings.TrimSpace(in.CommitSHA), in.GitHubUpdatedAt,
+		in.Line, strings.TrimSpace(in.Side), in.DiffHunk, strings.TrimSpace(in.CommitSHA), sqliteTimeArg(in.GitHubUpdatedAt),
 		FeedbackStatusIgnored, workspaceID, strings.TrimSpace(in.SourceType), in.GitHubCommentID, in.GitHubReviewID, tag,
 	)
 	if err != nil {
@@ -809,17 +809,24 @@ func scanSelfImprovementFeedback(row selfImprovementScanner) (SelfImprovementFee
 	var ev SelfImprovementFeedback
 	var authorized int
 	var skillIDs, guardrailIDs string
+	var githubCreatedAt, githubUpdatedAt, ingestedAt SQLiteTime
 	if err := row.Scan(
 		&ev.ID, &ev.WorkspaceID, &ev.RepoOwner, &ev.RepoName, &ev.SourceType, &ev.GitHubCommentID, &ev.GitHubReviewID,
 		&ev.GitHubReviewCommentID, &ev.GitHubParentCommentID, &ev.GitHubPullRequestReviewID,
 		&ev.GitHubDeliveryID, &ev.SourceURL, &ev.AuthorLogin, &authorized, &ev.IssueNumber, &ev.PRNumber,
-		&ev.RawBody, &ev.Tag, &ev.FilePath, &ev.Line, &ev.Side, &ev.DiffHunk, &ev.CommitSHA, &ev.GitHubCreatedAt,
-		&ev.GitHubUpdatedAt, &ev.IngestedAt, &ev.LinkedSpanID, &ev.LinkedEventID, &ev.LinkedAgentID,
+		&ev.RawBody, &ev.Tag, &ev.FilePath, &ev.Line, &ev.Side, &ev.DiffHunk, &ev.CommitSHA, &githubCreatedAt,
+		&githubUpdatedAt, &ingestedAt, &ev.LinkedSpanID, &ev.LinkedEventID, &ev.LinkedAgentID,
 		&ev.LinkedAgentName, &ev.LinkedPromptVersionID, &skillIDs, &guardrailIDs, &ev.LinkConfidence,
 		&ev.LinkDiagnostics, &ev.Status,
 	); err != nil {
 		return SelfImprovementFeedback{}, err
 	}
+	if err := ingestedAt.Err(); err != nil {
+		return SelfImprovementFeedback{}, fmt.Errorf("store: scan self-improvement feedback ingested_at: %w", err)
+	}
+	ev.GitHubCreatedAt = githubCreatedAt.Ptr()
+	ev.GitHubUpdatedAt = githubUpdatedAt.Ptr()
+	ev.IngestedAt = ingestedAt.OrZero()
 	ev.AuthorAuthorized = authorized == 1
 	ev.LinkedSkillVersionIDs = splitCSV(skillIDs)
 	ev.LinkedGuardrailVersionIDs = splitCSV(guardrailIDs)
@@ -853,6 +860,7 @@ func scanSelfImprovementRecommendation(row selfImprovementScanner, includeFeedba
 	var evidenceIDs, evidenceURLs, structured string
 	var authorized int
 	var skillIDs, guardrailIDs string
+	var githubCreatedAt, githubUpdatedAt, ingestedAt SQLiteTime
 	if err := row.Scan(
 		&rec.ID, &rec.WorkspaceID, &rec.FeedbackEventID, &rec.Type, &rec.Status, &rec.Confidence, &rec.Risk,
 		&rec.Finding, &rec.NormalizedLesson, &rec.Rationale, &evidenceIDs, &evidenceURLs,
@@ -865,7 +873,7 @@ func scanSelfImprovementRecommendation(row selfImprovementScanner, includeFeedba
 		&feedback.GitHubDeliveryID, &feedback.SourceURL,
 		&feedback.AuthorLogin, &authorized, &feedback.IssueNumber, &feedback.PRNumber, &feedback.RawBody,
 		&feedback.Tag, &feedback.FilePath, &feedback.Line, &feedback.Side, &feedback.DiffHunk,
-		&feedback.CommitSHA, &feedback.GitHubCreatedAt, &feedback.GitHubUpdatedAt, &feedback.IngestedAt,
+		&feedback.CommitSHA, &githubCreatedAt, &githubUpdatedAt, &ingestedAt,
 		&feedback.LinkedSpanID, &feedback.LinkedEventID, &feedback.LinkedAgentID, &feedback.LinkedAgentName,
 		&feedback.LinkedPromptVersionID, &skillIDs, &guardrailIDs, &feedback.LinkConfidence,
 		&feedback.LinkDiagnostics, &feedback.Status, &clarification.RecommendationID, &clarification.Author,
@@ -873,12 +881,18 @@ func scanSelfImprovementRecommendation(row selfImprovementScanner, includeFeedba
 	); err != nil {
 		return SelfImprovementRecommendationRow{}, err
 	}
+	if err := ingestedAt.Err(); err != nil {
+		return SelfImprovementRecommendationRow{}, fmt.Errorf("store: scan self-improvement recommendation feedback ingested_at: %w", err)
+	}
 	rec.EvidenceFeedbackIDs = splitInt64CSV(evidenceIDs)
 	rec.EvidenceSourceURLs = splitCSV(evidenceURLs)
 	if structured != "" {
 		_ = json.Unmarshal([]byte(structured), &rec.StructuredOutput)
 	}
 	feedback.AuthorAuthorized = authorized == 1
+	feedback.GitHubCreatedAt = githubCreatedAt.Ptr()
+	feedback.GitHubUpdatedAt = githubUpdatedAt.Ptr()
+	feedback.IngestedAt = ingestedAt.OrZero()
 	feedback.LinkedSkillVersionIDs = splitCSV(skillIDs)
 	feedback.LinkedGuardrailVersionIDs = splitCSV(guardrailIDs)
 	if includeFeedback {

--- a/internal/store/sqlite_time_test.go
+++ b/internal/store/sqlite_time_test.go
@@ -1,0 +1,66 @@
+package store_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/eloylp/agents/internal/store"
+)
+
+func TestSQLiteTimeScansSupportedDriverShapes(t *testing.T) {
+	t.Parallel()
+
+	want := time.Date(2026, 6, 18, 11, 6, 20, 123456789, time.UTC)
+	tests := []struct {
+		name  string
+		value any
+		want  time.Time
+		valid bool
+	}{
+		{name: "nil nullable timestamp", value: nil, valid: false},
+		{name: "time value", value: want, want: want, valid: true},
+		{name: "rfc3339 nano text", value: "2026-06-18T11:06:20.123456789Z", want: want, valid: true},
+		{name: "sqlite datetime text", value: "2026-06-18 11:06:20", want: want.Truncate(time.Second), valid: true},
+		{name: "driver zone text", value: []byte("2026-06-18 13:06:20 +0200 +0200"), want: time.Date(2026, 6, 18, 11, 6, 20, 0, time.UTC), valid: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got store.SQLiteTime
+			if err := got.Scan(tt.value); err != nil {
+				t.Fatalf("Scan() error = %v", err)
+			}
+			if err := got.Err(); err != nil {
+				t.Fatalf("Err() = %v, want nil", err)
+			}
+			if got.Valid != tt.valid {
+				t.Fatalf("Valid = %v, want %v", got.Valid, tt.valid)
+			}
+			if !got.OrZero().Equal(tt.want) {
+				t.Fatalf("OrZero() = %v, want %v", got.OrZero(), tt.want)
+			}
+			if tt.valid && got.Ptr() == nil {
+				t.Fatalf("Ptr() = nil, want parsed time")
+			}
+			if !tt.valid && got.Ptr() != nil {
+				t.Fatalf("Ptr() = %v, want nil", got.Ptr())
+			}
+		})
+	}
+}
+
+func TestSQLiteTimeReportsUnsupportedText(t *testing.T) {
+	t.Parallel()
+
+	var got store.SQLiteTime
+	if err := got.Scan("not-a-time"); err != nil {
+		t.Fatalf("Scan() error = %v", err)
+	}
+	if err := got.Err(); err == nil {
+		t.Fatal("Err() = nil, want parse error")
+	}
+	if !got.OrZero().IsZero() {
+		t.Fatalf("OrZero() = %v, want zero time", got.OrZero())
+	}
+}


### PR DESCRIPTION
## Summary

- add a shared SQLite timestamp scanner for store/observe reads that accepts driver time.Time values, RFC3339 text, SQLite datetime text, and legacy zone-formatted strings
- use the scanner for auth, memory, runner, observe event/trace/dispatch, run attribution, and self-improvement timestamp reads
- normalize new attribution/event timestamp writes to RFC3339Nano text and keep event since filtering compatible with older timestamp text

## Verification

- `go test ./internal/store -run 'TestSQLiteTime|TestRunAttributionArtifact'`
- `go test ./internal/store ./internal/observe -race -run 'TestSQLiteTime|TestRunAttributionArtifact|TestReadWriteMemory|TestAuthBootstrapLoginAndAPITokenLifecycle|TestStoreListEventsSinceFilter'`
- `go test ./internal/mcp -run TestToolListEventsSinceFilter`
- `go test ./internal/observe -run TestStoreListEventsSinceFilter`
- `go test ./...`

Closes #706

<!-- agents-run: {"v":1,"instance_id":"ts-lonestar","workspace":"default","repo":"eloylp/agents","span_id":"e45950a4a5b00718","agent_id":"agent_0fb82d1fe34e45408bd2fee153f7003d","agent_name":"coder","sig":"O86S5SgkaMA5cwlr18d3m9raOqSWH9ypint8CmziFcM"} -->
