### PR TITLE
Handle stale self-improvement attribution context

### DIFF
--- a/docs/self-improvement-feedback.md
+++ b/docs/self-improvement-feedback.md
@@ -119,9 +119,14 @@ command; the analyzer never auto-applies, publishes, or mutates agents,
 guardrails, prompts, skills, or dispatch wiring.
 
 The analyst receives only the catalog versions linked by run attribution. It
-does not scan the entire catalog. When attribution is unresolved or the linked
-catalog bodies are insufficient to build a safe editable bundle, the analyst
-must ask for clarification instead of guessing a target.
+does not scan the entire catalog. If feedback points at an old run and the
+linked catalog asset has moved on, the analyst receives both the historical
+attributed version and the current version of that same asset. The historical
+version is evidence for why the feedback happened; the current version is the
+safe base for any proposed update. When attribution is unresolved, an
+historical version is unavailable, or the supplied catalog bodies are
+insufficient to build a safe editable bundle, the analyst must ask for
+clarification instead of guessing a target.
 
 The v1 self-improvement loop has no assistant preference memory. The analyst's
 decision process is intentionally prompt-led: feedback, attribution, current

--- a/internal/store/facade.go
+++ b/internal/store/facade.go
@@ -121,6 +121,9 @@ func (s *Store) ReplaceWorkspaceGuardrails(workspace string, refs []fleet.Worksp
 func (s *Store) ReadGuardrailVersion(versionID string) (fleet.Guardrail, error) {
 	return ReadGuardrailVersion(s.db, versionID)
 }
+func (s *Store) CurrentSelfImprovementCatalogVersionID(assetType, assetID string) (string, error) {
+	return CurrentSelfImprovementCatalogVersionID(s.db, assetType, assetID)
+}
 func (s *Store) UpsertPrompt(p fleet.Prompt) (fleet.Prompt, error) {
 	return UpsertPrompt(s.db, p)
 }

--- a/internal/store/migrations/059_self_improvement_analyst_prompt_v9_stale_context.sql
+++ b/internal/store/migrations/059_self_improvement_analyst_prompt_v9_stale_context.sql
@@ -1,0 +1,47 @@
+-- 059_self_improvement_analyst_prompt_v9_stale_context: explain how the
+-- analyst should use stale attributed catalog versions alongside current
+-- versions when feedback points at an older run.
+
+INSERT INTO prompt_versions (
+    id, prompt_id, version_number, state, description, content,
+    source_type, source_ref, author, changelog, base_version_id, body_hash, created_at, published_at
+)
+SELECT
+    'promptver_self_improvement_analyst_v9',
+    p.id,
+    COALESCE((SELECT MAX(version_number) FROM prompt_versions WHERE prompt_id = p.id), 0) + 1,
+    'published',
+    v8.description,
+    REPLACE(
+        v8.content,
+        'Catalog context is attribution-only. Full catalog bodies are supplied only for run-attributed prompt, skill, and guardrail versions. If no catalog bodies are supplied, or if the supplied bodies are insufficient to identify a safe target and complete change, return status=needs_user_input instead of scanning or guessing from the wider catalog.',
+        'Catalog context is attribution-only. Full catalog bodies are supplied only for run-attributed prompt, skill, and guardrail versions, plus the current version of the same catalog asset when the attributed version is stale. Treat relation=attributed entries as historical evidence of what produced the feedback. Treat relation=current entries as the safe base for any proposed update. If an attributed version is marked unavailable, explain that the historical body is missing and return needs_user_input unless the supplied current asset context and maintainer feedback are enough to make a precise, non-speculative recommendation. Never scan or guess from the wider catalog.'
+    ),
+    'manual',
+    '',
+    'system',
+    'Teach analyst to compare stale attributed versions with current catalog versions',
+    'promptver_self_improvement_analyst_v8',
+    '4fba6f0e469213a57addd04c914abf844c159779cc95c58052d8b0010f73d7e9',
+    datetime('now'),
+    datetime('now')
+FROM prompts p
+JOIN prompt_versions v8 ON v8.id = 'promptver_self_improvement_analyst_v8'
+WHERE p.ref = 'prompt_self-improvement-analyst'
+  AND NOT EXISTS (
+      SELECT 1 FROM prompt_versions
+      WHERE id = 'promptver_self_improvement_analyst_v9'
+  );
+
+UPDATE prompts
+SET
+    description = (SELECT description FROM prompt_versions WHERE id = 'promptver_self_improvement_analyst_v9'),
+    content = (SELECT content FROM prompt_versions WHERE id = 'promptver_self_improvement_analyst_v9'),
+    current_version_id = 'promptver_self_improvement_analyst_v9',
+    updated_at = datetime('now')
+WHERE ref = 'prompt_self-improvement-analyst'
+  AND current_version_id = 'promptver_self_improvement_analyst_v8'
+  AND EXISTS (
+      SELECT 1 FROM prompt_versions
+      WHERE id = 'promptver_self_improvement_analyst_v9'
+  );

--- a/internal/store/self_improvement_migration_test.go
+++ b/internal/store/self_improvement_migration_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/eloylp/agents/internal/fleet"
 )
 
