### PR TITLE
feat: paginate dashboard CRUD lists

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -115,11 +115,19 @@ These routes are always mounted and backed by the SQLite database.
 
 Workspace-local resources accept `?workspace=<id-or-name>` and default to `default` when omitted. This applies to fleet snapshots, agents, repos, bindings, graph layout, runners, events, traces, memory, and workspace-scoped token leaderboard queries. Prompt and skill catalog rows expose `workspace_id` and `repo` to express global, workspace-scoped, or repo-scoped visibility. Guardrail catalog rows expose only `workspace_id`: empty means global, set means workspace-scoped.
 
+Dashboard CRUD list routes are server-paginated. `GET /agents`, `/repos`, `/workspaces`, `/prompts`, `/skills`, `/backends`, `/guardrails`, and `/token_budgets` accept `limit` and `offset`, clamp missing or invalid values to `limit=50&offset=0`, and cap `limit` at `500`. They return:
+
+```json
+{ "items": [], "total": 0, "limit": 50, "offset": 0 }
+```
+
+`GET /runners` keeps its compatibility key (`runners` instead of `items`) because completed events can expand to multiple per-agent rows after the trace JOIN.
+
 Prompt catalog rows expose a stable public `id` plus a display `name`; the SQLite primary key behind that ref is internal. Agents accept `prompt_id`; human-facing REST writes may provide `prompt_ref` plus optional `prompt_scope` instead. `prompt_scope` is case-insensitive and accepts `global`, `workspace`, or `workspace/owner/repo`, for example `default/eloylp/agents`. Agents track the latest published prompt and skill versions. To return to older catalog content, publish a rollback as a new current version.
 
 | Method | Path | Description |
 |---|---|---|
-| `GET` | `/{resource}` | List all entries for a resource type (`workspaces`, `prompts`, `skills`, `backends`, `repos`, `guardrails`). Note: `GET /agents` is the workspace-filterable fleet snapshot above, not the CRUD list. |
+| `GET` | `/{resource}` | List entries for a resource type (`workspaces`, `prompts`, `skills`, `backends`, `repos`, `guardrails`) with `limit`, `offset`, `total`, and `items`. Note: `GET /agents` is the workspace-filterable fleet snapshot above, not the CRUD list, but uses the same paginated envelope. |
 | `GET` | `/{resource}/{name-or-id}` | Fetch one entry. Repos use two path segments: `/repos/{owner}/{repo}`. Catalog routes (`prompts`, `skills`, `guardrails`) use stable public refs; legacy global names are accepted as a compatibility fallback. |
 | `POST` | `/{resource}` | Create or replace an entry. Resources: `workspaces`, `prompts`, `agents`, `skills`, `backends`, `repos`, `guardrails`. |
 | `PATCH` | `/{resource}/{name-or-id}` | Partial update of an entry. Only fields present in the JSON body are applied; unset fields are preserved. At least one field required. Resources: `workspaces`, `prompts`, `agents`, `skills`, `backends`, `guardrails`. Catalog routes (`prompts`, `skills`, `guardrails`) use stable public refs; legacy global names are accepted as a compatibility fallback. |

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -31,6 +31,8 @@ The same pattern works for Cursor, Cline, and any other MCP-compatible client; c
 
 Most fleet tools accept `workspace` for workspace-local resources and default to `Default` when omitted. Prompt catalog tools expose stable public prompt refs as `id`, and agent tools accept either `prompt_id` or the human selector `prompt_ref` plus optional `prompt_scope`. `prompt_scope` is case-insensitive and accepts `global`, `workspace`, or `workspace/owner/repo`, for example `default/eloylp/agents`. Agent creation is prompt-first: call `create_prompt` or select an existing prompt with `list_prompts`/`get_prompt`, then call `create_agent` with `prompt_ref` or `prompt_id`; inline agent prompt bodies are unsupported. Agents track the latest published catalog versions. To return to older catalog content, publish a rollback as a new current version.
 
+CRUD list tools are paginated. `list_agents`, `list_repos`, `list_workspaces`, `list_prompts`, `list_skills`, `list_backends`, `list_guardrails`, and `list_token_budgets` accept optional `limit` and `offset` parameters, default to `limit=50&offset=0`, cap `limit` at `500`, and return `{ "items": [...], "total": n, "limit": n, "offset": n }`. `list_runners` retains its `runners` key to match the REST compatibility shape.
+
 For agent lifecycle changes, use `create_agent` when adding a new agent or intentionally importing an upserted full definition. Use `update_agent` when changing an existing agent's backend, model, prompt reference, skills, dispatch permissions, PR permission, memory setting, scope, or description. `update_agent` patches only the supplied fields, preserves the stable agent ID, and returns a not-found error when the target agent does not exist.
 
 ### Fleet management

--- a/internal/daemon/api_test.go
+++ b/internal/daemon/api_test.go
@@ -60,9 +60,7 @@ func TestHandleAPIAgentsReturnsConfiguredAgents(t *testing.T) {
 	}
 
 	var agents []viewAgentJSON
-	if err := json.NewDecoder(rec.Body).Decode(&agents); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+	decodeItems(t, rec.Body, &agents)
 	// Locate "reviewer" in the response, the fixture also seeds an agent
 	// and "sec-reviewer" exists for the can_dispatch reference.
 	idx := slices.IndexFunc(agents, func(a viewAgentJSON) bool { return a.Name == "reviewer" })
