### PR TITLE
refactor: centralize frontend api routes

### DIFF
--- a/internal/ui/src/app/config/page.tsx
+++ b/internal/ui/src/app/config/page.tsx
@@ -5,10 +5,11 @@ import Modal from '@/components/Modal'
 import RepoFilter from '@/components/RepoFilter'
 import WorkspaceSelect from '@/components/WorkspaceSelect'
 import PaginationControls from '@/components/PaginationControls'
+import { apiRoutes } from '@/lib/api-routes'
 import { AuthTokenSettings } from '@/lib/auth'
 import { budgetScopeDescription, budgetScopeLabel, budgetScopeOptions, isGlobalSimpleBudgetScope } from '@/lib/budget-copy'
 import { itemsFromResponse, pageFromResponse, selectorURL } from '@/lib/pagination'
-import { defaultWorkspaceID, useSelectedWorkspace, withWorkspace } from '@/lib/workspace'
+import { defaultWorkspaceID, useSelectedWorkspace } from '@/lib/workspace'
 
 type Config = Record<string, unknown>
 
@@ -349,7 +350,7 @@ export default function ConfigPage() {
   }
 
   useEffect(() => {
-    fetch('/config')
+    fetch(apiRoutes.config())
       .then(r => r.json())
       .then(data => { setConfig(data); setLoading(false) })
       .catch(e => { setError(String(e)); setLoading(false) })
@@ -376,7 +377,12 @@ export default function ConfigPage() {
 
   const loadBackends = () => {
     setBackendsLoading(true)
-    Promise.all([fetch(`/backends?limit=${backendsLimit}&offset=${backendsOffset}`), fetch(selectorURL('/backends')), fetch('/backends/status'), fetch('/agents/orphans/status')])
+    Promise.all([
+      fetch(apiRoutes.backends.list({ limit: backendsLimit, offset: backendsOffset })),
+      fetch(selectorURL(apiRoutes.backends.list())),
+      fetch(apiRoutes.backends.status()),
+      fetch(apiRoutes.agents.orphansStatus()),
+    ])
       .then(async ([dbRes, selectorRes, diagRes, orphanRes]) => {
         if (!dbRes.ok) throw new Error((await dbRes.text()) || 'Failed to load backends from database')
         if (!selectorRes.ok) throw new Error((await selectorRes.text()) || 'Failed to load backend selector options')
@@ -458,7 +464,7 @@ export default function ConfigPage() {
   const loadRuntime = () => {
     setRuntimeLoading(true)
     setRuntimeError('')
-    fetch('/runtime')
+    fetch(apiRoutes.runtime())
       .then(async r => {
         if (!r.ok) throw new Error((await r.text()) || 'Failed to load runtime settings')
         return r.json()
@@ -514,7 +520,7 @@ export default function ConfigPage() {
     setRuntimeSaving(true)
     setRuntimeError('')
     setRuntimeStatus('')
-    fetch('/runtime', {
+    fetch(apiRoutes.runtime(), {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(runtimeForm),
@@ -540,7 +546,7 @@ export default function ConfigPage() {
     setRuntimeSaving(true)
     setRuntimeError('')
     setRuntimeStatus('')
-    fetch(`/workspaces/${encodeURIComponent(selectedRuntimeWorkspace)}/runtime`, {
+    fetch(apiRoutes.workspaces.runtime(selectedRuntimeWorkspace), {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ runner_image: workspaceRunnerImage }),
@@ -576,7 +582,7 @@ export default function ConfigPage() {
     setDiscoveryRunning(true)
     setSaveError('')
     try {
-      const res = await fetch('/backends/discover', { method: 'POST' })
+      const res = await fetch(apiRoutes.backends.discover(), { method: 'POST' })
       if (!res.ok) {
         setSaveError((await res.text()) || 'Discovery failed')
         return
@@ -593,7 +599,7 @@ export default function ConfigPage() {
     setSaving(true)
     setSaveError('')
     try {
-      const res = await fetch('/backends/local', {
+      const res = await fetch(apiRoutes.backends.local(), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name: localBackendName, url: localBackendURL }),
@@ -616,7 +622,7 @@ export default function ConfigPage() {
     setSaving(true)
     setSaveError('')
     try {
-      const res = await fetch(`/backends/${encodeURIComponent(deleteTarget.name)}`, { method: 'DELETE' })
+      const res = await fetch(apiRoutes.backends.one(deleteTarget.name), { method: 'DELETE' })
       if (!res.ok && res.status !== 204) {
         setSaveError((await res.text()) || 'Remove failed')
         setSaving(false)
@@ -653,7 +659,7 @@ export default function ConfigPage() {
     setSaveError('')
     try {
       if (isLocalBackend) {
-        const localRes = await fetch('/backends/local', {
+        const localRes = await fetch(apiRoutes.backends.local(), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -667,7 +673,7 @@ export default function ConfigPage() {
           return
         }
       }
-      const res = await fetch(`/backends/${encodeURIComponent(settingsTarget.name)}`, {
+      const res = await fetch(apiRoutes.backends.one(settingsTarget.name), {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -690,7 +696,7 @@ export default function ConfigPage() {
 
   const upsertAgentModel = async (orphan: OrphanedAgent, model: string) => {
     const targetWorkspace = orphan.workspace_id || 'default'
-    const readRes = await fetch(withWorkspace(`/agents/${encodeURIComponent(orphan.name)}`, targetWorkspace))
+    const readRes = await fetch(apiRoutes.agents.one(orphan.name, { workspace: targetWorkspace }))
     if (!readRes.ok) {
       throw new Error((await readRes.text()) || `Failed to load agent ${orphan.name} in ${targetWorkspace}`)
     }
@@ -698,7 +704,7 @@ export default function ConfigPage() {
     agent.model = model
     agent.workspace_id = targetWorkspace
 
-    const writeRes = await fetch(withWorkspace('/agents', targetWorkspace), {
+    const writeRes = await fetch(apiRoutes.agents.list({ workspace: targetWorkspace }), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(agent),
@@ -755,7 +761,7 @@ export default function ConfigPage() {
   }
 
   const handleExport = async () => {
-    const res = await fetch('/export')
+    const res = await fetch(apiRoutes.exportConfig())
     if (!res.ok) {
       setErrorDialog({ title: 'Export failed', message: (await res.text()).trim() || `HTTP ${res.status}` })
       return
@@ -773,7 +779,7 @@ export default function ConfigPage() {
     setImportStatus('')
     setImportError('')
     const text = await file.text()
-    const url = importMode === 'replace' ? '/import?mode=replace' : '/import'
+    const url = apiRoutes.importConfig(importMode === 'replace' ? { mode: 'replace' } : undefined)
     const res = await fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-yaml' },
@@ -791,7 +797,7 @@ export default function ConfigPage() {
     setBudgetsLoading(true)
     setBudgetError('')
     try {
-      const res = await fetch(`/token_budgets?limit=${budgetsLimit}&offset=${budgetsOffset}`)
+      const res = await fetch(apiRoutes.tokenBudgets.list({ limit: budgetsLimit, offset: budgetsOffset }))
       if (!res.ok) throw new Error((await res.text()) || 'Failed to load budgets')
       const page = pageFromResponse<TokenBudget>(await res.json(), budgetsLimit, budgetsOffset)
       setBudgets(page.items)
@@ -805,9 +811,7 @@ export default function ConfigPage() {
   const loadLeaderboard = async (period: string, repo: string) => {
     setLbLoading(true)
     try {
-      const params = new URLSearchParams({ period })
-      if (repo) params.set('repo', repo)
-      const res = await fetch(withWorkspace(`/token_leaderboard?${params}`, workspace))
+      const res = await fetch(apiRoutes.tokenBudgets.leaderboard({ workspace, period, repo }))
       if (!res.ok) throw new Error((await res.text()) || 'Failed to load leaderboard')
       const data = await res.json() as LeaderboardEntry[] | null
       setLeaderboard(data ?? [])
@@ -819,7 +823,11 @@ export default function ConfigPage() {
 
   const loadBudgetScopeOptions = async () => {
     try {
-      const [backendRes, agentRes, repoRes] = await Promise.all([fetch(selectorURL('/backends')), fetch(selectorURL(withWorkspace('/agents', workspace))), fetch(selectorURL(withWorkspace('/repos', workspace)))])
+      const [backendRes, agentRes, repoRes] = await Promise.all([
+        fetch(selectorURL(apiRoutes.backends.list())),
+        fetch(selectorURL(apiRoutes.agents.list({ workspace }))),
+        fetch(selectorURL(apiRoutes.repos.list({ workspace }))),
+      ])
       if (backendRes.ok) {
         setBackendOptions(sortBackends(itemsFromResponse<Backend>(await backendRes.json())))
       }
@@ -850,13 +858,13 @@ export default function ConfigPage() {
       })
       let res: Response
       if (editBudget) {
-        res = await fetch(`/token_budgets/${editBudget.id}`, {
+        res = await fetch(apiRoutes.tokenBudgets.one(editBudget.id), {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
           body,
         })
       } else {
-        res = await fetch('/token_budgets', {
+        res = await fetch(apiRoutes.tokenBudgets.list(), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body,
@@ -878,7 +886,7 @@ export default function ConfigPage() {
     setBudgetSaving(true)
     setBudgetError('')
     try {
-      const res = await fetch(`/token_budgets/${deleteBudgetTarget.id}`, { method: 'DELETE' })
+      const res = await fetch(apiRoutes.tokenBudgets.one(deleteBudgetTarget.id), { method: 'DELETE' })
       if (!res.ok && res.status !== 204) throw new Error((await res.text()) || 'Failed to delete budget')
       setDeleteBudgetTarget(null)
       await loadBudgets()

--- a/internal/ui/src/app/events/page.tsx
+++ b/internal/ui/src/app/events/page.tsx
@@ -5,10 +5,11 @@ import Card from '@/components/Card'
 import PaginationControls from '@/components/PaginationControls'
 import RepoFilter, { useRepoFilter } from '@/components/RepoFilter'
 import WorkspaceSelect from '@/components/WorkspaceSelect'
+import { apiRoutes } from '@/lib/api-routes'
 import { formatTime } from '@/lib/datetime'
 import { pageFromResponse } from '@/lib/pagination'
 import { openAuthenticatedSSE } from '@/lib/sse'
-import { useSelectedWorkspace, withWorkspace } from '@/lib/workspace'
+import { useSelectedWorkspace } from '@/lib/workspace'
 
 interface Event {
   at: string
@@ -140,7 +141,7 @@ export default function EventsPage() {
     setLoading(true)
     const sinceMs = Date.now() - (timeRanges[timeRange] ?? 3600) * 1000
     const since = new Date(sinceMs).toISOString()
-    fetch(withWorkspace(`/events?since=${encodeURIComponent(since)}&limit=${limit}&offset=${offset}`, workspace))
+    fetch(apiRoutes.events.list({ workspace, since, limit, offset }))
       .then(r => r.json())
       .then(data => {
         const page = pageFromResponse<Event>(data, limit, offset)
@@ -156,7 +157,7 @@ export default function EventsPage() {
   useEffect(() => { setOffset(0) }, [timeRange, workspace])
 
   useEffect(() => {
-    const stream = openAuthenticatedSSE(withWorkspace('/events/stream', workspace), {
+    const stream = openAuthenticatedSSE(apiRoutes.events.stream({ workspace }), {
       onOpen: () => setStreaming(true),
       onMessage: data => {
         try {

--- a/internal/ui/src/app/graph/page.tsx
+++ b/internal/ui/src/app/graph/page.tsx
@@ -30,7 +30,8 @@ import LiveTraceModal, { type LiveTraceSpan } from '@/components/LiveTraceModal'
 import MarkdownEditor from '@/components/MarkdownEditor'
 import RunButton from '@/components/RunButton'
 import WorkspaceSelect from '@/components/WorkspaceSelect'
-import { useSelectedWorkspace, withWorkspace, type CatalogItem } from '@/lib/workspace'
+import { apiRoutes } from '@/lib/api-routes'
+import { useSelectedWorkspace, type CatalogItem } from '@/lib/workspace'
 import { type Binding } from '@/lib/bindings'
 import { fmtDuration } from '@/lib/format'
 import { graphPromptIdentifier, resolveGraphPrompt, type GraphPromptItem } from '@/lib/graph-prompt'
@@ -192,6 +193,11 @@ function repoPath(name: string): string {
   const [owner, ...rest] = name.split('/')
   const repo = rest.join('/')
   return `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`
+}
+
+function repoParts(name: string): [string, string] {
+  const [owner, ...rest] = name.split('/')
+  return [owner, rest.join('/')]
 }
 
 function repoNodeID(repo: string): string {
@@ -468,19 +474,19 @@ export default function GraphPage() {
   }, [repos, bindingDraft.repo])
 
   const loadLookups = useCallback(() => {
-    fetch(selectorURL('/backends'))
+    fetch(selectorURL(apiRoutes.backends.list()))
       .then(r => r.ok ? r.json() : [])
       .then((data) => setBackendOptions(itemsFromResponse<BackendOption>(data).filter(b => b.detected !== false)))
       .catch(() => {})
-    fetch(selectorURL('/skills'))
+    fetch(selectorURL(apiRoutes.catalog.skills.list()))
       .then(r => r.ok ? r.json() : [])
       .then((data) => setSkillOptions(itemsFromResponse<CatalogItem>(data)))
       .catch(() => {})
-    fetch(selectorURL(withWorkspace('/agents', workspace)))
+    fetch(selectorURL(apiRoutes.agents.list({ workspace })))
       .then(r => r.ok ? r.json() : [])
       .then((data) => setAgentNames(itemsFromResponse<{ name: string }>(data).map(a => a.name)))
       .catch(() => {})
-    fetch(selectorURL('/prompts'))
+    fetch(selectorURL(apiRoutes.catalog.prompts.list()))
       .then(r => r.ok ? r.json() : [])
       .then((data) => {
         setPromptOptions(itemsFromResponse<GraphPromptItem>(data))
@@ -493,10 +499,10 @@ export default function GraphPage() {
     if (!loadedOnce.current) setLoading(true)
     loadedOnce.current = true
     Promise.all([
-      fetch(withWorkspace('/graph', workspace)).then(r => r.json()),
-      fetch(selectorURL(withWorkspace('/agents', workspace))).then(r => r.json()),
-      fetch(withWorkspace('/graph/layout', workspace)).then(r => r.ok ? r.json() : { positions: [] }),
-      fetch(selectorURL(withWorkspace('/repos', workspace))).then(r => r.ok ? r.json() : []),
+      fetch(apiRoutes.graph.view({ workspace })).then(r => r.json()),
+      fetch(selectorURL(apiRoutes.agents.list({ workspace }))).then(r => r.json()),
+      fetch(apiRoutes.graph.layout({ workspace })).then(r => r.ok ? r.json() : { positions: [] }),
+      fetch(selectorURL(apiRoutes.repos.list({ workspace }))).then(r => r.ok ? r.json() : []),
     ]).then(([gd, ad, ld, rd]) => {
       setGraphData(gd)
       const agentItems = itemsFromResponse<AgentInfo>(ad)
@@ -522,7 +528,7 @@ export default function GraphPage() {
   const loadAgentActivity = useCallback(async (agentName: string) => {
     setAgentActivityLoading(true)
     try {
-      const res = await fetch(withWorkspace('/runners?limit=200', workspace), { cache: 'no-store' })
+      const res = await fetch(apiRoutes.runners.list({ workspace, limit: 200 }), { cache: 'no-store' })
       if (!res.ok) throw new Error(`runners ${res.status}`)
       const data = await res.json() as { runners?: RunnerRow[] }
       const rows = (data.runners ?? [])
@@ -777,7 +783,7 @@ export default function GraphPage() {
     const next = { x: node.position.x, y: node.position.y }
     setLayoutPositions(prev => ({ ...prev, [nodeID]: next }))
     if (nodeID.startsWith('repo-anchor:')) return
-    fetch(withWorkspace('/graph/layout', workspace), {
+    fetch(apiRoutes.graph.layout({ workspace }), {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ positions: [{ node_id: nodeID, x: next.x, y: next.y }] }),
@@ -788,14 +794,14 @@ export default function GraphPage() {
   }, [workspace])
 
   const autoLayout = useCallback(() => {
-    fetch(withWorkspace('/graph/layout', workspace), { method: 'DELETE' }).finally(() => {
+    fetch(apiRoutes.graph.layout({ workspace }), { method: 'DELETE' }).finally(() => {
       setLayoutPositions({})
       load()
     })
   }, [load, workspace])
 
   const fetchStoreAgent = useCallback(async (name: string): Promise<StoreAgent> => {
-    const res = await fetch(withWorkspace(`/agents/${encodeURIComponent(name)}`, workspace))
+    const res = await fetch(apiRoutes.agents.one(name, { workspace }))
     if (!res.ok) throw new Error(`fetch ${name}: ${res.status}`)
     const data = await res.json() as Partial<StoreAgent>
     return storeAgentFromResponse(data, name)
@@ -828,7 +834,7 @@ export default function GraphPage() {
   }, [agentPanelTab, fetchStoreAgent, loadLookups, panelMode, selectedNodeName])
 
   const postStoreAgent = useCallback(async (a: StoreAgent): Promise<void> => {
-    const res = await fetch(withWorkspace('/agents', workspace), {
+    const res = await fetch(apiRoutes.agents.list({ workspace }), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ ...a, workspace_id: workspace }),
@@ -955,7 +961,7 @@ export default function GraphPage() {
     setAgentSaving(true)
     setAgentSaveError('')
     try {
-      const res = await fetch(withWorkspace('/agents', workspace), {
+      const res = await fetch(apiRoutes.agents.list({ workspace }), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ ...form, workspace_id: workspace }),
@@ -1001,7 +1007,8 @@ export default function GraphPage() {
     setBindingSaving(true)
     setBindingError('')
     try {
-      const res = await fetch(withWorkspace(`${repoPath(draft.repo)}/bindings`, workspace), {
+      const [owner, repo] = repoParts(draft.repo)
+      const res = await fetch(apiRoutes.repos.bindings(owner, repo, { workspace }), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(bindingFromDraft(agent, draft)),
@@ -1024,7 +1031,8 @@ export default function GraphPage() {
     setBindingSaving(true)
     setBindingError('')
     try {
-      const res = await fetch(withWorkspace(`${repoPath(repo)}/bindings/${binding.id}`, workspace), {
+      const [owner, repoName] = repoParts(repo)
+      const res = await fetch(apiRoutes.repos.binding(owner, repoName, binding.id, { workspace }), {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ ...binding, enabled }),
@@ -1046,7 +1054,8 @@ export default function GraphPage() {
     setBindingSaving(true)
     setBindingError('')
     try {
-      const res = await fetch(withWorkspace(`${repoPath(repo)}/bindings/${binding.id}`, workspace), { method: 'DELETE' })
+      const [owner, repoName] = repoParts(repo)
+      const res = await fetch(apiRoutes.repos.binding(owner, repoName, binding.id, { workspace }), { method: 'DELETE' })
       if (!res.ok && res.status !== 204) {
         setBindingError((await res.text()) || 'Binding delete failed')
         return
@@ -1098,7 +1107,7 @@ export default function GraphPage() {
     setPromptSaving(true)
     setPromptSaveError('')
     try {
-      const res = await fetch(`/prompts/${encodeURIComponent(graphPromptIdentifier(selectedPrompt))}`, {
+      const res = await fetch(apiRoutes.catalog.prompts.one(graphPromptIdentifier(selectedPrompt)), {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ description: selectedPrompt.description ?? '', content: promptDraft }),

--- a/internal/ui/src/app/improvements/page.tsx
+++ b/internal/ui/src/app/improvements/page.tsx
@@ -3,9 +3,9 @@ import { type CSSProperties, type ReactNode, useCallback, useEffect, useMemo, us
 import MarkdownEditor from '@/components/MarkdownEditor'
 import Modal from '@/components/Modal'
 import PaginationControls from '@/components/PaginationControls'
+import { apiRoutes } from '@/lib/api-routes'
 import { formatDateTime } from '@/lib/datetime'
 import { pageFromResponse } from '@/lib/pagination'
-import { withWorkspace } from '@/lib/workspace'
 
 interface FeedbackEvent {
   id: number
@@ -238,10 +238,9 @@ function diffLines(oldText: string, newText: string) {
 }
 
 function catalogAssetEndpoint(type: string, id: string) {
-  const encoded = encodeURIComponent(id)
-  if (type === 'prompt') return `/prompts/${encoded}`
-  if (type === 'skill') return `/skills/${encoded}`
-  if (type === 'guardrail') return `/guardrails/${encoded}`
+  if (type === 'prompt') return apiRoutes.catalog.prompts.one(id)
+  if (type === 'skill') return apiRoutes.catalog.skills.one(id)
+  if (type === 'guardrail') return apiRoutes.catalog.guardrails.one(id)
   return ''
 }
 
@@ -508,9 +507,9 @@ function catalogTargetLabel(assetType: string | undefined, assetID: string | und
 }
 
 function catalogEndpointForType(assetType: string) {
-  if (assetType === 'prompt') return '/prompts'
-  if (assetType === 'skill') return '/skills'
-  if (assetType === 'guardrail') return '/guardrails'
+  if (assetType === 'prompt') return apiRoutes.catalog.prompts.list()
+  if (assetType === 'skill') return apiRoutes.catalog.skills.list()
+  if (assetType === 'guardrail') return apiRoutes.catalog.guardrails.list()
   return ''
 }
 
@@ -553,10 +552,9 @@ export default function ImprovementsPage() {
 
   const load = useCallback((showLoading = true) => {
     if (showLoading) setLoading(true)
-    const statusParam = status ? `&status=${encodeURIComponent(status)}` : ''
     Promise.all([
-      fetch(`/improvements/feedback?limit=${feedbackLimit}&offset=${feedbackOffset}${statusParam}`, { cache: 'no-store' }).then(r => r.ok ? r.json() : []),
-      fetch(`/improvements/recommendations?limit=${recommendationsLimit}&offset=${recommendationsOffset}${statusParam}`, { cache: 'no-store' }).then(r => r.ok ? r.json() : []),
+      fetch(apiRoutes.improvements.feedback({ limit: feedbackLimit, offset: feedbackOffset, status }), { cache: 'no-store' }).then(r => r.ok ? r.json() : []),
+      fetch(apiRoutes.improvements.recommendations({ limit: recommendationsLimit, offset: recommendationsOffset, status }), { cache: 'no-store' }).then(r => r.ok ? r.json() : []),
     ])
       .then(([feedbackRows, recommendationRows]) => {
         const feedbackPage = pageFromResponse<FeedbackEvent>(feedbackRows, feedbackLimit, feedbackOffset)
@@ -645,7 +643,7 @@ export default function ImprovementsPage() {
   }, {}), [recommendations])
 
   const updateStatus = async (id: string, next: string, reason = '') => {
-    const res = await fetch(`/improvements/recommendations/${encodeURIComponent(id)}/status`, {
+    const res = await fetch(apiRoutes.improvements.recommendationStatus(id), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ status: next, reason }),
@@ -673,7 +671,7 @@ export default function ImprovementsPage() {
   const openClarification = async (row: Recommendation) => {
     setClarifying(row)
     setClarificationBody(row.clarification?.body ?? '')
-    const res = await fetch(`/improvements/recommendations/${encodeURIComponent(row.id)}`, { cache: 'no-store' })
+    const res = await fetch(apiRoutes.improvements.recommendation(row.id), { cache: 'no-store' })
     if (!res.ok) return
     const detail = await res.json()
     setClarifying(detail)
@@ -683,7 +681,7 @@ export default function ImprovementsPage() {
   const submitClarification = async () => {
     if (!clarifying || clarificationSaving) return
     setClarificationSaving(true)
-    const res = await fetch(`/improvements/recommendations/${encodeURIComponent(clarifying.id)}/clarification`, {
+    const res = await fetch(apiRoutes.improvements.clarification(clarifying.id), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ body: clarificationBody }),
@@ -698,7 +696,7 @@ export default function ImprovementsPage() {
 
   const reanalyzeRecommendation = async (row: Recommendation) => {
     setActionMessage(null)
-    const res = await fetch(`/improvements/feedback/${row.feedback_event_id}/analyze`, { method: 'POST' })
+    const res = await fetch(apiRoutes.improvements.analyzeFeedback(row.feedback_event_id), { method: 'POST' })
     if (res.ok) {
       setActionMessage('Re-analysis queued.')
       load()
@@ -715,7 +713,7 @@ export default function ImprovementsPage() {
       await reanalyzeRecommendation(row)
       return
     }
-    const res = await fetch(`/improvements/recommendations/${encodeURIComponent(row.id)}/clarification`, {
+    const res = await fetch(apiRoutes.improvements.clarification(row.id), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ body }),
@@ -732,7 +730,7 @@ export default function ImprovementsPage() {
   const editBundleItem = async (bundleID: string, item: ProposalBundleItem) => {
     const draft = bundleItemDraft(item, itemDrafts)
     const proposedScope = item.operation === 'create_new' && reviewingProposal ? resolvedBundleScopeValue(draft.proposed_scope, reviewingProposal) : draft.proposed_scope
-    const res = await fetch(`/improvements/proposal-bundles/${encodeURIComponent(bundleID)}/items/${encodeURIComponent(item.id)}`, {
+    const res = await fetch(apiRoutes.improvements.bundleItem(bundleID, item.id), {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -793,7 +791,7 @@ export default function ImprovementsPage() {
     if (!bundleDecision || bundleDecisionSaving) return
     setBundleDecisionSaving(true)
     if (bundleDecision.kind === 'reject') {
-      const res = await fetch(`/improvements/proposal-bundles/${encodeURIComponent(bundleDecision.bundleID)}/items/${encodeURIComponent(bundleDecision.itemID)}/reject`, {
+      const res = await fetch(apiRoutes.improvements.rejectBundleItem(bundleDecision.bundleID, bundleDecision.itemID), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ reason: bundleDecision.reason }),
@@ -812,7 +810,7 @@ export default function ImprovementsPage() {
       setBundleDecisionSaving(false)
       return
     }
-    const res = await fetch(`/improvements/proposal-bundles/${encodeURIComponent(bundleDecision.bundleID)}/items/${encodeURIComponent(bundleDecision.itemID)}/link-existing`, {
+    const res = await fetch(apiRoutes.improvements.linkExistingBundleItem(bundleDecision.bundleID, bundleDecision.itemID), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ asset_id: assetID, reason: bundleDecision.reason }),
@@ -825,7 +823,8 @@ export default function ImprovementsPage() {
   }
 
   const postBundleAction = async (bundleID: string, action: 'publish' | 'discard') => {
-    const res = await fetch(`/improvements/proposal-bundles/${encodeURIComponent(bundleID)}/${action}`, { method: 'POST' })
+    const route = action === 'publish' ? apiRoutes.improvements.publishBundle(bundleID) : apiRoutes.improvements.discardBundle(bundleID)
+    const res = await fetch(route, { method: 'POST' })
     if (res.ok) {
       load()
       return
@@ -870,7 +869,7 @@ export default function ImprovementsPage() {
     setLinkingSkillItem(item.id)
     setActionMessage(null)
     try {
-      const url = withWorkspace(`/agents/${encodeURIComponent(agentName)}`, targetWorkspace)
+      const url = apiRoutes.agents.one(agentName, { workspace: targetWorkspace })
       const read = await fetch(url, { cache: 'no-store' })
       if (!read.ok) throw new Error(`read agent returned HTTP ${read.status}`)
       const agent = await read.json()

--- a/internal/ui/src/app/memory/page.tsx
+++ b/internal/ui/src/app/memory/page.tsx
@@ -2,10 +2,11 @@
 import { useState, useEffect, useRef } from 'react'
 import Card from '@/components/Card'
 import WorkspaceSelect from '@/components/WorkspaceSelect'
+import { apiRoutes } from '@/lib/api-routes'
 import { formatDateTime } from '@/lib/datetime'
 import { itemsFromResponse, selectorURL } from '@/lib/pagination'
 import { openAuthenticatedSSE } from '@/lib/sse'
-import { useSelectedWorkspace, withWorkspace } from '@/lib/workspace'
+import { useSelectedWorkspace } from '@/lib/workspace'
 
 interface Agent {
   name: string
@@ -28,7 +29,7 @@ export default function MemoryPage() {
   const { workspace } = useSelectedWorkspace()
 
   useEffect(() => {
-    fetch(selectorURL(withWorkspace('/agents', workspace)))
+    fetch(selectorURL(apiRoutes.agents.list({ workspace })))
       .then(r => r.json())
       .then(data => setAgents(itemsFromResponse<Agent>(data)))
       .catch(() => {})
@@ -41,7 +42,7 @@ export default function MemoryPage() {
 
   // Watch memory stream for change notifications
   useEffect(() => {
-    const stream = openAuthenticatedSSE(withWorkspace('/memory/stream', workspace), {
+    const stream = openAuthenticatedSSE(apiRoutes.memory.stream({ workspace }), {
       onOpen: () => setStreaming(true),
       onMessage: data => {
         try {
@@ -58,7 +59,7 @@ export default function MemoryPage() {
 
   const loadFile = (agent: string, repoKey: string) => {
     setLoading(true)
-    fetch(withWorkspace(`/memory/${encodeURIComponent(agent)}/${encodeURIComponent(repoKey)}`, workspace))
+    fetch(apiRoutes.memory.one(agent, repoKey, { workspace }))
       .then(async r => {
         if (!r.ok) throw new Error(`${r.status}`)
         const text = await r.text()

--- a/internal/ui/src/app/page.tsx
+++ b/internal/ui/src/app/page.tsx
@@ -10,8 +10,9 @@ import RunButton from '@/components/RunButton'
 import WorkspaceSelect from '@/components/WorkspaceSelect'
 import AgentForm, { emptyAgentForm, type BackendOption, type StoreAgent } from '@/components/AgentForm'
 import { formatDateTime } from '@/lib/datetime'
+import { apiRoutes } from '@/lib/api-routes'
 import { itemsFromResponse, pageFromResponse, selectorURL } from '@/lib/pagination'
-import { useSelectedWorkspace, withWorkspace, type CatalogItem } from '@/lib/workspace'
+import { useSelectedWorkspace, type CatalogItem } from '@/lib/workspace'
 
 interface Binding {
   repo: string
@@ -145,23 +146,23 @@ export default function FleetPage() {
 
   const loadRef = useRef(false)
   const loadLookups = () => {
-    fetch(selectorURL('/backends'))
+    fetch(selectorURL(apiRoutes.backends.list()))
       .then(r => r.ok ? r.json() : [])
       .then((data) => setBackendOptions(itemsFromResponse<BackendOption>(data).filter(b => b.detected !== false)))
       .catch(() => {})
-    fetch(selectorURL('/skills'))
+    fetch(selectorURL(apiRoutes.catalog.skills.list()))
       .then(r => r.ok ? r.json() : [])
       .then((data) => setSkillOptions(itemsFromResponse<CatalogItem>(data)))
       .catch(() => {})
-    fetch(selectorURL(withWorkspace('/agents', workspace)))
+    fetch(selectorURL(apiRoutes.agents.list({ workspace })))
       .then(r => r.ok ? r.json() : [])
       .then((data) => setAgentNames(itemsFromResponse<{ name: string }>(data).map(a => a.name)))
       .catch(() => {})
-    fetch(selectorURL('/prompts'))
+    fetch(selectorURL(apiRoutes.catalog.prompts.list()))
       .then(r => r.ok ? r.json() : [])
       .then((data) => setPromptOptions(itemsFromResponse<CatalogItem>(data)))
       .catch(() => {})
-    fetch(selectorURL(withWorkspace('/repos', workspace)))
+    fetch(selectorURL(apiRoutes.repos.list({ workspace })))
       .then(r => r.ok ? r.json() : [])
       .then((data) => setRepoNames(itemsFromResponse<{ name: string }>(data).map(r => r.name)))
       .catch(() => {})
@@ -170,7 +171,7 @@ export default function FleetPage() {
   const load = () => {
     if (!loadRef.current) setLoading(true)
     loadRef.current = true
-    fetch(withWorkspace(`/agents?limit=${limit}&offset=${offset}`, workspace))
+    fetch(apiRoutes.agents.list({ workspace, limit, offset }))
       .then(r => r.json())
       .then(data => {
         const page = pageFromResponse<Agent>(data, limit, offset)
@@ -213,7 +214,7 @@ export default function FleetPage() {
     })
     setModal('edit')
     try {
-      const res = await fetch(withWorkspace(`/agents/${encodeURIComponent(agentName)}`, workspace))
+      const res = await fetch(apiRoutes.agents.one(agentName, { workspace }))
       if (res.ok) {
         const data = await res.json() as Partial<StoreAgent>
         setSelected({
@@ -249,7 +250,7 @@ export default function FleetPage() {
     setSaving(true)
     setSaveError('')
     try {
-      const res = await fetch(withWorkspace('/agents', workspace), {
+      const res = await fetch(apiRoutes.agents.list({ workspace }), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ ...form, workspace_id: workspace }),
@@ -280,7 +281,7 @@ export default function FleetPage() {
     setSaving(true)
     try {
       const cascade = deleteTarget.bindings.length > 0
-      const url = withWorkspace(`/agents/${encodeURIComponent(deleteTarget.name)}${cascade ? '?cascade=true' : ''}`, workspace)
+      const url = apiRoutes.agents.one(deleteTarget.name, cascade ? { workspace, cascade: true } : { workspace })
       const res = await fetch(url, { method: 'DELETE' })
       if (!res.ok && res.status !== 204) {
         const msg = await res.text()

--- a/internal/ui/src/app/prompts/page.tsx
+++ b/internal/ui/src/app/prompts/page.tsx
@@ -6,6 +6,7 @@ import Modal from '@/components/Modal'
 import PaginationControls from '@/components/PaginationControls'
 import MarkdownEditor from '@/components/MarkdownEditor'
 import CatalogVersionsPanel from '@/components/CatalogVersionsPanel'
+import { apiRoutes } from '@/lib/api-routes'
 import { itemsFromResponse, pageFromResponse, selectorURL } from '@/lib/pagination'
 
 interface Prompt {
@@ -56,7 +57,7 @@ export default function PromptsPage() {
 
   const load = () => {
     setLoading(true)
-    fetch(`/prompts?limit=${limit}&offset=${offset}`, { cache: 'no-store' })
+    fetch(apiRoutes.catalog.prompts.list({ limit, offset }), { cache: 'no-store' })
       .then(r => r.ok ? r.json() : [])
       .then((data) => {
         const page = pageFromResponse<Prompt>(data, limit, offset)
@@ -69,7 +70,7 @@ export default function PromptsPage() {
 
   useEffect(() => {
     load()
-    fetch(selectorURL('/workspaces'), { cache: 'no-store' })
+    fetch(selectorURL(apiRoutes.workspaces.list()), { cache: 'no-store' })
       .then(r => r.ok ? r.json() : [])
       .then((data) => setWorkspaces(itemsFromResponse<Workspace>(data)))
       .catch(() => setWorkspaces([]))
@@ -80,7 +81,7 @@ export default function PromptsPage() {
       setRepos([])
       return
     }
-    fetch(selectorURL(`/repos?workspace=${encodeURIComponent(selected.workspace_id)}`), { cache: 'no-store' })
+    fetch(selectorURL(apiRoutes.repos.list({ workspace: selected.workspace_id })), { cache: 'no-store' })
       .then(r => r.ok ? r.json() : [])
       .then((data) => setRepos(itemsFromResponse<Repo>(data)))
       .catch(() => setRepos([]))
@@ -91,7 +92,7 @@ export default function PromptsPage() {
       setFilterRepos([])
       return
     }
-    fetch(selectorURL(`/repos?workspace=${encodeURIComponent(filterWorkspace)}`), { cache: 'no-store' })
+    fetch(selectorURL(apiRoutes.repos.list({ workspace: filterWorkspace })), { cache: 'no-store' })
       .then(r => r.ok ? r.json() : [])
       .then((data) => setFilterRepos(itemsFromResponse<Repo>(data)))
       .catch(() => setFilterRepos([]))
@@ -101,7 +102,7 @@ export default function PromptsPage() {
     setSaving(true)
     setError('')
     const isNew = modal === 'create'
-    const url = isNew ? '/prompts' : `/prompts/${encodeURIComponent(selected.id || selected.name)}`
+    const url = isNew ? apiRoutes.catalog.prompts.list() : apiRoutes.catalog.prompts.one(selected.id || selected.name)
     const body = isNew
       ? {
           ...selected,
@@ -132,7 +133,7 @@ export default function PromptsPage() {
     setSaving(true)
     setError('')
     try {
-      const res = await fetch(`/prompts/${encodeURIComponent(selected.id || selected.name)}`, { method: 'DELETE' })
+      const res = await fetch(apiRoutes.catalog.prompts.one(selected.id || selected.name), { method: 'DELETE' })
       if (!res.ok && res.status !== 204) {
         setError(await res.text() || 'Delete failed')
         setSaving(false)

--- a/internal/ui/src/app/repos/page.tsx
+++ b/internal/ui/src/app/repos/page.tsx
@@ -6,9 +6,10 @@ import PaginationControls from '@/components/PaginationControls'
 import BadgePicker from '@/components/BadgePicker'
 import RunButton from '@/components/RunButton'
 import WorkspaceSelect from '@/components/WorkspaceSelect'
+import { apiRoutes } from '@/lib/api-routes'
 import { Binding, groupByAgent, bindingsEqual } from '@/lib/bindings'
 import { itemsFromResponse, pageFromResponse, selectorURL } from '@/lib/pagination'
-import { useSelectedWorkspace, withWorkspace } from '@/lib/workspace'
+import { useSelectedWorkspace } from '@/lib/workspace'
 
 interface Repo {
   name: string
@@ -396,7 +397,7 @@ export default function ReposPage() {
 
   const load = useCallback(() => {
     setLoading(true)
-    fetch(withWorkspace(`/repos?limit=${limit}&offset=${offset}`, workspace))
+    fetch(apiRoutes.repos.list({ workspace, limit, offset }))
       .then(r => r.json())
       .then((data) => {
         const page = pageFromResponse<Repo>(data, limit, offset)
@@ -413,7 +414,7 @@ export default function ReposPage() {
 
   useEffect(() => {
     load()
-    fetch(selectorURL(withWorkspace('/agents', workspace)))
+    fetch(selectorURL(apiRoutes.agents.list({ workspace })))
       .then(r => r.ok ? r.json() : [])
       .then((data) => setAgentNames(itemsFromResponse<{ name: string }>(data).map(a => a.name)))
       .catch(() => { /* store not configured, no-op */ })
@@ -449,7 +450,7 @@ export default function ReposPage() {
     try {
       const isNew = !repos.some(r => r.name === form.name)
       if (isNew) {
-        const res = await fetch(withWorkspace('/repos', workspace), {
+        const res = await fetch(apiRoutes.repos.list({ workspace }), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ ...form, workspace_id: workspace }),
@@ -470,35 +471,37 @@ export default function ReposPage() {
         }
         const seenIDs = new Set<number>()
         const ops: Promise<Response>[] = []
-        const encRepo = (n: string) => {
+        const repoParts = (n: string): [string, string] => {
           const [o, r] = n.split('/')
-          return `/repos/${encodeURIComponent(o)}/${encodeURIComponent(r)}`
+          return [o, r]
         }
         for (const b of form.bindings) {
+          const [owner, repo] = repoParts(form.name)
           if (typeof b.id === 'number' && originalById.has(b.id)) {
             seenIDs.add(b.id)
             if (!bindingsEqual(originalById.get(b.id)!, b)) {
-              ops.push(fetch(withWorkspace(`${encRepo(form.name)}/bindings/${b.id}`, workspace), {
+              ops.push(fetch(apiRoutes.repos.binding(owner, repo, b.id, { workspace }), {
                 method: 'PATCH',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(b),
               }))
             }
           } else {
-            ops.push(fetch(withWorkspace(`${encRepo(form.name)}/bindings`, workspace), {
+            ops.push(fetch(apiRoutes.repos.bindings(owner, repo, { workspace }), {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify(b),
             }))
           }
         }
+        const [owner, repo] = repoParts(form.name)
         for (const b of original.bindings) {
           if (typeof b.id === 'number' && !seenIDs.has(b.id)) {
-            ops.push(fetch(withWorkspace(`${encRepo(form.name)}/bindings/${b.id}`, workspace), { method: 'DELETE' }))
+            ops.push(fetch(apiRoutes.repos.binding(owner, repo, b.id, { workspace }), { method: 'DELETE' }))
           }
         }
         if (form.enabled !== original.enabled) {
-          ops.push(fetch(withWorkspace(encRepo(form.name), workspace), {
+          ops.push(fetch(apiRoutes.repos.one(owner, repo, { workspace }), {
             method: 'PATCH',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ enabled: form.enabled }),
@@ -525,7 +528,7 @@ export default function ReposPage() {
     setSaving(true)
     const [owner, repo] = deleteTarget.split('/')
     try {
-      const res = await fetch(withWorkspace(`/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`, workspace), { method: 'DELETE' })
+      const res = await fetch(apiRoutes.repos.one(owner, repo, { workspace }), { method: 'DELETE' })
       if (!res.ok && res.status !== 204) {
         setSaveError((await res.text()) || 'Delete failed')
         setSaving(false)

--- a/internal/ui/src/app/runners/page.tsx
+++ b/internal/ui/src/app/runners/page.tsx
@@ -10,8 +10,9 @@ import RepoFilter from '@/components/RepoFilter'
 import WorkspaceSelect from '@/components/WorkspaceSelect'
 import { formatDateTime, formatTime } from '@/lib/datetime'
 import { fmtDuration } from '@/lib/format'
+import { apiRoutes } from '@/lib/api-routes'
 import { newRunnerTimeoutTracker, observeRunnerTimeouts } from '@/lib/runner-timeouts'
-import { useSelectedWorkspace, withWorkspace } from '@/lib/workspace'
+import { useSelectedWorkspace } from '@/lib/workspace'
 
 interface RunnerRow {
   id: number
@@ -125,7 +126,7 @@ function RunnersInner() {
 
   const load = async () => {
     try {
-      const url = withWorkspace(`/runners?limit=${limit}&offset=${offset}${status ? `&status=${status}` : ''}`, workspace)
+      const url = apiRoutes.runners.list({ workspace, limit, offset, status })
       const res = await fetch(url, { cache: 'no-store' })
       if (!res.ok) throw new Error(`status ${res.status}`)
       const data: ListResponse = await res.json()
@@ -205,7 +206,7 @@ function RunnersInner() {
     setDialog(null)
     setPendingId(id)
     try {
-      const res = await fetch(`/runners/${id}`, { method: 'DELETE' })
+      const res = await fetch(apiRoutes.runners.one(id), { method: 'DELETE' })
       if (!res.ok && res.status !== 404) {
         const body = await res.text()
         setDialog({ kind: 'error', title: 'Delete failed', message: body || `HTTP ${res.status}` })
@@ -220,7 +221,7 @@ function RunnersInner() {
     setDialog(null)
     setPendingId(id)
     try {
-      const res = await fetch(`/runners/${id}/retry`, { method: 'POST' })
+      const res = await fetch(apiRoutes.runners.retry(id), { method: 'POST' })
       if (!res.ok) {
         const body = await res.text()
         setDialog({ kind: 'error', title: 'Retry failed', message: body || `HTTP ${res.status}` })

--- a/internal/ui/src/app/skills/page.tsx
+++ b/internal/ui/src/app/skills/page.tsx
@@ -5,6 +5,7 @@ import Modal from '@/components/Modal'
 import PaginationControls from '@/components/PaginationControls'
 import MarkdownEditor from '@/components/MarkdownEditor'
 import CatalogVersionsPanel from '@/components/CatalogVersionsPanel'
+import { apiRoutes } from '@/lib/api-routes'
 import { itemsFromResponse, pageFromResponse, selectorURL } from '@/lib/pagination'
 
 interface Skill {
@@ -83,7 +84,7 @@ function SkillForm({
       setRepoOptions([])
       return
     }
-    fetch(selectorURL(`/repos?workspace=${encodeURIComponent(form.workspace_id)}`), { cache: 'no-store' })
+    fetch(selectorURL(apiRoutes.repos.list({ workspace: form.workspace_id })), { cache: 'no-store' })
       .then(r => r.ok ? r.json() : [])
       .then((data) => setRepoOptions(itemsFromResponse<Repo>(data)))
       .catch(() => setRepoOptions([]))
@@ -214,7 +215,7 @@ export default function SkillsPage() {
 
   const load = () => {
     setLoading(true)
-    fetch(`/skills?limit=${limit}&offset=${offset}`)
+    fetch(apiRoutes.catalog.skills.list({ limit, offset }))
       .then(r => r.json())
       .then((data) => {
         const page = pageFromResponse<Skill>(data, limit, offset)
@@ -227,7 +228,7 @@ export default function SkillsPage() {
 
   useEffect(() => {
     load()
-    fetch(selectorURL('/workspaces'), { cache: 'no-store' })
+    fetch(selectorURL(apiRoutes.workspaces.list()), { cache: 'no-store' })
       .then(r => r.ok ? r.json() : [])
       .then((data) => setWorkspaces(itemsFromResponse<Workspace>(data)))
       .catch(() => setWorkspaces([]))
@@ -238,7 +239,7 @@ export default function SkillsPage() {
       setFilterRepos([])
       return
     }
-    fetch(selectorURL(`/repos?workspace=${encodeURIComponent(filterWorkspace)}`), { cache: 'no-store' })
+    fetch(selectorURL(apiRoutes.repos.list({ workspace: filterWorkspace })), { cache: 'no-store' })
       .then(r => r.ok ? r.json() : [])
       .then((data) => setFilterRepos(itemsFromResponse<Repo>(data)))
       .catch(() => setFilterRepos([]))
@@ -261,7 +262,7 @@ export default function SkillsPage() {
     setSaveError('')
     try {
       const isNew = modal === 'create'
-      const res = await fetch(isNew ? '/skills' : `/skills/${encodeURIComponent(stableSkillID(form))}`, {
+      const res = await fetch(isNew ? apiRoutes.catalog.skills.list() : apiRoutes.catalog.skills.one(stableSkillID(form)), {
         method: isNew ? 'POST' : 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(isNew ? {
@@ -294,7 +295,7 @@ export default function SkillsPage() {
     if (!deleteTarget) return
     setSaving(true)
     try {
-      const res = await fetch(`/skills/${encodeURIComponent(stableSkillID(deleteTarget))}`, { method: 'DELETE' })
+      const res = await fetch(apiRoutes.catalog.skills.one(stableSkillID(deleteTarget)), { method: 'DELETE' })
       if (!res.ok && res.status !== 204) {
         setSaveError((await res.text()) || 'Delete failed')
         setSaving(false)

--- a/internal/ui/src/app/traces/page.tsx
+++ b/internal/ui/src/app/traces/page.tsx
@@ -8,11 +8,12 @@ import Link from 'next/link'
 import RepoFilter, { useRepoFilter } from '@/components/RepoFilter'
 import WorkspaceSelect from '@/components/WorkspaceSelect'
 import { StreamCard, TranscriptFilter, allStreamCardKinds, stepToCardEntries, type PersistedStep, type StreamCardKind } from '@/components/StreamCard'
+import { apiRoutes } from '@/lib/api-routes'
 import { formatDateTime } from '@/lib/datetime'
 import { fmtDuration } from '@/lib/format'
 import { pageFromResponse } from '@/lib/pagination'
 import { openAuthenticatedSSE } from '@/lib/sse'
-import { useSelectedWorkspace, withWorkspace } from '@/lib/workspace'
+import { useSelectedWorkspace } from '@/lib/workspace'
 
 type TraceStep = PersistedStep
 
@@ -74,7 +75,7 @@ function PromptPanel({ span }: { span: Span }) {
   const toggle = () => {
     if (!open && text === null) {
       setLoading(true)
-      fetch(`/traces/${encodeURIComponent(span.span_id)}/prompt`)
+      fetch(apiRoutes.traces.prompt(span.span_id))
         .then(async r => {
           if (r.status === 404) { setText(''); return }
           if (!r.ok) throw new Error(`status ${r.status}`)
@@ -191,7 +192,7 @@ function SpanTranscript({ spanId, stepCount }: { spanId: string; stepCount?: num
   const toggle = () => {
     if (!open && steps === null) {
       setLoading(true)
-      fetch(`/traces/${encodeURIComponent(spanId)}/steps`)
+      fetch(apiRoutes.traces.steps(spanId))
         .then(r => r.json())
         .then((data: TraceStep[]) => { setSteps(data ?? []); setLoading(false) })
         .catch(() => { setSteps([]); setLoading(false) })
@@ -390,7 +391,7 @@ function TracesContent() {
 
   const load = () => {
     setLoading(true)
-    fetch(withWorkspace(`/traces?limit=${limit}&offset=${offset}`, workspace))
+    fetch(apiRoutes.traces.list({ workspace, limit, offset }))
       .then(r => r.json())
       .then(data => {
         const page = pageFromResponse<Span>(data, limit, offset)
@@ -403,7 +404,7 @@ function TracesContent() {
 
   useEffect(() => {
     load()
-    const stream = openAuthenticatedSSE(withWorkspace('/traces/stream', workspace), {
+    const stream = openAuthenticatedSSE(apiRoutes.traces.stream({ workspace }), {
       onOpen: () => setStreaming(true),
       onMessage: data => {
         try {

--- a/internal/ui/src/app/workspaces/page.tsx
+++ b/internal/ui/src/app/workspaces/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import Card from '@/components/Card'
 import Modal from '@/components/Modal'
 import PaginationControls from '@/components/PaginationControls'
+import { apiRoutes } from '@/lib/api-routes'
 import { itemsFromResponse } from '@/lib/pagination'
 import { defaultWorkspaceID } from '@/lib/workspace'
 
@@ -120,7 +121,7 @@ export default function WorkspacesPage() {
   const load = () => {
     setLoading(true)
     setError('')
-    fetch(`/workspaces?limit=${limit}&offset=${offset}`, { cache: 'no-store' })
+    fetch(apiRoutes.workspaces.list({ limit, offset }), { cache: 'no-store' })
       .then(async res => {
         if (!res.ok) throw new Error((await res.text()) || 'Failed to load workspaces')
         return res.json()
@@ -165,7 +166,7 @@ export default function WorkspacesPage() {
     const body = isNew
       ? { id: workspace.id.trim(), name: workspace.name.trim(), description: (workspace.description ?? '').trim() }
       : { name: workspace.name.trim(), description: (workspace.description ?? '').trim() }
-    const url = isNew ? '/workspaces' : `/workspaces/${encodeURIComponent(selected.id)}`
+    const url = isNew ? apiRoutes.workspaces.list() : apiRoutes.workspaces.one(selected.id)
     try {
       const res = await fetch(url, {
         method: isNew ? 'POST' : 'PATCH',
@@ -189,7 +190,7 @@ export default function WorkspacesPage() {
     setSaving(true)
     setSaveError('')
     try {
-      const res = await fetch(`/workspaces/${encodeURIComponent(selected.id)}`, { method: 'DELETE' })
+      const res = await fetch(apiRoutes.workspaces.one(selected.id), { method: 'DELETE' })
       if (!res.ok && res.status !== 204) {
         setSaveError((await res.text()) || 'Delete failed')
         setSaving(false)

--- a/internal/ui/src/components/CatalogVersionsPanel.tsx
+++ b/internal/ui/src/components/CatalogVersionsPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { ReactNode } from 'react'
+import { apiRoutes } from '@/lib/api-routes'
 import { formatDateTime } from '@/lib/datetime'
 
 type AssetType = 'prompt' | 'skill' | 'guardrail'
@@ -34,10 +35,10 @@ interface CatalogVersionReference {
 
 const panelBorder = '1px solid var(--border)'
 
-function assetPath(type: AssetType) {
-  if (type === 'prompt') return 'prompts'
-  if (type === 'skill') return 'skills'
-  return 'guardrails'
+function assetRoutes(type: AssetType) {
+  if (type === 'prompt') return apiRoutes.catalog.prompts
+  if (type === 'skill') return apiRoutes.catalog.skills
+  return apiRoutes.catalog.guardrails
 }
 
 function versionBody(type: AssetType, version: CatalogVersion) {
@@ -175,7 +176,7 @@ export default function CatalogVersionsPanel({
   const load = useCallback((signal?: AbortSignal) => {
     if (!assetID) return
     setError('')
-    fetch(`/${assetPath(type)}/${encodeURIComponent(assetID)}/versions`, { cache: 'no-store', signal })
+    fetch(assetRoutes(type).versions(assetID), { cache: 'no-store', signal })
       .then(r => {
         if (!r.ok) throw new Error(`load versions: ${r.status}`)
         return r.json()
@@ -185,7 +186,7 @@ export default function CatalogVersionsPanel({
         setVersions(next)
         setExpanded(e => e || next[0]?.id || '')
         return Promise.all(next.map(v =>
-          fetch(`/${assetPath(type)}/${encodeURIComponent(assetID)}/versions/${encodeURIComponent(v.id)}/references`, { cache: 'no-store', signal })
+          fetch(assetRoutes(type).versionReferences(assetID, v.id), { cache: 'no-store', signal })
             .then(r => {
               if (!r.ok) throw new Error(`load references: ${r.status}`)
               return r.json()

--- a/internal/ui/src/components/DashboardShell.tsx
+++ b/internal/ui/src/components/DashboardShell.tsx
@@ -2,6 +2,7 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useEffect, useState } from 'react'
+import { apiRoutes } from '@/lib/api-routes'
 import { SIDEBAR_COLLAPSE_EVENT } from '@/lib/shell-events'
 import { useTheme } from '@/lib/theme'
 
@@ -38,7 +39,7 @@ export default function DashboardShell({ children }: { children: React.ReactNode
   const [budgetAlertCount, setBudgetAlertCount] = useState(0)
 
   const signOut = async () => {
-    await fetch('/auth/logout', { method: 'POST', credentials: 'same-origin' })
+    await fetch(apiRoutes.auth.logout(), { method: 'POST', credentials: 'same-origin' })
     window.location.replace('/')
   }
 
@@ -77,7 +78,7 @@ export default function DashboardShell({ children }: { children: React.ReactNode
     let cancelled = false
     const load = async () => {
       try {
-        const res = await fetch('/status', { cache: 'no-store' })
+        const res = await fetch(apiRoutes.status(), { cache: 'no-store' })
         if (!res.ok) return
         const data = await res.json() as { orphaned_agents?: { count?: number } }
         if (!cancelled) setOrphanCount(Number(data.orphaned_agents?.count ?? 0))
@@ -97,7 +98,7 @@ export default function DashboardShell({ children }: { children: React.ReactNode
     let cancelled = false
     const load = async () => {
       try {
-        const res = await fetch('/token_budgets/alerts', { cache: 'no-store' })
+        const res = await fetch(apiRoutes.tokenBudgets.alerts(), { cache: 'no-store' })
         if (!res.ok) return
         const data = await res.json() as { count?: number }
         if (!cancelled) setBudgetAlertCount(Number(data.count ?? 0))

--- a/internal/ui/src/components/GuardrailsManager.tsx
+++ b/internal/ui/src/components/GuardrailsManager.tsx
@@ -7,6 +7,7 @@ import MarkdownEditor from '@/components/MarkdownEditor'
 import WorkspaceSelect from '@/components/WorkspaceSelect'
 import CatalogVersionsPanel from '@/components/CatalogVersionsPanel'
 import PaginationControls from '@/components/PaginationControls'
+import { apiRoutes } from '@/lib/api-routes'
 import { itemsFromResponse, pageFromResponse, selectorURL } from '@/lib/pagination'
 import { useSelectedWorkspace } from '@/lib/workspace'
 
@@ -209,15 +210,15 @@ export default function GuardrailsManager() {
     setLoading(true)
     setLoadError('')
     Promise.all([
-      fetch(`/guardrails?limit=${guardrailsLimit}&offset=${guardrailsOffset}`).then(r => {
+      fetch(apiRoutes.catalog.guardrails.list({ limit: guardrailsLimit, offset: guardrailsOffset })).then(r => {
         if (!r.ok) throw new Error(`load guardrails: ${r.status}`)
         return r.json()
       }),
-      fetch(selectorURL('/guardrails')).then(r => {
+      fetch(selectorURL(apiRoutes.catalog.guardrails.list())).then(r => {
         if (!r.ok) throw new Error(`load guardrail lookups: ${r.status}`)
         return r.json()
       }),
-      fetch(`/workspaces/${encodeURIComponent(workspace)}/guardrails`).then(r => {
+      fetch(apiRoutes.workspaces.guardrails(workspace)).then(r => {
         if (!r.ok) throw new Error(`load workspace guardrails: ${r.status}`)
         return r.json()
       }),
@@ -274,7 +275,7 @@ export default function GuardrailsManager() {
         position: index,
         enabled: ref.enabled,
       }))
-      const res = await fetch(`/workspaces/${encodeURIComponent(workspace)}/guardrails`, {
+      const res = await fetch(apiRoutes.workspaces.guardrails(workspace), {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
@@ -327,7 +328,7 @@ export default function GuardrailsManager() {
     setSaveError('')
     try {
       const isNew = modal === 'create'
-      const url = isNew ? '/guardrails' : `/guardrails/${encodeURIComponent(guardrailID(g))}`
+      const url = isNew ? apiRoutes.catalog.guardrails.list() : apiRoutes.catalog.guardrails.one(guardrailID(g))
       const method = isNew ? 'POST' : 'PATCH'
       const body = isNew
         ? { name: g.name, workspace_id: g.workspace_id, description: g.description, content: g.content, enabled: g.enabled, position: g.position }
@@ -363,7 +364,7 @@ export default function GuardrailsManager() {
     setSaving(true)
     setSaveError('')
     try {
-      const res = await fetch(`/guardrails/${encodeURIComponent(guardrailID(selected))}`, {
+      const res = await fetch(apiRoutes.catalog.guardrails.one(guardrailID(selected)), {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -389,7 +390,7 @@ export default function GuardrailsManager() {
     setSaving(true)
     setSaveError('')
     try {
-      const res = await fetch(`/guardrails/${encodeURIComponent(guardrailID(selected))}/reset`, { method: 'POST' })
+      const res = await fetch(apiRoutes.catalog.guardrails.reset(guardrailID(selected)), { method: 'POST' })
       if (!res.ok) {
         setSaveError((await res.text()) || 'Reset failed')
         setSaving(false)
@@ -408,7 +409,7 @@ export default function GuardrailsManager() {
     setSaving(true)
     setSaveError('')
     try {
-      const res = await fetch(`/guardrails/${encodeURIComponent(guardrailID(selected))}`, { method: 'DELETE' })
+      const res = await fetch(apiRoutes.catalog.guardrails.one(guardrailID(selected)), { method: 'DELETE' })
       if (!res.ok && res.status !== 204) {
         setSaveError((await res.text()) || 'Delete failed')
         setSaving(false)

--- a/internal/ui/src/components/LiveTraceModal.tsx
+++ b/internal/ui/src/components/LiveTraceModal.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import { StreamCard, TranscriptFilter, allStreamCardKinds, stepToCardEntries, type PersistedStep, type StreamCardEntry, type StreamCardKind } from '@/components/StreamCard'
+import { apiRoutes } from '@/lib/api-routes'
 import { openAuthenticatedSSE } from '@/lib/sse'
 
 export interface LiveTraceSpan {
@@ -21,10 +22,10 @@ export default function LiveTraceModal({ span, onClose }: { span: LiveTraceSpan;
   const stuckToBottom = useRef(true)
   const [hasNewWhileDetached, setHasNewWhileDetached] = useState(false)
   const visibleEntries = entries.filter(e => visibleKinds.has(e.kind))
-  const traceHref = `/traces/?id=${encodeURIComponent(span.rootEventId || span.id)}`
+  const traceHref = `${apiRoutes.traces.list()}?id=${encodeURIComponent(span.rootEventId || span.id)}`
 
   useEffect(() => {
-    const stream = openAuthenticatedSSE(`/traces/${encodeURIComponent(span.id)}/stream`, {
+    const stream = openAuthenticatedSSE(apiRoutes.traces.spanStream(span.id), {
       onOpen: () => setStatus('live'),
       onMessage: data => {
         try {

--- a/internal/ui/src/components/RepoFilter.tsx
+++ b/internal/ui/src/components/RepoFilter.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useState, useEffect } from 'react'
+import { apiRoutes } from '@/lib/api-routes'
 import { itemsFromResponse, selectorURL } from '@/lib/pagination'
-import { withWorkspace } from '@/lib/workspace'
 
 const STORAGE_KEY = 'agents_repo_filter'
 
@@ -28,7 +28,7 @@ export default function RepoFilter({ selected, onChange, workspace }: { selected
 
   useEffect(() => {
     setLoaded(false)
-    fetch(selectorURL(workspace ? withWorkspace('/repos', workspace) : '/repos'))
+    fetch(selectorURL(apiRoutes.repos.list(workspace ? { workspace } : undefined)))
       .then(r => r.ok ? r.json() : [])
       .then((data) => {
         setRepos(itemsFromResponse<{ name: string }>(data).map(r => r.name))

--- a/internal/ui/src/components/RunButton.tsx
+++ b/internal/ui/src/components/RunButton.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { apiRoutes } from '@/lib/api-routes'
 import { useSelectedWorkspace } from '@/lib/workspace'
 
 const ALL_REPOS = '__all__'
@@ -39,7 +40,7 @@ export default function RunButton({ agent, repos }: { agent: string; repos: stri
     setStatusMsg('')
     const results = await Promise.all(targets.map(async (repo) => {
       try {
-        const res = await fetch('/run', {
+        const res = await fetch(apiRoutes.run(), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ agent, repo, workspace }),

--- a/internal/ui/src/lib/api-routes.test.ts
+++ b/internal/ui/src/lib/api-routes.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { apiRoutes, withWorkspace, workspaceQuery } from './api-routes'
+
+describe('apiRoutes', () => {
+  it('keeps paths relative and encodes path parameters', () => {
+    expect(apiRoutes.repos.binding('acme org', 'agent/repo', 'bind/1', { workspace: 'team a' }))
+      .toBe('/repos/acme%20org/agent%2Frepo/bindings/bind%2F1?workspace=team+a')
+    expect(apiRoutes.traces.prompt('span/1')).toBe('/traces/span%2F1/prompt')
+  })
+
+  it('builds query strings with workspace composition', () => {
+    expect(apiRoutes.runners.list({ workspace: 'team-a', status: 'running', limit: 25, offset: 50 }))
+      .toBe('/runners?status=running&limit=25&offset=50&workspace=team-a')
+    expect(withWorkspace('/events?since=2026-01-01T00%3A00%3A00Z', 'demo'))
+      .toBe('/events?since=2026-01-01T00%3A00%3A00Z&workspace=demo')
+    expect(workspaceQuery('')).toBe('workspace=default')
+  })
+
+  it('skips empty optional filters', () => {
+    expect(apiRoutes.improvements.feedback({ workspace: 'default', offset: 0, limit: undefined }))
+      .toBe('/improvements/feedback?offset=0&workspace=default')
+    expect(apiRoutes.catalog.prompts.list({ workspace: '' })).toBe('/prompts')
+  })
+})

--- a/internal/ui/src/lib/api-routes.ts
+++ b/internal/ui/src/lib/api-routes.ts
@@ -1,0 +1,148 @@
+import { defaultWorkspaceID } from './workspace-constants'
+
+type QueryValue = string | number | boolean | null | undefined
+type Query = Record<string, QueryValue>
+
+function cleanQuery(query?: Query): URLSearchParams {
+  const params = new URLSearchParams()
+  if (!query) return params
+  Object.entries(query).forEach(([key, value]) => {
+    if (value === undefined || value === null || value === '') return
+    params.set(key, String(value))
+  })
+  return params
+}
+
+function path(base: string, query?: Query): string {
+  const params = cleanQuery(query)
+  const suffix = params.toString()
+  return suffix ? `${base}?${suffix}` : base
+}
+
+function appendQuery(base: string, query?: Query): string {
+  const params = cleanQuery(query)
+  const suffix = params.toString()
+  if (!suffix) return base
+  return `${base}${base.includes('?') ? '&' : '?'}${suffix}`
+}
+
+function enc(value: string | number): string {
+  return encodeURIComponent(String(value))
+}
+
+export function workspaceQuery(workspace: string): string {
+  const id = workspace.trim() || defaultWorkspaceID
+  return cleanQuery({ workspace: id }).toString()
+}
+
+export function withWorkspace(base: string, workspace: string): string {
+  const id = workspace.trim() || defaultWorkspaceID
+  return appendQuery(base, { workspace: id })
+}
+
+function scopedList(base: string, query?: Query & { workspace?: string }): string {
+  const { workspace, ...rest } = query ?? {}
+  return workspace ? withWorkspace(path(base, rest), workspace) : path(base, rest)
+}
+
+function catalogRoutes(assetPath: 'prompts' | 'skills' | 'guardrails') {
+  return {
+    list: (query?: Query) => path(`/${assetPath}`, query),
+    one: (id: string) => `/${assetPath}/${enc(id)}`,
+    versions: (id: string) => `/${assetPath}/${enc(id)}/versions`,
+    versionReferences: (id: string, versionID: string) => `/${assetPath}/${enc(id)}/versions/${enc(versionID)}/references`,
+  }
+}
+
+export const apiRoutes = {
+  status: () => '/status',
+  run: () => '/run',
+  config: () => '/config',
+  runtime: () => '/runtime',
+  exportConfig: () => '/export',
+  importConfig: (query?: Query) => path('/import', query),
+  runners: {
+    list: (query?: Query & { workspace?: string; status?: string; limit?: number; offset?: number }) => scopedList('/runners', query),
+    one: (id: string | number) => `/runners/${enc(id)}`,
+    retry: (id: string | number) => `/runners/${enc(id)}/retry`,
+  },
+  agents: {
+    list: (query?: Query & { workspace?: string; limit?: number; offset?: number }) => scopedList('/agents', query),
+    one: (name: string, query?: Query & { workspace?: string }) => scopedList(`/agents/${enc(name)}`, query),
+    orphansStatus: () => '/agents/orphans/status',
+  },
+  repos: {
+    list: (query?: Query & { workspace?: string; limit?: number; offset?: number }) => scopedList('/repos', query),
+    one: (owner: string, repo: string, query?: { workspace?: string }) => scopedList(`/repos/${enc(owner)}/${enc(repo)}`, query),
+    bindings: (owner: string, repo: string, query?: { workspace?: string }) => scopedList(`/repos/${enc(owner)}/${enc(repo)}/bindings`, query),
+    binding: (owner: string, repo: string, bindingID: string | number, query?: { workspace?: string }) => scopedList(`/repos/${enc(owner)}/${enc(repo)}/bindings/${enc(bindingID)}`, query),
+  },
+  workspaces: {
+    list: (query?: Query) => path('/workspaces', query),
+    one: (id: string) => `/workspaces/${enc(id)}`,
+    runtime: (id: string) => `/workspaces/${enc(id)}/runtime`,
+    guardrails: (id: string) => `/workspaces/${enc(id)}/guardrails`,
+  },
+  catalog: {
+    prompts: catalogRoutes('prompts'),
+    skills: catalogRoutes('skills'),
+    guardrails: {
+      ...catalogRoutes('guardrails'),
+      reset: (id: string) => `/guardrails/${enc(id)}/reset`,
+    },
+  },
+  graph: {
+    view: (query?: { workspace?: string }) => scopedList('/graph', query),
+    layout: (query?: { workspace?: string }) => scopedList('/graph/layout', query),
+  },
+  improvements: {
+    feedback: (query?: Query & { workspace?: string }) => scopedList('/improvements/feedback', query),
+    recommendations: (query?: Query & { workspace?: string }) => scopedList('/improvements/recommendations', query),
+    recommendation: (id: string) => `/improvements/recommendations/${enc(id)}`,
+    recommendationStatus: (id: string) => `/improvements/recommendations/${enc(id)}/status`,
+    clarification: (id: string) => `/improvements/recommendations/${enc(id)}/clarification`,
+    analyzeFeedback: (feedbackID: string | number) => `/improvements/feedback/${enc(feedbackID)}/analyze`,
+    bundleItem: (bundleID: string, itemID: string) => `/improvements/proposal-bundles/${enc(bundleID)}/items/${enc(itemID)}`,
+    rejectBundleItem: (bundleID: string, itemID: string) => `/improvements/proposal-bundles/${enc(bundleID)}/items/${enc(itemID)}/reject`,
+    linkExistingBundleItem: (bundleID: string, itemID: string) => `/improvements/proposal-bundles/${enc(bundleID)}/items/${enc(itemID)}/link-existing`,
+    publishBundle: (bundleID: string) => `/improvements/proposal-bundles/${enc(bundleID)}/publish`,
+    discardBundle: (bundleID: string) => `/improvements/proposal-bundles/${enc(bundleID)}/discard`,
+  },
+  traces: {
+    list: (query?: Query & { workspace?: string }) => scopedList('/traces', query),
+    prompt: (spanID: string) => `/traces/${enc(spanID)}/prompt`,
+    steps: (spanID: string) => `/traces/${enc(spanID)}/steps`,
+    stream: (query?: { workspace?: string }) => scopedList('/traces/stream', query),
+    spanStream: (spanID: string) => `/traces/${enc(spanID)}/stream`,
+  },
+  events: {
+    list: (query?: Query & { workspace?: string }) => scopedList('/events', query),
+    stream: (query?: { workspace?: string }) => scopedList('/events/stream', query),
+  },
+  auth: {
+    status: () => '/auth/status',
+    users: (query?: Query) => path('/auth/users', query),
+    user: (id: string | number) => `/auth/users/${enc(id)}`,
+    tokens: (query?: Query) => path('/auth/tokens', query),
+    token: (id: string | number) => `/auth/tokens/${enc(id)}`,
+    logout: () => '/auth/logout',
+    password: () => '/auth/me/password',
+  },
+  backends: {
+    list: (query?: Query) => path('/backends', query),
+    one: (name: string) => `/backends/${enc(name)}`,
+    status: () => '/backends/status',
+    discover: () => '/backends/discover',
+    local: () => '/backends/local',
+  },
+  tokenBudgets: {
+    list: (query?: Query) => path('/token_budgets', query),
+    one: (id: string | number) => `/token_budgets/${enc(id)}`,
+    leaderboard: (query?: Query & { workspace?: string }) => scopedList('/token_leaderboard', query),
+    alerts: () => '/token_budgets/alerts',
+  },
+  memory: {
+    stream: (query?: { workspace?: string }) => scopedList('/memory/stream', query),
+    one: (agent: string, repoKey: string, query?: { workspace?: string }) => scopedList(`/memory/${enc(agent)}/${enc(repoKey)}`, query),
+  },
+}

--- a/internal/ui/src/lib/auth.tsx
+++ b/internal/ui/src/lib/auth.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import PaginationControls from '@/components/PaginationControls'
+import { apiRoutes } from '@/lib/api-routes'
 import { formatDateTime } from '@/lib/datetime'
 import { pageFromResponse } from '@/lib/pagination'
 
@@ -72,7 +73,7 @@ function patchFetch() {
 
 async function loadAuthStatus(): Promise<AuthStatus | null> {
   try {
-    const res = await fetch('/auth/status', { cache: 'no-store' })
+    const res = await fetch(apiRoutes.auth.status(), { cache: 'no-store' })
     if (!res.ok) return null
     return await res.json() as AuthStatus
   } catch {
@@ -134,8 +135,8 @@ export function AuthTokenSettings() {
     setStatus(next)
     if (!next?.authenticated) return
     const [usersRes, tokensRes] = await Promise.all([
-      fetch(pageURL('/auth/users', usersLimit, usersOffset), { cache: 'no-store' }),
-      fetch(pageURL('/auth/tokens', tokensLimit, tokensOffset), { cache: 'no-store' }),
+      fetch(apiRoutes.auth.users({ limit: usersLimit, offset: usersOffset }), { cache: 'no-store' }),
+      fetch(apiRoutes.auth.tokens({ limit: tokensLimit, offset: tokensOffset }), { cache: 'no-store' }),
     ])
     if (usersRes.ok) {
       const page = pageFromResponse<AuthUser>(await usersRes.json(), usersLimit, usersOffset)
@@ -160,7 +161,7 @@ export function AuthTokenSettings() {
   const create = async () => {
     setCreated('')
     setTokenError('')
-    const res = await fetch('/auth/tokens', {
+    const res = await fetch(apiRoutes.auth.tokens(), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name }),
@@ -176,7 +177,7 @@ export function AuthTokenSettings() {
 
   const createUser = async () => {
     setUserError('')
-    const res = await fetch('/auth/users', {
+    const res = await fetch(apiRoutes.auth.users(), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username: newUsername, password: newPassword }),
@@ -193,7 +194,7 @@ export function AuthTokenSettings() {
 
   const deleteUser = async (id: number) => {
     setUserError('')
-    const res = await fetch(`/auth/users/${id}`, { method: 'DELETE' })
+    const res = await fetch(apiRoutes.auth.user(id), { method: 'DELETE' })
     if (!res.ok) {
       const text = await res.text()
       setUserError(text.trim() || 'Could not remove user.')
@@ -209,7 +210,7 @@ export function AuthTokenSettings() {
       setPasswordError('New passwords do not match.')
       return
     }
-    const res = await fetch('/auth/me/password', {
+    const res = await fetch(apiRoutes.auth.password(), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ current_password: currentPassword, new_password: ownNewPassword }),
@@ -227,7 +228,7 @@ export function AuthTokenSettings() {
   }
 
   const revoke = async (id: number) => {
-    const res = await fetch(`/auth/tokens/${id}`, { method: 'DELETE' })
+    const res = await fetch(apiRoutes.auth.token(id), { method: 'DELETE' })
     if (res.ok) await refresh()
   }
 
@@ -367,10 +368,6 @@ function AuthRedirectScreen({ loading }: { loading: boolean }) {
 
 function formatDate(value: string) {
   return formatDateTime(value) || 'unknown'
-}
-
-function pageURL(path: string, limit: number, offset: number): string {
-  return `${path}?limit=${limit}&offset=${offset}`
 }
 
 const sectionStyle: React.CSSProperties = {

--- a/internal/ui/src/lib/workspace-constants.ts
+++ b/internal/ui/src/lib/workspace-constants.ts
@@ -1,0 +1,1 @@
+export const defaultWorkspaceID = 'default'

--- a/internal/ui/src/lib/workspace.ts
+++ b/internal/ui/src/lib/workspace.ts
@@ -2,6 +2,10 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import { itemsFromResponse, selectorURL } from './pagination'
+import { apiRoutes } from './api-routes'
+import { defaultWorkspaceID } from './workspace-constants'
+export { withWorkspace, workspaceQuery } from './api-routes'
+export { defaultWorkspaceID } from './workspace-constants'
 
 export interface Workspace {
   id: string
@@ -18,17 +22,6 @@ export interface CatalogItem {
 }
 
 const storageKey = 'agents.workspace'
-export const defaultWorkspaceID = 'default'
-
-export function workspaceQuery(workspace: string): string {
-  const id = workspace.trim() || defaultWorkspaceID
-  return `workspace=${encodeURIComponent(id)}`
-}
-
-export function withWorkspace(path: string, workspace: string): string {
-  const separator = path.includes('?') ? '&' : '?'
-  return `${path}${separator}${workspaceQuery(workspace)}`
-}
 
 export function visibleCatalogItems<T extends CatalogItem>(items: T[], workspace: string, repo = ''): T[] {
   const workspaceID = (workspace || defaultWorkspaceID).trim()
@@ -70,7 +63,7 @@ export function useSelectedWorkspace() {
 
   useEffect(() => {
     let cancelled = false
-    fetch(selectorURL('/workspaces'), { cache: 'no-store' })
+    fetch(selectorURL(apiRoutes.workspaces.list()), { cache: 'no-store' })
       .then(r => r.ok ? r.json() : [])
       .then((data) => {
         if (cancelled) return


### PR DESCRIPTION
## Summary

- add a pure frontend `apiRoutes` helper for internal daemon route construction with encoded path params and URLSearchParams-backed query handling
- migrate dashboard fetch/SSE call sites across fleet, graph, config, catalog, auth, observability, runners, repos, workspaces, and improvements to use shared route builders
- keep existing workspace helper exports by delegating them to the route builder and add focused route-builder tests

## Verification

- `npm --prefix internal/ui test -- api-routes`
- `npm --prefix internal/ui run build`
- `npm --prefix internal/ui test`
- `go test ./...`

Closes #714

<!-- agents-run: {"v":1,"instance_id":"ts-lonestar","workspace":"default","repo":"eloylp/agents","span_id":"ba6a3442c94fc45b","agent_id":"agent_0fb82d1fe34e45408bd2fee153f7003d","agent_name":"coder","sig":"7A34bvP4SVBd5XMM0d6HKs0Tp7VXn5eNpnCcZo2SShg"} -->