-func TestSelfImprovementAnalystPromptV8BecomesCurrentOnFreshStore(t *testing.T) {
+func TestSelfImprovementAnalystPromptV9BecomesCurrentOnFreshStore(t *testing.T) {
 	t.Parallel()
 
 	db, err := Open(filepath.Join(t.TempDir(), "test.db"))
@@ -24,8 +24,8 @@ func TestSelfImprovementAnalystPromptV8BecomesCurrentOnFreshStore(t *testing.T) 
 	if err != nil {
 		t.Fatalf("read seeded prompt: %v", err)
 	}
-	if prompt.VersionID != "promptver_self_improvement_analyst_v8" {
-		t.Fatalf("version_id = %q, want v8", prompt.VersionID)
+	if prompt.VersionID != "promptver_self_improvement_analyst_v9" {
+		t.Fatalf("version_id = %q, want v9", prompt.VersionID)
 	}
 	for _, want := range []string{
 		"Supplied context:",
@@ -41,7 +41,9 @@ func TestSelfImprovementAnalystPromptV8BecomesCurrentOnFreshStore(t *testing.T) 
 		"Every status=recommended catalog-changing result must be directly reviewable",
 		"proposed_body must be the full replacement body",
 		"Catalog context is attribution-only.",
-		"return status=needs_user_input instead of scanning or guessing from the wider catalog",
+		"relation=attributed",
+		"relation=current",
+		"Never scan or guess from the wider catalog",
 		"changes, and no_auto_apply_confirmed",
 	} {
 		if !strings.Contains(prompt.Content, want) {

--- a/internal/workflow/self_improvement.go
+++ b/internal/workflow/self_improvement.go
@@ -104,15 +104,21 @@ type selfImprovementOutputChange struct {
 }
 
 type selfImprovementCatalogVersion struct {
-	AssetType   string `json:"asset_type"`
-	ID          string `json:"id"`
-	Scope       string `json:"scope"`
-	VersionID   string `json:"version_id"`
-	Version     int    `json:"version"`
-	Description string `json:"description,omitempty"`
-	Content     string `json:"content,omitempty"`
-	Prompt      string `json:"prompt,omitempty"`
-	IndexOnly   bool   `json:"index_only,omitempty"`
+	AssetType        string `json:"asset_type"`
+	ID               string `json:"id"`
+	Scope            string `json:"scope"`
+	VersionID        string `json:"version_id"`
+	Version          int    `json:"version"`
+	Relation         string `json:"relation"`
+	LinkedVersionID  string `json:"linked_version_id,omitempty"`
+	CurrentVersionID string `json:"current_version_id,omitempty"`
+	Stale            bool   `json:"stale,omitempty"`
+	Unavailable      bool   `json:"unavailable,omitempty"`
+	Diagnostics      string `json:"diagnostics,omitempty"`
+	Description      string `json:"description,omitempty"`
+	Content          string `json:"content,omitempty"`
+	Prompt           string `json:"prompt,omitempty"`
+	IndexOnly        bool   `json:"index_only,omitempty"`
 }
 
 type selfImprovementInput struct {
@@ -407,36 +413,108 @@ func (e *Engine) currentCatalogVersions(feedback store.SelfImprovementFeedback) 
 		return nil
 	}
 
+	seen := map[string]struct{}{}
 	for _, versionID := range sortedSetValues(linkedPromptIDs) {
 		prompt, err := e.store.ReadPromptVersion(versionID)
 		if err != nil {
+			out = appendCatalogVersion(out, seen, unavailableCatalogVersion("prompt", versionID, err))
 			continue
 		}
 		version := catalogVersion("prompt", prompt.ID, prompt.WorkspaceID, prompt.Repo, prompt.VersionID, prompt.Version)
+		version.Relation = "attributed"
+		version.LinkedVersionID = versionID
 		version.Description = prompt.Description
 		version.Content = prompt.Content
-		out = append(out, version)
+		out = e.appendCurrentCatalogVersion(out, seen, version)
 	}
 	for _, versionID := range sortedSetValues(linkedSkillIDs) {
 		skill, err := e.store.ReadSkillVersion(versionID)
 		if err != nil {
+			out = appendCatalogVersion(out, seen, unavailableCatalogVersion("skill", versionID, err))
 			continue
 		}
 		version := catalogVersion("skill", skill.ID, skill.WorkspaceID, skill.Repo, skill.VersionID, skill.Version)
+		version.Relation = "attributed"
+		version.LinkedVersionID = versionID
 		version.Prompt = skill.Prompt
-		out = append(out, version)
+		out = e.appendCurrentCatalogVersion(out, seen, version)
 	}
 	for _, versionID := range sortedSetValues(linkedGuardrailIDs) {
 		guardrail, err := e.store.ReadGuardrailVersion(versionID)
 		if err != nil {
+			out = appendCatalogVersion(out, seen, unavailableCatalogVersion("guardrail", versionID, err))
 			continue
+		}
+		version := catalogVersion("guardrail", guardrail.ID, guardrail.WorkspaceID, "", guardrail.VersionID, guardrail.Version)
+		version.Relation = "attributed"
+		version.LinkedVersionID = versionID
+		version.Description = guardrail.Description
+		version.Content = guardrail.Content
+		out = e.appendCurrentCatalogVersion(out, seen, version)
+	}
+	return out
+}
+
+func (e *Engine) appendCurrentCatalogVersion(out []selfImprovementCatalogVersion, seen map[string]struct{}, attributed selfImprovementCatalogVersion) []selfImprovementCatalogVersion {
+	currentVersionID, err := e.store.CurrentSelfImprovementCatalogVersionID(attributed.AssetType, attributed.ID)
+	if err != nil {
+		attributed.Diagnostics = fmt.Sprintf("could not resolve current %s version: %v", attributed.AssetType, err)
+		return appendCatalogVersion(out, seen, attributed)
+	}
+	attributed.CurrentVersionID = currentVersionID
+	if currentVersionID == attributed.VersionID {
+		return appendCatalogVersion(out, seen, attributed)
+	}
+	attributed.Stale = true
+	out = appendCatalogVersion(out, seen, attributed)
+
+	current, err := e.readCurrentCatalogVersion(attributed.AssetType, currentVersionID)
+	if err != nil {
+		missing := unavailableCatalogVersion(attributed.AssetType, currentVersionID, err)
+		missing.ID = attributed.ID
+		missing.Scope = attributed.Scope
+		missing.Relation = "current"
+		missing.LinkedVersionID = attributed.VersionID
+		missing.CurrentVersionID = currentVersionID
+		return appendCatalogVersion(out, seen, missing)
+	}
+	current.Relation = "current"
+	current.LinkedVersionID = attributed.VersionID
+	current.CurrentVersionID = currentVersionID
+	return appendCatalogVersion(out, seen, current)
+}
+
+func (e *Engine) readCurrentCatalogVersion(assetType, versionID string) (selfImprovementCatalogVersion, error) {
+	switch assetType {
+	case "prompt":
+		prompt, err := e.store.ReadPromptVersion(versionID)
+		if err != nil {
+			return selfImprovementCatalogVersion{}, err
+		}
+		version := catalogVersion("prompt", prompt.ID, prompt.WorkspaceID, prompt.Repo, prompt.VersionID, prompt.Version)
+		version.Description = prompt.Description
+		version.Content = prompt.Content
+		return version, nil
+	case "skill":
+		skill, err := e.store.ReadSkillVersion(versionID)
+		if err != nil {
+			return selfImprovementCatalogVersion{}, err
+		}
+		version := catalogVersion("skill", skill.ID, skill.WorkspaceID, skill.Repo, skill.VersionID, skill.Version)
+		version.Prompt = skill.Prompt
+		return version, nil
+	case "guardrail":
+		guardrail, err := e.store.ReadGuardrailVersion(versionID)
+		if err != nil {
+			return selfImprovementCatalogVersion{}, err
 		}
 		version := catalogVersion("guardrail", guardrail.ID, guardrail.WorkspaceID, "", guardrail.VersionID, guardrail.Version)
 		version.Description = guardrail.Description
 		version.Content = guardrail.Content
-		out = append(out, version)
+		return version, nil
+	default:
+		return selfImprovementCatalogVersion{}, fmt.Errorf("unsupported catalog asset type %q", assetType)
 	}
-	return out
 }
 
 func catalogVersion(assetType, id, workspace, repo, versionID string, version int) selfImprovementCatalogVersion {
@@ -448,6 +526,27 @@ func catalogVersion(assetType, id, workspace, repo, versionID string, version in
 		scope += "/" + repo
 	}
 	return selfImprovementCatalogVersion{AssetType: assetType, ID: id, Scope: scope, VersionID: versionID, Version: version}
+}
+
+func unavailableCatalogVersion(assetType, versionID string, err error) selfImprovementCatalogVersion {
+	return selfImprovementCatalogVersion{
+		AssetType:       assetType,
+		VersionID:       versionID,
+		Relation:        "attributed",
+		LinkedVersionID: versionID,
+		IndexOnly:       true,
+		Unavailable:     true,
+		Diagnostics:     err.Error(),
+	}
+}
+
+func appendCatalogVersion(out []selfImprovementCatalogVersion, seen map[string]struct{}, version selfImprovementCatalogVersion) []selfImprovementCatalogVersion {
+	key := version.AssetType + "\x00" + version.Relation + "\x00" + version.VersionID
+	if _, ok := seen[key]; ok {
+		return out
+	}
+	seen[key] = struct{}{}
+	return append(out, version)
 }
 
 func recommendationInputFromAssistant(feedback store.SelfImprovementFeedback, promptVersionID string, raw json.RawMessage) (selfimprovement.SelfImprovementRecommendationInput, error) {

--- a/internal/workflow/self_improvement_test.go
+++ b/internal/workflow/self_improvement_test.go
@@ -75,7 +75,7 @@ func TestAnalyzeSelfImprovementFeedbackRunsStructuredAssistant(t *testing.T) {
 		IssueNumber:           7,
 		RawBody:               "Keep files under 800 lines /agents improve",
 		Tag:                   store.FeedbackTag,
-		LinkedPromptVersionID: "promptver_self_improvement_analyst_v8",
+		LinkedPromptVersionID: "promptver_self_improvement_analyst_v9",
 		LinkConfidence:        "exact",
 		LinkDiagnostics:       "matched run attribution metadata",
 		Status:                store.FeedbackStatusNew,
@@ -96,14 +96,14 @@ func TestAnalyzeSelfImprovementFeedbackRunsStructuredAssistant(t *testing.T) {
 		"attribution_confidence":"exact",
 			"target_asset_type":"prompt",
 			"target_asset_id":"prompt_self-improvement-analyst",
-				"target_base_version_id":"promptver_self_improvement_analyst_v8",
+				"target_base_version_id":"promptver_self_improvement_analyst_v9",
 		"proposed_patch":"",
 		"proposed_new_body":"",
 		"changes":[{
 				"operation":"update_existing",
 				"asset_type":"prompt",
 				"asset_id":"prompt_self-improvement-analyst",
-					"base_version_id":"promptver_self_improvement_analyst_v8",
+					"base_version_id":"promptver_self_improvement_analyst_v9",
 			"proposed_body":"Prefer files under 800 lines when practical.",
 			"rationale":"Feedback event 1 provides direct evidence."
 		}],
@@ -196,6 +196,69 @@ func TestCurrentCatalogVersionsRequiresAttribution(t *testing.T) {
 	})
 	if len(versions) != 0 {
 		t.Fatalf("catalog versions = %+v, want none without attribution", versions)
+	}
+}
+
+func TestCurrentCatalogVersionsIncludesCurrentWhenAttributedVersionIsStale(t *testing.T) {
+	t.Parallel()
+
+	st := newTempStore(t)
+	if err := st.UpsertSkill("go-api", fleet.Skill{Name: "go-api", Prompt: "Initial handler guidance."}); err != nil {
+		t.Fatalf("upsert skill v1: %v", err)
+	}
+	if err := st.UpsertSkill("go-api", fleet.Skill{Name: "go-api", Prompt: "Current handler guidance."}); err != nil {
+		t.Fatalf("upsert skill v2: %v", err)
+	}
+	versions, err := st.ListSkillVersions("go-api")
+	if err != nil {
+		t.Fatalf("list skill versions: %v", err)
+	}
+	var v1, v2 string
+	for _, version := range versions {
+		switch version.Version {
+		case 1:
+			v1 = version.ID
+		case 2:
+			v2 = version.ID
+		}
+	}
+	if v1 == "" || v2 == "" {
+		t.Fatalf("skill versions = %+v, want v1 and v2", versions)
+	}
+
+	e := NewEngine(st, config.ProcessorConfig{}, nil, zerolog.Nop())
+	got := e.currentCatalogVersions(store.SelfImprovementFeedback{
+		WorkspaceID:           fleet.DefaultWorkspaceID,
+		LinkedSkillVersionIDs: []string{v1},
+	})
+
+	if len(got) != 2 {
+		t.Fatalf("catalog versions = %+v, want stale attributed and current entries", got)
+	}
+	if got[0].Relation != "attributed" || !got[0].Stale || got[0].VersionID != v1 || got[0].CurrentVersionID != v2 || got[0].Prompt != "Initial handler guidance." {
+		t.Fatalf("attributed entry = %+v, want stale v1 with current pointer", got[0])
+	}
+	if got[1].Relation != "current" || got[1].Stale || got[1].VersionID != v2 || got[1].LinkedVersionID != v1 || got[1].Prompt != "Current handler guidance." {
+		t.Fatalf("current entry = %+v, want current v2 with linked pointer", got[1])
+	}
+}
+
+func TestCurrentCatalogVersionsSurfacesUnavailableAttributedVersion(t *testing.T) {
+	t.Parallel()
+
+	st := newTempStore(t)
+	e := NewEngine(st, config.ProcessorConfig{}, nil, zerolog.Nop())
+
+	got := e.currentCatalogVersions(store.SelfImprovementFeedback{
+		WorkspaceID:           fleet.DefaultWorkspaceID,
+		LinkedSkillVersionIDs: []string{"skillver_missing"},
+	})
+
+	if len(got) != 1 {
+		t.Fatalf("catalog versions = %+v, want one unavailable attributed entry", got)
+	}
+	if got[0].Relation != "attributed" || !got[0].Unavailable || !got[0].IndexOnly || got[0].VersionID != "skillver_missing" || got[0].Diagnostics == "" {
+		t.Fatalf("unavailable entry = %+v, want diagnostic tombstone", got[0])
 	}
 }
 


### PR DESCRIPTION
## Summary

- Include both attributed historical catalog versions and current versions when self-improvement feedback points at stale prompt/skill/guardrail versions.
- Surface unavailable attributed versions as diagnostic context instead of silently dropping them.
- Seed analyst prompt v9 with stale/current context guidance and document the behavior.

## Validation

- GOCACHE=/tmp/go-build-agents go test ./internal/workflow ./internal/store