@@ -107,9 +105,7 @@ func TestHandleAPIAgentsAttachesScheduleForCronBindings(t *testing.T) {
 	srv.Handler().ServeHTTP(rec, req)
 
 	var agents []viewAgentJSON
-	if err := json.NewDecoder(rec.Body).Decode(&agents); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	decodeItems(t, rec.Body, &agents)
 	if len(agents) != 1 {
 		t.Fatalf("want 1 agent")
 	}
@@ -159,9 +155,7 @@ func TestHandleAPIAgentsMultiRepoSchedulePreserved(t *testing.T) {
 	srv.Handler().ServeHTTP(rec, req)
 
 	var agents []viewAgentJSON
-	if err := json.NewDecoder(rec.Body).Decode(&agents); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	decodeItems(t, rec.Body, &agents)
 	if len(agents) != 1 {
 		t.Fatalf("want 1 agent, got %d", len(agents))
 	}
@@ -238,9 +232,7 @@ func TestHandleAPIAgentsIncludesDisabledRepoBindings(t *testing.T) {
 		t.Fatalf("want 200, got %d", rec.Code)
 	}
 	var agents []viewAgentJSON
-	if err := json.NewDecoder(rec.Body).Decode(&agents); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	decodeItems(t, rec.Body, &agents)
 	if len(agents) != 1 {
 		t.Fatalf("want 1 agent, got %d", len(agents))
 	}
@@ -284,9 +276,7 @@ func TestHandleAPIAgentsReturnsArrayShape(t *testing.T) {
 		t.Fatalf("want 200, got %d", rec.Code)
 	}
 	var agents []viewAgentJSON
-	if err := json.NewDecoder(rec.Body).Decode(&agents); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	decodeItems(t, rec.Body, &agents)
 	if agents == nil {
 		t.Errorf("/agents returned nil slice, want JSON array")
 	}
@@ -305,9 +295,7 @@ func TestHandleAPIAgentsCurrentStatusIdleWhenNotRunning(t *testing.T) {
 		t.Fatalf("want 200, got %d", rec.Code)
 	}
 	var agents []viewAgentJSON
-	if err := json.NewDecoder(rec.Body).Decode(&agents); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	decodeItems(t, rec.Body, &agents)
 	for _, a := range agents {
 		if a.CurrentStatus != "idle" {
 			t.Errorf("agent %q: want current_status=idle, got %q", a.Name, a.CurrentStatus)
@@ -342,9 +330,7 @@ func TestHandleAPIAgentsCurrentStatusRunningWhenActive(t *testing.T) {
 		t.Fatalf("want 200, got %d", rec.Code)
 	}
 	var agents []viewAgentJSON
-	if err := json.NewDecoder(rec.Body).Decode(&agents); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	decodeItems(t, rec.Body, &agents)
 	coderIdx := slices.IndexFunc(agents, func(a viewAgentJSON) bool {
 		return a.Name == "coder"
 	})

--- a/internal/daemon/auth.go
+++ b/internal/daemon/auth.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/eloylp/agents/internal/daemon/pagination"
 	"github.com/eloylp/agents/internal/store"
 )
 
@@ -259,13 +260,20 @@ func (d *Daemon) handleAuthUsersList(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
-	users, err := d.store.ListUsers(r.Context())
+	page := pagination.Parse(r)
+	users, err := d.store.ListUsersPage(r.Context(), page.Limit, page.Offset)
 	if err != nil {
 		d.logger.Error().Err(err).Msg("auth users: list")
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
-	writeJSON(w, users, http.StatusOK)
+	total, err := d.store.UserCount(r.Context())
+	if err != nil {
+		d.logger.Error().Err(err).Msg("auth users: count")
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, pagination.NewPage(users, total, page), http.StatusOK)
 }
 
 func (d *Daemon) handleAuthUsersCreate(w http.ResponseWriter, r *http.Request) {
@@ -338,13 +346,20 @@ func (d *Daemon) handleAuthTokensList(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
-	tokens, err := d.store.ListAuthTokens(r.Context(), identity.User.ID)
+	page := pagination.Parse(r)
+	tokens, err := d.store.ListAuthTokensPage(r.Context(), identity.User.ID, page.Limit, page.Offset)
 	if err != nil {
 		d.logger.Error().Err(err).Msg("auth tokens: list")
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
-	writeJSON(w, tokens, http.StatusOK)
+	total, err := d.store.AuthTokenCount(r.Context(), identity.User.ID)
+	if err != nil {
+		d.logger.Error().Err(err).Msg("auth tokens: count")
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, pagination.NewPage(tokens, total, page), http.StatusOK)
 }
 
 func (d *Daemon) handleAuthTokensCreate(w http.ResponseWriter, r *http.Request) {

--- a/internal/daemon/config/budgets.go
+++ b/internal/daemon/config/budgets.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/eloylp/agents/internal/daemon/pagination"
 	"github.com/eloylp/agents/internal/store"
 )
 
@@ -72,18 +73,22 @@ func (h *Handler) deleteTokenBudgetByID(w http.ResponseWriter, r *http.Request) 
 	h.deleteTokenBudget(w, r, id)
 }
 
-func (h *Handler) listTokenBudgets(w http.ResponseWriter, _ *http.Request) {
-	budgets, err := h.store.ListTokenBudgets()
+func (h *Handler) listTokenBudgets(w http.ResponseWriter, r *http.Request) {
+	page := pagination.Parse(r)
+	budgets, err := h.store.ListTokenBudgetsPage(page.Limit, page.Offset)
 	if err != nil {
 		h.logger.Error().Err(err).Msg("list token budgets")
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
-	if budgets == nil {
-		budgets = []store.TokenBudget{}
+	total, err := h.store.CountTokenBudgets()
+	if err != nil {
+		h.logger.Error().Err(err).Msg("count token budgets")
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(budgets)
+	_ = json.NewEncoder(w).Encode(pagination.NewPage(budgets, total, page))
 }
 
 func (h *Handler) createTokenBudget(w http.ResponseWriter, r *http.Request) {

--- a/internal/daemon/crud_test.go
+++ b/internal/daemon/crud_test.go
@@ -113,7 +113,7 @@ func crudMinimalConfig() *config.Config {
 
 // ── /agents ────────────────────────────────────────────────────────
 
-func TestStoreCRUDAgentListReturnsArray(t *testing.T) {
+func TestStoreCRUDAgentListReturnsPage(t *testing.T) {
 	t.Parallel()
 	s := openCRUDTestServer(t)
 
@@ -122,14 +122,11 @@ func TestStoreCRUDAgentListReturnsArray(t *testing.T) {
 		t.Fatalf("GET /agents: got %d, want 200", rr.Code)
 	}
 	var agents []any
-	if err := json.NewDecoder(rr.Body).Decode(&agents); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	// Store invariants require ≥1 agent, so the fixture pre-seeds one. The
-	// endpoint just needs to return a JSON array, the array shape, not its
-	// emptiness, is what /agents commits to.
+	decodeItems(t, rr.Body, &agents)
+	// Store invariants require >=1 agent, so the fixture pre-seeds one. The
+	// endpoint commits to a non-nil items slice inside the pagination envelope.
 	if agents == nil {
-		t.Errorf("/agents returned nil slice, want JSON array")
+		t.Errorf("/agents returned nil items slice")
 	}
 }
 
@@ -177,9 +174,7 @@ func TestStoreCRUDAgentCreateAndGet(t *testing.T) {
 		t.Fatalf("GET /agents: got %d", rr.Code)
 	}
 	var agents []map[string]any
-	if err := json.NewDecoder(rr.Body).Decode(&agents); err != nil {
-		t.Fatalf("decode list: %v", err)
-	}
+	decodeItems(t, rr.Body, &agents)
 	if !slices.ContainsFunc(agents, func(a map[string]any) bool {
 		return a["name"] == "coder"
 	}) {
@@ -256,9 +251,7 @@ func TestStoreCRUDAgentsListFiltersByWorkspace(t *testing.T) {
 		t.Fatalf("GET team agents: got %d, %s", rr.Code, rr.Body.String())
 	}
 	var agents []viewAgentJSON
-	if err := json.NewDecoder(rr.Body).Decode(&agents); err != nil {
-		t.Fatalf("decode agents: %v", err)
-	}
+	decodeItems(t, rr.Body, &agents)
 	if len(agents) != 1 || agents[0].Name != "team-reviewer" || agents[0].WorkspaceID != "team-a" {
 		t.Fatalf("team agents = %+v, want only team-reviewer", agents)
 	}
@@ -786,9 +779,7 @@ func TestStoreCRUDReposListFiltersByWorkspace(t *testing.T) {
 		t.Fatalf("GET team repos: got %d, %s", rr.Code, rr.Body.String())
 	}
 	var repos []storeRepoJSON
-	if err := json.NewDecoder(rr.Body).Decode(&repos); err != nil {
-		t.Fatalf("decode repos: %v", err)
-	}
+	decodeItems(t, rr.Body, &repos)
 	if len(repos) != 1 || repos[0].Name != "owner/team" || repos[0].WorkspaceID != "team-a" {
 		t.Fatalf("team repos = %+v, want only owner/team", repos)
 	}
@@ -810,9 +801,7 @@ func TestStoreCRUDGuardrailsListSeeded(t *testing.T) {
 		t.Fatalf("GET /guardrails: got %d, %s", rr.Code, rr.Body.String())
 	}
 	var rows []map[string]any
-	if err := json.NewDecoder(rr.Body).Decode(&rows); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	decodeItems(t, rr.Body, &rows)
 	if len(rows) != 4 ||
 		rows[0]["name"] != "security" || rows[0]["is_builtin"] != true ||
 		rows[1]["name"] != "discretion" || rows[1]["is_builtin"] != true ||
@@ -960,9 +949,7 @@ func TestStoreCRUDBackendGetRedactsEnv(t *testing.T) {
 		t.Fatalf("GET backends: got %d", rr.Code)
 	}
 	var list []storeBackendJSON
-	if err := json.NewDecoder(rr.Body).Decode(&list); err != nil {
-		t.Fatalf("decode list: %v", err)
-	}
+	decodeItems(t, rr.Body, &list)
 	if len(list) != 1 {
 		t.Fatalf("want 1 backend, got %d", len(list))
 	}
@@ -1246,9 +1233,7 @@ func TestStoreCRUDRepoCreateAndDelete(t *testing.T) {
 		t.Fatalf("GET repos: got %d", rr.Code)
 	}
 	var repos []map[string]any
-	if err := json.NewDecoder(rr.Body).Decode(&repos); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	decodeItems(t, rr.Body, &repos)
 	if len(repos) != 2 {
 		t.Fatalf("got %d repos, want 2", len(repos))
 	}
@@ -2139,9 +2124,7 @@ func TestServerCfgUpdatedAfterCRUDWrite(t *testing.T) {
 		t.Fatalf("GET /api/agents: %d, %s", rr.Code, rr.Body.String())
 	}
 	var apiAgents []map[string]any
-	if err := json.NewDecoder(rr.Body).Decode(&apiAgents); err != nil {
-		t.Fatalf("decode /api/agents: %v", err)
-	}
+	decodeItems(t, rr.Body, &apiAgents)
 	if len(apiAgents) != 1 {
 		t.Fatalf("/api/agents: want 1 agent, got %d", len(apiAgents))
 	}

--- a/internal/daemon/fleet/fleet.go
+++ b/internal/daemon/fleet/fleet.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/eloylp/agents/internal/backends"
 	agentconfig "github.com/eloylp/agents/internal/config"
+	"github.com/eloylp/agents/internal/daemon/pagination"
 	"github.com/eloylp/agents/internal/fleet"
 	"github.com/eloylp/agents/internal/observe"
 	"github.com/eloylp/agents/internal/scheduler"
@@ -492,17 +493,23 @@ func (p SkillPatch) apply(s *fleet.Skill) {
 
 // ── Skill handlers ────────────────────────────────────────────────────────────────────────────────────
 
-func (h *Handler) handleSkillsList(w http.ResponseWriter, _ *http.Request) {
-	skills, err := h.store.ReadSkills()
+func (h *Handler) handleSkillsList(w http.ResponseWriter, r *http.Request) {
+	page := pagination.Parse(r)
+	skills, err := h.store.ListSkills(page.Limit, page.Offset)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("read skills: %v", err), http.StatusInternalServerError)
 		return
 	}
-	out := make([]storeSkillJSON, 0, len(skills))
-	for id, sk := range skills {
-		out = append(out, skillToStoreJSON(id, sk))
+	total, err := h.store.CountSkills()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("count skills: %v", err), http.StatusInternalServerError)
+		return
 	}
-	writeJSON(w, http.StatusOK, out)
+	out := make([]storeSkillJSON, 0, len(skills))
+	for _, rec := range skills {
+		out = append(out, skillToStoreJSON(rec.ID, rec.Skill))
+	}
+	writeJSON(w, http.StatusOK, pagination.NewPage(out, total, page))
 }
 
 func (h *Handler) handleSkillCreate(w http.ResponseWriter, r *http.Request) {
@@ -730,17 +737,23 @@ func (j storePromptJSON) toConfig() fleet.Prompt {
 	}
 }
 
-func (h *Handler) handlePromptsList(w http.ResponseWriter, _ *http.Request) {
-	prompts, err := h.store.ReadPrompts()
+func (h *Handler) handlePromptsList(w http.ResponseWriter, r *http.Request) {
+	page := pagination.Parse(r)
+	prompts, err := h.store.ListPrompts(page.Limit, page.Offset)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("read prompts: %v", err), http.StatusInternalServerError)
+		return
+	}
+	total, err := h.store.CountPrompts()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("count prompts: %v", err), http.StatusInternalServerError)
 		return
 	}
 	out := make([]storePromptJSON, 0, len(prompts))
 	for _, p := range prompts {
 		out = append(out, promptToStoreJSON(p))
 	}
-	writeJSON(w, http.StatusOK, out)
+	writeJSON(w, http.StatusOK, pagination.NewPage(out, total, page))
 }
 
 func (h *Handler) handlePromptCreate(w http.ResponseWriter, r *http.Request) {
@@ -955,17 +968,23 @@ func (j storeBackendJSON) toConfig() fleet.Backend {
 
 // ── Backend handlers ────────────────────────────────────────────────────────────────────────────────────
 
-func (h *Handler) handleBackendsList(w http.ResponseWriter, _ *http.Request) {
-	all, err := h.store.ReadBackends()
+func (h *Handler) handleBackendsList(w http.ResponseWriter, r *http.Request) {
+	page := pagination.Parse(r)
+	all, err := h.store.ListBackends(page.Limit, page.Offset)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("read backends: %v", err), http.StatusInternalServerError)
 		return
 	}
-	out := make([]storeBackendJSON, 0, len(all))
-	for name, b := range all {
-		out = append(out, backendToStoreJSON(name, b))
+	total, err := h.store.CountBackends()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("count backends: %v", err), http.StatusInternalServerError)
+		return
 	}
-	writeJSON(w, http.StatusOK, out)
+	out := make([]storeBackendJSON, 0, len(all))
+	for _, rec := range all {
+		out = append(out, backendToStoreJSON(rec.Name, rec.Backend))
+	}
+	writeJSON(w, http.StatusOK, pagination.NewPage(out, total, page))
 }
 
 func (h *Handler) handleBackendCreate(w http.ResponseWriter, r *http.Request) {

--- a/internal/daemon/fleet/guardrails.go
+++ b/internal/daemon/fleet/guardrails.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/eloylp/agents/internal/daemon/pagination"
 	"github.com/eloylp/agents/internal/fleet"
 	"github.com/eloylp/agents/internal/store"
 )
@@ -79,17 +80,23 @@ func (p GuardrailPatch) apply(g *fleet.Guardrail) {
 
 // ── Guardrail handlers ───────────────────────────────────────────────────────
 
-func (h *Handler) handleGuardrailsList(w http.ResponseWriter, _ *http.Request) {
-	gs, err := h.store.ReadAllGuardrails()
+func (h *Handler) handleGuardrailsList(w http.ResponseWriter, r *http.Request) {
+	page := pagination.Parse(r)
+	gs, err := h.store.ListAllGuardrails(page.Limit, page.Offset)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("read guardrails: %v", err), http.StatusInternalServerError)
+		return
+	}
+	total, err := h.store.CountAllGuardrails()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("count guardrails: %v", err), http.StatusInternalServerError)
 		return
 	}
 	out := make([]storeGuardrailJSON, 0, len(gs))
 	for _, g := range gs {
 		out = append(out, guardrailToJSON(g))
 	}
-	writeJSON(w, http.StatusOK, out)
+	writeJSON(w, http.StatusOK, pagination.NewPage(out, total, page))
 }
 
 func (h *Handler) handleGuardrailCreate(w http.ResponseWriter, r *http.Request) {

--- a/internal/daemon/fleet/view.go
+++ b/internal/daemon/fleet/view.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/eloylp/agents/internal/daemon/pagination"
 	fleetcfg "github.com/eloylp/agents/internal/fleet"
 	"github.com/eloylp/agents/internal/scheduler"
 )
@@ -61,6 +62,7 @@ type apiAgentJSON struct {
 // requests to HandleAgentsCreate.
 func (h *Handler) HandleAgentsView(w http.ResponseWriter, r *http.Request) {
 	workspaceID := fleetcfg.NormalizeWorkspaceID(r.URL.Query().Get("workspace"))
+	page := pagination.Parse(r)
 	// Index scheduling state by (workspace, agent, repo) for O(1) lookup below.
 	type scheduleKey struct {
 		Workspace string
@@ -74,18 +76,25 @@ func (h *Handler) HandleAgentsView(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	storedAgents, storedRepos, _, _, err := h.store.ReadSnapshot()
+	storedAgents, err := h.store.ListWorkspaceAgents(workspaceID, page.Limit, page.Offset)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("read snapshot: %v", err), http.StatusInternalServerError)
+		http.Error(w, fmt.Sprintf("read agents: %v", err), http.StatusInternalServerError)
+		return
+	}
+	total, err := h.store.CountWorkspaceAgents(workspaceID)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("count agents: %v", err), http.StatusInternalServerError)
+		return
+	}
+	storedRepos, err := h.store.ReadRepos()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("read repos: %v", err), http.StatusInternalServerError)
 		return
 	}
 
 	// Build one entry per configured agent.
 	agents := make([]apiAgentJSON, 0, len(storedAgents))
 	for _, a := range storedAgents {
-		if fleetcfg.NormalizeWorkspaceID(a.WorkspaceID) != workspaceID {
-			continue
-		}
 		currentStatus := "idle"
 		if h.obs != nil && h.obs.IsRunningInWorkspace(workspaceID, a.Name) {
 			currentStatus = "running"
@@ -155,5 +164,5 @@ func (h *Handler) HandleAgentsView(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(agents)
+	_ = json.NewEncoder(w).Encode(pagination.NewPage(agents, total, page))
 }

--- a/internal/daemon/fleet/workspaces.go
+++ b/internal/daemon/fleet/workspaces.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/eloylp/agents/internal/daemon/pagination"
 	"github.com/eloylp/agents/internal/fleet"
 )
 
@@ -69,17 +70,23 @@ func (j workspaceGuardrailJSON) toConfig(defaultPosition int) fleet.WorkspaceGua
 	}
 }
 
-func (h *Handler) handleWorkspacesList(w http.ResponseWriter, _ *http.Request) {
-	workspaces, err := h.store.ReadWorkspaces()
+func (h *Handler) handleWorkspacesList(w http.ResponseWriter, r *http.Request) {
+	page := pagination.Parse(r)
+	workspaces, err := h.store.ListWorkspaces(page.Limit, page.Offset)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("read workspaces: %v", err), http.StatusInternalServerError)
+		return
+	}
+	total, err := h.store.CountWorkspaces()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("count workspaces: %v", err), http.StatusInternalServerError)
 		return
 	}
 	out := make([]storeWorkspaceJSON, 0, len(workspaces))
 	for _, workspace := range workspaces {
 		out = append(out, workspaceToStoreJSON(workspace))
 	}
-	writeJSON(w, http.StatusOK, out)
+	writeJSON(w, http.StatusOK, pagination.NewPage(out, total, page))
 }
 
 func (h *Handler) handleWorkspaceCreate(w http.ResponseWriter, r *http.Request) {

--- a/internal/daemon/observe/observe.go
+++ b/internal/daemon/observe/observe.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/rs/zerolog"
 
+	"github.com/eloylp/agents/internal/daemon/pagination"
 	"github.com/eloylp/agents/internal/fleet"
 	obstore "github.com/eloylp/agents/internal/observe"
 	"github.com/eloylp/agents/internal/scheduler"
@@ -149,7 +150,8 @@ func (h *Handler) HandleEvents(w http.ResponseWriter, r *http.Request) {
 	}
 
 	workspaceID := fleet.NormalizeWorkspaceID(r.URL.Query().Get("workspace"))
-	events := h.events.ListEventsForWorkspace(workspaceID, since)
+	page := pagination.Parse(r)
+	events := h.events.ListEventsForWorkspacePage(workspaceID, since, page.Limit, page.Offset)
 	out := make([]eventJSON, 0, len(events))
 	for _, e := range events {
 		out = append(out, eventJSON{
@@ -165,40 +167,51 @@ func (h *Handler) HandleEvents(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(out)
+	_ = json.NewEncoder(w).Encode(pagination.NewPage(out, h.events.CountEventsForWorkspace(workspaceID, since), page))
 }
 
 // HandleImprovementFeedback serves GET /improvements/feedback, the durable
 // tagged feedback events that later recommendation runs consume.
 func (h *Handler) HandleImprovementFeedback(w http.ResponseWriter, r *http.Request) {
-	limit := 100
-	rows, err := h.store.ListSelfImprovementFeedback(improvementWorkspaceFilter(r), r.URL.Query().Get("status"), limit)
+	page := pagination.Parse(r)
+	workspace := improvementWorkspaceFilter(r)
+	status := r.URL.Query().Get("status")
+	rows, err := h.store.ListSelfImprovementFeedbackPage(workspace, status, page.Limit, page.Offset)
 	if err != nil {
 		h.logger.Error().Err(err).Msg("list self-improvement feedback")
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
-	if rows == nil {
-		rows = []store.SelfImprovementFeedback{}
+	total, err := h.store.CountSelfImprovementFeedback(workspace, status)
+	if err != nil {
+		h.logger.Error().Err(err).Msg("count self-improvement feedback")
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(rows)
+	_ = json.NewEncoder(w).Encode(pagination.NewPage(rows, total, page))
 }
 
 // HandleImprovementRecommendations serves GET /improvements/recommendations,
 // the durable review inbox generated from stored feedback evidence.
 func (h *Handler) HandleImprovementRecommendations(w http.ResponseWriter, r *http.Request) {
-	rows, err := h.improve.ListRecommendations(improvementWorkspaceFilter(r), r.URL.Query().Get("status"), 100)
+	page := pagination.Parse(r)
+	workspace := improvementWorkspaceFilter(r)
+	status := r.URL.Query().Get("status")
+	rows, err := h.improve.ListRecommendationsPage(workspace, status, page.Limit, page.Offset)
 	if err != nil {
 		h.logger.Error().Err(err).Msg("list self-improvement recommendations")
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
-	if rows == nil {
-		rows = []selfimprovement.SelfImprovementRecommendation{}
+	total, err := h.improve.CountRecommendations(workspace, status)
+	if err != nil {
+		h.logger.Error().Err(err).Msg("count self-improvement recommendations")
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(rows)
+	_ = json.NewEncoder(w).Encode(pagination.NewPage(rows, total, page))
 }
 
 func improvementWorkspaceFilter(r *http.Request) string {
@@ -514,9 +527,11 @@ func agentsForEvent(s *obstore.Store, workspaceID, eventID string) []string {
 
 // HandleTraces serves GET /traces, the most recent agent run spans.
 func (h *Handler) HandleTraces(w http.ResponseWriter, r *http.Request) {
-	spans := h.events.ListTracesForWorkspace(r.URL.Query().Get("workspace"))
+	workspaceID := fleet.NormalizeWorkspaceID(r.URL.Query().Get("workspace"))
+	page := pagination.Parse(r)
+	spans := h.events.ListTracesForWorkspacePage(workspaceID, page.Limit, page.Offset)
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(spans)
+	_ = json.NewEncoder(w).Encode(pagination.NewPage(spans, h.events.CountTracesForWorkspace(workspaceID), page))
 }
 
 // HandleTrace serves GET /traces/{root_event_id}, all spans for one root.

--- a/internal/daemon/observe/observe_test.go
+++ b/internal/daemon/observe/observe_test.go
@@ -129,10 +129,13 @@ func waitForEvents(t *testing.T, h *Handler, path string, want int) []eventJSON 
 		if rec.Code != http.StatusOK {
 			t.Fatalf("want 200, got %d", rec.Code)
 		}
-		events = nil
-		if err := json.NewDecoder(rec.Body).Decode(&events); err != nil {
+		var page struct {
+			Items []eventJSON `json:"items"`
+		}
+		if err := json.NewDecoder(rec.Body).Decode(&page); err != nil {
 			t.Fatalf("decode: %v", err)
 		}
+		events = page.Items
 		if len(events) == want {
 			return events
 		}
@@ -717,10 +720,13 @@ func TestHandleTracesReturnsStoredSpans(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d", rec.Code)
 	}
-	var spans []map[string]any
-	if err := json.NewDecoder(rec.Body).Decode(&spans); err != nil {
+	var page struct {
+		Items []map[string]any `json:"items"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&page); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
+	spans := page.Items
 	if len(spans) != 2 {
 		t.Fatalf("want 2 spans, got %d", len(spans))
 	}

--- a/internal/daemon/pagination/pagination.go
+++ b/internal/daemon/pagination/pagination.go
@@ -1,0 +1,50 @@
+package pagination
+
+import (
+	"net/http"
+	"strconv"
+)
+
+const (
+	DefaultLimit = 50
+	MaxLimit     = 500
+)
+
+type Params struct {
+	Limit  int
+	Offset int
+}
+
+type Page[T any] struct {
+	Items  []T `json:"items"`
+	Total  int `json:"total"`
+	Limit  int `json:"limit"`
+	Offset int `json:"offset"`
+}
+
+func Clamp(limit, offset int) Params {
+	if limit <= 0 {
+		limit = DefaultLimit
+	}
+	if limit > MaxLimit {
+		limit = MaxLimit
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	return Params{Limit: limit, Offset: offset}
+}
+
+func Parse(r *http.Request) Params {
+	q := r.URL.Query()
+	limit, _ := strconv.Atoi(q.Get("limit"))
+	offset, _ := strconv.Atoi(q.Get("offset"))
+	return Clamp(limit, offset)
+}
+
+func NewPage[T any](items []T, total int, params Params) Page[T] {
+	if items == nil {
+		items = []T{}
+	}
+	return Page[T]{Items: items, Total: total, Limit: params.Limit, Offset: params.Offset}
+}

--- a/internal/daemon/pagination_test_helpers_test.go
+++ b/internal/daemon/pagination_test_helpers_test.go
@@ -1,0 +1,21 @@
+package daemon_test
+
+import (
+	"encoding/json"
+	"io"
+	"testing"
+)
+
+func decodeItems[T any](t *testing.T, r io.Reader, out *[]T) {
+	t.Helper()
+	var page struct {
+		Items  []T `json:"items"`
+		Total  int `json:"total"`
+		Limit  int `json:"limit"`
+		Offset int `json:"offset"`
+	}
+	if err := json.NewDecoder(r).Decode(&page); err != nil {
+		t.Fatalf("decode page: %v", err)
+	}
+	*out = page.Items
+}

--- a/internal/daemon/repos/repos.go
+++ b/internal/daemon/repos/repos.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/rs/zerolog"
 
+	"github.com/eloylp/agents/internal/daemon/pagination"
 	"github.com/eloylp/agents/internal/fleet"
 	"github.com/eloylp/agents/internal/service"
 	"github.com/eloylp/agents/internal/store"
@@ -132,19 +133,22 @@ type repoRuntimeSettingsJSON struct {
 
 func (h *Handler) handleReposList(w http.ResponseWriter, r *http.Request) {
 	workspaceID := fleet.NormalizeWorkspaceID(r.URL.Query().Get("workspace"))
-	repos, err := h.store.ReadRepos()
+	page := pagination.Parse(r)
+	repos, err := h.store.ListWorkspaceRepos(workspaceID, page.Limit, page.Offset)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("read repos: %v", err), http.StatusInternalServerError)
 		return
 	}
+	total, err := h.store.CountWorkspaceRepos(workspaceID)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("count repos: %v", err), http.StatusInternalServerError)
+		return
+	}
 	out := make([]storeRepoJSON, 0, len(repos))
 	for _, r := range repos {
-		if fleet.NormalizeWorkspaceID(r.WorkspaceID) != workspaceID {
-			continue
-		}
 		out = append(out, repoToStoreJSON(r))
 	}
-	writeJSON(w, http.StatusOK, out)
+	writeJSON(w, http.StatusOK, pagination.NewPage(out, total, page))
 }
 
 func (h *Handler) handleRepoCreate(w http.ResponseWriter, r *http.Request) {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -21,6 +21,8 @@ func registerTools(srv *server.MCPServer, deps Deps) {
 			mcpgo.WithString("workspace",
 				mcpgo.Description("Optional workspace id/name filter. Omit to list all workspace-local agents."),
 			),
+			mcpgo.WithNumber("limit", mcpgo.Description("Maximum rows to return. Defaults to 50; maximum 500.")),
+			mcpgo.WithNumber("offset", mcpgo.Description("Pagination offset. Defaults to 0.")),
 		),
 		toolListAgents(deps),
 	)
@@ -40,18 +42,24 @@ func registerTools(srv *server.MCPServer, deps Deps) {
 	srv.AddTool(
 		mcpgo.NewTool("list_skills",
 			mcpgo.WithDescription("List every configured skill with its prompt body. Skills are reusable prompt fragments agents can compose."),
+			mcpgo.WithNumber("limit", mcpgo.Description("Maximum rows to return. Defaults to 50; maximum 500.")),
+			mcpgo.WithNumber("offset", mcpgo.Description("Pagination offset. Defaults to 0.")),
 		),
 		toolListSkills(deps),
 	)
 	srv.AddTool(
 		mcpgo.NewTool("list_prompts",
 			mcpgo.WithDescription("List every prompt catalog entry. Prompts are reusable task/personality contracts that may be global, workspace-scoped, or repo-scoped."),
+			mcpgo.WithNumber("limit", mcpgo.Description("Maximum rows to return. Defaults to 50; maximum 500.")),
+			mcpgo.WithNumber("offset", mcpgo.Description("Pagination offset. Defaults to 0.")),
 		),
 		toolListPrompts(deps),
 	)
 	srv.AddTool(
 		mcpgo.NewTool("list_workspaces",
 			mcpgo.WithDescription("List every workspace. Workspaces scope repos, agents, runs, memory, graph layout, and budgets."),
+			mcpgo.WithNumber("limit", mcpgo.Description("Maximum rows to return. Defaults to 50; maximum 500.")),
+			mcpgo.WithNumber("offset", mcpgo.Description("Pagination offset. Defaults to 0.")),
 		),
 		toolListWorkspaces(deps),
 	)
@@ -101,6 +109,8 @@ func registerTools(srv *server.MCPServer, deps Deps) {
 	srv.AddTool(
 		mcpgo.NewTool("list_guardrails",
 			mcpgo.WithDescription("List every prompt guardrail (operator-defined policy blocks prepended to every agent's composed prompt). Includes the shipped 'security' default and any operator-added rules. Returns enabled and disabled rows in render order (position ASC, name ASC)."),
+			mcpgo.WithNumber("limit", mcpgo.Description("Maximum rows to return. Defaults to 50; maximum 500.")),
+			mcpgo.WithNumber("offset", mcpgo.Description("Pagination offset. Defaults to 0.")),
 		),
 		toolListGuardrails(deps),
 	)
@@ -126,6 +136,8 @@ func registerTools(srv *server.MCPServer, deps Deps) {
 	srv.AddTool(
 		mcpgo.NewTool("list_backends",
 			mcpgo.WithDescription("List every configured AI backend (command, models, timeouts). Includes local backends routed through the translation proxy."),
+			mcpgo.WithNumber("limit", mcpgo.Description("Maximum rows to return. Defaults to 50; maximum 500.")),
+			mcpgo.WithNumber("offset", mcpgo.Description("Pagination offset. Defaults to 0.")),
 		),
 		toolListBackends(deps),
 	)
@@ -145,6 +157,8 @@ func registerTools(srv *server.MCPServer, deps Deps) {
 			mcpgo.WithString("workspace",
 				mcpgo.Description("Optional workspace id/name filter. Omit to list all workspace-local repos."),
 			),
+			mcpgo.WithNumber("limit", mcpgo.Description("Maximum rows to return. Defaults to 50; maximum 500.")),
+			mcpgo.WithNumber("offset", mcpgo.Description("Pagination offset. Defaults to 0.")),
 		),
 		toolListRepos(deps),
 	)

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -201,13 +201,15 @@ func registerTools(srv *server.MCPServer, deps Deps) {
 	if deps.Observe != nil {
 		srv.AddTool(
 			mcpgo.NewTool("list_events",
-				mcpgo.WithDescription("List recent events (GitHub webhook deliveries, cron firings, on-demand runs, dispatches) for one workspace. Ordered oldest→newest, capped at 500. Omitted workspace defaults to default."),
+				mcpgo.WithDescription("List recent events (GitHub webhook deliveries, cron firings, on-demand runs, dispatches) for one workspace. Ordered oldest→newest. Omitted workspace defaults to default."),
 				mcpgo.WithString("workspace",
 					mcpgo.Description("Optional workspace id or display name. Defaults to default."),
 				),
 				mcpgo.WithString("since",
 					mcpgo.Description("Optional RFC3339 timestamp; return only events strictly after this time."),
 				),
+				mcpgo.WithNumber("limit", mcpgo.Description("Maximum rows to return. Defaults to 50; maximum 500.")),
+				mcpgo.WithNumber("offset", mcpgo.Description("Pagination offset. Defaults to 0.")),
 			),
 			toolListEvents(deps),
 		)
@@ -220,6 +222,8 @@ func registerTools(srv *server.MCPServer, deps Deps) {
 				mcpgo.WithString("status",
 					mcpgo.Description("Optional status filter such as new or ignored."),
 				),
+				mcpgo.WithNumber("limit", mcpgo.Description("Maximum rows to return. Defaults to 50; maximum 500.")),
+				mcpgo.WithNumber("offset", mcpgo.Description("Pagination offset. Defaults to 0.")),
 			),
 			toolListImprovementFeedback(deps),
 		)
@@ -232,6 +236,8 @@ func registerTools(srv *server.MCPServer, deps Deps) {
 				mcpgo.WithString("status",
 					mcpgo.Description("Optional status filter such as recommended, needs_user_input, clarifying, analyzing, rejected, or failed. recommended means ready for human review and may already include a proposal bundle."),
 				),
+				mcpgo.WithNumber("limit", mcpgo.Description("Maximum rows to return. Defaults to 50; maximum 500.")),
+				mcpgo.WithNumber("offset", mcpgo.Description("Pagination offset. Defaults to 0.")),
 			),
 			toolListImprovementRecommendations(deps),
 		)
@@ -349,15 +355,19 @@ func registerTools(srv *server.MCPServer, deps Deps) {
 			mcpgo.NewTool("list_improvement_recommendations_with_bundles",
 				mcpgo.WithDescription("List self-improvement proposal records that already have linked proposal bundles."),
 				mcpgo.WithString("workspace", mcpgo.Description("Optional workspace id or display name to narrow the global proposal set.")),
+				mcpgo.WithNumber("limit", mcpgo.Description("Maximum rows to return. Defaults to 50; maximum 500.")),
+				mcpgo.WithNumber("offset", mcpgo.Description("Pagination offset. Defaults to 0.")),
 			),
 			toolListImprovementRecommendationsWithBundles(deps),
 		)
 		srv.AddTool(
 			mcpgo.NewTool("list_traces",
-				mcpgo.WithDescription("List recent agent run spans for one workspace. Ordered newest→oldest, capped at 200. Each span records backend, repo, status, duration, and summary. Omitted workspace defaults to default."),
+				mcpgo.WithDescription("List recent agent run spans for one workspace. Ordered newest→oldest. Each span records backend, repo, status, duration, and summary. Omitted workspace defaults to default."),
 				mcpgo.WithString("workspace",
 					mcpgo.Description("Optional workspace id or display name. Defaults to default."),
 				),
+				mcpgo.WithNumber("limit", mcpgo.Description("Maximum rows to return. Defaults to 50; maximum 500.")),
+				mcpgo.WithNumber("offset", mcpgo.Description("Pagination offset. Defaults to 0.")),
 			),
 			toolListTraces(deps),
 		)

--- a/internal/mcp/tools_budgets.go
+++ b/internal/mcp/tools_budgets.go
@@ -6,6 +6,7 @@ import (
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
+	"github.com/eloylp/agents/internal/daemon/pagination"
 	"github.com/eloylp/agents/internal/store"
 )
 
@@ -16,6 +17,8 @@ func registerBudgetTools(srv *server.MCPServer, deps Deps) {
 	srv.AddTool(
 		mcpgo.NewTool("list_token_budgets",
 			mcpgo.WithDescription("List all token budgets. Each budget caps token usage over a UTC calendar period: daily starts 00:00 UTC, weekly starts Sunday 00:00 UTC, and monthly starts on the first day at 00:00 UTC. Simple repo, agent, and backend scopes are global across workspaces; use workspace+repo, workspace+agent, or workspace+backend for workspace isolation."),
+			mcpgo.WithNumber("limit", mcpgo.Description("Maximum rows to return. Defaults to 50; maximum 500.")),
+			mcpgo.WithNumber("offset", mcpgo.Description("Pagination offset. Defaults to 0.")),
 		),
 		toolListTokenBudgets(deps),
 	)
@@ -118,15 +121,17 @@ func registerBudgetTools(srv *server.MCPServer, deps Deps) {
 }
 
 func toolListTokenBudgets(deps Deps) server.ToolHandlerFunc {
-	return func(_ context.Context, _ mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
-		budgets, err := deps.Store.ListTokenBudgets()
+	return func(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		page := pagination.Clamp(mcpInt(req, "limit", 0), mcpInt(req, "offset", 0))
+		budgets, err := deps.Store.ListTokenBudgetsPage(page.Limit, page.Offset)
 		if err != nil {
 			return mcpgo.NewToolResultErrorFromErr("list token budgets", err), nil
 		}
-		if budgets == nil {
-			budgets = []store.TokenBudget{}
+		total, err := deps.Store.CountTokenBudgets()
+		if err != nil {
+			return mcpgo.NewToolResultErrorFromErr("count token budgets", err), nil
 		}
-		return jsonResult(budgets)
+		return jsonResult(pagination.NewPage(budgets, total, page))
 	}
 }
 

--- a/internal/mcp/tools_fleet.go
+++ b/internal/mcp/tools_fleet.go
@@ -2,10 +2,10 @@ package mcp
 
 import (
 	"context"
-	"maps"
 	"slices"
 	"strings"
 
+	"github.com/eloylp/agents/internal/daemon/pagination"
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
@@ -19,18 +19,21 @@ import (
 func toolListAgents(deps Deps) server.ToolHandlerFunc {
 	return func(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 		workspace := strings.TrimSpace(req.GetString("workspace", ""))
-		agents, err := deps.Store.ReadAgents()
+		page := pagination.Clamp(mcpInt(req, "limit", 0), mcpInt(req, "offset", 0))
+		workspaceID := fleet.NormalizeWorkspaceID(workspace)
+		agents, err := deps.Store.ListWorkspaceAgents(workspaceID, page.Limit, page.Offset)
 		if err != nil {
 			return mcpgo.NewToolResultErrorFromErr("list agents", err), nil
 		}
+		total, err := deps.Store.CountWorkspaceAgents(workspaceID)
+		if err != nil {
+			return mcpgo.NewToolResultErrorFromErr("count agents", err), nil
+		}
 		out := make([]map[string]any, 0, len(agents))
 		for _, a := range agents {
-			if workspace != "" && fleet.NormalizeWorkspaceID(a.WorkspaceID) != fleet.NormalizeWorkspaceID(workspace) {
-				continue
-			}
 			out = append(out, agentJSON(a))
 		}
-		return jsonResult(out)
+		return jsonResult(pagination.NewPage(out, total, page))
 	}
 }
 
@@ -59,45 +62,59 @@ func toolGetAgent(deps Deps) server.ToolHandlerFunc {
 }
 
 func toolListSkills(deps Deps) server.ToolHandlerFunc {
-	return func(_ context.Context, _ mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
-		skills, err := deps.Store.ReadSkills()
+	return func(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		page := pagination.Clamp(mcpInt(req, "limit", 0), mcpInt(req, "offset", 0))
+		skills, err := deps.Store.ListSkills(page.Limit, page.Offset)
 		if err != nil {
 			return mcpgo.NewToolResultErrorFromErr("list skills", err), nil
 		}
-		names := slices.Sorted(maps.Keys(skills))
-		out := make([]map[string]any, 0, len(names))
-		for _, n := range names {
-			out = append(out, skillJSON(n, skills[n]))
+		total, err := deps.Store.CountSkills()
+		if err != nil {
+			return mcpgo.NewToolResultErrorFromErr("count skills", err), nil
 		}
-		return jsonResult(out)
+		out := make([]map[string]any, 0, len(skills))
+		for _, rec := range skills {
+			out = append(out, skillJSON(rec.ID, rec.Skill))
+		}
+		return jsonResult(pagination.NewPage(out, total, page))
 	}
 }
 
 func toolListPrompts(deps Deps) server.ToolHandlerFunc {
-	return func(_ context.Context, _ mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
-		prompts, err := deps.Store.ReadPrompts()
+	return func(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		page := pagination.Clamp(mcpInt(req, "limit", 0), mcpInt(req, "offset", 0))
+		prompts, err := deps.Store.ListPrompts(page.Limit, page.Offset)
 		if err != nil {
 			return mcpgo.NewToolResultErrorFromErr("list prompts", err), nil
+		}
+		total, err := deps.Store.CountPrompts()
+		if err != nil {
+			return mcpgo.NewToolResultErrorFromErr("count prompts", err), nil
 		}
 		out := make([]map[string]any, 0, len(prompts))
 		for _, p := range prompts {
 			out = append(out, promptJSON(p))
 		}
-		return jsonResult(out)
+		return jsonResult(pagination.NewPage(out, total, page))
 	}
 }
 
 func toolListWorkspaces(deps Deps) server.ToolHandlerFunc {
-	return func(_ context.Context, _ mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
-		workspaces, err := deps.Store.ReadWorkspaces()
+	return func(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		page := pagination.Clamp(mcpInt(req, "limit", 0), mcpInt(req, "offset", 0))
+		workspaces, err := deps.Store.ListWorkspaces(page.Limit, page.Offset)
 		if err != nil {
 			return mcpgo.NewToolResultErrorFromErr("list workspaces", err), nil
+		}
+		total, err := deps.Store.CountWorkspaces()
+		if err != nil {
+			return mcpgo.NewToolResultErrorFromErr("count workspaces", err), nil
 		}
 		out := make([]map[string]any, 0, len(workspaces))
 		for _, w := range workspaces {
 			out = append(out, workspaceJSON(w))
 		}
-		return jsonResult(out)
+		return jsonResult(pagination.NewPage(out, total, page))
 	}
 }
 
@@ -170,17 +187,21 @@ func toolGetSkill(deps Deps) server.ToolHandlerFunc {
 }
 
 func toolListBackends(deps Deps) server.ToolHandlerFunc {
-	return func(_ context.Context, _ mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
-		backends, err := deps.Store.ReadBackends()
+	return func(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		page := pagination.Clamp(mcpInt(req, "limit", 0), mcpInt(req, "offset", 0))
+		backends, err := deps.Store.ListBackends(page.Limit, page.Offset)
 		if err != nil {
 			return mcpgo.NewToolResultErrorFromErr("list backends", err), nil
 		}
-		names := slices.Sorted(maps.Keys(backends))
-		out := make([]map[string]any, 0, len(names))
-		for _, n := range names {
-			out = append(out, backendJSON(n, backends[n]))
+		total, err := deps.Store.CountBackends()
+		if err != nil {
+			return mcpgo.NewToolResultErrorFromErr("count backends", err), nil
 		}
-		return jsonResult(out)
+		out := make([]map[string]any, 0, len(backends))
+		for _, rec := range backends {
+			out = append(out, backendJSON(rec.Name, rec.Backend))
+		}
+		return jsonResult(pagination.NewPage(out, total, page))
 	}
 }
 
@@ -208,18 +229,21 @@ func toolGetBackend(deps Deps) server.ToolHandlerFunc {
 func toolListRepos(deps Deps) server.ToolHandlerFunc {
 	return func(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 		workspace := strings.TrimSpace(req.GetString("workspace", ""))
-		repos, err := deps.Store.ReadRepos()
+		page := pagination.Clamp(mcpInt(req, "limit", 0), mcpInt(req, "offset", 0))
+		workspaceID := fleet.NormalizeWorkspaceID(workspace)
+		repos, err := deps.Store.ListWorkspaceRepos(workspaceID, page.Limit, page.Offset)
 		if err != nil {
 			return mcpgo.NewToolResultErrorFromErr("list repos", err), nil
 		}
+		total, err := deps.Store.CountWorkspaceRepos(workspaceID)
+		if err != nil {
+			return mcpgo.NewToolResultErrorFromErr("count repos", err), nil
+		}
 		out := make([]map[string]any, 0, len(repos))
 		for _, r := range repos {
-			if workspace != "" && fleet.NormalizeWorkspaceID(r.WorkspaceID) != fleet.NormalizeWorkspaceID(workspace) {
-				continue
-			}
 			out = append(out, repoJSON(r))
 		}
-		return jsonResult(out)
+		return jsonResult(pagination.NewPage(out, total, page))
 	}
 }
 

--- a/internal/mcp/tools_guardrails.go
+++ b/internal/mcp/tools_guardrails.go
@@ -7,6 +7,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 
 	daemonfleet "github.com/eloylp/agents/internal/daemon/fleet"
+	"github.com/eloylp/agents/internal/daemon/pagination"
 	"github.com/eloylp/agents/internal/fleet"
 )
 
@@ -30,16 +31,21 @@ func guardrailJSON(g fleet.Guardrail) map[string]any {
 }
 
 func toolListGuardrails(deps Deps) server.ToolHandlerFunc {
-	return func(_ context.Context, _ mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
-		gs, err := deps.Store.ReadAllGuardrails()
+	return func(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		page := pagination.Clamp(mcpInt(req, "limit", 0), mcpInt(req, "offset", 0))
+		gs, err := deps.Store.ListAllGuardrails(page.Limit, page.Offset)
 		if err != nil {
 			return mcpgo.NewToolResultErrorFromErr("list guardrails", err), nil
+		}
+		total, err := deps.Store.CountAllGuardrails()
+		if err != nil {
+			return mcpgo.NewToolResultErrorFromErr("count guardrails", err), nil
 		}
 		out := make([]map[string]any, 0, len(gs))
 		for _, g := range gs {
 			out = append(out, guardrailJSON(g))
 		}
-		return jsonResult(out)
+		return jsonResult(pagination.NewPage(out, total, page))
 	}
 }
 

--- a/internal/mcp/tools_observe.go
+++ b/internal/mcp/tools_observe.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 
 	"github.com/eloylp/agents/internal/ai"
+	"github.com/eloylp/agents/internal/daemon/pagination"
 	"github.com/eloylp/agents/internal/fleet"
 	"github.com/eloylp/agents/internal/selfimprovement"
 	"github.com/eloylp/agents/internal/store"
@@ -55,7 +56,10 @@ func toolListEvents(deps Deps) server.ToolHandlerFunc {
 			}
 		}
 		workspace, _ := trimmedStringOptional(req, "workspace")
-		return jsonResult(nilSafe(deps.Observe.ListEventsForWorkspace(workspace, since)))
+		page := pagination.Clamp(mcpInt(req, "limit", 0), mcpInt(req, "offset", 0))
+		rows := deps.Observe.ListEventsForWorkspacePage(workspace, since, page.Limit, page.Offset)
+		total := deps.Observe.CountEventsForWorkspace(workspace, since)
+		return jsonResult(pagination.NewPage(rows, total, page))
 	}
 }
 
@@ -66,11 +70,16 @@ func toolListImprovementFeedback(deps Deps) server.ToolHandlerFunc {
 			workspace = store.SelfImprovementAllWorkspaces
 		}
 		status, _ := trimmedStringOptional(req, "status")
-		rows, err := deps.Store.ListSelfImprovementFeedback(workspace, status, 100)
+		page := pagination.Clamp(mcpInt(req, "limit", 0), mcpInt(req, "offset", 0))
+		rows, err := deps.Store.ListSelfImprovementFeedbackPage(workspace, status, page.Limit, page.Offset)
 		if err != nil {
 			return mcpgo.NewToolResultErrorFromErr("list improvement feedback", err), nil
 		}
-		return jsonResult(nilSafe(rows))
+		total, err := deps.Store.CountSelfImprovementFeedback(workspace, status)
+		if err != nil {
+			return mcpgo.NewToolResultErrorFromErr("count improvement feedback", err), nil
+		}
+		return jsonResult(pagination.NewPage(rows, total, page))
 	}
 }
 
@@ -81,11 +90,16 @@ func toolListImprovementRecommendations(deps Deps) server.ToolHandlerFunc {
 			workspace = store.SelfImprovementAllWorkspaces
 		}
 		status, _ := trimmedStringOptional(req, "status")
-		rows, err := deps.Improvements.ListRecommendations(workspace, status, 100)
+		page := pagination.Clamp(mcpInt(req, "limit", 0), mcpInt(req, "offset", 0))
+		rows, err := deps.Improvements.ListRecommendationsPage(workspace, status, page.Limit, page.Offset)
 		if err != nil {
 			return mcpgo.NewToolResultErrorFromErr("list improvement recommendations", err), nil
 		}
-		return jsonResult(nilSafe(rows))
+		total, err := deps.Improvements.CountRecommendations(workspace, status)
+		if err != nil {
+			return mcpgo.NewToolResultErrorFromErr("count improvement recommendations", err), nil
+		}
+		return jsonResult(pagination.NewPage(rows, total, page))
 	}
 }
 
@@ -375,11 +389,16 @@ func toolListImprovementRecommendationsWithBundles(deps Deps) server.ToolHandler
 		if !ok {
 			workspace = store.SelfImprovementAllWorkspaces
 		}
-		rows, err := deps.Improvements.ListRecommendationsWithBundles(workspace, 100)
+		page := pagination.Clamp(mcpInt(req, "limit", 0), mcpInt(req, "offset", 0))
+		rows, err := deps.Improvements.ListRecommendationsPage(workspace, "", page.Limit, page.Offset)
 		if err != nil {
 			return mcpgo.NewToolResultErrorFromErr("list improvement recommendations with bundles", err), nil
 		}
-		return jsonResult(nilSafe(rows))
+		total, err := deps.Improvements.CountRecommendations(workspace, "")
+		if err != nil {
+			return mcpgo.NewToolResultErrorFromErr("count improvement recommendations with bundles", err), nil
+		}
+		return jsonResult(pagination.NewPage(rows, total, page))
 	}
 }
 
@@ -389,7 +408,10 @@ func toolListImprovementRecommendationsWithBundles(deps Deps) server.ToolHandler
 func toolListTraces(deps Deps) server.ToolHandlerFunc {
 	return func(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 		workspace, _ := trimmedStringOptional(req, "workspace")
-		return jsonResult(nilSafe(deps.Observe.ListTracesForWorkspace(workspace)))
+		page := pagination.Clamp(mcpInt(req, "limit", 0), mcpInt(req, "offset", 0))
+		rows := deps.Observe.ListTracesForWorkspacePage(workspace, page.Limit, page.Offset)
+		total := deps.Observe.CountTracesForWorkspace(workspace)
+		return jsonResult(pagination.NewPage(rows, total, page))
 	}
 }
 

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -462,8 +462,15 @@ func TestToolListAgents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	var got []map[string]any
-	decodeText(t, res, &got)
+	var page struct {
+		Items []map[string]any `json:"items"`
+		Total int              `json:"total"`
+	}
+	decodeText(t, res, &page)
+	got := page.Items
+	if page.Total != 2 {
+		t.Fatalf("total = %d, want 2", page.Total)
+	}
 	if len(got) != 2 {
 		t.Fatalf("expected 2 agents, got %d: %+v", len(got), got)
 	}
@@ -547,8 +554,12 @@ func TestToolListSkillsSorted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	var got []map[string]any
-	decodeText(t, res, &got)
+	var page struct {
+		Items []map[string]any `json:"items"`
+		Total int              `json:"total"`
+	}
+	decodeText(t, res, &page)
+	got := page.Items
 	if len(got) != 2 {
 		t.Fatalf("expected 2 skills, got %d", len(got))
 	}
@@ -788,8 +799,12 @@ func TestToolListBackendsSorted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	var got []map[string]any
-	decodeText(t, res, &got)
+	var page struct {
+		Items []map[string]any `json:"items"`
+		Total int              `json:"total"`
+	}
+	decodeText(t, res, &page)
+	got := page.Items
 	if len(got) != 2 || got[0]["name"] != "claude" || got[1]["name"] != "codex" {
 		t.Fatalf("backends should be sorted alphabetically, got %+v", got)
 	}
@@ -836,8 +851,12 @@ func TestToolListRepos(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	var got []map[string]any
-	decodeText(t, res, &got)
+	var page struct {
+		Items []map[string]any `json:"items"`
+		Total int              `json:"total"`
+	}
+	decodeText(t, res, &page)
+	got := page.Items
 	if len(got) != 2 {
 		t.Fatalf("expected 2 repos, got %d", len(got))
 	}

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -217,6 +217,19 @@ func decodeText(t *testing.T, res *mcpgo.CallToolResult, v any) {
 	}
 }
 
+func decodePageItems(t *testing.T, res *mcpgo.CallToolResult) []map[string]any {
+	t.Helper()
+	var page struct {
+		Items []map[string]any `json:"items"`
+		Total int              `json:"total"`
+	}
+	decodeText(t, res, &page)
+	if page.Items == nil {
+		return []map[string]any{}
+	}
+	return page.Items
+}
+
 func textOf(t *testing.T, res *mcpgo.CallToolResult) string {
 	t.Helper()
 	if res == nil || len(res.Content) == 0 {
@@ -447,8 +460,7 @@ func TestToolImprovementProposalBundleLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list recommendations with bundles: %v", err)
 	}
-	var linked []map[string]any
-	decodeText(t, res, &linked)
+	linked := decodePageItems(t, res)
 	if len(linked) != 1 || linked[0]["id"] != rec.ID {
 		t.Fatalf("linked recommendations = %+v, want %s", linked, rec.ID)
 	}
@@ -1127,8 +1139,7 @@ func TestToolListEvents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	var got []map[string]any
-	decodeText(t, res, &got)
+	got := decodePageItems(t, res)
 	if len(got) != 2 || got[0]["id"] != "e1" || got[1]["id"] != "e2" {
 		t.Fatalf("unexpected events payload: %+v", got)
 	}
@@ -1147,8 +1158,7 @@ func TestToolListEventsSinceFilter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	var got []map[string]any
-	decodeText(t, res, &got)
+	got := decodePageItems(t, res)
 	if len(got) != 1 || got[0]["id"] != "new" {
 		t.Fatalf("since filter expected only new event, got %+v", got)
 	}
@@ -1160,7 +1170,7 @@ func TestToolListEventsSinceFilter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	decodeText(t, res, &got)
+	got = decodePageItems(t, res)
 	if len(got) != 2 {
 		t.Fatalf("unparseable since should fall back to no filter, got %+v", got)
 	}
@@ -1181,8 +1191,7 @@ func TestToolListEventsFiltersWorkspace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	var got []map[string]any
-	decodeText(t, res, &got)
+	got := decodePageItems(t, res)
 	if len(got) != 1 || got[0]["id"] != "team-a-event" {
 		t.Fatalf("workspace filter expected only team-a event, got %+v", got)
 	}
@@ -1196,11 +1205,9 @@ func TestToolListEventsNilSlice(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// Nil slice from the store should serialise as [] not null, easier for
-	// LLM clients that don't distinguish the two.
-	got := textOf(t, res)
-	if got != "[]" {
-		t.Fatalf("expected []\\n, got %q", got)
+	got := decodePageItems(t, res)
+	if len(got) != 0 {
+		t.Fatalf("expected empty items, got %+v", got)
 	}
 }
 
@@ -1244,8 +1251,7 @@ func TestToolListImprovementFeedback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	var got []map[string]any
-	decodeText(t, res, &got)
+	got := decodePageItems(t, res)
 	if len(got) != 1 || got[0]["github_comment_id"] != float64(101) || got[0]["status"] != "new" {
 		t.Fatalf("feedback filter returned %+v, want only comment 101", got)
 	}
@@ -1262,8 +1268,7 @@ func TestToolListTraces(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	var got []map[string]any
-	decodeText(t, res, &got)
+	got := decodePageItems(t, res)
 	if len(got) != 2 {
 		t.Fatalf("expected 2 traces, got %+v", got)
 	}
@@ -1285,8 +1290,7 @@ func TestToolListTracesFiltersWorkspace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	var got []map[string]any
-	decodeText(t, res, &got)
+	got := decodePageItems(t, res)
 	if len(got) != 1 || got[0]["span_id"] != "team-a-span" {
 		t.Fatalf("workspace filter expected only team-a span, got %+v", got)
 	}

--- a/internal/observe/observe.go
+++ b/internal/observe/observe.go
@@ -465,13 +465,18 @@ func (s *Store) ListEvents(since time.Time) []TimestampedEvent {
 }
 
 func (s *Store) ListEventsForWorkspace(workspaceID string, since time.Time) []TimestampedEvent {
+	return s.ListEventsForWorkspacePage(workspaceID, since, 500, 0)
+}
+
+func (s *Store) ListEventsForWorkspacePage(workspaceID string, since time.Time, limit, offset int) []TimestampedEvent {
 	workspaceID = fleet.NormalizeWorkspaceID(workspaceID)
+	limit, offset = clampObservePage(limit, offset)
 	var rows *sql.Rows
 	var err error
 	if since.IsZero() {
 		rows, err = s.db.Query(
-			`SELECT id, workspace_id, at, repo, kind, number, actor, payload FROM events WHERE workspace_id = ? ORDER BY at ASC LIMIT 500`,
-			workspaceID,
+			`SELECT id, workspace_id, at, repo, kind, number, actor, payload FROM events WHERE workspace_id = ? ORDER BY at ASC LIMIT ? OFFSET ?`,
+			workspaceID, limit, offset,
 		)
 	} else {
 		sinceTime := since.UTC()
@@ -480,8 +485,8 @@ func (s *Store) ListEventsForWorkspace(workspaceID string, since time.Time) []Ti
 			FROM events
 			WHERE workspace_id = ?
 			  AND (at > ? OR replace(substr(at, 1, 19), 'T', ' ') > ?)
-			ORDER BY at ASC LIMIT 500`,
-			workspaceID, sinceTime.Format(time.RFC3339Nano), sinceTime.Format(time.DateTime),
+			ORDER BY at ASC LIMIT ? OFFSET ?`,
+			workspaceID, sinceTime.Format(time.RFC3339Nano), sinceTime.Format(time.DateTime), limit, offset,
 		)
 	}
 	if err != nil {
@@ -511,6 +516,30 @@ func (s *Store) ListEventsForWorkspace(workspaceID string, since time.Time) []Ti
 	return out
 }
 
+func (s *Store) CountEventsForWorkspace(workspaceID string, since time.Time) int {
+	workspaceID = fleet.NormalizeWorkspaceID(workspaceID)
+	var (
+		row *sql.Row
+		n   int
+	)
+	if since.IsZero() {
+		row = s.db.QueryRow(`SELECT COUNT(*) FROM events WHERE workspace_id = ?`, workspaceID)
+	} else {
+		sinceTime := since.UTC()
+		row = s.db.QueryRow(
+			`SELECT COUNT(*) FROM events
+			WHERE workspace_id = ?
+			  AND (at > ? OR replace(substr(at, 1, 19), 'T', ' ') > ?)`,
+			workspaceID, sinceTime.Format(time.RFC3339Nano), sinceTime.Format(time.DateTime),
+		)
+	}
+	if err := row.Scan(&n); err != nil {
+		log.Printf("observe: count events: %v", err)
+		return 0
+	}
+	return n
+}
+
 // spanColumns is the column list used by every read query, kept in
 // one place so adding a new column means editing one line. The
 // prompt_gz blob is intentionally excluded; bodies are fetched on
@@ -528,10 +557,15 @@ func (s *Store) ListTraces() []Span {
 }
 
 func (s *Store) ListTracesForWorkspace(workspaceID string) []Span {
+	return s.ListTracesForWorkspacePage(workspaceID, 200, 0)
+}
+
+func (s *Store) ListTracesForWorkspacePage(workspaceID string, limit, offset int) []Span {
 	workspaceID = fleet.NormalizeWorkspaceID(workspaceID)
+	limit, offset = clampObservePage(limit, offset)
 	rows, err := s.db.Query(
-		`SELECT `+spanColumns+` FROM traces WHERE workspace_id = ? ORDER BY started_at DESC LIMIT 200`,
-		workspaceID,
+		`SELECT `+spanColumns+` FROM traces WHERE workspace_id = ? ORDER BY started_at DESC LIMIT ? OFFSET ?`,
+		workspaceID, limit, offset,
 	)
 	if err != nil {
 		log.Printf("observe: list traces: %v", err)
@@ -539,6 +573,29 @@ func (s *Store) ListTracesForWorkspace(workspaceID string) []Span {
 	}
 	defer rows.Close()
 	return scanSpans(rows)
+}
+
+func (s *Store) CountTracesForWorkspace(workspaceID string) int {
+	workspaceID = fleet.NormalizeWorkspaceID(workspaceID)
+	var n int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM traces WHERE workspace_id = ?`, workspaceID).Scan(&n); err != nil {
+		log.Printf("observe: count traces: %v", err)
+		return 0
+	}
+	return n
+}
+
+func clampObservePage(limit, offset int) (int, int) {
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 500 {
+		limit = 500
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	return limit, offset
 }
 
 // TracesByRootEventID returns all spans whose root_event_id matches id.

--- a/internal/selfimprovement/service.go
+++ b/internal/selfimprovement/service.go
@@ -19,7 +19,11 @@ func New(st *store.Store) *Service {
 }
 
 func (s *Service) ListRecommendations(workspace, status string, limit int) ([]SelfImprovementRecommendation, error) {
-	rows, err := s.store.ListSelfImprovementRecommendations(workspace, status, limit)
+	return s.ListRecommendationsPage(workspace, status, limit, 0)
+}
+
+func (s *Service) ListRecommendationsPage(workspace, status string, limit, offset int) ([]SelfImprovementRecommendation, error) {
+	rows, err := s.store.ListSelfImprovementRecommendationsPage(workspace, status, limit, offset)
 	if err != nil {
 		return nil, err
 	}
@@ -37,6 +41,10 @@ func (s *Service) ListRecommendations(workspace, status string, limit int) ([]Se
 		out = append(out, rec)
 	}
 	return out, nil
+}
+
+func (s *Service) CountRecommendations(workspace, status string) (int, error) {
+	return s.store.CountSelfImprovementRecommendations(workspace, status)
 }
 
 func (s *Service) GetRecommendation(id string) (SelfImprovementRecommendation, error) {

--- a/internal/store/agents.go
+++ b/internal/store/agents.go
@@ -267,6 +267,82 @@ func ReadAgents(db *sql.DB) ([]fleet.Agent, error) {
 	return cfg.Agents, nil
 }
 
+// ListWorkspaceAgents returns one deterministic page of agents in a workspace.
+func ListWorkspaceAgents(db *sql.DB, workspaceID string, limit, offset int) ([]fleet.Agent, error) {
+	workspaceID = fleet.NormalizeWorkspaceID(workspaceID)
+	limit, offset = clampPage(limit, offset)
+	rows, err := db.Query(`
+		SELECT a.id,a.workspace_id,a.name,a.backend,a.model,COALESCE(p.ref, ''),COALESCE(p.name, ''),COALESCE(p.workspace_id, ''),COALESCE(p.repo, ''),a.scope_type,a.scope_repo,a.allow_prs,a.allow_dispatch,a.description,a.allow_memory
+		FROM agents a
+		LEFT JOIN prompts p ON p.id = a.prompt_id
+		WHERE a.workspace_id=?
+		ORDER BY a.name
+		LIMIT ? OFFSET ?`, workspaceID, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("store: list agents: %w", err)
+	}
+	defer rows.Close()
+	var agents []fleet.Agent
+	var agentIDs []string
+	for rows.Next() {
+		var id, rowWorkspace, name, backend, model, promptID, promptRef, promptWorkspace, promptRepo, scopeType, scopeRepo, description string
+		var allowPRs, allowDispatch, allowMemory int
+		if err := rows.Scan(
+			&id, &rowWorkspace, &name, &backend, &model, &promptID, &promptRef, &promptWorkspace, &promptRepo, &scopeType, &scopeRepo,
+			&allowPRs, &allowDispatch, &description, &allowMemory,
+		); err != nil {
+			return nil, fmt.Errorf("store: list agents: scan: %w", err)
+		}
+		allowMem := intToBool(allowMemory)
+		promptScope := ""
+		if promptID != "" {
+			promptScope = fleet.CatalogScopePath(promptWorkspace, promptRepo)
+		}
+		agents = append(agents, fleet.Agent{
+			ID:            id,
+			WorkspaceID:   rowWorkspace,
+			Name:          name,
+			Backend:       backend,
+			Model:         model,
+			PromptID:      promptID,
+			PromptRef:     promptRef,
+			PromptScope:   promptScope,
+			ScopeType:     scopeType,
+			ScopeRepo:     scopeRepo,
+			AllowPRs:      intToBool(allowPRs),
+			AllowDispatch: intToBool(allowDispatch),
+			Description:   description,
+			AllowMemory:   &allowMem,
+		})
+		agentIDs = append(agentIDs, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("store: list agents: iterate: %w", err)
+	}
+	for i, id := range agentIDs {
+		skills, _, err := loadAgentSkillRefs(db, id)
+		if err != nil {
+			return nil, fmt.Errorf("store: list agents: load %s skills: %w", agents[i].Name, err)
+		}
+		canDispatch, err := loadAgentDispatchRefs(db, id)
+		if err != nil {
+			return nil, fmt.Errorf("store: list agents: load %s can_dispatch: %w", agents[i].Name, err)
+		}
+		agents[i].Skills = skills
+		agents[i].CanDispatch = canDispatch
+	}
+	return agents, nil
+}
+
+func CountWorkspaceAgents(db *sql.DB, workspaceID string) (int, error) {
+	workspaceID = fleet.NormalizeWorkspaceID(workspaceID)
+	var total int
+	if err := db.QueryRow("SELECT COUNT(*) FROM agents WHERE workspace_id=?", workspaceID).Scan(&total); err != nil {
+		return 0, fmt.Errorf("store: count agents: %w", err)
+	}
+	return total, nil
+}
+
 // UpsertAgent inserts or replaces a single agent definition.
 //
 // This non-Tx wrapper is retained for compatibility with store-level tests and

--- a/internal/store/auth.go
+++ b/internal/store/auth.go
@@ -74,9 +74,19 @@ func (s *Store) UserCount(ctx context.Context) (int, error) {
 }
 
 func (s *Store) ListUsers(ctx context.Context) ([]User, error) {
-	rows, err := s.db.QueryContext(ctx, `
+	return s.ListUsersPage(ctx, 0, 0)
+}
+
+func (s *Store) ListUsersPage(ctx context.Context, limit, offset int) ([]User, error) {
+	query := `
 		SELECT id,username,created_at,updated_at,last_login_at,disabled_at,is_admin
-		FROM users ORDER BY username ASC, id ASC`)
+		FROM users ORDER BY username ASC, id ASC`
+	args := []any{}
+	if limit > 0 {
+		query += " LIMIT ? OFFSET ?"
+		args = append(args, limit, offset)
+	}
+	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("auth: list users: %w", err)
 	}
@@ -335,9 +345,19 @@ func (s *Store) CreateAPIToken(ctx context.Context, userID int64, name string, e
 }
 
 func (s *Store) ListAuthTokens(ctx context.Context, userID int64) ([]AuthToken, error) {
-	rows, err := s.db.QueryContext(ctx, `
+	return s.ListAuthTokensPage(ctx, userID, 0, 0)
+}
+
+func (s *Store) ListAuthTokensPage(ctx context.Context, userID int64, limit, offset int) ([]AuthToken, error) {
+	query := `
 		SELECT id,user_id,kind,name,prefix,created_at,expires_at,last_used_at,revoked_at
-		FROM auth_tokens WHERE user_id=? ORDER BY created_at DESC, id DESC`, userID)
+		FROM auth_tokens WHERE user_id=? ORDER BY created_at DESC, id DESC`
+	args := []any{userID}
+	if limit > 0 {
+		query += " LIMIT ? OFFSET ?"
+		args = append(args, limit, offset)
+	}
+	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("auth: list tokens: %w", err)
 	}
@@ -354,6 +374,14 @@ func (s *Store) ListAuthTokens(ctx context.Context, userID int64) ([]AuthToken, 
 		return nil, fmt.Errorf("auth: list tokens rows: %w", err)
 	}
 	return out, nil
+}
+
+func (s *Store) AuthTokenCount(ctx context.Context, userID int64) (int, error) {
+	var count int
+	if err := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM auth_tokens WHERE user_id=?", userID).Scan(&count); err != nil {
+		return 0, fmt.Errorf("auth: count tokens: %w", err)
+	}
+	return count, nil
 }
 
 func (s *Store) RevokeAuthToken(ctx context.Context, userID, tokenID int64) error {

--- a/internal/store/auth_test.go
+++ b/internal/store/auth_test.go
@@ -49,6 +49,20 @@ func TestAuthBootstrapLoginAndAPITokenLifecycle(t *testing.T) {
 	if len(users) != 2 {
 		t.Fatalf("ListUsers() len = %d, want 2", len(users))
 	}
+	userPage, err := st.ListUsersPage(ctx, 1, 1)
+	if err != nil {
+		t.Fatalf("ListUsersPage() error = %v", err)
+	}
+	if len(userPage) != 1 || userPage[0].Username != "other" {
+		t.Fatalf("ListUsersPage() = %+v, want other", userPage)
+	}
+	userCount, err := st.UserCount(ctx)
+	if err != nil {
+		t.Fatalf("UserCount() error = %v", err)
+	}
+	if userCount != 2 {
+		t.Fatalf("UserCount() = %d, want 2", userCount)
+	}
 	for _, user := range users {
 		if user.Username == "admin" && !user.IsAdmin {
 			t.Fatal("bootstrap user is not marked admin")
@@ -106,6 +120,20 @@ func TestAuthBootstrapLoginAndAPITokenLifecycle(t *testing.T) {
 	}
 	if len(tokens) != 3 {
 		t.Fatalf("ListAuthTokens() len = %d, want 3", len(tokens))
+	}
+	tokenPage, err := st.ListAuthTokensPage(ctx, identity.User.ID, 2, 1)
+	if err != nil {
+		t.Fatalf("ListAuthTokensPage() error = %v", err)
+	}
+	if len(tokenPage) != 2 {
+		t.Fatalf("ListAuthTokensPage() len = %d, want 2", len(tokenPage))
+	}
+	tokenCount, err := st.AuthTokenCount(ctx, identity.User.ID)
+	if err != nil {
+		t.Fatalf("AuthTokenCount() error = %v", err)
+	}
+	if tokenCount != 3 {
+		t.Fatalf("AuthTokenCount() = %d, want 3", tokenCount)
 	}
 	for _, token := range tokens {
 		if token.Prefix == api.Token {

--- a/internal/store/backends.go
+++ b/internal/store/backends.go
@@ -93,6 +93,45 @@ func ReadBackends(db *sql.DB) (map[string]fleet.Backend, error) {
 	return cfg.Daemon.AIBackends, nil
 }
 
+type BackendRecord struct {
+	Name    string
+	Backend fleet.Backend
+}
+
+func ListBackends(db *sql.DB, limit, offset int) ([]BackendRecord, error) {
+	limit, offset = clampPage(limit, offset)
+	rows, err := db.Query("SELECT name,command,version,models,healthy,health_detail,local_model_url,timeout_seconds,max_prompt_chars FROM backends ORDER BY name LIMIT ? OFFSET ?", limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("store: list backends: %w", err)
+	}
+	defer rows.Close()
+	var out []BackendRecord
+	for rows.Next() {
+		var rec BackendRecord
+		var modelsJSON string
+		var healthy, timeout, maxChars int
+		if err := rows.Scan(&rec.Name, &rec.Backend.Command, &rec.Backend.Version, &modelsJSON, &healthy, &rec.Backend.HealthDetail, &rec.Backend.LocalModelURL, &timeout, &maxChars); err != nil {
+			return nil, fmt.Errorf("store: list backends: %w", err)
+		}
+		if err := json.Unmarshal([]byte(modelsJSON), &rec.Backend.Models); err != nil {
+			return nil, fmt.Errorf("store: list backends: parse %s models: %w", rec.Name, err)
+		}
+		rec.Backend.Healthy = intToBool(healthy)
+		rec.Backend.TimeoutSeconds = timeout
+		rec.Backend.MaxPromptChars = maxChars
+		out = append(out, rec)
+	}
+	return out, rows.Err()
+}
+
+func CountBackends(db *sql.DB) (int, error) {
+	var total int
+	if err := db.QueryRow("SELECT COUNT(*) FROM backends").Scan(&total); err != nil {
+		return 0, fmt.Errorf("store: count backends: %w", err)
+	}
+	return total, nil
+}
+
 // UpsertBackend inserts or replaces a single AI backend configuration.
 // Before writing, the backend is fully normalized to match what startup
 // produces: the name is lowercased and trimmed, Command is trimmed, blank env

--- a/internal/store/budgets.go
+++ b/internal/store/budgets.go
@@ -290,6 +290,32 @@ func ListTokenBudgets(db *sql.DB) ([]TokenBudget, error) {
 	return out, rows.Err()
 }
 
+func ListTokenBudgetsPage(db *sql.DB, limit, offset int) ([]TokenBudget, error) {
+	limit, offset = clampPage(limit, offset)
+	rows, err := db.Query(`SELECT id, scope_kind, scope_name, workspace_id, repo, agent, backend, period, cap_tokens, alert_at_pct, enabled FROM token_budgets ORDER BY scope_kind, workspace_id, repo, agent, backend, period LIMIT ? OFFSET ?`, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []TokenBudget
+	for rows.Next() {
+		b, err := scanTokenBudget(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, b)
+	}
+	return out, rows.Err()
+}
+
+func CountTokenBudgets(db *sql.DB) (int, error) {
+	var total int
+	if err := db.QueryRow("SELECT COUNT(*) FROM token_budgets").Scan(&total); err != nil {
+		return 0, err
+	}
+	return total, nil
+}
+
 // GetTokenBudget returns one budget by ID.
 func GetTokenBudget(db *sql.DB, id int64) (TokenBudget, error) {
 	return GetTokenBudgetFrom(db, id)

--- a/internal/store/facade.go
+++ b/internal/store/facade.go
@@ -64,6 +64,12 @@ func (s *Store) ReadAgents() ([]fleet.Agent, error)   { return ReadAgents(s.db) 
 func (s *Store) UpsertAgent(a fleet.Agent) error      { return UpsertAgent(s.db, a) }
 func (s *Store) DeleteAgent(name string) error        { return DeleteAgent(s.db, name) }
 func (s *Store) DeleteAgentCascade(name string) error { return DeleteAgentCascade(s.db, name) }
+func (s *Store) ListWorkspaceAgents(workspace string, limit, offset int) ([]fleet.Agent, error) {
+	return ListWorkspaceAgents(s.db, workspace, limit, offset)
+}
+func (s *Store) CountWorkspaceAgents(workspace string) (int, error) {
+	return CountWorkspaceAgents(s.db, workspace)
+}
 func (s *Store) DeleteWorkspaceAgent(workspace, name string) error {
 	return DeleteWorkspaceAgent(s.db, workspace, name)
 }
@@ -91,6 +97,14 @@ func (s *Store) ClearWorkspaceGraphLayout(workspace string) error {
 
 func (s *Store) ReadWorkspaces() ([]fleet.Workspace, error) { return ReadWorkspaces(s.db) }
 func (s *Store) ReadPrompts() ([]fleet.Prompt, error)       { return ReadPrompts(s.db) }
+func (s *Store) ListWorkspaces(limit, offset int) ([]fleet.Workspace, error) {
+	return ListWorkspaces(s.db, limit, offset)
+}
+func (s *Store) CountWorkspaces() (int, error) { return CountWorkspaces(s.db) }
+func (s *Store) ListPrompts(limit, offset int) ([]fleet.Prompt, error) {
+	return ListPrompts(s.db, limit, offset)
+}
+func (s *Store) CountPrompts() (int, error) { return CountPrompts(s.db) }
 func (s *Store) ReadRuntimeSettings() (fleet.RuntimeSettings, error) {
 	return ReadRuntimeSettings(s.db)
 }
@@ -142,6 +156,10 @@ func (s *Store) DeletePrompt(ref string) error { return DeletePrompt(s.db, ref) 
 // ── Skills ──────────────────────────────────────────────────────────────
 
 func (s *Store) ReadSkills() (map[string]fleet.Skill, error) { return ReadSkills(s.db) }
+func (s *Store) ListSkills(limit, offset int) ([]SkillRecord, error) {
+	return ListSkills(s.db, limit, offset)
+}
+func (s *Store) CountSkills() (int, error) { return CountSkills(s.db) }
 func (s *Store) ReadSkillVersion(versionID string) (fleet.Skill, error) {
 	return ReadSkillVersion(s.db, versionID)
 }
@@ -157,6 +175,10 @@ func (s *Store) DeleteSkill(name string) error                 { return DeleteSk
 // ── Backends ────────────────────────────────────────────────────────────
 
 func (s *Store) ReadBackends() (map[string]fleet.Backend, error) { return ReadBackends(s.db) }
+func (s *Store) ListBackends(limit, offset int) ([]BackendRecord, error) {
+	return ListBackends(s.db, limit, offset)
+}
+func (s *Store) CountBackends() (int, error) { return CountBackends(s.db) }
 func (s *Store) UpsertBackend(name string, b fleet.Backend) error {
 	return UpsertBackend(s.db, name, b)
 }
@@ -167,6 +189,12 @@ func (s *Store) DeleteBackend(name string) error { return DeleteBackend(s.db, na
 func (s *Store) ReadRepos() ([]fleet.Repo, error) { return ReadRepos(s.db) }
 func (s *Store) UpsertRepo(r fleet.Repo) error    { return UpsertRepo(s.db, r) }
 func (s *Store) DeleteRepo(name string) error     { return DeleteRepo(s.db, name) }
+func (s *Store) ListWorkspaceRepos(workspace string, limit, offset int) ([]fleet.Repo, error) {
+	return ListWorkspaceRepos(s.db, workspace, limit, offset)
+}
+func (s *Store) CountWorkspaceRepos(workspace string) (int, error) {
+	return CountWorkspaceRepos(s.db, workspace)
+}
 func (s *Store) DeleteWorkspaceRepo(workspace, name string) error {
 	return DeleteWorkspaceRepo(s.db, workspace, name)
 }
@@ -207,7 +235,11 @@ func (s *Store) ReadEnabledGuardrails() ([]fleet.Guardrail, error) {
 func (s *Store) ReadWorkspacePromptGuardrails(workspace string) ([]fleet.Guardrail, error) {
 	return ReadWorkspacePromptGuardrails(s.db, workspace)
 }
-func (s *Store) ReadAllGuardrails() ([]fleet.Guardrail, error)     { return ReadAllGuardrails(s.db) }
+func (s *Store) ReadAllGuardrails() ([]fleet.Guardrail, error) { return ReadAllGuardrails(s.db) }
+func (s *Store) ListAllGuardrails(limit, offset int) ([]fleet.Guardrail, error) {
+	return ListAllGuardrails(s.db, limit, offset)
+}
+func (s *Store) CountAllGuardrails() (int, error)                  { return CountAllGuardrails(s.db) }
 func (s *Store) GetGuardrail(name string) (fleet.Guardrail, error) { return GetGuardrail(s.db, name) }
 func (s *Store) ListGuardrailVersions(ref string) ([]fleet.CatalogVersion, error) {
 	return ListGuardrailVersions(s.db, ref)
@@ -280,7 +312,11 @@ func (s *Store) CountFrom() (ImportCount, error)          { return CountFrom(s.d
 
 // ── Token budgets and leaderboard ────────────────────────────────────────
 
-func (s *Store) ListTokenBudgets() ([]TokenBudget, error)     { return ListTokenBudgets(s.db) }
+func (s *Store) ListTokenBudgets() ([]TokenBudget, error) { return ListTokenBudgets(s.db) }
+func (s *Store) ListTokenBudgetsPage(limit, offset int) ([]TokenBudget, error) {
+	return ListTokenBudgetsPage(s.db, limit, offset)
+}
+func (s *Store) CountTokenBudgets() (int, error)              { return CountTokenBudgets(s.db) }
 func (s *Store) GetTokenBudget(id int64) (TokenBudget, error) { return GetTokenBudget(s.db, id) }
 func (s *Store) CreateTokenBudget(b TokenBudget) (TokenBudget, error) {
 	return CreateTokenBudget(s.db, b)

--- a/internal/store/guardrails.go
+++ b/internal/store/guardrails.go
@@ -58,6 +58,27 @@ func ReadAllGuardrails(db *sql.DB) ([]fleet.Guardrail, error) {
 	return scanGuardrails(db, q)
 }
 
+func ListAllGuardrails(db *sql.DB, limit, offset int) ([]fleet.Guardrail, error) {
+	limit, offset = clampPage(limit, offset)
+	const q = `
+		SELECT g.ref, COALESCE(g.workspace_id, ''), g.name, COALESCE(g.description, ''), g.content,
+		       COALESCE(g.default_content, ''), g.is_builtin, g.enabled, g.position,
+		       COALESCE(gv.id, ''), COALESCE(gv.version_number, 0)
+		FROM guardrails g
+		LEFT JOIN guardrail_versions gv ON gv.id = g.current_version_id
+		ORDER BY g.position ASC, g.name ASC
+		LIMIT ? OFFSET ?`
+	return scanGuardrails(db, q, limit, offset)
+}
+
+func CountAllGuardrails(db *sql.DB) (int, error) {
+	var total int
+	if err := db.QueryRow("SELECT COUNT(*) FROM guardrails").Scan(&total); err != nil {
+		return 0, fmt.Errorf("store: count guardrails: %w", err)
+	}
+	return total, nil
+}
+
 // GetGuardrail returns the named guardrail. Returns *ErrNotFound when the
 // row does not exist.
 func GetGuardrail(db *sql.DB, name string) (fleet.Guardrail, error) {

--- a/internal/store/pagination.go
+++ b/internal/store/pagination.go
@@ -1,0 +1,19 @@
+package store
+
+const (
+	DefaultPageLimit = 50
+	MaxPageLimit     = 500
+)
+
+func clampPage(limit, offset int) (int, int) {
+	if limit <= 0 {
+		limit = DefaultPageLimit
+	}
+	if limit > MaxPageLimit {
+		limit = MaxPageLimit
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	return limit, offset
+}

--- a/internal/store/repos.go
+++ b/internal/store/repos.go
@@ -151,6 +151,48 @@ func ReadRepos(db *sql.DB) ([]fleet.Repo, error) {
 	return cfg.Repos, nil
 }
 
+func ListWorkspaceRepos(db *sql.DB, workspaceID string, limit, offset int) ([]fleet.Repo, error) {
+	workspaceID = fleet.NormalizeWorkspaceID(workspaceID)
+	limit, offset = clampPage(limit, offset)
+	rows, err := db.Query("SELECT workspace_id,name,enabled FROM repos WHERE workspace_id=? ORDER BY name LIMIT ? OFFSET ?", workspaceID, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("store: list repos: %w", err)
+	}
+	var repos []fleet.Repo
+	for rows.Next() {
+		var r fleet.Repo
+		var enabled int
+		if err := rows.Scan(&r.WorkspaceID, &r.Name, &enabled); err != nil {
+			return nil, fmt.Errorf("store: list repos: scan: %w", err)
+		}
+		r.Enabled = intToBool(enabled)
+		repos = append(repos, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("store: list repos: iterate: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, fmt.Errorf("store: list repos: close: %w", err)
+	}
+	for i := range repos {
+		bindings, err := loadBindingsForRepo(db, repos[i].WorkspaceID, repos[i].Name)
+		if err != nil {
+			return nil, err
+		}
+		repos[i].Use = bindings
+	}
+	return repos, nil
+}
+
+func CountWorkspaceRepos(db *sql.DB, workspaceID string) (int, error) {
+	workspaceID = fleet.NormalizeWorkspaceID(workspaceID)
+	var total int
+	if err := db.QueryRow("SELECT COUNT(*) FROM repos WHERE workspace_id=?", workspaceID).Scan(&total); err != nil {
+		return 0, fmt.Errorf("store: count repos: %w", err)
+	}
+	return total, nil
+}
+
 // UpsertRepo inserts or replaces a repo and its bindings. Bindings are
 // replaced wholesale: any existing bindings for the repo are removed before
 // the new list is written. The repo name and binding agents/events are

--- a/internal/store/self_improvement.go
+++ b/internal/store/self_improvement.go
@@ -172,6 +172,14 @@ func (s *Store) ListSelfImprovementFeedback(workspace, status string, limit int)
 	return ListSelfImprovementFeedback(s.db, workspace, status, limit)
 }
 
+func (s *Store) ListSelfImprovementFeedbackPage(workspace, status string, limit, offset int) ([]SelfImprovementFeedback, error) {
+	return ListSelfImprovementFeedbackPage(s.db, workspace, status, limit, offset)
+}
+
+func (s *Store) CountSelfImprovementFeedback(workspace, status string) (int, error) {
+	return CountSelfImprovementFeedback(s.db, workspace, status)
+}
+
 func (s *Store) GetSelfImprovementFeedback(id int64) (SelfImprovementFeedback, error) {
 	return GetSelfImprovementFeedback(s.db, id)
 }
@@ -182,6 +190,14 @@ func (s *Store) GetSelfImprovementRecommendationByFeedback(workspaceID string, f
 
 func (s *Store) ListSelfImprovementRecommendations(workspace, status string, limit int) ([]SelfImprovementRecommendationRow, error) {
 	return ListSelfImprovementRecommendations(s.db, workspace, status, limit)
+}
+
+func (s *Store) ListSelfImprovementRecommendationsPage(workspace, status string, limit, offset int) ([]SelfImprovementRecommendationRow, error) {
+	return ListSelfImprovementRecommendationsPage(s.db, workspace, status, limit, offset)
+}
+
+func (s *Store) CountSelfImprovementRecommendations(workspace, status string) (int, error) {
+	return CountSelfImprovementRecommendations(s.db, workspace, status)
 }
 
 func (s *Store) GetSelfImprovementRecommendation(id string) (SelfImprovementRecommendationRow, error) {
@@ -434,9 +450,12 @@ func IgnoreSelfImprovementFeedback(db *sql.DB, in SelfImprovementFeedbackInput) 
 }
 
 func ListSelfImprovementFeedback(db *sql.DB, workspace, status string, limit int) ([]SelfImprovementFeedback, error) {
-	if limit <= 0 || limit > 500 {
-		limit = 100
-	}
+	rows, err := ListSelfImprovementFeedbackPage(db, workspace, status, limit, 0)
+	return rows, err
+}
+
+func ListSelfImprovementFeedbackPage(db *sql.DB, workspace, status string, limit, offset int) ([]SelfImprovementFeedback, error) {
+	limit, offset = clampSelfImprovementPage(limit, offset)
 	allWorkspaces := selfImprovementAllWorkspaces(workspace)
 	workspaceID := fleet.NormalizeWorkspaceID(workspace)
 	status = strings.TrimSpace(status)
@@ -455,8 +474,8 @@ func ListSelfImprovementFeedback(db *sql.DB, workspace, status string, limit int
 				linked_agent_name, linked_prompt_version_id, linked_skill_version_ids,
 				linked_guardrail_version_ids, link_confidence, link_diagnostics, status
 			FROM self_improvement_feedback
-			ORDER BY ingested_at DESC, id DESC LIMIT ?`,
-			limit,
+			ORDER BY ingested_at DESC, id DESC LIMIT ? OFFSET ?`,
+			limit, offset,
 		)
 	case allWorkspaces:
 		rows, err = db.Query(
@@ -469,8 +488,8 @@ func ListSelfImprovementFeedback(db *sql.DB, workspace, status string, limit int
 				linked_guardrail_version_ids, link_confidence, link_diagnostics, status
 			FROM self_improvement_feedback
 			WHERE status=?
-			ORDER BY ingested_at DESC, id DESC LIMIT ?`,
-			status, limit,
+			ORDER BY ingested_at DESC, id DESC LIMIT ? OFFSET ?`,
+			status, limit, offset,
 		)
 	case status == "":
 		rows, err = db.Query(
@@ -483,8 +502,8 @@ func ListSelfImprovementFeedback(db *sql.DB, workspace, status string, limit int
 				linked_guardrail_version_ids, link_confidence, link_diagnostics, status
 			FROM self_improvement_feedback
 			WHERE workspace_id=?
-			ORDER BY ingested_at DESC, id DESC LIMIT ?`,
-			workspaceID, limit,
+			ORDER BY ingested_at DESC, id DESC LIMIT ? OFFSET ?`,
+			workspaceID, limit, offset,
 		)
 	default:
 		rows, err = db.Query(
@@ -497,8 +516,8 @@ func ListSelfImprovementFeedback(db *sql.DB, workspace, status string, limit int
 				linked_guardrail_version_ids, link_confidence, link_diagnostics, status
 			FROM self_improvement_feedback
 			WHERE workspace_id=? AND status=?
-			ORDER BY ingested_at DESC, id DESC LIMIT ?`,
-			workspaceID, status, limit,
+			ORDER BY ingested_at DESC, id DESC LIMIT ? OFFSET ?`,
+			workspaceID, status, limit, offset,
 		)
 	}
 	if err != nil {
@@ -514,6 +533,10 @@ func ListSelfImprovementFeedback(db *sql.DB, workspace, status string, limit int
 		out = append(out, ev)
 	}
 	return out, rows.Err()
+}
+
+func CountSelfImprovementFeedback(db *sql.DB, workspace, status string) (int, error) {
+	return countSelfImprovementRows(db, "self_improvement_feedback", "workspace_id", workspace, status)
 }
 
 func GetSelfImprovementFeedback(db *sql.DB, id int64) (SelfImprovementFeedback, error) {
@@ -589,9 +612,11 @@ func UpsertSelfImprovementRecommendationRow(q sqlExec, in SelfImprovementRecomme
 }
 
 func ListSelfImprovementRecommendations(db *sql.DB, workspace, status string, limit int) ([]SelfImprovementRecommendationRow, error) {
-	if limit <= 0 || limit > 500 {
-		limit = 100
-	}
+	return ListSelfImprovementRecommendationsPage(db, workspace, status, limit, 0)
+}
+
+func ListSelfImprovementRecommendationsPage(db *sql.DB, workspace, status string, limit, offset int) ([]SelfImprovementRecommendationRow, error) {
+	limit, offset = clampSelfImprovementPage(limit, offset)
 	allWorkspaces := selfImprovementAllWorkspaces(workspace)
 	workspaceID := fleet.NormalizeWorkspaceID(workspace)
 	status = strings.TrimSpace(status)
@@ -599,13 +624,13 @@ func ListSelfImprovementRecommendations(db *sql.DB, workspace, status string, li
 	var err error
 	switch {
 	case allWorkspaces && status == "":
-		rows, err = db.Query(recommendationSelectSQL()+` ORDER BY r.updated_at DESC, r.id DESC LIMIT ?`, limit)
+		rows, err = db.Query(recommendationSelectSQL()+` ORDER BY r.updated_at DESC, r.id DESC LIMIT ? OFFSET ?`, limit, offset)
 	case allWorkspaces:
-		rows, err = db.Query(recommendationSelectSQL()+` WHERE r.status=? ORDER BY r.updated_at DESC, r.id DESC LIMIT ?`, status, limit)
+		rows, err = db.Query(recommendationSelectSQL()+` WHERE r.status=? ORDER BY r.updated_at DESC, r.id DESC LIMIT ? OFFSET ?`, status, limit, offset)
 	case status == "":
-		rows, err = db.Query(recommendationSelectSQL()+` WHERE r.workspace_id=? ORDER BY r.updated_at DESC, r.id DESC LIMIT ?`, workspaceID, limit)
+		rows, err = db.Query(recommendationSelectSQL()+` WHERE r.workspace_id=? ORDER BY r.updated_at DESC, r.id DESC LIMIT ? OFFSET ?`, workspaceID, limit, offset)
 	default:
-		rows, err = db.Query(recommendationSelectSQL()+` WHERE r.workspace_id=? AND r.status=? ORDER BY r.updated_at DESC, r.id DESC LIMIT ?`, workspaceID, status, limit)
+		rows, err = db.Query(recommendationSelectSQL()+` WHERE r.workspace_id=? AND r.status=? ORDER BY r.updated_at DESC, r.id DESC LIMIT ? OFFSET ?`, workspaceID, status, limit, offset)
 	}
 	if err != nil {
 		return nil, err
@@ -620,6 +645,42 @@ func ListSelfImprovementRecommendations(db *sql.DB, workspace, status string, li
 		out = append(out, rec)
 	}
 	return out, rows.Err()
+}
+
+func CountSelfImprovementRecommendations(db *sql.DB, workspace, status string) (int, error) {
+	return countSelfImprovementRows(db, "self_improvement_recommendations", "workspace_id", workspace, status)
+}
+
+func clampSelfImprovementPage(limit, offset int) (int, int) {
+	if limit <= 0 {
+		limit = 100
+	}
+	if limit > MaxPageLimit {
+		limit = MaxPageLimit
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	return limit, offset
+}
+
+func countSelfImprovementRows(db *sql.DB, table, workspaceColumn, workspace, status string) (int, error) {
+	allWorkspaces := selfImprovementAllWorkspaces(workspace)
+	workspaceID := fleet.NormalizeWorkspaceID(workspace)
+	status = strings.TrimSpace(status)
+	var row *sql.Row
+	switch {
+	case allWorkspaces && status == "":
+		row = db.QueryRow(`SELECT COUNT(*) FROM ` + table)
+	case allWorkspaces:
+		row = db.QueryRow(`SELECT COUNT(*) FROM `+table+` WHERE status=?`, status)
+	case status == "":
+		row = db.QueryRow(`SELECT COUNT(*) FROM `+table+` WHERE `+workspaceColumn+`=?`, workspaceID)
+	default:
+		row = db.QueryRow(`SELECT COUNT(*) FROM `+table+` WHERE `+workspaceColumn+`=? AND status=?`, workspaceID, status)
+	}
+	var total int
+	return total, row.Scan(&total)
 }
 
 func GetSelfImprovementRecommendation(db *sql.DB, id string) (SelfImprovementRecommendationRow, error) {

--- a/internal/store/skills.go
+++ b/internal/store/skills.go
@@ -145,6 +145,44 @@ func ReadSkills(db *sql.DB) (map[string]fleet.Skill, error) {
 	return cfg.Skills, nil
 }
 
+type SkillRecord struct {
+	ID    string
+	Skill fleet.Skill
+}
+
+func ListSkills(db *sql.DB, limit, offset int) ([]SkillRecord, error) {
+	limit, offset = clampPage(limit, offset)
+	rows, err := db.Query(`
+		SELECT s.ref, COALESCE(s.workspace_id, ''), COALESCE(s.repo, ''), s.name, s.prompt,
+		       COALESCE(sv.id, ''), COALESCE(sv.version_number, 0)
+		FROM skills s
+		LEFT JOIN skill_versions sv ON sv.id = s.current_version_id
+		ORDER BY COALESCE(s.workspace_id, ''), COALESCE(s.repo, ''), s.name
+		LIMIT ? OFFSET ?`, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("store: list skills: %w", err)
+	}
+	defer rows.Close()
+	var out []SkillRecord
+	for rows.Next() {
+		var rec SkillRecord
+		if err := rows.Scan(&rec.ID, &rec.Skill.WorkspaceID, &rec.Skill.Repo, &rec.Skill.Name, &rec.Skill.Prompt, &rec.Skill.VersionID, &rec.Skill.Version); err != nil {
+			return nil, fmt.Errorf("store: list skills: %w", err)
+		}
+		rec.Skill.ID = rec.ID
+		out = append(out, rec)
+	}
+	return out, rows.Err()
+}
+
+func CountSkills(db *sql.DB) (int, error) {
+	var total int
+	if err := db.QueryRow("SELECT COUNT(*) FROM skills").Scan(&total); err != nil {
+		return 0, fmt.Errorf("store: count skills: %w", err)
+	}
+	return total, nil
+}
+
 // UpsertSkill inserts or replaces a single skill.
 // The skill name is normalized (lowercase, trimmed) and Skill.Prompt is
 // trimmed before writing, matching the normalization startup applies in

--- a/internal/store/workspaces.go
+++ b/internal/store/workspaces.go
@@ -28,6 +28,32 @@ func ReadWorkspaces(db *sql.DB) ([]fleet.Workspace, error) {
 	return out, rows.Err()
 }
 
+func ListWorkspaces(db *sql.DB, limit, offset int) ([]fleet.Workspace, error) {
+	limit, offset = clampPage(limit, offset)
+	rows, err := db.Query("SELECT id, name, description, runner_image FROM workspaces ORDER BY name LIMIT ? OFFSET ?", limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("store: list workspaces: %w", err)
+	}
+	defer rows.Close()
+	var out []fleet.Workspace
+	for rows.Next() {
+		var w fleet.Workspace
+		if err := rows.Scan(&w.ID, &w.Name, &w.Description, &w.RunnerImage); err != nil {
+			return nil, fmt.Errorf("store: list workspaces: %w", err)
+		}
+		out = append(out, w)
+	}
+	return out, rows.Err()
+}
+
+func CountWorkspaces(db *sql.DB) (int, error) {
+	var total int
+	if err := db.QueryRow("SELECT COUNT(*) FROM workspaces").Scan(&total); err != nil {
+		return 0, fmt.Errorf("store: count workspaces: %w", err)
+	}
+	return total, nil
+}
+
 // ResolveWorkspaceID resolves either a workspace id or display name to the
 // stable workspace id used by storage.
 func ResolveWorkspaceID(db *sql.DB, workspace string) (string, error) {
@@ -334,4 +360,36 @@ func ReadPrompts(db *sql.DB) ([]fleet.Prompt, error) {
 		out = append(out, p)
 	}
 	return out, rows.Err()
+}
+
+func ListPrompts(db *sql.DB, limit, offset int) ([]fleet.Prompt, error) {
+	limit, offset = clampPage(limit, offset)
+	rows, err := db.Query(`
+		SELECT p.ref, COALESCE(p.workspace_id, ''), COALESCE(p.repo, ''), p.name, p.description, p.content,
+		       COALESCE(pv.id, ''), COALESCE(pv.version_number, 0)
+		FROM prompts p
+		LEFT JOIN prompt_versions pv ON pv.id = p.current_version_id
+		ORDER BY COALESCE(p.workspace_id, ''), COALESCE(p.repo, ''), p.name
+		LIMIT ? OFFSET ?`, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("store: list prompts: %w", err)
+	}
+	defer rows.Close()
+	var out []fleet.Prompt
+	for rows.Next() {
+		var p fleet.Prompt
+		if err := rows.Scan(&p.ID, &p.WorkspaceID, &p.Repo, &p.Name, &p.Description, &p.Content, &p.VersionID, &p.Version); err != nil {
+			return nil, fmt.Errorf("store: list prompts: %w", err)
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+func CountPrompts(db *sql.DB) (int, error) {
+	var total int
+	if err := db.QueryRow("SELECT COUNT(*) FROM prompts").Scan(&total); err != nil {
+		return 0, fmt.Errorf("store: count prompts: %w", err)
+	}
+	return total, nil
 }

--- a/internal/ui/src/app/config/page.test.tsx
+++ b/internal/ui/src/app/config/page.test.tsx
@@ -76,3 +76,77 @@ describe('<ConfigPage /> runtime workspace overrides', () => {
     expect(await screen.findByText('Workspace runner override saved for Team B.')).toBeInTheDocument()
   })
 })
+
+describe('<ConfigPage /> backend pagination', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    window.history.replaceState(null, '', '/')
+  })
+
+  it('paginates the backend admin list while loading selector options separately', async () => {
+    window.history.replaceState(null, '', '/ui/config?tab=backends')
+
+    const backendPage = (offset: number) => ({
+      items: [{
+        name: offset === 0 ? 'backend-001' : 'backend-051',
+        command: 'codex',
+        healthy: true,
+        timeout_seconds: 600,
+        max_prompt_chars: 12000,
+      }],
+      total: 75,
+      limit: 50,
+      offset,
+    })
+    const fetchMock = vi.fn((url: string) => {
+      if (url === '/config') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response)
+      }
+      if (url === '/backends?limit=50&offset=0') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(backendPage(0)) } as Response)
+      }
+      if (url === '/backends?limit=50&offset=50') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(backendPage(50)) } as Response)
+      }
+      if (url === '/backends?limit=500&offset=0') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            items: [
+              backendPage(0).items[0],
+              backendPage(50).items[0],
+              { name: 'selector-only', command: 'claude', healthy: true, timeout_seconds: 600, max_prompt_chars: 12000 },
+            ],
+            total: 75,
+            limit: 500,
+            offset: 0,
+          }),
+        } as Response)
+      }
+      if (url === '/backends/status') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ backends: [], tools: [] }) } as Response)
+      }
+      if (url === '/agents/orphans/status') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ count: 0, agents: [] }) } as Response)
+      }
+      return Promise.resolve({
+        ok: false,
+        text: () => Promise.resolve(`unexpected request: ${url}`),
+        json: () => Promise.resolve({}),
+      } as Response)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<ConfigPage />)
+
+    expect(await screen.findByText('backend-001')).toBeInTheDocument()
+    expect(screen.getByText('1-50 of 75')).toBeInTheDocument()
+    expect(fetchMock).toHaveBeenCalledWith('/backends?limit=500&offset=0')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+
+    expect(await screen.findByText('backend-051')).toBeInTheDocument()
+    expect(screen.getByText('51-75 of 75')).toBeInTheDocument()
+    expect(fetchMock).toHaveBeenCalledWith('/backends?limit=50&offset=50')
+  })
+})

--- a/internal/ui/src/app/config/page.tsx
+++ b/internal/ui/src/app/config/page.tsx
@@ -279,6 +279,10 @@ export default function ConfigPage() {
   const [tab, setTab] = useState<'inspector' | 'authentication' | 'runtime' | 'improvement-analyst' | 'backends' | 'import-export' | 'tokens'>('inspector')
 
   const [backends, setBackends] = useState<Backend[]>([])
+  const [backendOptions, setBackendOptions] = useState<Backend[]>([])
+  const [backendsTotal, setBackendsTotal] = useState(0)
+  const [backendsLimit, setBackendsLimit] = useState(50)
+  const [backendsOffset, setBackendsOffset] = useState(0)
   const [tools, setTools] = useState<ToolStatus[]>([])
   const [agents, setAgents] = useState<Agent[]>([])
   const [repos, setRepos] = useState<Repo[]>([])
@@ -372,13 +376,16 @@ export default function ConfigPage() {
 
   const loadBackends = () => {
     setBackendsLoading(true)
-    Promise.all([fetch(selectorURL('/backends')), fetch('/backends/status'), fetch('/agents/orphans/status')])
-      .then(async ([dbRes, diagRes, orphanRes]) => {
+    Promise.all([fetch(`/backends?limit=${backendsLimit}&offset=${backendsOffset}`), fetch(selectorURL('/backends')), fetch('/backends/status'), fetch('/agents/orphans/status')])
+      .then(async ([dbRes, selectorRes, diagRes, orphanRes]) => {
         if (!dbRes.ok) throw new Error((await dbRes.text()) || 'Failed to load backends from database')
+        if (!selectorRes.ok) throw new Error((await selectorRes.text()) || 'Failed to load backend selector options')
         if (!diagRes.ok) throw new Error((await diagRes.text()) || 'Failed to load diagnostics')
         if (!orphanRes.ok) throw new Error((await orphanRes.text()) || 'Failed to load orphaned agents')
 
-        const dbData = sortBackends(itemsFromResponse<Backend>(await dbRes.json()))
+        const dbPage = pageFromResponse<Backend>(await dbRes.json(), backendsLimit, backendsOffset)
+        const dbData = sortBackends(dbPage.items)
+        const optionData = sortBackends(itemsFromResponse<Backend>(await selectorRes.json()))
         const diagData = await diagRes.json() as BackendsDiscoveryResponse
         const diagBackends = sortBackends(diagData.backends ?? [])
         const diagTools = diagData.tools ?? (diagData.github_cli ? [diagData.github_cli] : [])
@@ -386,9 +393,11 @@ export default function ConfigPage() {
         const orphanAgents = orphanData.agents ?? []
 
         setBackends(dbData)
+        setBackendOptions(optionData)
+        setBackendsTotal(dbPage.total)
         setTools(diagTools)
         setBackendRuntime(diagData.runtime ?? null)
-        setBackendDriftWarnings(buildBackendDriftWarnings(dbData, diagBackends))
+        setBackendDriftWarnings(buildBackendDriftWarnings(optionData, diagBackends))
         setOrphanedAgents(orphanAgents)
         setOrphanModelSelection(prev => {
           const next: Record<string, string> = {}
@@ -406,6 +415,8 @@ export default function ConfigPage() {
         setOrphanedAgents([])
         setOrphanModelSelection({})
         setBackends([])
+        setBackendOptions([])
+        setBackendsTotal(0)
         setTools([])
         setBackendsLoading(false)
       })
@@ -413,7 +424,7 @@ export default function ConfigPage() {
 
   const configWorkspaces = ((config?.workspaces as WorkspaceRuntime[] | undefined) ?? [])
   const configBackends = sortBackends(Object.entries((config?.backends as Record<string, Omit<Backend, 'name'>> | undefined) ?? {}).map(([name, backend]) => ({ name, ...backend })))
-  const runtimeBackendOptions = backends.length > 0 ? backends : configBackends
+  const runtimeBackendOptions = backendOptions.length > 0 ? backendOptions : backends.length > 0 ? backends : configBackends
   const selectedAnalystBackend = runtimeBackendOptions.find(b => b.name === runtimeForm.self_improvement_analyst?.backend)
   const analystModelOptions = selectedAnalystBackend?.models ?? []
   const runtimeWorkspaces = configWorkspaces.length > 0 ? configWorkspaces : (workspaceCatalog as WorkspaceRuntime[])
@@ -559,7 +570,7 @@ export default function ConfigPage() {
 
   useEffect(() => {
     if (tab === 'backends') loadBackends()
-  }, [tab])
+  }, [tab, backendsLimit, backendsOffset])
 
   const runDiscovery = async () => {
     setDiscoveryRunning(true)
@@ -810,7 +821,7 @@ export default function ConfigPage() {
     try {
       const [backendRes, agentRes, repoRes] = await Promise.all([fetch(selectorURL('/backends')), fetch(selectorURL(withWorkspace('/agents', workspace))), fetch(selectorURL(withWorkspace('/repos', workspace)))])
       if (backendRes.ok) {
-        setBackends(sortBackends(itemsFromResponse<Backend>(await backendRes.json())))
+        setBackendOptions(sortBackends(itemsFromResponse<Backend>(await backendRes.json())))
       }
       if (agentRes.ok) {
         setAgents(itemsFromResponse<Agent>(await agentRes.json()).slice().sort((a, b) => a.name.localeCompare(b.name)))
@@ -908,7 +919,7 @@ export default function ConfigPage() {
   const budgetNeedsBackend = budgetForm.scope_kind.includes('backend')
   const repoNames = repos.map(r => r.name)
   const agentNames = agents.map(a => a.name)
-  const backendNames = backends.map(b => b.name)
+  const backendNames = (backendOptions.length > 0 ? backendOptions : backends).map(b => b.name)
   const repoOptionsWithCurrent = budgetForm.repo && !repoNames.includes(budgetForm.repo) ? [budgetForm.repo, ...repoNames] : repoNames
   const agentOptionsWithCurrent = budgetForm.agent && !agentNames.includes(budgetForm.agent) ? [budgetForm.agent, ...agentNames] : agentNames
   const backendOptionsWithCurrent = budgetForm.backend && !backendNames.includes(budgetForm.backend) ? [budgetForm.backend, ...backendNames] : backendNames
@@ -1157,7 +1168,7 @@ export default function ConfigPage() {
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '1rem', marginBottom: '1rem' }}>
             <div style={{ display: 'grid', gap: '0.25rem' }}>
               <span style={{ color: 'var(--text-muted)', fontSize: '0.875rem' }}>
-                {backendsLoading ? 'Checking backend and tool diagnostics…' : `${backends.length} backend${backends.length !== 1 ? 's' : ''} configured`}
+                {backendsLoading ? 'Checking backend and tool diagnostics…' : `${backendsTotal} backend${backendsTotal !== 1 ? 's' : ''} configured`}
               </span>
               {backendsLoading && (
                 <span style={{ color: 'var(--text-faint)', fontSize: '0.78rem' }}>
@@ -1277,7 +1288,16 @@ export default function ConfigPage() {
           <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap', alignItems: 'flex-start' }}>
             <div style={{ flex: '2 1 540px', minWidth: 0 }}>
               <div style={{ border: '1px solid var(--border-subtle)', borderRadius: '6px', padding: '0.75rem', background: 'var(--bg)' }}>
-                <div style={{ fontWeight: 700, color: 'var(--text-heading)', marginBottom: '0.4rem' }}>Backends</div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '0.75rem', marginBottom: '0.6rem' }}>
+                  <div style={{ fontWeight: 700, color: 'var(--text-heading)' }}>Backends</div>
+                  <PaginationControls
+                    total={backendsTotal}
+                    limit={backendsLimit}
+                    offset={backendsOffset}
+                    onLimitChange={(next) => { setBackendsLimit(next); setBackendsOffset(0) }}
+                    onOffsetChange={setBackendsOffset}
+                  />
+                </div>
                 {!backendsLoading && backends.length === 0 && (
                   <p style={{ color: 'var(--text-faint)', fontSize: '0.85rem' }}>No backends configured.</p>
                 )}

--- a/internal/ui/src/app/config/page.tsx
+++ b/internal/ui/src/app/config/page.tsx
@@ -4,9 +4,10 @@ import Card from '@/components/Card'
 import Modal from '@/components/Modal'
 import RepoFilter from '@/components/RepoFilter'
 import WorkspaceSelect from '@/components/WorkspaceSelect'
+import PaginationControls from '@/components/PaginationControls'
 import { AuthTokenSettings } from '@/lib/auth'
 import { budgetScopeDescription, budgetScopeLabel, budgetScopeOptions, isGlobalSimpleBudgetScope } from '@/lib/budget-copy'
-import { itemsFromResponse } from '@/lib/pagination'
+import { itemsFromResponse, pageFromResponse, selectorURL } from '@/lib/pagination'
 import { defaultWorkspaceID, useSelectedWorkspace, withWorkspace } from '@/lib/workspace'
 
 type Config = Record<string, unknown>
@@ -315,6 +316,9 @@ export default function ConfigPage() {
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   const [budgets, setBudgets] = useState<TokenBudget[]>([])
+  const [budgetsTotal, setBudgetsTotal] = useState(0)
+  const [budgetsLimit, setBudgetsLimit] = useState(50)
+  const [budgetsOffset, setBudgetsOffset] = useState(0)
   const [budgetsLoading, setBudgetsLoading] = useState(false)
   const [budgetError, setBudgetError] = useState('')
   const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([])
@@ -776,9 +780,11 @@ export default function ConfigPage() {
     setBudgetsLoading(true)
     setBudgetError('')
     try {
-      const res = await fetch('/token_budgets')
+      const res = await fetch(`/token_budgets?limit=${budgetsLimit}&offset=${budgetsOffset}`)
       if (!res.ok) throw new Error((await res.text()) || 'Failed to load budgets')
-      setBudgets(itemsFromResponse<TokenBudget>(await res.json()))
+      const page = pageFromResponse<TokenBudget>(await res.json(), budgetsLimit, budgetsOffset)
+      setBudgets(page.items)
+      setBudgetsTotal(page.total)
     } catch (e) {
       setBudgetError(String(e))
     }
@@ -802,7 +808,7 @@ export default function ConfigPage() {
 
   const loadBudgetScopeOptions = async () => {
     try {
-      const [backendRes, agentRes, repoRes] = await Promise.all([fetch('/backends'), fetch(withWorkspace('/agents', workspace)), fetch(withWorkspace('/repos', workspace))])
+      const [backendRes, agentRes, repoRes] = await Promise.all([fetch('/backends'), fetch(selectorURL(withWorkspace('/agents', workspace))), fetch(selectorURL(withWorkspace('/repos', workspace)))])
       if (backendRes.ok) {
         setBackends(sortBackends(itemsFromResponse<Backend>(await backendRes.json())))
       }
@@ -877,7 +883,11 @@ export default function ConfigPage() {
       loadLeaderboard(lbPeriod, lbRepo)
       loadBudgetScopeOptions()
     }
-  }, [tab, workspace])
+  }, [tab, workspace, budgetsLimit, budgetsOffset])
+
+  useEffect(() => {
+    setBudgetsOffset(0)
+  }, [workspace])
 
   useEffect(() => {
     if (tab === 'tokens') loadLeaderboard(lbPeriod, lbRepo)
@@ -1527,6 +1537,15 @@ export default function ConfigPage() {
             <p style={{ color: 'var(--text-faint)', fontSize: '0.8rem', marginBottom: '0.75rem' }}>
               Budgets enforce token caps over UTC calendar periods. Simple repo, agent, and backend scopes are global across workspaces; choose workspace + repo, workspace + agent, or workspace + backend for workspace-isolated caps. Daily resets at 00:00 UTC, weekly resets Sunday 00:00 UTC, and monthly resets on the first day at 00:00 UTC.
             </p>
+            <div style={{ marginBottom: '0.75rem' }}>
+              <PaginationControls
+                total={budgetsTotal}
+                limit={budgetsLimit}
+                offset={budgetsOffset}
+                onLimitChange={(next) => { setBudgetsLimit(next); setBudgetsOffset(0) }}
+                onOffsetChange={setBudgetsOffset}
+              />
+            </div>
             {budgetsLoading ? (
               <p style={{ color: 'var(--text-muted)', fontSize: '0.85rem' }}>Loading…</p>
             ) : budgets.length === 0 ? (

--- a/internal/ui/src/app/config/page.tsx
+++ b/internal/ui/src/app/config/page.tsx
@@ -372,7 +372,7 @@ export default function ConfigPage() {
 
   const loadBackends = () => {
     setBackendsLoading(true)
-    Promise.all([fetch('/backends'), fetch('/backends/status'), fetch('/agents/orphans/status')])
+    Promise.all([fetch(selectorURL('/backends')), fetch('/backends/status'), fetch('/agents/orphans/status')])
       .then(async ([dbRes, diagRes, orphanRes]) => {
         if (!dbRes.ok) throw new Error((await dbRes.text()) || 'Failed to load backends from database')
         if (!diagRes.ok) throw new Error((await diagRes.text()) || 'Failed to load diagnostics')
@@ -808,7 +808,7 @@ export default function ConfigPage() {
 
   const loadBudgetScopeOptions = async () => {
     try {
-      const [backendRes, agentRes, repoRes] = await Promise.all([fetch('/backends'), fetch(selectorURL(withWorkspace('/agents', workspace))), fetch(selectorURL(withWorkspace('/repos', workspace)))])
+      const [backendRes, agentRes, repoRes] = await Promise.all([fetch(selectorURL('/backends')), fetch(selectorURL(withWorkspace('/agents', workspace))), fetch(selectorURL(withWorkspace('/repos', workspace)))])
       if (backendRes.ok) {
         setBackends(sortBackends(itemsFromResponse<Backend>(await backendRes.json())))
       }

--- a/internal/ui/src/app/config/page.tsx
+++ b/internal/ui/src/app/config/page.tsx
@@ -6,6 +6,7 @@ import RepoFilter from '@/components/RepoFilter'
 import WorkspaceSelect from '@/components/WorkspaceSelect'
 import { AuthTokenSettings } from '@/lib/auth'
 import { budgetScopeDescription, budgetScopeLabel, budgetScopeOptions, isGlobalSimpleBudgetScope } from '@/lib/budget-copy'
+import { itemsFromResponse } from '@/lib/pagination'
 import { defaultWorkspaceID, useSelectedWorkspace, withWorkspace } from '@/lib/workspace'
 
 type Config = Record<string, unknown>
@@ -373,7 +374,7 @@ export default function ConfigPage() {
         if (!diagRes.ok) throw new Error((await diagRes.text()) || 'Failed to load diagnostics')
         if (!orphanRes.ok) throw new Error((await orphanRes.text()) || 'Failed to load orphaned agents')
 
-        const dbData = sortBackends(await dbRes.json() as Backend[])
+        const dbData = sortBackends(itemsFromResponse<Backend>(await dbRes.json()))
         const diagData = await diagRes.json() as BackendsDiscoveryResponse
         const diagBackends = sortBackends(diagData.backends ?? [])
         const diagTools = diagData.tools ?? (diagData.github_cli ? [diagData.github_cli] : [])
@@ -777,8 +778,7 @@ export default function ConfigPage() {
     try {
       const res = await fetch('/token_budgets')
       if (!res.ok) throw new Error((await res.text()) || 'Failed to load budgets')
-      const data = await res.json() as TokenBudget[] | null
-      setBudgets(data ?? [])
+      setBudgets(itemsFromResponse<TokenBudget>(await res.json()))
     } catch (e) {
       setBudgetError(String(e))
     }
@@ -804,16 +804,13 @@ export default function ConfigPage() {
     try {
       const [backendRes, agentRes, repoRes] = await Promise.all([fetch('/backends'), fetch(withWorkspace('/agents', workspace)), fetch(withWorkspace('/repos', workspace))])
       if (backendRes.ok) {
-        const backendData = await backendRes.json() as Backend[] | null
-        setBackends(sortBackends(backendData ?? []))
+        setBackends(sortBackends(itemsFromResponse<Backend>(await backendRes.json())))
       }
       if (agentRes.ok) {
-        const agentData = await agentRes.json() as Agent[] | null
-        setAgents((agentData ?? []).slice().sort((a, b) => a.name.localeCompare(b.name)))
+        setAgents(itemsFromResponse<Agent>(await agentRes.json()).slice().sort((a, b) => a.name.localeCompare(b.name)))
       }
       if (repoRes.ok) {
-        const repoData = await repoRes.json() as Repo[] | null
-        setRepos((repoData ?? []).slice().sort((a, b) => a.name.localeCompare(b.name)))
+        setRepos(itemsFromResponse<Repo>(await repoRes.json()).slice().sort((a, b) => a.name.localeCompare(b.name)))
       }
     } catch {
       // Keep any already-loaded options; validation still happens server-side.

--- a/internal/ui/src/app/events/page.tsx
+++ b/internal/ui/src/app/events/page.tsx
@@ -2,9 +2,11 @@
 import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import Card from '@/components/Card'
+import PaginationControls from '@/components/PaginationControls'
 import RepoFilter, { useRepoFilter } from '@/components/RepoFilter'
 import WorkspaceSelect from '@/components/WorkspaceSelect'
 import { formatTime } from '@/lib/datetime'
+import { pageFromResponse } from '@/lib/pagination'
 import { openAuthenticatedSSE } from '@/lib/sse'
 import { useSelectedWorkspace, withWorkspace } from '@/lib/workspace'
 
@@ -128,6 +130,9 @@ export default function EventsPage() {
   const [timeRange, setTimeRange] = useState('1h')
   const [repoFilter, setRepoFilter] = useRepoFilter()
   const { workspace } = useSelectedWorkspace()
+  const [limit, setLimit] = useState(50)
+  const [offset, setOffset] = useState(0)
+  const [total, setTotal] = useState(0)
 
   const timeRanges: Record<string, number> = { '15m': 15 * 60, '1h': 3600, '6h': 6 * 3600, '24h': 24 * 3600 }
 
@@ -135,13 +140,20 @@ export default function EventsPage() {
     setLoading(true)
     const sinceMs = Date.now() - (timeRanges[timeRange] ?? 3600) * 1000
     const since = new Date(sinceMs).toISOString()
-    fetch(withWorkspace(`/events?since=${encodeURIComponent(since)}`, workspace))
+    fetch(withWorkspace(`/events?since=${encodeURIComponent(since)}&limit=${limit}&offset=${offset}`, workspace))
       .then(r => r.json())
-      .then(data => { setEvents((data ?? []).reverse()); setLoading(false) })
+      .then(data => {
+        const page = pageFromResponse<Event>(data, limit, offset)
+        setEvents(page.items.reverse())
+        setTotal(page.total)
+        setLoading(false)
+      })
       .catch(() => setLoading(false))
   }
 
-  useEffect(() => { load() }, [timeRange, workspace]) // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(() => { load() }, [timeRange, workspace, limit, offset]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => { setOffset(0) }, [timeRange, workspace])
 
   useEffect(() => {
     const stream = openAuthenticatedSSE(withWorkspace('/events/stream', workspace), {
@@ -181,6 +193,7 @@ export default function EventsPage() {
           <h1 style={{ fontSize: '1.4rem', fontWeight: 700, color: 'var(--text-heading)' }}>Events</h1>
           <p style={{ color: 'var(--text-muted)', fontSize: '0.875rem', marginTop: '4px' }}>
             {filtered.length} event{filtered.length !== 1 ? 's' : ''} · {streaming ? '🟢 live' : '🔴 disconnected'}
+            {total > filtered.length ? ` · ${total} total` : ''}
           </p>
         </div>
         <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
@@ -194,6 +207,13 @@ export default function EventsPage() {
             }}>{r}</button>
           ))}
           <RepoFilter selected={repoFilter} onChange={setRepoFilter} workspace={workspace} />
+          <PaginationControls
+            total={total}
+            limit={limit}
+            offset={offset}
+            onLimitChange={(next) => { setLimit(next); setOffset(0) }}
+            onOffsetChange={setOffset}
+          />
           <input
             placeholder="Filter..."
             value={filter}

--- a/internal/ui/src/app/graph/page.tsx
+++ b/internal/ui/src/app/graph/page.tsx
@@ -24,7 +24,7 @@ import dagre from 'dagre'
 import Card from '@/components/Card'
 import AgentForm, { emptyAgentForm, type BackendOption } from '@/components/AgentForm'
 import { formatDateTime } from '@/lib/datetime'
-import { itemsFromResponse } from '@/lib/pagination'
+import { itemsFromResponse, selectorURL } from '@/lib/pagination'
 import BadgePicker from '@/components/BadgePicker'
 import LiveTraceModal, { type LiveTraceSpan } from '@/components/LiveTraceModal'
 import MarkdownEditor from '@/components/MarkdownEditor'
@@ -476,7 +476,7 @@ export default function GraphPage() {
       .then(r => r.ok ? r.json() : [])
       .then((data) => setSkillOptions(itemsFromResponse<CatalogItem>(data)))
       .catch(() => {})
-    fetch(withWorkspace('/agents', workspace))
+    fetch(selectorURL(withWorkspace('/agents', workspace)))
       .then(r => r.ok ? r.json() : [])
       .then((data) => setAgentNames(itemsFromResponse<{ name: string }>(data).map(a => a.name)))
       .catch(() => {})
@@ -494,9 +494,9 @@ export default function GraphPage() {
     loadedOnce.current = true
     Promise.all([
       fetch(withWorkspace('/graph', workspace)).then(r => r.json()),
-      fetch(withWorkspace('/agents', workspace)).then(r => r.json()),
+      fetch(selectorURL(withWorkspace('/agents', workspace))).then(r => r.json()),
       fetch(withWorkspace('/graph/layout', workspace)).then(r => r.ok ? r.json() : { positions: [] }),
-      fetch(withWorkspace('/repos', workspace)).then(r => r.ok ? r.json() : []),
+      fetch(selectorURL(withWorkspace('/repos', workspace))).then(r => r.ok ? r.json() : []),
     ]).then(([gd, ad, ld, rd]) => {
       setGraphData(gd)
       const agentItems = itemsFromResponse<AgentInfo>(ad)

--- a/internal/ui/src/app/graph/page.tsx
+++ b/internal/ui/src/app/graph/page.tsx
@@ -468,11 +468,11 @@ export default function GraphPage() {
   }, [repos, bindingDraft.repo])
 
   const loadLookups = useCallback(() => {
-    fetch('/backends')
+    fetch(selectorURL('/backends'))
       .then(r => r.ok ? r.json() : [])
       .then((data) => setBackendOptions(itemsFromResponse<BackendOption>(data).filter(b => b.detected !== false)))
       .catch(() => {})
-    fetch('/skills')
+    fetch(selectorURL('/skills'))
       .then(r => r.ok ? r.json() : [])
       .then((data) => setSkillOptions(itemsFromResponse<CatalogItem>(data)))
       .catch(() => {})
@@ -480,7 +480,7 @@ export default function GraphPage() {
       .then(r => r.ok ? r.json() : [])
       .then((data) => setAgentNames(itemsFromResponse<{ name: string }>(data).map(a => a.name)))
       .catch(() => {})
-    fetch('/prompts')
+    fetch(selectorURL('/prompts'))
       .then(r => r.ok ? r.json() : [])
       .then((data) => {
         setPromptOptions(itemsFromResponse<GraphPromptItem>(data))

--- a/internal/ui/src/app/graph/page.tsx
+++ b/internal/ui/src/app/graph/page.tsx
@@ -24,6 +24,7 @@ import dagre from 'dagre'
 import Card from '@/components/Card'
 import AgentForm, { emptyAgentForm, type BackendOption } from '@/components/AgentForm'
 import { formatDateTime } from '@/lib/datetime'
+import { itemsFromResponse } from '@/lib/pagination'
 import BadgePicker from '@/components/BadgePicker'
 import LiveTraceModal, { type LiveTraceSpan } from '@/components/LiveTraceModal'
 import MarkdownEditor from '@/components/MarkdownEditor'
@@ -469,20 +470,20 @@ export default function GraphPage() {
   const loadLookups = useCallback(() => {
     fetch('/backends')
       .then(r => r.ok ? r.json() : [])
-      .then((data: BackendOption[]) => setBackendOptions((data ?? []).filter(b => b.detected !== false)))
+      .then((data) => setBackendOptions(itemsFromResponse<BackendOption>(data).filter(b => b.detected !== false)))
       .catch(() => {})
     fetch('/skills')
       .then(r => r.ok ? r.json() : [])
-      .then((data: CatalogItem[]) => setSkillOptions(data ?? []))
+      .then((data) => setSkillOptions(itemsFromResponse<CatalogItem>(data)))
       .catch(() => {})
     fetch(withWorkspace('/agents', workspace))
       .then(r => r.ok ? r.json() : [])
-      .then((data: { name: string }[]) => setAgentNames(data.map(a => a.name)))
+      .then((data) => setAgentNames(itemsFromResponse<{ name: string }>(data).map(a => a.name)))
       .catch(() => {})
     fetch('/prompts')
       .then(r => r.ok ? r.json() : [])
-      .then((data: GraphPromptItem[]) => {
-        setPromptOptions(data ?? [])
+      .then((data) => {
+        setPromptOptions(itemsFromResponse<GraphPromptItem>(data))
         setPromptOptionsLoaded(true)
       })
       .catch(() => setPromptOptionsLoaded(true))
@@ -498,9 +499,10 @@ export default function GraphPage() {
       fetch(withWorkspace('/repos', workspace)).then(r => r.ok ? r.json() : []),
     ]).then(([gd, ad, ld, rd]) => {
       setGraphData(gd)
-      setAgents(ad)
-      setRepos(rd ?? [])
-      setAgentNames((ad ?? []).map((a: AgentInfo) => a.name))
+      const agentItems = itemsFromResponse<AgentInfo>(ad)
+      setAgents(agentItems)
+      setRepos(itemsFromResponse<RepoInfo>(rd))
+      setAgentNames(agentItems.map((a: AgentInfo) => a.name))
       const nextPositions: Record<string, { x: number; y: number }> = {}
       ;(ld.positions ?? []).forEach((p: { node_id: string; x: number; y: number }) => {
         nextPositions[p.node_id] = { x: p.x, y: p.y }

--- a/internal/ui/src/app/improvements/page.tsx
+++ b/internal/ui/src/app/improvements/page.tsx
@@ -2,7 +2,9 @@
 import { type CSSProperties, type ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
 import MarkdownEditor from '@/components/MarkdownEditor'
 import Modal from '@/components/Modal'
+import PaginationControls from '@/components/PaginationControls'
 import { formatDateTime } from '@/lib/datetime'
+import { pageFromResponse } from '@/lib/pagination'
 import { withWorkspace } from '@/lib/workspace'
 
 interface FeedbackEvent {
@@ -542,18 +544,28 @@ export default function ImprovementsPage() {
   const [confirming, setConfirming] = useState<ConfirmationModal | null>(null)
   const [confirmSaving, setConfirmSaving] = useState(false)
   const [reviewingProposal, setReviewingProposal] = useState<Recommendation | null>(null)
+  const [recommendationsLimit, setRecommendationsLimit] = useState(50)
+  const [recommendationsOffset, setRecommendationsOffset] = useState(0)
+  const [recommendationsTotal, setRecommendationsTotal] = useState(0)
+  const [feedbackLimit, setFeedbackLimit] = useState(50)
+  const [feedbackOffset, setFeedbackOffset] = useState(0)
+  const [feedbackTotal, setFeedbackTotal] = useState(0)
 
   const load = useCallback((showLoading = true) => {
     if (showLoading) setLoading(true)
-    const suffix = status ? `?status=${encodeURIComponent(status)}` : ''
+    const statusParam = status ? `&status=${encodeURIComponent(status)}` : ''
     Promise.all([
-      fetch(`/improvements/feedback${suffix}`, { cache: 'no-store' }).then(r => r.ok ? r.json() : []),
-      fetch(`/improvements/recommendations${suffix}`, { cache: 'no-store' }).then(r => r.ok ? r.json() : []),
+      fetch(`/improvements/feedback?limit=${feedbackLimit}&offset=${feedbackOffset}${statusParam}`, { cache: 'no-store' }).then(r => r.ok ? r.json() : []),
+      fetch(`/improvements/recommendations?limit=${recommendationsLimit}&offset=${recommendationsOffset}${statusParam}`, { cache: 'no-store' }).then(r => r.ok ? r.json() : []),
     ])
       .then(([feedbackRows, recommendationRows]) => {
-        setFeedback(feedbackRows ?? [])
-        const recs = sortRecommendationsByActivity(recommendationRows ?? [])
+        const feedbackPage = pageFromResponse<FeedbackEvent>(feedbackRows, feedbackLimit, feedbackOffset)
+        const recommendationPage = pageFromResponse<Recommendation>(recommendationRows, recommendationsLimit, recommendationsOffset)
+        setFeedback(feedbackPage.items)
+        setFeedbackTotal(feedbackPage.total)
+        const recs = sortRecommendationsByActivity(recommendationPage.items)
         setRecommendations(recs)
+        setRecommendationsTotal(recommendationPage.total)
         setBundles(Object.fromEntries(recs.map((row: Recommendation) => [row.id, row.proposal_bundle ?? {}])))
       })
       .catch(() => {
@@ -565,9 +577,14 @@ export default function ImprovementsPage() {
       .finally(() => {
         if (showLoading) setLoading(false)
       })
-  }, [status])
+  }, [status, feedbackLimit, feedbackOffset, recommendationsLimit, recommendationsOffset])
 
   useEffect(() => { load() }, [load])
+
+  useEffect(() => {
+    setFeedbackOffset(0)
+    setRecommendationsOffset(0)
+  }, [status])
 
   useEffect(() => {
     let cancelled = false
@@ -904,6 +921,7 @@ export default function ImprovementsPage() {
 	          <h1 style={{ fontSize: '1.45rem', color: 'var(--text-heading)', marginBottom: '0.25rem' }}>Improvements</h1>
 	          <div style={{ color: 'var(--text-muted)', fontSize: '0.85rem' }}>
 	            {loading ? 'Loading' : `${shownRecommendations.length} proposals · ${feedback.length} feedback events`}
+	            {!loading ? ` · ${recommendationsTotal} proposal records · ${feedbackTotal} feedback records` : ''}
 	            {Object.keys(counts).length > 0 ? ` · ${Object.entries(counts).map(([k, v]) => `${k}: ${v}`).join(' · ')}` : ''}
 	          </div>
         </div>
@@ -942,6 +960,29 @@ export default function ImprovementsPage() {
           ))}
         </div>
 	      </section>
+
+      <section aria-label="Improvement pagination" style={{ display: 'flex', justifyContent: 'space-between', gap: 10, alignItems: 'center', flexWrap: 'wrap', color: 'var(--text-muted)', fontSize: '0.78rem' }}>
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+          <span>Proposals</span>
+          <PaginationControls
+            total={recommendationsTotal}
+            limit={recommendationsLimit}
+            offset={recommendationsOffset}
+            onLimitChange={(next) => { setRecommendationsLimit(next); setRecommendationsOffset(0) }}
+            onOffsetChange={setRecommendationsOffset}
+          />
+        </div>
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+          <span>Feedback</span>
+          <PaginationControls
+            total={feedbackTotal}
+            limit={feedbackLimit}
+            offset={feedbackOffset}
+            onLimitChange={(next) => { setFeedbackLimit(next); setFeedbackOffset(0) }}
+            onOffsetChange={setFeedbackOffset}
+          />
+        </div>
+      </section>
 
       {(tab === 'proposals' || tab === 'history') && (
         <section style={{ background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 6, overflow: 'hidden' }}>

--- a/internal/ui/src/app/memory/page.tsx
+++ b/internal/ui/src/app/memory/page.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect, useRef } from 'react'
 import Card from '@/components/Card'
 import WorkspaceSelect from '@/components/WorkspaceSelect'
 import { formatDateTime } from '@/lib/datetime'
-import { itemsFromResponse } from '@/lib/pagination'
+import { itemsFromResponse, selectorURL } from '@/lib/pagination'
 import { openAuthenticatedSSE } from '@/lib/sse'
 import { useSelectedWorkspace, withWorkspace } from '@/lib/workspace'
 
@@ -28,7 +28,7 @@ export default function MemoryPage() {
   const { workspace } = useSelectedWorkspace()
 
   useEffect(() => {
-    fetch(withWorkspace('/agents', workspace))
+    fetch(selectorURL(withWorkspace('/agents', workspace)))
       .then(r => r.json())
       .then(data => setAgents(itemsFromResponse<Agent>(data)))
       .catch(() => {})

--- a/internal/ui/src/app/memory/page.tsx
+++ b/internal/ui/src/app/memory/page.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect, useRef } from 'react'
 import Card from '@/components/Card'
 import WorkspaceSelect from '@/components/WorkspaceSelect'
 import { formatDateTime } from '@/lib/datetime'
+import { itemsFromResponse } from '@/lib/pagination'
 import { openAuthenticatedSSE } from '@/lib/sse'
 import { useSelectedWorkspace, withWorkspace } from '@/lib/workspace'
 
@@ -29,7 +30,7 @@ export default function MemoryPage() {
   useEffect(() => {
     fetch(withWorkspace('/agents', workspace))
       .then(r => r.json())
-      .then(data => setAgents(data ?? []))
+      .then(data => setAgents(itemsFromResponse<Agent>(data)))
       .catch(() => {})
   }, [workspace])
 

--- a/internal/ui/src/app/page.tsx
+++ b/internal/ui/src/app/page.tsx
@@ -10,7 +10,7 @@ import RunButton from '@/components/RunButton'
 import WorkspaceSelect from '@/components/WorkspaceSelect'
 import AgentForm, { emptyAgentForm, type BackendOption, type StoreAgent } from '@/components/AgentForm'
 import { formatDateTime } from '@/lib/datetime'
-import { itemsFromResponse, pageFromResponse } from '@/lib/pagination'
+import { itemsFromResponse, pageFromResponse, selectorURL } from '@/lib/pagination'
 import { useSelectedWorkspace, withWorkspace, type CatalogItem } from '@/lib/workspace'
 
 interface Binding {
@@ -153,7 +153,7 @@ export default function FleetPage() {
       .then(r => r.ok ? r.json() : [])
       .then((data) => setSkillOptions(itemsFromResponse<CatalogItem>(data)))
       .catch(() => {})
-    fetch(withWorkspace('/agents', workspace))
+    fetch(selectorURL(withWorkspace('/agents', workspace)))
       .then(r => r.ok ? r.json() : [])
       .then((data) => setAgentNames(itemsFromResponse<{ name: string }>(data).map(a => a.name)))
       .catch(() => {})
@@ -161,7 +161,7 @@ export default function FleetPage() {
       .then(r => r.ok ? r.json() : [])
       .then((data) => setPromptOptions(itemsFromResponse<CatalogItem>(data)))
       .catch(() => {})
-    fetch(withWorkspace('/repos', workspace))
+    fetch(selectorURL(withWorkspace('/repos', workspace)))
       .then(r => r.ok ? r.json() : [])
       .then((data) => setRepoNames(itemsFromResponse<{ name: string }>(data).map(r => r.name)))
       .catch(() => {})

--- a/internal/ui/src/app/page.tsx
+++ b/internal/ui/src/app/page.tsx
@@ -3,12 +3,14 @@ import { useState, useEffect, useRef } from 'react'
 import Card from '@/components/Card'
 import StatusBadge from '@/components/StatusBadge'
 import Modal from '@/components/Modal'
+import PaginationControls from '@/components/PaginationControls'
 import Link from 'next/link'
 import RepoFilter, { useRepoFilter } from '@/components/RepoFilter'
 import RunButton from '@/components/RunButton'
 import WorkspaceSelect from '@/components/WorkspaceSelect'
 import AgentForm, { emptyAgentForm, type BackendOption, type StoreAgent } from '@/components/AgentForm'
 import { formatDateTime } from '@/lib/datetime'
+import { itemsFromResponse, pageFromResponse } from '@/lib/pagination'
 import { useSelectedWorkspace, withWorkspace, type CatalogItem } from '@/lib/workspace'
 
 interface Binding {
@@ -122,6 +124,9 @@ function AgentCard({ agent, onEdit, onDelete }: { agent: Agent; onEdit: () => vo
 
 export default function FleetPage() {
   const [agents, setAgents] = useState<Agent[]>([])
+  const [total, setTotal] = useState(0)
+  const [limit, setLimit] = useState(50)
+  const [offset, setOffset] = useState(0)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
   const [backendOptions, setBackendOptions] = useState<BackendOption[]>([])
@@ -142,32 +147,37 @@ export default function FleetPage() {
   const loadLookups = () => {
     fetch('/backends')
       .then(r => r.ok ? r.json() : [])
-      .then((data: BackendOption[]) => setBackendOptions((data ?? []).filter(b => b.detected !== false)))
+      .then((data) => setBackendOptions(itemsFromResponse<BackendOption>(data).filter(b => b.detected !== false)))
       .catch(() => {})
     fetch('/skills')
       .then(r => r.ok ? r.json() : [])
-      .then((data: CatalogItem[]) => setSkillOptions(data ?? []))
+      .then((data) => setSkillOptions(itemsFromResponse<CatalogItem>(data)))
       .catch(() => {})
     fetch(withWorkspace('/agents', workspace))
       .then(r => r.ok ? r.json() : [])
-      .then((data: { name: string }[]) => setAgentNames(data.map(a => a.name)))
+      .then((data) => setAgentNames(itemsFromResponse<{ name: string }>(data).map(a => a.name)))
       .catch(() => {})
     fetch('/prompts')
       .then(r => r.ok ? r.json() : [])
-      .then((data: CatalogItem[]) => setPromptOptions(data ?? []))
+      .then((data) => setPromptOptions(itemsFromResponse<CatalogItem>(data)))
       .catch(() => {})
     fetch(withWorkspace('/repos', workspace))
       .then(r => r.ok ? r.json() : [])
-      .then((data: { name: string }[]) => setRepoNames(data.map(r => r.name)))
+      .then((data) => setRepoNames(itemsFromResponse<{ name: string }>(data).map(r => r.name)))
       .catch(() => {})
   }
 
   const load = () => {
     if (!loadRef.current) setLoading(true)
     loadRef.current = true
-    fetch(withWorkspace('/agents', workspace))
+    fetch(withWorkspace(`/agents?limit=${limit}&offset=${offset}`, workspace))
       .then(r => r.json())
-      .then(data => { setAgents(data); setLoading(false) })
+      .then(data => {
+        const page = pageFromResponse<Agent>(data, limit, offset)
+        setAgents(page.items)
+        setTotal(page.total)
+        setLoading(false)
+      })
       .catch(e => { setError(String(e)); setLoading(false) })
   }
 
@@ -176,6 +186,10 @@ export default function FleetPage() {
     loadLookups()
     const interval = setInterval(load, 5000)
     return () => clearInterval(interval)
+  }, [workspace, limit, offset])
+
+  useEffect(() => {
+    setOffset(0)
   }, [workspace])
 
   const openEdit = async (agentName: string) => {
@@ -320,6 +334,16 @@ export default function FleetPage() {
             Refresh
           </button>
         </div>
+      </div>
+
+      <div style={{ marginBottom: '1rem' }}>
+        <PaginationControls
+          total={total}
+          limit={limit}
+          offset={offset}
+          onLimitChange={(next) => { setLimit(next); setOffset(0) }}
+          onOffsetChange={setOffset}
+        />
       </div>
 
       {loading && <p style={{ color: 'var(--text-muted)' }}>Loading…</p>}

--- a/internal/ui/src/app/page.tsx
+++ b/internal/ui/src/app/page.tsx
@@ -145,11 +145,11 @@ export default function FleetPage() {
 
   const loadRef = useRef(false)
   const loadLookups = () => {
-    fetch('/backends')
+    fetch(selectorURL('/backends'))
       .then(r => r.ok ? r.json() : [])
       .then((data) => setBackendOptions(itemsFromResponse<BackendOption>(data).filter(b => b.detected !== false)))
       .catch(() => {})
-    fetch('/skills')
+    fetch(selectorURL('/skills'))
       .then(r => r.ok ? r.json() : [])
       .then((data) => setSkillOptions(itemsFromResponse<CatalogItem>(data)))
       .catch(() => {})
@@ -157,7 +157,7 @@ export default function FleetPage() {
       .then(r => r.ok ? r.json() : [])
       .then((data) => setAgentNames(itemsFromResponse<{ name: string }>(data).map(a => a.name)))
       .catch(() => {})
-    fetch('/prompts')
+    fetch(selectorURL('/prompts'))
       .then(r => r.ok ? r.json() : [])
       .then((data) => setPromptOptions(itemsFromResponse<CatalogItem>(data)))
       .catch(() => {})

--- a/internal/ui/src/app/prompts/page.test.tsx
+++ b/internal/ui/src/app/prompts/page.test.tsx
@@ -1,0 +1,86 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/components/MarkdownEditor', () => ({
+  default: ({ value, onChange }: { value: string; onChange: (v: string) => void }) => (
+    <textarea aria-label="Prompt content editor" value={value} onChange={e => onChange(e.target.value)} />
+  ),
+}))
+
+vi.mock('@/components/CatalogVersionsPanel', () => ({
+  default: ({ assetID }: { assetID: string }) => (
+    <div data-testid="catalog-versions">versions for {assetID}</div>
+  ),
+}))
+
+import PromptsPage from './page'
+
+describe('<PromptsPage />', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('uses selector-sized workspace and repo option lookups', async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url === '/prompts?limit=50&offset=0') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            items: [{
+              id: 'repo-prompt',
+              workspace_id: 'workspace-a',
+              repo: 'repo-a',
+              name: 'repo prompt',
+              description: 'Repo prompt',
+              content: 'Use repo context.',
+            }],
+            total: 1,
+            limit: 50,
+            offset: 0,
+          }),
+        } as Response)
+      }
+      if (url === '/workspaces?limit=500&offset=0') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            items: [{ id: 'workspace-a', name: 'Workspace A' }],
+            total: 1,
+            limit: 500,
+            offset: 0,
+          }),
+        } as Response)
+      }
+      if (url === '/repos?workspace=workspace-a&limit=500&offset=0') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            items: [{ name: 'repo-a' }, { name: 'repo-b' }],
+            total: 2,
+            limit: 500,
+            offset: 0,
+          }),
+        } as Response)
+      }
+      return Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve([]) } as Response)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<PromptsPage />)
+
+    expect(await screen.findByText('repo prompt')).toBeInTheDocument()
+    expect(fetchMock).toHaveBeenCalledWith('/workspaces?limit=500&offset=0', { cache: 'no-store' })
+
+    fireEvent.change(screen.getByDisplayValue('All scopes'), { target: { value: 'repo' } })
+    fireEvent.change(await screen.findByDisplayValue('All workspaces'), { target: { value: 'workspace-a' } })
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/repos?workspace=workspace-a&limit=500&offset=0', { cache: 'no-store' }))
+
+    fireEvent.click(screen.getByRole('button', { name: '+ New prompt' }))
+    fireEvent.change(within(screen.getByRole('dialog')).getByDisplayValue('Global'), { target: { value: 'repo' } })
+    fireEvent.change(within(screen.getByRole('dialog')).getByDisplayValue('Select workspace...'), { target: { value: 'workspace-a' } })
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/repos?workspace=workspace-a&limit=500&offset=0', { cache: 'no-store' }))
+  })
+})

--- a/internal/ui/src/app/prompts/page.tsx
+++ b/internal/ui/src/app/prompts/page.tsx
@@ -3,8 +3,10 @@
 import { useEffect, useState } from 'react'
 import Card from '@/components/Card'
 import Modal from '@/components/Modal'
+import PaginationControls from '@/components/PaginationControls'
 import MarkdownEditor from '@/components/MarkdownEditor'
 import CatalogVersionsPanel from '@/components/CatalogVersionsPanel'
+import { itemsFromResponse, pageFromResponse } from '@/lib/pagination'
 
 interface Prompt {
   id?: string
@@ -36,6 +38,9 @@ function scopeType(item: { workspace_id?: string; repo?: string }): 'global' | '
 
 export default function PromptsPage() {
   const [prompts, setPrompts] = useState<Prompt[]>([])
+  const [total, setTotal] = useState(0)
+  const [limit, setLimit] = useState(50)
+  const [offset, setOffset] = useState(0)
   const [workspaces, setWorkspaces] = useState<Workspace[]>([])
   const [repos, setRepos] = useState<Repo[]>([])
   const [loading, setLoading] = useState(true)
@@ -51,9 +56,14 @@ export default function PromptsPage() {
 
   const load = () => {
     setLoading(true)
-    fetch('/prompts', { cache: 'no-store' })
+    fetch(`/prompts?limit=${limit}&offset=${offset}`, { cache: 'no-store' })
       .then(r => r.ok ? r.json() : [])
-      .then((data: Prompt[]) => { setPrompts(data ?? []); setLoading(false) })
+      .then((data) => {
+        const page = pageFromResponse<Prompt>(data, limit, offset)
+        setPrompts(page.items)
+        setTotal(page.total)
+        setLoading(false)
+      })
       .catch(e => { setError(String(e)); setLoading(false) })
   }
 
@@ -61,9 +71,9 @@ export default function PromptsPage() {
     load()
     fetch('/workspaces', { cache: 'no-store' })
       .then(r => r.ok ? r.json() : [])
-      .then((data: Workspace[]) => setWorkspaces(data ?? []))
+      .then((data) => setWorkspaces(itemsFromResponse<Workspace>(data)))
       .catch(() => setWorkspaces([]))
-  }, [])
+  }, [limit, offset])
 
   useEffect(() => {
     if (selectedScope !== 'repo' || !selected.workspace_id) {
@@ -72,7 +82,7 @@ export default function PromptsPage() {
     }
     fetch(`/repos?workspace=${encodeURIComponent(selected.workspace_id)}`, { cache: 'no-store' })
       .then(r => r.ok ? r.json() : [])
-      .then((data: Repo[]) => setRepos(data ?? []))
+      .then((data) => setRepos(itemsFromResponse<Repo>(data)))
       .catch(() => setRepos([]))
   }, [selectedScope, selected.workspace_id])
 
@@ -83,7 +93,7 @@ export default function PromptsPage() {
     }
     fetch(`/repos?workspace=${encodeURIComponent(filterWorkspace)}`, { cache: 'no-store' })
       .then(r => r.ok ? r.json() : [])
-      .then((data: Repo[]) => setFilterRepos(data ?? []))
+      .then((data) => setFilterRepos(itemsFromResponse<Repo>(data)))
       .catch(() => setFilterRepos([]))
   }, [filterScope, filterWorkspace])
 
@@ -206,6 +216,16 @@ export default function PromptsPage() {
             + New prompt
           </button>
         </div>
+      </div>
+
+      <div style={{ marginBottom: '1rem' }}>
+        <PaginationControls
+          total={total}
+          limit={limit}
+          offset={offset}
+          onLimitChange={(next) => { setLimit(next); setOffset(0) }}
+          onOffsetChange={setOffset}
+        />
       </div>
 
       {loading && <p style={{ color: 'var(--text-muted)' }}>Loading...</p>}

--- a/internal/ui/src/app/prompts/page.tsx
+++ b/internal/ui/src/app/prompts/page.tsx
@@ -6,7 +6,7 @@ import Modal from '@/components/Modal'
 import PaginationControls from '@/components/PaginationControls'
 import MarkdownEditor from '@/components/MarkdownEditor'
 import CatalogVersionsPanel from '@/components/CatalogVersionsPanel'
-import { itemsFromResponse, pageFromResponse } from '@/lib/pagination'
+import { itemsFromResponse, pageFromResponse, selectorURL } from '@/lib/pagination'
 
 interface Prompt {
   id?: string
@@ -69,7 +69,7 @@ export default function PromptsPage() {
 
   useEffect(() => {
     load()
-    fetch('/workspaces', { cache: 'no-store' })
+    fetch(selectorURL('/workspaces'), { cache: 'no-store' })
       .then(r => r.ok ? r.json() : [])
       .then((data) => setWorkspaces(itemsFromResponse<Workspace>(data)))
       .catch(() => setWorkspaces([]))
@@ -80,7 +80,7 @@ export default function PromptsPage() {
       setRepos([])
       return
     }
-    fetch(`/repos?workspace=${encodeURIComponent(selected.workspace_id)}`, { cache: 'no-store' })
+    fetch(selectorURL(`/repos?workspace=${encodeURIComponent(selected.workspace_id)}`), { cache: 'no-store' })
       .then(r => r.ok ? r.json() : [])
       .then((data) => setRepos(itemsFromResponse<Repo>(data)))
       .catch(() => setRepos([]))
@@ -91,7 +91,7 @@ export default function PromptsPage() {
       setFilterRepos([])
       return
     }
-    fetch(`/repos?workspace=${encodeURIComponent(filterWorkspace)}`, { cache: 'no-store' })
+    fetch(selectorURL(`/repos?workspace=${encodeURIComponent(filterWorkspace)}`), { cache: 'no-store' })
       .then(r => r.ok ? r.json() : [])
       .then((data) => setFilterRepos(itemsFromResponse<Repo>(data)))
       .catch(() => setFilterRepos([]))

--- a/internal/ui/src/app/repos/page.tsx
+++ b/internal/ui/src/app/repos/page.tsx
@@ -7,7 +7,7 @@ import BadgePicker from '@/components/BadgePicker'
 import RunButton from '@/components/RunButton'
 import WorkspaceSelect from '@/components/WorkspaceSelect'
 import { Binding, groupByAgent, bindingsEqual } from '@/lib/bindings'
-import { itemsFromResponse, pageFromResponse } from '@/lib/pagination'
+import { itemsFromResponse, pageFromResponse, selectorURL } from '@/lib/pagination'
 import { useSelectedWorkspace, withWorkspace } from '@/lib/workspace'
 
 interface Repo {
@@ -413,7 +413,7 @@ export default function ReposPage() {
 
   useEffect(() => {
     load()
-    fetch(withWorkspace('/agents', workspace))
+    fetch(selectorURL(withWorkspace('/agents', workspace)))
       .then(r => r.ok ? r.json() : [])
       .then((data) => setAgentNames(itemsFromResponse<{ name: string }>(data).map(a => a.name)))
       .catch(() => { /* store not configured, no-op */ })

--- a/internal/ui/src/app/repos/page.tsx
+++ b/internal/ui/src/app/repos/page.tsx
@@ -2,10 +2,12 @@
 import { useState, useEffect, useMemo, useCallback } from 'react'
 import Card from '@/components/Card'
 import Modal from '@/components/Modal'
+import PaginationControls from '@/components/PaginationControls'
 import BadgePicker from '@/components/BadgePicker'
 import RunButton from '@/components/RunButton'
 import WorkspaceSelect from '@/components/WorkspaceSelect'
 import { Binding, groupByAgent, bindingsEqual } from '@/lib/bindings'
+import { itemsFromResponse, pageFromResponse } from '@/lib/pagination'
 import { useSelectedWorkspace, withWorkspace } from '@/lib/workspace'
 
 interface Repo {
@@ -369,6 +371,9 @@ function RepoForm({ initial, isNew, agentNames, knownLabels, existingRepos, onSa
 export default function ReposPage() {
   const { workspace } = useSelectedWorkspace()
   const [repos, setRepos] = useState<Repo[]>([])
+  const [total, setTotal] = useState(0)
+  const [limit, setLimit] = useState(50)
+  const [offset, setOffset] = useState(0)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
 
@@ -391,17 +396,26 @@ export default function ReposPage() {
 
   const load = useCallback(() => {
     setLoading(true)
-    fetch(withWorkspace('/repos', workspace))
+    fetch(withWorkspace(`/repos?limit=${limit}&offset=${offset}`, workspace))
       .then(r => r.json())
-      .then((data: Repo[]) => { setRepos(data); setLoading(false) })
+      .then((data) => {
+        const page = pageFromResponse<Repo>(data, limit, offset)
+        setRepos(page.items)
+        setTotal(page.total)
+        setLoading(false)
+      })
       .catch(e => { setError(String(e)); setLoading(false) })
+  }, [workspace, limit, offset])
+
+  useEffect(() => {
+    setOffset(0)
   }, [workspace])
 
   useEffect(() => {
     load()
     fetch(withWorkspace('/agents', workspace))
       .then(r => r.ok ? r.json() : [])
-      .then((data: { name: string }[]) => setAgentNames(data.map(a => a.name)))
+      .then((data) => setAgentNames(itemsFromResponse<{ name: string }>(data).map(a => a.name)))
       .catch(() => { /* store not configured, no-op */ })
   }, [load, workspace])
 
@@ -546,6 +560,16 @@ export default function ReposPage() {
             Refresh
           </button>
         </div>
+      </div>
+
+      <div style={{ marginBottom: '1rem' }}>
+        <PaginationControls
+          total={total}
+          limit={limit}
+          offset={offset}
+          onLimitChange={(next) => { setLimit(next); setOffset(0) }}
+          onOffsetChange={setOffset}
+        />
       </div>
 
       {loading && <p style={{ color: 'var(--text-muted)' }}>Loading…</p>}

--- a/internal/ui/src/app/runners/page.tsx
+++ b/internal/ui/src/app/runners/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import Card from '@/components/Card'
 import LiveTraceModal, { type LiveTraceSpan } from '@/components/LiveTraceModal'
 import Modal from '@/components/Modal'
+import PaginationControls from '@/components/PaginationControls'
 import RepoFilter from '@/components/RepoFilter'
 import WorkspaceSelect from '@/components/WorkspaceSelect'
 import { formatDateTime, formatTime } from '@/lib/datetime'
@@ -106,6 +107,9 @@ function RunnersInner() {
   }
 
   const [rows, setRows] = useState<RunnerRow[]>([])
+  const [total, setTotal] = useState(0)
+  const [limit, setLimit] = useState(50)
+  const [offset, setOffset] = useState(0)
   const [status, setStatus] = useState<'' | 'enqueued' | 'running' | 'completed'>('')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -121,11 +125,12 @@ function RunnersInner() {
 
   const load = async () => {
     try {
-      const url = withWorkspace(`/runners?limit=200${status ? `&status=${status}` : ''}`, workspace)
+      const url = withWorkspace(`/runners?limit=${limit}&offset=${offset}${status ? `&status=${status}` : ''}`, workspace)
       const res = await fetch(url, { cache: 'no-store' })
       if (!res.ok) throw new Error(`status ${res.status}`)
       const data: ListResponse = await res.json()
       const nextRows = data.runners ?? []
+      setTotal(data.total ?? nextRows.length)
       const newTimeout = observeRunnerTimeouts(nextRows, timeoutTracker.current)
       if (newTimeout) setTimeoutToast(newTimeout)
       let newFailure: RunnerRow | null = null
@@ -154,7 +159,11 @@ function RunnersInner() {
     load()
     const id = window.setInterval(load, POLL_MS)
     return () => window.clearInterval(id)
-  }, [status, workspace]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [status, workspace, limit, offset]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    setOffset(0)
+  }, [status, workspace])
 
   // Trigger highlight pulse when arriving with ?event=X. Wait until
   // the first batch of rows lands, otherwise the animation runs while
@@ -275,6 +284,13 @@ function RunnersInner() {
               padding: '4px 10px', borderRadius: '4px', cursor: 'pointer', fontSize: '0.8rem',
             }}>{s || 'All'}</button>
           ))}
+          <PaginationControls
+            total={total}
+            limit={limit}
+            offset={offset}
+            onLimitChange={(next) => { setLimit(next); setOffset(0) }}
+            onOffsetChange={setOffset}
+          />
         </div>
       </div>
 

--- a/internal/ui/src/app/skills/page.test.tsx
+++ b/internal/ui/src/app/skills/page.test.tsx
@@ -23,7 +23,7 @@ describe('<SkillsPage />', () => {
   it('keeps long stable skill ids in tooltips instead of row labels', async () => {
     const fetchMock = vi.fn((input: RequestInfo | URL) => {
       const url = String(input)
-      if (url === '/skills') {
+      if (url === '/skills?limit=50&offset=0') {
         return Promise.resolve({
           ok: true,
           json: () => Promise.resolve([
@@ -44,7 +44,7 @@ describe('<SkillsPage />', () => {
           ]),
         } as Response)
       }
-      if (url === '/workspaces') {
+      if (url === '/workspaces?limit=500&offset=0') {
         return Promise.resolve({ ok: true, json: () => Promise.resolve([{ id: 'default', name: 'Default' }]) } as Response)
       }
       return Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve([]) } as Response)
@@ -54,6 +54,7 @@ describe('<SkillsPage />', () => {
     render(<SkillsPage />)
 
     expect(await screen.findByText('go api boundaries')).toBeInTheDocument()
+    expect(fetchMock).toHaveBeenCalledWith('/workspaces?limit=500&offset=0', { cache: 'no-store' })
     expect(screen.getByText('testing')).toBeInTheDocument()
     expect(screen.queryByText('go-api · go api boundaries')).not.toBeInTheDocument()
     expect(screen.getByText('go api boundaries')).toHaveAttribute('title', 'go api boundaries · go-api')

--- a/internal/ui/src/app/skills/page.tsx
+++ b/internal/ui/src/app/skills/page.tsx
@@ -5,7 +5,7 @@ import Modal from '@/components/Modal'
 import PaginationControls from '@/components/PaginationControls'
 import MarkdownEditor from '@/components/MarkdownEditor'
 import CatalogVersionsPanel from '@/components/CatalogVersionsPanel'
-import { itemsFromResponse, pageFromResponse } from '@/lib/pagination'
+import { itemsFromResponse, pageFromResponse, selectorURL } from '@/lib/pagination'
 
 interface Skill {
   id?: string
@@ -83,7 +83,7 @@ function SkillForm({
       setRepoOptions([])
       return
     }
-    fetch(`/repos?workspace=${encodeURIComponent(form.workspace_id)}`, { cache: 'no-store' })
+    fetch(selectorURL(`/repos?workspace=${encodeURIComponent(form.workspace_id)}`), { cache: 'no-store' })
       .then(r => r.ok ? r.json() : [])
       .then((data) => setRepoOptions(itemsFromResponse<Repo>(data)))
       .catch(() => setRepoOptions([]))
@@ -227,7 +227,7 @@ export default function SkillsPage() {
 
   useEffect(() => {
     load()
-    fetch('/workspaces', { cache: 'no-store' })
+    fetch(selectorURL('/workspaces'), { cache: 'no-store' })
       .then(r => r.ok ? r.json() : [])
       .then((data) => setWorkspaces(itemsFromResponse<Workspace>(data)))
       .catch(() => setWorkspaces([]))
@@ -238,7 +238,7 @@ export default function SkillsPage() {
       setFilterRepos([])
       return
     }
-    fetch(`/repos?workspace=${encodeURIComponent(filterWorkspace)}`, { cache: 'no-store' })
+    fetch(selectorURL(`/repos?workspace=${encodeURIComponent(filterWorkspace)}`), { cache: 'no-store' })
       .then(r => r.ok ? r.json() : [])
       .then((data) => setFilterRepos(itemsFromResponse<Repo>(data)))
       .catch(() => setFilterRepos([]))

--- a/internal/ui/src/app/skills/page.tsx
+++ b/internal/ui/src/app/skills/page.tsx
@@ -2,8 +2,10 @@
 import { useState, useEffect } from 'react'
 import Card from '@/components/Card'
 import Modal from '@/components/Modal'
+import PaginationControls from '@/components/PaginationControls'
 import MarkdownEditor from '@/components/MarkdownEditor'
 import CatalogVersionsPanel from '@/components/CatalogVersionsPanel'
+import { itemsFromResponse, pageFromResponse } from '@/lib/pagination'
 
 interface Skill {
   id?: string
@@ -83,7 +85,7 @@ function SkillForm({
     }
     fetch(`/repos?workspace=${encodeURIComponent(form.workspace_id)}`, { cache: 'no-store' })
       .then(r => r.ok ? r.json() : [])
-      .then((data: Repo[]) => setRepoOptions(data ?? []))
+      .then((data) => setRepoOptions(itemsFromResponse<Repo>(data)))
       .catch(() => setRepoOptions([]))
   }, [selectedScope, form.workspace_id])
 
@@ -193,6 +195,9 @@ function SkillForm({
 
 export default function SkillsPage() {
   const [skills, setSkills] = useState<Skill[]>([])
+  const [total, setTotal] = useState(0)
+  const [limit, setLimit] = useState(50)
+  const [offset, setOffset] = useState(0)
   const [workspaces, setWorkspaces] = useState<Workspace[]>([])
   const [filterScope, setFilterScope] = useState<'all' | 'global' | 'workspace' | 'repo'>('all')
   const [filterWorkspace, setFilterWorkspace] = useState('')
@@ -209,10 +214,12 @@ export default function SkillsPage() {
 
   const load = () => {
     setLoading(true)
-    fetch('/skills')
+    fetch(`/skills?limit=${limit}&offset=${offset}`)
       .then(r => r.json())
-      .then((data: Skill[]) => {
-        setSkills((data ?? []).map(s => ({ ...s, id: stableSkillID(s) || s.name })))
+      .then((data) => {
+        const page = pageFromResponse<Skill>(data, limit, offset)
+        setSkills(page.items.map(s => ({ ...s, id: stableSkillID(s) || s.name })))
+        setTotal(page.total)
         setLoading(false)
       })
       .catch(e => { setError(String(e)); setLoading(false) })
@@ -222,9 +229,9 @@ export default function SkillsPage() {
     load()
     fetch('/workspaces', { cache: 'no-store' })
       .then(r => r.ok ? r.json() : [])
-      .then((data: Workspace[]) => setWorkspaces(data ?? []))
+      .then((data) => setWorkspaces(itemsFromResponse<Workspace>(data)))
       .catch(() => setWorkspaces([]))
-  }, [])
+  }, [limit, offset])
 
   useEffect(() => {
     if (filterScope !== 'repo' || !filterWorkspace) {
@@ -233,7 +240,7 @@ export default function SkillsPage() {
     }
     fetch(`/repos?workspace=${encodeURIComponent(filterWorkspace)}`, { cache: 'no-store' })
       .then(r => r.ok ? r.json() : [])
-      .then((data: Repo[]) => setFilterRepos(data ?? []))
+      .then((data) => setFilterRepos(itemsFromResponse<Repo>(data)))
       .catch(() => setFilterRepos([]))
   }, [filterScope, filterWorkspace])
 
@@ -380,6 +387,16 @@ export default function SkillsPage() {
             Refresh
           </button>
         </div>
+      </div>
+
+      <div style={{ marginBottom: '1rem' }}>
+        <PaginationControls
+          total={total}
+          limit={limit}
+          offset={offset}
+          onLimitChange={(next) => { setLimit(next); setOffset(0) }}
+          onOffsetChange={setOffset}
+        />
       </div>
 
       {loading && <p style={{ color: 'var(--text-muted)' }}>Loading…</p>}

--- a/internal/ui/src/app/traces/page.tsx
+++ b/internal/ui/src/app/traces/page.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect, useRef, Suspense } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
 import Card from '@/components/Card'
+import PaginationControls from '@/components/PaginationControls'
 import StatusBadge from '@/components/StatusBadge'
 import Link from 'next/link'
 import RepoFilter, { useRepoFilter } from '@/components/RepoFilter'
@@ -9,6 +10,7 @@ import WorkspaceSelect from '@/components/WorkspaceSelect'
 import { StreamCard, TranscriptFilter, allStreamCardKinds, stepToCardEntries, type PersistedStep, type StreamCardKind } from '@/components/StreamCard'
 import { formatDateTime } from '@/lib/datetime'
 import { fmtDuration } from '@/lib/format'
+import { pageFromResponse } from '@/lib/pagination'
 import { openAuthenticatedSSE } from '@/lib/sse'
 import { useSelectedWorkspace, withWorkspace } from '@/lib/workspace'
 
@@ -382,12 +384,20 @@ function TracesContent() {
   const [streaming, setStreaming] = useState(false)
   const [repoFilter, setRepoFilter] = useRepoFilter()
   const { workspace } = useSelectedWorkspace()
+  const [limit, setLimit] = useState(50)
+  const [offset, setOffset] = useState(0)
+  const [total, setTotal] = useState(0)
 
   const load = () => {
     setLoading(true)
-    fetch(withWorkspace('/traces', workspace))
+    fetch(withWorkspace(`/traces?limit=${limit}&offset=${offset}`, workspace))
       .then(r => r.json())
-      .then(data => { setSpans(data ?? []); setLoading(false) })
+      .then(data => {
+        const page = pageFromResponse<Span>(data, limit, offset)
+        setSpans(page.items)
+        setTotal(page.total)
+        setLoading(false)
+      })
       .catch(() => setLoading(false))
   }
 
@@ -404,7 +414,9 @@ function TracesContent() {
       onError: () => setStreaming(false),
     })
     return () => stream.close()
-  }, [workspace])
+  }, [workspace, limit, offset])
+
+  useEffect(() => { setOffset(0) }, [workspace])
 
   const handleSelect = (id: string) => {
     router.push(`/traces/?id=${encodeURIComponent(id)}`)
@@ -434,11 +446,19 @@ function TracesContent() {
           <h1 style={{ fontSize: '1.4rem', fontWeight: 700, color: 'var(--text-heading)' }}>Traces</h1>
           <p style={{ color: 'var(--text-muted)', fontSize: '0.875rem', marginTop: '4px' }}>
             {rootIds.length} trace{rootIds.length !== 1 ? 's' : ''} · {streaming ? '🟢 live' : '🔴 disconnected'}
+            {total > rootIds.length ? ` · ${total} spans total` : ''}
           </p>
         </div>
         <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
           <WorkspaceSelect compact />
           <RepoFilter selected={repoFilter} onChange={setRepoFilter} workspace={workspace} />
+          <PaginationControls
+            total={total}
+            limit={limit}
+            offset={offset}
+            onLimitChange={(next) => { setLimit(next); setOffset(0) }}
+            onOffsetChange={setOffset}
+          />
           <input
             placeholder="Filter by agent, repo, or ID…"
             value={filter}

--- a/internal/ui/src/app/workspaces/page.tsx
+++ b/internal/ui/src/app/workspaces/page.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useState } from 'react'
 import Card from '@/components/Card'
 import Modal from '@/components/Modal'
+import PaginationControls from '@/components/PaginationControls'
+import { itemsFromResponse } from '@/lib/pagination'
 import { defaultWorkspaceID } from '@/lib/workspace'
 
 interface Workspace {
@@ -105,6 +107,9 @@ function WorkspaceForm({ initial, isNew, saving, error, onSave, onCancel }: {
 
 export default function WorkspacesPage() {
   const [workspaces, setWorkspaces] = useState<Workspace[]>([])
+  const [total, setTotal] = useState(0)
+  const [limit, setLimit] = useState(50)
+  const [offset, setOffset] = useState(0)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
   const [saveError, setSaveError] = useState('')
@@ -115,13 +120,16 @@ export default function WorkspacesPage() {
   const load = () => {
     setLoading(true)
     setError('')
-    fetch('/workspaces', { cache: 'no-store' })
+    fetch(`/workspaces?limit=${limit}&offset=${offset}`, { cache: 'no-store' })
       .then(async res => {
         if (!res.ok) throw new Error((await res.text()) || 'Failed to load workspaces')
         return res.json()
       })
-      .then((data: Workspace[] | null) => {
-        setWorkspaces((data ?? []).slice().sort((a, b) => (a.name || a.id).localeCompare(b.name || b.id)))
+      .then((data) => {
+        const items = itemsFromResponse<Workspace>(data)
+        const page = data as { total?: number }
+        setWorkspaces(items.slice().sort((a, b) => (a.name || a.id).localeCompare(b.name || b.id)))
+        setTotal(page.total ?? items.length)
         setLoading(false)
       })
       .catch(e => {
@@ -130,7 +138,7 @@ export default function WorkspacesPage() {
       })
   }
 
-  useEffect(() => load(), [])
+  useEffect(() => load(), [limit, offset])
 
   const openCreate = () => {
     setSaveError('')
@@ -210,6 +218,15 @@ export default function WorkspacesPage() {
       </div>
 
       <Card>
+        <div style={{ marginBottom: '1rem' }}>
+          <PaginationControls
+            total={total}
+            limit={limit}
+            offset={offset}
+            onLimitChange={(next) => { setLimit(next); setOffset(0) }}
+            onOffsetChange={setOffset}
+          />
+        </div>
         {loading && <p style={{ color: 'var(--text-muted)' }}>Loading…</p>}
         {error && <p style={{ color: 'var(--text-danger)' }}>{error}</p>}
         {!loading && !error && workspaces.length === 0 && (

--- a/internal/ui/src/components/GuardrailsManager.test.tsx
+++ b/internal/ui/src/components/GuardrailsManager.test.tsx
@@ -32,8 +32,12 @@ vi.mock('@/components/MarkdownEditor', () => ({
 
 const catalog = [
   { name: 'a', description: '', content: 'A', default_content: 'A', is_builtin: true, enabled: true, position: 0 },
-  { name: 'b', description: '', content: 'B', default_content: 'B', is_builtin: true, enabled: true, position: 1 },
   { name: 'c', description: '', content: 'C', default_content: 'C', is_builtin: true, enabled: true, position: 2 },
+]
+
+const lookupCatalog = [
+  ...catalog,
+  { name: 'b', description: '', content: 'B', default_content: 'B', is_builtin: true, enabled: true, position: 1 },
 ]
 
 const workspaceRefs = [
@@ -48,8 +52,11 @@ describe('<GuardrailsManager />', () => {
 
   it('renders selected workspace guardrails in workspace position order', async () => {
     const fetchMock = vi.fn((url: string) => {
-      if (url === '/guardrails') {
-        return Promise.resolve({ ok: true, json: () => Promise.resolve(catalog) } as Response)
+      if (url === '/guardrails?limit=50&offset=0') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ items: catalog, total: 3, limit: 50, offset: 0 }) } as Response)
+      }
+      if (url === '/guardrails?limit=500&offset=0') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ items: lookupCatalog, total: 3, limit: 500, offset: 0 }) } as Response)
       }
       if (url === '/workspaces/team-a/guardrails') {
         return Promise.resolve({ ok: true, json: () => Promise.resolve(workspaceRefs) } as Response)

--- a/internal/ui/src/components/GuardrailsManager.tsx
+++ b/internal/ui/src/components/GuardrailsManager.tsx
@@ -6,6 +6,7 @@ import FullscreenModal from '@/components/FullscreenModal'
 import MarkdownEditor from '@/components/MarkdownEditor'
 import WorkspaceSelect from '@/components/WorkspaceSelect'
 import CatalogVersionsPanel from '@/components/CatalogVersionsPanel'
+import { itemsFromResponse } from '@/lib/pagination'
 import { useSelectedWorkspace } from '@/lib/workspace'
 
 interface Guardrail {
@@ -212,8 +213,9 @@ export default function GuardrailsManager() {
         return r.json()
       }),
     ])
-      .then(([catalog, refs]: [Guardrail[], WorkspaceGuardrailRef[]]) => {
+      .then(([catalogRaw, refs]: [unknown, WorkspaceGuardrailRef[]]) => {
         if (isCancelled() || currentWorkspaceRef.current !== targetWorkspace) return
+        const catalog = itemsFromResponse<Guardrail>(catalogRaw)
         setGuardrails(catalog ?? [])
         setWorkspaceRefs((refs ?? []).slice().sort((a, b) => a.position - b.position || a.guardrail_name.localeCompare(b.guardrail_name)))
         setLoading(false)

--- a/internal/ui/src/components/GuardrailsManager.tsx
+++ b/internal/ui/src/components/GuardrailsManager.tsx
@@ -6,7 +6,8 @@ import FullscreenModal from '@/components/FullscreenModal'
 import MarkdownEditor from '@/components/MarkdownEditor'
 import WorkspaceSelect from '@/components/WorkspaceSelect'
 import CatalogVersionsPanel from '@/components/CatalogVersionsPanel'
-import { itemsFromResponse } from '@/lib/pagination'
+import PaginationControls from '@/components/PaginationControls'
+import { pageFromResponse } from '@/lib/pagination'
 import { useSelectedWorkspace } from '@/lib/workspace'
 
 interface Guardrail {
@@ -184,6 +185,9 @@ export default function GuardrailsManager() {
   const { workspace, workspaces } = useSelectedWorkspace()
   const currentWorkspaceRef = useRef(workspace)
   const [guardrails, setGuardrails] = useState<Guardrail[]>([])
+  const [guardrailsTotal, setGuardrailsTotal] = useState(0)
+  const [guardrailsLimit, setGuardrailsLimit] = useState(50)
+  const [guardrailsOffset, setGuardrailsOffset] = useState(0)
   const [workspaceRefs, setWorkspaceRefs] = useState<WorkspaceGuardrailRef[]>([])
   const [loading, setLoading] = useState(true)
   const [loadError, setLoadError] = useState('')
@@ -204,7 +208,7 @@ export default function GuardrailsManager() {
     setLoading(true)
     setLoadError('')
     Promise.all([
-      fetch('/guardrails').then(r => {
+      fetch(`/guardrails?limit=${guardrailsLimit}&offset=${guardrailsOffset}`).then(r => {
         if (!r.ok) throw new Error(`load guardrails: ${r.status}`)
         return r.json()
       }),
@@ -215,8 +219,9 @@ export default function GuardrailsManager() {
     ])
       .then(([catalogRaw, refs]: [unknown, WorkspaceGuardrailRef[]]) => {
         if (isCancelled() || currentWorkspaceRef.current !== targetWorkspace) return
-        const catalog = itemsFromResponse<Guardrail>(catalogRaw)
-        setGuardrails(catalog ?? [])
+        const catalog = pageFromResponse<Guardrail>(catalogRaw, guardrailsLimit, guardrailsOffset)
+        setGuardrails(catalog.items ?? [])
+        setGuardrailsTotal(catalog.total)
         setWorkspaceRefs((refs ?? []).slice().sort((a, b) => a.position - b.position || a.guardrail_name.localeCompare(b.guardrail_name)))
         setLoading(false)
       })
@@ -230,6 +235,10 @@ export default function GuardrailsManager() {
     let cancelled = false
     load(() => cancelled)
     return () => { cancelled = true }
+  }, [workspace, guardrailsLimit, guardrailsOffset])
+
+  useEffect(() => {
+    setGuardrailsOffset(0)
   }, [workspace])
 
   const selectedWorkspace = workspaces.find(w => w.id === workspace)
@@ -520,7 +529,7 @@ export default function GuardrailsManager() {
 
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
         <span style={{ color: 'var(--text-muted)', fontSize: '0.875rem' }}>
-          {guardrails.length} guardrail catalog entr{guardrails.length === 1 ? 'y' : 'ies'}.
+          {guardrailsTotal} guardrail catalog entr{guardrailsTotal === 1 ? 'y' : 'ies'}.
         </span>
         <button
           onClick={() => { setSelected(emptyForm); setModal('create') }}
@@ -528,6 +537,16 @@ export default function GuardrailsManager() {
         >
           New guardrail
         </button>
+      </div>
+
+      <div style={{ marginBottom: '1rem' }}>
+        <PaginationControls
+          total={guardrailsTotal}
+          limit={guardrailsLimit}
+          offset={guardrailsOffset}
+          onLimitChange={(next) => { setGuardrailsLimit(next); setGuardrailsOffset(0) }}
+          onOffsetChange={setGuardrailsOffset}
+        />
       </div>
 
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>

--- a/internal/ui/src/components/GuardrailsManager.tsx
+++ b/internal/ui/src/components/GuardrailsManager.tsx
@@ -7,7 +7,7 @@ import MarkdownEditor from '@/components/MarkdownEditor'
 import WorkspaceSelect from '@/components/WorkspaceSelect'
 import CatalogVersionsPanel from '@/components/CatalogVersionsPanel'
 import PaginationControls from '@/components/PaginationControls'
-import { pageFromResponse } from '@/lib/pagination'
+import { itemsFromResponse, pageFromResponse, selectorURL } from '@/lib/pagination'
 import { useSelectedWorkspace } from '@/lib/workspace'
 
 interface Guardrail {
@@ -185,6 +185,7 @@ export default function GuardrailsManager() {
   const { workspace, workspaces } = useSelectedWorkspace()
   const currentWorkspaceRef = useRef(workspace)
   const [guardrails, setGuardrails] = useState<Guardrail[]>([])
+  const [guardrailLookups, setGuardrailLookups] = useState<Guardrail[]>([])
   const [guardrailsTotal, setGuardrailsTotal] = useState(0)
   const [guardrailsLimit, setGuardrailsLimit] = useState(50)
   const [guardrailsOffset, setGuardrailsOffset] = useState(0)
@@ -212,15 +213,20 @@ export default function GuardrailsManager() {
         if (!r.ok) throw new Error(`load guardrails: ${r.status}`)
         return r.json()
       }),
+      fetch(selectorURL('/guardrails')).then(r => {
+        if (!r.ok) throw new Error(`load guardrail lookups: ${r.status}`)
+        return r.json()
+      }),
       fetch(`/workspaces/${encodeURIComponent(workspace)}/guardrails`).then(r => {
         if (!r.ok) throw new Error(`load workspace guardrails: ${r.status}`)
         return r.json()
       }),
     ])
-      .then(([catalogRaw, refs]: [unknown, WorkspaceGuardrailRef[]]) => {
+      .then(([catalogRaw, lookupRaw, refs]: [unknown, unknown, WorkspaceGuardrailRef[]]) => {
         if (isCancelled() || currentWorkspaceRef.current !== targetWorkspace) return
         const catalog = pageFromResponse<Guardrail>(catalogRaw, guardrailsLimit, guardrailsOffset)
         setGuardrails(catalog.items ?? [])
+        setGuardrailLookups(itemsFromResponse<Guardrail>(lookupRaw))
         setGuardrailsTotal(catalog.total)
         setWorkspaceRefs((refs ?? []).slice().sort((a, b) => a.position - b.position || a.guardrail_name.localeCompare(b.guardrail_name)))
         setLoading(false)
@@ -250,7 +256,7 @@ export default function GuardrailsManager() {
   }
   const workspaceRefIDs = new Set(workspaceRefs.map(r => r.guardrail_name))
   const workspaceRefByID = new Map(workspaceRefs.map(r => [r.guardrail_name, r]))
-  const guardrailByID = new Map(guardrails.map(g => [guardrailID(g), g]))
+  const guardrailByID = new Map([...guardrails, ...guardrailLookups].map(g => [guardrailID(g), g]))
   const selectedWorkspaceRows = workspaceRefs.map((ref, index) => ({
     ref,
     index,

--- a/internal/ui/src/components/PaginationControls.tsx
+++ b/internal/ui/src/components/PaginationControls.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+interface PaginationControlsProps {
+  total: number
+  limit: number
+  offset: number
+  onLimitChange: (limit: number) => void
+  onOffsetChange: (offset: number) => void
+  pageSizes?: number[]
+}
+
+export default function PaginationControls({ total, limit, offset, onLimitChange, onOffsetChange, pageSizes = [25, 50, 100, 200] }: PaginationControlsProps) {
+  const start = total === 0 ? 0 : offset + 1
+  const end = Math.min(offset + limit, total)
+  const prevDisabled = offset <= 0
+  const nextDisabled = offset + limit >= total
+  const buttonStyle = (disabled: boolean): React.CSSProperties => ({
+    border: '1px solid var(--border)',
+    borderRadius: '4px',
+    background: disabled ? 'var(--bg-card)' : 'var(--bg)',
+    color: disabled ? 'var(--text-muted)' : 'var(--text)',
+    cursor: disabled ? 'not-allowed' : 'pointer',
+    padding: '4px 8px',
+    minWidth: '32px',
+  })
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap', color: 'var(--text-muted)', fontSize: '0.8rem' }}>
+      <span>{start}-{end} of {total}</span>
+      <select
+        value={limit}
+        onChange={e => onLimitChange(Number(e.target.value))}
+        style={{ background: 'var(--bg)', border: '1px solid var(--border)', borderRadius: '4px', color: 'var(--text)', padding: '4px 6px' }}
+      >
+        {pageSizes.map(size => <option key={size} value={size}>{size}</option>)}
+      </select>
+      <button disabled={prevDisabled} onClick={() => onOffsetChange(Math.max(0, offset - limit))} style={buttonStyle(prevDisabled)}>Prev</button>
+      <button disabled={nextDisabled} onClick={() => onOffsetChange(offset + limit)} style={buttonStyle(nextDisabled)}>Next</button>
+    </div>
+  )
+}

--- a/internal/ui/src/components/RepoFilter.test.tsx
+++ b/internal/ui/src/components/RepoFilter.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import RepoFilter, { useRepoFilter } from './RepoFilter'
 
 const STORAGE_KEY = 'agents_repo_filter'
+const REPOS_SELECTOR_URL = '/repos?limit=500&offset=0'
 
 describe('useRepoFilter', () => {
   beforeEach(() => {
@@ -64,7 +65,7 @@ describe('<RepoFilter />', () => {
     mockReposResponse([])
     const onChange = vi.fn()
     const { container } = render(<RepoFilter selected="" onChange={onChange} />)
-    await waitFor(() => expect(fetch).toHaveBeenCalledWith('/repos'))
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith(REPOS_SELECTOR_URL))
     expect(container).toBeEmptyDOMElement()
   })
 
@@ -79,7 +80,7 @@ describe('<RepoFilter />', () => {
     mockReposResponse(['owner/solo'])
     const onChange = vi.fn()
     const { container } = render(<RepoFilter selected="" onChange={onChange} />)
-    await waitFor(() => expect(fetch).toHaveBeenCalledWith('/repos'))
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith(REPOS_SELECTOR_URL))
     // Give React a tick to run effects after fetch resolves.
     await act(async () => {})
     expect(container).toBeEmptyDOMElement()

--- a/internal/ui/src/components/RepoFilter.tsx
+++ b/internal/ui/src/components/RepoFilter.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { useState, useEffect } from 'react'
-import { itemsFromResponse } from '@/lib/pagination'
+import { itemsFromResponse, selectorURL } from '@/lib/pagination'
 import { withWorkspace } from '@/lib/workspace'
 
 const STORAGE_KEY = 'agents_repo_filter'
@@ -28,7 +28,7 @@ export default function RepoFilter({ selected, onChange, workspace }: { selected
 
   useEffect(() => {
     setLoaded(false)
-    fetch(workspace ? withWorkspace('/repos', workspace) : '/repos')
+    fetch(selectorURL(workspace ? withWorkspace('/repos', workspace) : '/repos'))
       .then(r => r.ok ? r.json() : [])
       .then((data) => {
         setRepos(itemsFromResponse<{ name: string }>(data).map(r => r.name))

--- a/internal/ui/src/components/RepoFilter.tsx
+++ b/internal/ui/src/components/RepoFilter.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useState, useEffect } from 'react'
+import { itemsFromResponse } from '@/lib/pagination'
 import { withWorkspace } from '@/lib/workspace'
 
 const STORAGE_KEY = 'agents_repo_filter'
@@ -29,8 +30,8 @@ export default function RepoFilter({ selected, onChange, workspace }: { selected
     setLoaded(false)
     fetch(workspace ? withWorkspace('/repos', workspace) : '/repos')
       .then(r => r.ok ? r.json() : [])
-      .then((data: { name: string }[]) => {
-        setRepos((data ?? []).map(r => r.name))
+      .then((data) => {
+        setRepos(itemsFromResponse<{ name: string }>(data).map(r => r.name))
         setLoaded(true)
       })
       .catch(() => setLoaded(true))

--- a/internal/ui/src/lib/auth.test.tsx
+++ b/internal/ui/src/lib/auth.test.tsx
@@ -51,8 +51,8 @@ describe('AuthTokenSettings', () => {
       if (url === '/auth/status') {
         return jsonResponse({ authenticated: true, bootstrap_required: false, user: { username: 'operator', is_admin: false } })
       }
-      if (url === '/auth/users') return jsonResponse([])
-      if (url === '/auth/tokens') return jsonResponse([])
+      if (url === '/auth/users?limit=50&offset=0') return jsonResponse({ items: [], total: 0, limit: 50, offset: 0 })
+      if (url === '/auth/tokens?limit=50&offset=0') return jsonResponse({ items: [], total: 0, limit: 50, offset: 0 })
       if (url === '/auth/me/password' && init?.method === 'POST') return jsonResponse({ ok: true })
       return new Response('not found', { status: 404 })
     })
@@ -82,8 +82,8 @@ describe('AuthTokenSettings', () => {
       if (url === '/auth/status') {
         return jsonResponse({ authenticated: true, bootstrap_required: false, user: { username: 'operator', is_admin: false } })
       }
-      if (url === '/auth/users') return jsonResponse([])
-      if (url === '/auth/tokens') return jsonResponse([])
+      if (url === '/auth/users?limit=50&offset=0') return jsonResponse({ items: [], total: 0, limit: 50, offset: 0 })
+      if (url === '/auth/tokens?limit=50&offset=0') return jsonResponse({ items: [], total: 0, limit: 50, offset: 0 })
       return new Response('not found', { status: 404 })
     })
 
@@ -97,5 +97,66 @@ describe('AuthTokenSettings', () => {
 
     await screen.findByText('New passwords do not match.')
     await waitFor(() => expect(fetchMock).not.toHaveBeenCalled())
+  })
+
+  it('paginates users and API tokens independently', async () => {
+    const fetchMock = mockFetch(url => {
+      if (url === '/auth/status') {
+        return jsonResponse({ authenticated: true, bootstrap_required: false, user: { username: 'operator', is_admin: true } })
+      }
+      if (url === '/auth/users?limit=50&offset=0') {
+        return jsonResponse({
+          items: [{ id: 1, username: 'operator', created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z', is_admin: true }],
+          total: 75,
+          limit: 50,
+          offset: 0,
+        })
+      }
+      if (url === '/auth/users?limit=50&offset=50') {
+        return jsonResponse({
+          items: [{ id: 2, username: 'viewer', created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z', is_admin: false }],
+          total: 75,
+          limit: 50,
+          offset: 50,
+        })
+      }
+      if (url === '/auth/tokens?limit=50&offset=0') {
+        return jsonResponse({
+          items: [{ id: 10, kind: 'api', name: 'first token', prefix: 'agt_abc', created_at: '2026-01-01T00:00:00Z' }],
+          total: 120,
+          limit: 50,
+          offset: 0,
+        })
+      }
+      if (url === '/auth/tokens?limit=50&offset=50') {
+        return jsonResponse({
+          items: [{ id: 11, kind: 'api', name: 'second token', prefix: 'agt_def', created_at: '2026-01-01T00:00:00Z' }],
+          total: 120,
+          limit: 50,
+          offset: 50,
+        })
+      }
+      return new Response('not found', { status: 404 })
+    })
+
+    render(<AuthTokenSettings />)
+
+    expect(await screen.findByText('operator')).toBeInTheDocument()
+    expect(await screen.findByText('first token')).toBeInTheDocument()
+    expect(screen.getByText('1-50 of 75')).toBeInTheDocument()
+    expect(screen.getByText('1-50 of 120')).toBeInTheDocument()
+
+    const nextButtons = screen.getAllByRole('button', { name: 'Next' })
+    fireEvent.click(nextButtons[0])
+
+    expect(await screen.findByText('viewer')).toBeInTheDocument()
+    expect(screen.getByText('51-75 of 75')).toBeInTheDocument()
+    expect(fetchMock).toHaveBeenCalledWith('/auth/users?limit=50&offset=50', { cache: 'no-store' })
+
+    fireEvent.click(nextButtons[1])
+
+    expect(await screen.findByText('second token')).toBeInTheDocument()
+    expect(screen.getByText('51-100 of 120')).toBeInTheDocument()
+    expect(fetchMock).toHaveBeenCalledWith('/auth/tokens?limit=50&offset=50', { cache: 'no-store' })
   })
 })

--- a/internal/ui/src/lib/auth.tsx
+++ b/internal/ui/src/lib/auth.tsx
@@ -1,7 +1,9 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import PaginationControls from '@/components/PaginationControls'
 import { formatDateTime } from '@/lib/datetime'
+import { pageFromResponse } from '@/lib/pagination'
 
 const openAuthModalEvent = 'agents-auth-token-request'
 
@@ -109,6 +111,12 @@ export function AuthTokenSettings() {
   const [status, setStatus] = useState<AuthStatus | null>(null)
   const [users, setUsers] = useState<AuthUser[]>([])
   const [tokens, setTokens] = useState<AuthToken[]>([])
+  const [usersTotal, setUsersTotal] = useState(0)
+  const [usersLimit, setUsersLimit] = useState(50)
+  const [usersOffset, setUsersOffset] = useState(0)
+  const [tokensTotal, setTokensTotal] = useState(0)
+  const [tokensLimit, setTokensLimit] = useState(50)
+  const [tokensOffset, setTokensOffset] = useState(0)
   const [name, setName] = useState('Codex MCP')
   const [created, setCreated] = useState('')
   const [newUsername, setNewUsername] = useState('')
@@ -126,16 +134,28 @@ export function AuthTokenSettings() {
     setStatus(next)
     if (!next?.authenticated) return
     const [usersRes, tokensRes] = await Promise.all([
-      fetch('/auth/users', { cache: 'no-store' }),
-      fetch('/auth/tokens', { cache: 'no-store' }),
+      fetch(pageURL('/auth/users', usersLimit, usersOffset), { cache: 'no-store' }),
+      fetch(pageURL('/auth/tokens', tokensLimit, tokensOffset), { cache: 'no-store' }),
     ])
-    if (usersRes.ok) setUsers(await usersRes.json() as AuthUser[])
-    if (tokensRes.ok) setTokens(await tokensRes.json() as AuthToken[])
+    if (usersRes.ok) {
+      const page = pageFromResponse<AuthUser>(await usersRes.json(), usersLimit, usersOffset)
+      setUsers(page.items)
+      setUsersTotal(page.total)
+      setUsersLimit(page.limit)
+      setUsersOffset(page.offset)
+    }
+    if (tokensRes.ok) {
+      const page = pageFromResponse<AuthToken>(await tokensRes.json(), tokensLimit, tokensOffset)
+      setTokens(page.items)
+      setTokensTotal(page.total)
+      setTokensLimit(page.limit)
+      setTokensOffset(page.offset)
+    }
   }
 
   useEffect(() => {
     void refresh()
-  }, [])
+  }, [usersLimit, usersOffset, tokensLimit, tokensOffset])
 
   const create = async () => {
     setCreated('')
@@ -274,6 +294,16 @@ export function AuthTokenSettings() {
               <p style={{ color: 'var(--text-muted)', fontSize: '0.78rem' }}>Only the admin user can create or remove dashboard users.</p>
             )}
             {userError && <p style={{ color: 'var(--text-danger)', fontSize: '0.78rem' }}>{userError}</p>}
+            <PaginationControls
+              total={usersTotal}
+              limit={usersLimit}
+              offset={usersOffset}
+              onLimitChange={limit => {
+                setUsersLimit(limit)
+                setUsersOffset(0)
+              }}
+              onOffsetChange={setUsersOffset}
+            />
           </section>
 
           <section style={sectionStyle}>
@@ -302,6 +332,16 @@ export function AuthTokenSettings() {
                 </div>
               ))}
             </div>
+            <PaginationControls
+              total={tokensTotal}
+              limit={tokensLimit}
+              offset={tokensOffset}
+              onLimitChange={limit => {
+                setTokensLimit(limit)
+                setTokensOffset(0)
+              }}
+              onOffsetChange={setTokensOffset}
+            />
           </section>
         </>
       )}
@@ -327,6 +367,10 @@ function AuthRedirectScreen({ loading }: { loading: boolean }) {
 
 function formatDate(value: string) {
   return formatDateTime(value) || 'unknown'
+}
+
+function pageURL(path: string, limit: number, offset: number): string {
+  return `${path}?limit=${limit}&offset=${offset}`
 }
 
 const sectionStyle: React.CSSProperties = {

--- a/internal/ui/src/lib/pagination.ts
+++ b/internal/ui/src/lib/pagination.ts
@@ -1,0 +1,27 @@
+export interface PaginatedResponse<T> {
+  items: T[]
+  total: number
+  limit: number
+  offset: number
+}
+
+export function itemsFromResponse<T>(value: unknown): T[] {
+	if (!value) return []
+	if (Array.isArray(value)) return value as T[]
+	const page = value as Partial<PaginatedResponse<T>>
+	return page.items ?? []
+}
+
+export function pageFromResponse<T>(value: unknown, fallbackLimit: number, fallbackOffset: number): PaginatedResponse<T> {
+  if (Array.isArray(value)) {
+    return { items: value as T[], total: value.length, limit: fallbackLimit, offset: fallbackOffset }
+  }
+  const page = value as Partial<PaginatedResponse<T>>
+  const items = page?.items ?? []
+  return {
+    items,
+    total: page?.total ?? items.length,
+    limit: page?.limit ?? fallbackLimit,
+    offset: page?.offset ?? fallbackOffset,
+  }
+}

--- a/internal/ui/src/lib/pagination.ts
+++ b/internal/ui/src/lib/pagination.ts
@@ -5,6 +5,13 @@ export interface PaginatedResponse<T> {
   offset: number
 }
 
+export const selectorLimit = 500
+
+export function selectorURL(path: string): string {
+  const separator = path.includes('?') ? '&' : '?'
+  return `${path}${separator}limit=${selectorLimit}&offset=0`
+}
+
 export function itemsFromResponse<T>(value: unknown): T[] {
 	if (!value) return []
 	if (Array.isArray(value)) return value as T[]

--- a/internal/ui/src/lib/workspace.ts
+++ b/internal/ui/src/lib/workspace.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useMemo, useState } from 'react'
-import { itemsFromResponse } from './pagination'
+import { itemsFromResponse, selectorURL } from './pagination'
 
 export interface Workspace {
   id: string
@@ -70,7 +70,7 @@ export function useSelectedWorkspace() {
 
   useEffect(() => {
     let cancelled = false
-    fetch('/workspaces', { cache: 'no-store' })
+    fetch(selectorURL('/workspaces'), { cache: 'no-store' })
       .then(r => r.ok ? r.json() : [])
       .then((data) => {
         if (cancelled) return

--- a/internal/ui/src/lib/workspace.ts
+++ b/internal/ui/src/lib/workspace.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useMemo, useState } from 'react'
+import { itemsFromResponse } from './pagination'
 
 export interface Workspace {
   id: string
@@ -71,9 +72,9 @@ export function useSelectedWorkspace() {
     let cancelled = false
     fetch('/workspaces', { cache: 'no-store' })
       .then(r => r.ok ? r.json() : [])
-      .then((data: Workspace[]) => {
+      .then((data) => {
         if (cancelled) return
-        const rows = data ?? []
+        const rows = itemsFromResponse<Workspace>(data)
         setWorkspaces(rows)
       })
       .catch(() => {})


### PR DESCRIPTION
## Summary

- add shared pagination parsing/envelopes for CRUD REST list endpoints and matching store list/count queries
- expose limit/offset on MCP list tools with paginated `items` responses
- add reusable dashboard pagination controls and response helpers for agents, repos, prompts, skills, workspaces, and runners
- document the REST/MCP pagination contract

## Verification

- `go test ./...`
- `npm --prefix internal/ui run build`

Closes #712

<!-- agents-run: {"v":1,"instance_id":"ts-lonestar","workspace":"default","repo":"eloylp/agents","span_id":"357a8a8f126e4b40","agent_id":"agent_0fb82d1fe34e45408bd2fee153f7003d","agent_name":"coder","sig":"wSU5Z1U_n3G5OfZhqrfrahKvk05B_3ftmNvd__SKKgQ"} -->