### PR TITLE
[codex] Move pagination controls into data sections

### DIFF
--- a/internal/ui/src/app/config/page.test.tsx
+++ b/internal/ui/src/app/config/page.test.tsx
@@ -140,13 +140,13 @@ describe('<ConfigPage /> backend pagination', () => {
     render(<ConfigPage />)
 
     expect(await screen.findByText('backend-001')).toBeInTheDocument()
-    expect(screen.getByText('1-50 of 75')).toBeInTheDocument()
+    expect(screen.getAllByText('1-50 of 75')).toHaveLength(2)
     expect(fetchMock).toHaveBeenCalledWith('/backends?limit=500&offset=0')
 
-    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    fireEvent.click(screen.getAllByRole('button', { name: 'Next' })[0])
 
     expect(await screen.findByText('backend-051')).toBeInTheDocument()
-    expect(screen.getByText('51-75 of 75')).toBeInTheDocument()
+    expect(screen.getAllByText('51-75 of 75')).toHaveLength(2)
     expect(fetchMock).toHaveBeenCalledWith('/backends?limit=50&offset=50')
   })
 })

--- a/internal/ui/src/app/config/page.tsx
+++ b/internal/ui/src/app/config/page.tsx
@@ -4,7 +4,7 @@ import Card from '@/components/Card'
 import Modal from '@/components/Modal'
 import RepoFilter from '@/components/RepoFilter'
 import WorkspaceSelect from '@/components/WorkspaceSelect'
-import PaginationControls from '@/components/PaginationControls'
+import PaginatedDataSection from '@/components/PaginatedDataSection'
 import { apiRoutes } from '@/lib/api-routes'
 import { AuthTokenSettings } from '@/lib/auth'
 import { budgetScopeDescription, budgetScopeLabel, budgetScopeOptions, isGlobalSimpleBudgetScope } from '@/lib/budget-copy'
@@ -1296,22 +1296,20 @@ export default function ConfigPage() {
           <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap', alignItems: 'flex-start' }}>
             <div style={{ flex: '2 1 540px', minWidth: 0 }}>
               <div style={{ border: '1px solid var(--border-subtle)', borderRadius: '6px', padding: '0.75rem', background: 'var(--bg)' }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '0.75rem', marginBottom: '0.6rem' }}>
-                  <div style={{ fontWeight: 700, color: 'var(--text-heading)' }}>Backends</div>
-                  <PaginationControls
+                <PaginatedDataSection
                     total={backendsTotal}
                     limit={backendsLimit}
                     offset={backendsOffset}
                     onLimitChange={(next) => { setBackendsLimit(next); setBackendsOffset(0) }}
                     onOffsetChange={setBackendsOffset}
-                  />
-                </div>
-                {!backendsLoading && backends.length === 0 && (
-                  <p style={{ color: 'var(--text-faint)', fontSize: '0.85rem' }}>No backends configured.</p>
-                )}
-                <div style={{ display: 'flex', flexDirection: 'column', gap: '0.6rem' }}>
-                  {backends.map(b => (
-                    <div key={b.name} style={{ border: `1px solid ${b.healthy ? 'var(--border-subtle)' : 'var(--border-danger)'}`, borderRadius: '6px', padding: '0.75rem', background: 'var(--bg)' }}>
+                    topLeft={<div style={{ fontWeight: 700, color: 'var(--text-heading)' }}>Backends</div>}
+                  >
+                  {!backendsLoading && backends.length === 0 && (
+                    <p style={{ color: 'var(--text-faint)', fontSize: '0.85rem' }}>No backends configured.</p>
+                  )}
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '0.6rem' }}>
+                    {backends.map(b => (
+                      <div key={b.name} style={{ border: `1px solid ${b.healthy ? 'var(--border-subtle)' : 'var(--border-danger)'}`, borderRadius: '6px', padding: '0.75rem', background: 'var(--bg)' }}>
                       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '0.75rem' }}>
                         <div style={{ minWidth: 0, flex: 1 }}>
                           <div style={{ display: 'flex', alignItems: 'center', gap: '0.45rem' }}>
@@ -1372,9 +1370,10 @@ export default function ConfigPage() {
                           )}
                         </div>
                       </div>
-                    </div>
-                  ))}
-                </div>
+                      </div>
+                    ))}
+                  </div>
+                </PaginatedDataSection>
               </div>
             </div>
 
@@ -1565,23 +1564,21 @@ export default function ConfigPage() {
             <p style={{ color: 'var(--text-faint)', fontSize: '0.8rem', marginBottom: '0.75rem' }}>
               Budgets enforce token caps over UTC calendar periods. Simple repo, agent, and backend scopes are global across workspaces; choose workspace + repo, workspace + agent, or workspace + backend for workspace-isolated caps. Daily resets at 00:00 UTC, weekly resets Sunday 00:00 UTC, and monthly resets on the first day at 00:00 UTC.
             </p>
-            <div style={{ marginBottom: '0.75rem' }}>
-              <PaginationControls
+            <PaginatedDataSection
                 total={budgetsTotal}
                 limit={budgetsLimit}
                 offset={budgetsOffset}
                 onLimitChange={(next) => { setBudgetsLimit(next); setBudgetsOffset(0) }}
                 onOffsetChange={setBudgetsOffset}
-              />
-            </div>
-            {budgetsLoading ? (
-              <p style={{ color: 'var(--text-muted)', fontSize: '0.85rem' }}>Loading…</p>
-            ) : budgets.length === 0 ? (
-              <p style={{ color: 'var(--text-faint)', fontSize: '0.85rem' }}>No token budgets configured. Add one to enforce token caps and receive alerts.</p>
-            ) : (
-              <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
-                {budgets.map(b => (
-                  <div key={b.id} style={{ border: '1px solid var(--border-subtle)', borderRadius: '6px', padding: '0.65rem 0.75rem', background: 'var(--bg)', display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '1rem' }}>
+              >
+              {budgetsLoading ? (
+                <p style={{ color: 'var(--text-muted)', fontSize: '0.85rem' }}>Loading…</p>
+              ) : budgets.length === 0 ? (
+                <p style={{ color: 'var(--text-faint)', fontSize: '0.85rem' }}>No token budgets configured. Add one to enforce token caps and receive alerts.</p>
+              ) : (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+                  {budgets.map(b => (
+                    <div key={b.id} style={{ border: '1px solid var(--border-subtle)', borderRadius: '6px', padding: '0.65rem 0.75rem', background: 'var(--bg)', display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '1rem' }}>
                     <div style={{ minWidth: 0, flex: 1 }}>
                       <div style={{ fontSize: '0.82rem', fontWeight: 700, color: 'var(--text-heading)' }}>
                         {budgetScopeLabel(b)}
@@ -1621,10 +1618,11 @@ export default function ConfigPage() {
                         Delete
                       </button>
                     </div>
-                  </div>
-                ))}
-              </div>
-            )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </PaginatedDataSection>
             {budgetError && <p style={{ color: 'var(--text-danger)', fontSize: '0.85rem', marginTop: '0.75rem' }}>{budgetError}</p>}
           </div>
         </Card>

--- a/internal/ui/src/app/events/page.tsx
+++ b/internal/ui/src/app/events/page.tsx
@@ -2,7 +2,7 @@
 import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import Card from '@/components/Card'
-import PaginationControls from '@/components/PaginationControls'
+import PaginatedDataSection from '@/components/PaginatedDataSection'
 import RepoFilter, { useRepoFilter } from '@/components/RepoFilter'
 import WorkspaceSelect from '@/components/WorkspaceSelect'
 import { apiRoutes } from '@/lib/api-routes'
@@ -208,13 +208,6 @@ export default function EventsPage() {
             }}>{r}</button>
           ))}
           <RepoFilter selected={repoFilter} onChange={setRepoFilter} workspace={workspace} />
-          <PaginationControls
-            total={total}
-            limit={limit}
-            offset={offset}
-            onLimitChange={(next) => { setLimit(next); setOffset(0) }}
-            onOffsetChange={setOffset}
-          />
           <input
             placeholder="Filter..."
             value={filter}
@@ -241,6 +234,13 @@ export default function EventsPage() {
         </div>
       </Card>
 
+      <PaginatedDataSection
+        total={total}
+        limit={limit}
+        offset={offset}
+        onLimitChange={(next) => { setLimit(next); setOffset(0) }}
+        onOffsetChange={setOffset}
+      >
       <Card title="Event Stream">
         <div style={{
           display: 'grid',
@@ -262,6 +262,7 @@ export default function EventsPage() {
           {filtered.map(e => <EventRow key={e.id + e.at} event={e} isNew={newIds.has(e.id)} />)}
         </div>
       </Card>
+      </PaginatedDataSection>
     </div>
   )
 }

--- a/internal/ui/src/app/improvements/page.test.tsx
+++ b/internal/ui/src/app/improvements/page.test.tsx
@@ -27,6 +27,10 @@ function catalogEndpointResponse(url: string) {
   return Promise.resolve({ ok: true, json: () => Promise.resolve(catalogEndpointRows[url]) } as Response)
 }
 
+function matchesEndpoint(url: string, path: string) {
+  return url === path || url.startsWith(`${path}?`)
+}
+
 describe('<ImprovementsPage />', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
@@ -41,10 +45,10 @@ describe('<ImprovementsPage />', () => {
       }
       const catalogResponse = catalogEndpointResponse(url)
       if (catalogResponse) return catalogResponse
-      if (url === '/improvements/feedback') {
+      if (matchesEndpoint(url, '/improvements/feedback')) {
         return Promise.resolve({ ok: true, json: () => Promise.resolve([]) } as Response)
       }
-      if (url === '/improvements/recommendations') {
+      if (matchesEndpoint(url, '/improvements/recommendations')) {
         return Promise.resolve({
           ok: true,
           json: () => Promise.resolve([
@@ -176,8 +180,8 @@ describe('<ImprovementsPage />', () => {
       if (url === '/workspaces') return Promise.resolve({ ok: true, json: () => Promise.resolve([{ id: 'default', name: 'Default' }]) } as Response)
       const catalogResponse = catalogEndpointResponse(url)
       if (catalogResponse) return catalogResponse
-      if (url === '/improvements/feedback') return Promise.resolve({ ok: true, json: () => Promise.resolve([]) } as Response)
-      if (url === '/improvements/recommendations') return Promise.resolve({ ok: true, json: () => Promise.resolve(recommendations) } as Response)
+      if (matchesEndpoint(url, '/improvements/feedback')) return Promise.resolve({ ok: true, json: () => Promise.resolve([]) } as Response)
+      if (matchesEndpoint(url, '/improvements/recommendations')) return Promise.resolve({ ok: true, json: () => Promise.resolve(recommendations) } as Response)
       if (url === '/skills/go-api') return Promise.resolve({ ok: true, json: () => Promise.resolve({ id: 'go-api', version_id: 'skillver-base' }) } as Response)
       return Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve([]) } as Response)
     })
@@ -202,10 +206,10 @@ describe('<ImprovementsPage />', () => {
       }
       const catalogResponse = catalogEndpointResponse(url)
       if (catalogResponse) return catalogResponse
-      if (url === '/improvements/feedback') {
+      if (matchesEndpoint(url, '/improvements/feedback')) {
         return Promise.resolve({ ok: true, json: () => Promise.resolve([]) } as Response)
       }
-      if (url === '/improvements/recommendations') {
+      if (matchesEndpoint(url, '/improvements/recommendations')) {
         return Promise.resolve({
           ok: true,
           json: () => Promise.resolve([
@@ -388,10 +392,10 @@ describe('<ImprovementsPage />', () => {
   it('links a published create-new skill to the attributed agent', async () => {
     const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input)
-      if (url === '/improvements/feedback') {
+      if (matchesEndpoint(url, '/improvements/feedback')) {
         return Promise.resolve({ ok: true, json: () => Promise.resolve([]) } as Response)
       }
-      if (url === '/improvements/recommendations') {
+      if (matchesEndpoint(url, '/improvements/recommendations')) {
         return Promise.resolve({
           ok: true,
           json: () => Promise.resolve([
@@ -477,10 +481,10 @@ describe('<ImprovementsPage />', () => {
   it('does not mark published history bundles as stale or actionable', async () => {
     const fetchMock = vi.fn((input: RequestInfo | URL) => {
       const url = String(input)
-      if (url === '/improvements/feedback') {
+      if (matchesEndpoint(url, '/improvements/feedback')) {
         return Promise.resolve({ ok: true, json: () => Promise.resolve([]) } as Response)
       }
-      if (url === '/improvements/recommendations') {
+      if (matchesEndpoint(url, '/improvements/recommendations')) {
         return Promise.resolve({
           ok: true,
           json: () => Promise.resolve([
@@ -550,10 +554,10 @@ describe('<ImprovementsPage />', () => {
   it('shows resolved bundles as terminal history', async () => {
     const fetchMock = vi.fn((input: RequestInfo | URL) => {
       const url = String(input)
-      if (url === '/improvements/feedback') {
+      if (matchesEndpoint(url, '/improvements/feedback')) {
         return Promise.resolve({ ok: true, json: () => Promise.resolve([]) } as Response)
       }
-      if (url === '/improvements/recommendations') {
+      if (matchesEndpoint(url, '/improvements/recommendations')) {
         return Promise.resolve({
           ok: true,
           json: () => Promise.resolve([
@@ -615,10 +619,10 @@ describe('<ImprovementsPage />', () => {
       if (url === '/workspaces') {
         return Promise.resolve({ ok: true, json: () => Promise.resolve([{ id: 'lab', name: 'Lab' }]) } as Response)
       }
-      if (url === '/improvements/feedback') {
+      if (matchesEndpoint(url, '/improvements/feedback')) {
         return Promise.resolve({ ok: true, json: () => Promise.resolve([]) } as Response)
       }
-      if (url === '/improvements/recommendations') {
+      if (matchesEndpoint(url, '/improvements/recommendations')) {
         return Promise.resolve({
           ok: true,
           json: () => Promise.resolve([
@@ -677,10 +681,10 @@ describe('<ImprovementsPage />', () => {
   it('blocks finalizing stale proposal bundles in the review modal', async () => {
     const fetchMock = vi.fn((input: RequestInfo | URL) => {
       const url = String(input)
-      if (url === '/improvements/feedback') {
+      if (matchesEndpoint(url, '/improvements/feedback')) {
         return Promise.resolve({ ok: true, json: () => Promise.resolve([]) } as Response)
       }
-      if (url === '/improvements/recommendations') {
+      if (matchesEndpoint(url, '/improvements/recommendations')) {
         return Promise.resolve({
           ok: true,
           json: () => Promise.resolve([
@@ -738,10 +742,10 @@ describe('<ImprovementsPage />', () => {
   it('preflights stale recommendation targets and offers re-analysis instead of bundle review', async () => {
     const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input)
-      if (url === '/improvements/feedback') {
+      if (matchesEndpoint(url, '/improvements/feedback')) {
         return Promise.resolve({ ok: true, json: () => Promise.resolve([]) } as Response)
       }
-      if (url === '/improvements/recommendations') {
+      if (matchesEndpoint(url, '/improvements/recommendations')) {
         return Promise.resolve({
           ok: true,
           json: () => Promise.resolve([
@@ -791,10 +795,10 @@ describe('<ImprovementsPage />', () => {
     let resolveSkill: ((value: Response) => void) | undefined
     const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input)
-      if (url === '/improvements/feedback') {
+      if (matchesEndpoint(url, '/improvements/feedback')) {
         return Promise.resolve({ ok: true, json: () => Promise.resolve([]) } as Response)
       }
-      if (url === '/improvements/recommendations') {
+      if (matchesEndpoint(url, '/improvements/recommendations')) {
         return Promise.resolve({
           ok: true,
           json: () => Promise.resolve([
@@ -848,10 +852,10 @@ describe('<ImprovementsPage />', () => {
   it('limits needs-input actions and loads full clarification context', async () => {
     const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input)
-      if (url === '/improvements/feedback') {
+      if (matchesEndpoint(url, '/improvements/feedback')) {
         return Promise.resolve({ ok: true, json: () => Promise.resolve([]) } as Response)
       }
-      if (url === '/improvements/recommendations') {
+      if (matchesEndpoint(url, '/improvements/recommendations')) {
         return Promise.resolve({
           ok: true,
           json: () => Promise.resolve([

--- a/internal/ui/src/app/improvements/page.tsx
+++ b/internal/ui/src/app/improvements/page.tsx
@@ -2,7 +2,7 @@
 import { type CSSProperties, type ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
 import MarkdownEditor from '@/components/MarkdownEditor'
 import Modal from '@/components/Modal'
-import PaginationControls from '@/components/PaginationControls'
+import PaginatedDataSection from '@/components/PaginatedDataSection'
 import { apiRoutes } from '@/lib/api-routes'
 import { formatDateTime } from '@/lib/datetime'
 import { pageFromResponse } from '@/lib/pagination'
@@ -960,30 +960,14 @@ export default function ImprovementsPage() {
         </div>
 	      </section>
 
-      <section aria-label="Improvement pagination" style={{ display: 'flex', justifyContent: 'space-between', gap: 10, alignItems: 'center', flexWrap: 'wrap', color: 'var(--text-muted)', fontSize: '0.78rem' }}>
-        <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
-          <span>Proposals</span>
-          <PaginationControls
-            total={recommendationsTotal}
-            limit={recommendationsLimit}
-            offset={recommendationsOffset}
-            onLimitChange={(next) => { setRecommendationsLimit(next); setRecommendationsOffset(0) }}
-            onOffsetChange={setRecommendationsOffset}
-          />
-        </div>
-        <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
-          <span>Feedback</span>
-          <PaginationControls
-            total={feedbackTotal}
-            limit={feedbackLimit}
-            offset={feedbackOffset}
-            onLimitChange={(next) => { setFeedbackLimit(next); setFeedbackOffset(0) }}
-            onOffsetChange={setFeedbackOffset}
-          />
-        </div>
-      </section>
-
       {(tab === 'proposals' || tab === 'history') && (
+        <PaginatedDataSection
+          total={recommendationsTotal}
+          limit={recommendationsLimit}
+          offset={recommendationsOffset}
+          onLimitChange={(next) => { setRecommendationsLimit(next); setRecommendationsOffset(0) }}
+          onOffsetChange={setRecommendationsOffset}
+        >
         <section style={{ background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 6, overflow: 'hidden' }}>
           <div style={{ display: 'grid', gridTemplateColumns: '92px 92px minmax(260px, 1fr) 170px 130px 170px', gap: '0.75rem', padding: '0.65rem 0.8rem', borderBottom: '1px solid var(--border-subtle)', color: 'var(--text-muted)', fontSize: '0.72rem', fontWeight: 700, textTransform: 'uppercase' }}>
             <span>ID</span>
@@ -1076,6 +1060,7 @@ export default function ImprovementsPage() {
             <div style={{ padding: '1rem', color: 'var(--text-muted)', fontSize: '0.85rem' }}>No matching proposals.</div>
           )}
         </section>
+        </PaginatedDataSection>
       )}
 
       {reviewingProposal && (

--- a/internal/ui/src/app/page.tsx
+++ b/internal/ui/src/app/page.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect, useRef } from 'react'
 import Card from '@/components/Card'
 import StatusBadge from '@/components/StatusBadge'
 import Modal from '@/components/Modal'
-import PaginationControls from '@/components/PaginationControls'
+import PaginatedDataSection from '@/components/PaginatedDataSection'
 import Link from 'next/link'
 import RepoFilter, { useRepoFilter } from '@/components/RepoFilter'
 import RunButton from '@/components/RunButton'
@@ -337,32 +337,30 @@ export default function FleetPage() {
         </div>
       </div>
 
-      <div style={{ marginBottom: '1rem' }}>
-        <PaginationControls
+      <PaginatedDataSection
           total={total}
           limit={limit}
           offset={offset}
           onLimitChange={(next) => { setLimit(next); setOffset(0) }}
           onOffsetChange={setOffset}
-        />
-      </div>
+        >
+        {loading && <p style={{ color: 'var(--text-muted)' }}>Loading…</p>}
+        {error && <p style={{ color: 'var(--text-danger)' }}>Error: {error}</p>}
+        {!loading && !error && visibleAgents.length === 0 && (
+          <p style={{ color: 'var(--text-muted)' }}>No agents configured.</p>
+        )}
 
-      {loading && <p style={{ color: 'var(--text-muted)' }}>Loading…</p>}
-      {error && <p style={{ color: 'var(--text-danger)' }}>Error: {error}</p>}
-      {!loading && !error && visibleAgents.length === 0 && (
-        <p style={{ color: 'var(--text-muted)' }}>No agents configured.</p>
-      )}
-
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-        {visibleAgents.map(a => (
-          <AgentCard
-            key={a.name}
-            agent={a}
-            onEdit={() => openEdit(a.name)}
-            onDelete={() => confirmDelete(a.name)}
-          />
-        ))}
-      </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+          {visibleAgents.map(a => (
+            <AgentCard
+              key={a.name}
+              agent={a}
+              onEdit={() => openEdit(a.name)}
+              onDelete={() => confirmDelete(a.name)}
+            />
+          ))}
+        </div>
+      </PaginatedDataSection>
 
       {(modal === 'create' || modal === 'edit') && (
         <Modal title={modal === 'create' ? 'Create agent' : `Edit, ${selected.name}`} onClose={() => setModal(null)}>

--- a/internal/ui/src/app/prompts/page.tsx
+++ b/internal/ui/src/app/prompts/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react'
 import Card from '@/components/Card'
 import Modal from '@/components/Modal'
-import PaginationControls from '@/components/PaginationControls'
+import PaginatedDataSection from '@/components/PaginatedDataSection'
 import MarkdownEditor from '@/components/MarkdownEditor'
 import CatalogVersionsPanel from '@/components/CatalogVersionsPanel'
 import { apiRoutes } from '@/lib/api-routes'
@@ -219,39 +219,37 @@ export default function PromptsPage() {
         </div>
       </div>
 
-      <div style={{ marginBottom: '1rem' }}>
-        <PaginationControls
+      <PaginatedDataSection
           total={total}
           limit={limit}
           offset={offset}
           onLimitChange={(next) => { setLimit(next); setOffset(0) }}
           onOffsetChange={setOffset}
-        />
-      </div>
-
-      {loading && <p style={{ color: 'var(--text-muted)' }}>Loading...</p>}
-      {!loading && prompts.length === 0 && <p style={{ color: 'var(--text-muted)' }}>No prompts configured.</p>}
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: '1rem' }}>
-        {visiblePrompts.map(p => (
-          <Card key={p.id || p.name} style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
-            <div>
-              <div style={{ fontWeight: 700, color: 'var(--text-heading)' }}>{p.name}</div>
-              <div style={{ color: 'var(--text-muted)', fontSize: '0.72rem', marginTop: 2 }}>
-                {p.repo ? `${p.workspace_id || 'default'} / ${p.repo}` : p.workspace_id ? `${p.workspace_id} workspace` : 'Global'}
-                {p.version ? ` · v${p.version}` : ''}
+        >
+        {loading && <p style={{ color: 'var(--text-muted)' }}>Loading...</p>}
+        {!loading && prompts.length === 0 && <p style={{ color: 'var(--text-muted)' }}>No prompts configured.</p>}
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: '1rem' }}>
+          {visiblePrompts.map(p => (
+            <Card key={p.id || p.name} style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+              <div>
+                <div style={{ fontWeight: 700, color: 'var(--text-heading)' }}>{p.name}</div>
+                <div style={{ color: 'var(--text-muted)', fontSize: '0.72rem', marginTop: 2 }}>
+                  {p.repo ? `${p.workspace_id || 'default'} / ${p.repo}` : p.workspace_id ? `${p.workspace_id} workspace` : 'Global'}
+                  {p.version ? ` · v${p.version}` : ''}
+                </div>
+                {p.description && <div style={{ color: 'var(--text-muted)', fontSize: '0.8rem', marginTop: 2 }}>{p.description}</div>}
               </div>
-              {p.description && <div style={{ color: 'var(--text-muted)', fontSize: '0.8rem', marginTop: 2 }}>{p.description}</div>}
-            </div>
-            <pre style={{ whiteSpace: 'pre-wrap', overflow: 'hidden', color: 'var(--text-muted)', fontSize: '0.78rem', lineHeight: 1.4, maxHeight: 110, margin: 0 }}>
-              {p.content || '-'}
-            </pre>
-            <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end', marginTop: 'auto' }}>
-              <button onClick={() => { setSelected(p); setSelectedScope(scopeType(p)); setError(''); setModal('edit') }} style={{ padding: '4px 10px', borderRadius: 5, border: '1px solid var(--border)', background: 'var(--bg)', cursor: 'pointer', color: 'var(--accent)' }}>Edit</button>
-              <button onClick={() => { setSelected(p); setError(''); setModal('delete') }} style={{ padding: '4px 10px', borderRadius: 5, border: '1px solid var(--border-danger)', background: 'var(--bg-danger)', cursor: 'pointer', color: 'var(--text-danger)' }}>Delete</button>
-            </div>
-          </Card>
-        ))}
-      </div>
+              <pre style={{ whiteSpace: 'pre-wrap', overflow: 'hidden', color: 'var(--text-muted)', fontSize: '0.78rem', lineHeight: 1.4, maxHeight: 110, margin: 0 }}>
+                {p.content || '-'}
+              </pre>
+              <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end', marginTop: 'auto' }}>
+                <button onClick={() => { setSelected(p); setSelectedScope(scopeType(p)); setError(''); setModal('edit') }} style={{ padding: '4px 10px', borderRadius: 5, border: '1px solid var(--border)', background: 'var(--bg)', cursor: 'pointer', color: 'var(--accent)' }}>Edit</button>
+                <button onClick={() => { setSelected(p); setError(''); setModal('delete') }} style={{ padding: '4px 10px', borderRadius: 5, border: '1px solid var(--border-danger)', background: 'var(--bg-danger)', cursor: 'pointer', color: 'var(--text-danger)' }}>Delete</button>
+              </div>
+            </Card>
+          ))}
+        </div>
+      </PaginatedDataSection>
 
       {(modal === 'create' || modal === 'edit') && (
         <Modal title={modal === 'create' ? 'New prompt' : `Edit ${selected.name}`} onClose={() => setModal(null)} maxWidth={modal === 'edit' ? '1100px' : undefined}>

--- a/internal/ui/src/app/repos/page.tsx
+++ b/internal/ui/src/app/repos/page.tsx
@@ -2,7 +2,7 @@
 import { useState, useEffect, useMemo, useCallback } from 'react'
 import Card from '@/components/Card'
 import Modal from '@/components/Modal'
-import PaginationControls from '@/components/PaginationControls'
+import PaginatedDataSection from '@/components/PaginatedDataSection'
 import BadgePicker from '@/components/BadgePicker'
 import RunButton from '@/components/RunButton'
 import WorkspaceSelect from '@/components/WorkspaceSelect'
@@ -565,59 +565,56 @@ export default function ReposPage() {
         </div>
       </div>
 
-      <div style={{ marginBottom: '1rem' }}>
-        <PaginationControls
-          total={total}
-          limit={limit}
-          offset={offset}
-          onLimitChange={(next) => { setLimit(next); setOffset(0) }}
-          onOffsetChange={setOffset}
-        />
-      </div>
+      <PaginatedDataSection
+        total={total}
+        limit={limit}
+        offset={offset}
+        onLimitChange={(next) => { setLimit(next); setOffset(0) }}
+        onOffsetChange={setOffset}
+      >
+        {loading && <p style={{ color: 'var(--text-muted)' }}>Loading…</p>}
+        {error && <p style={{ color: 'var(--text-danger)' }}>Error: {error}</p>}
+        {!loading && !error && repos.length === 0 && (
+          <p style={{ color: 'var(--text-muted)' }}>No repos configured.</p>
+        )}
 
-      {loading && <p style={{ color: 'var(--text-muted)' }}>Loading…</p>}
-      {error && <p style={{ color: 'var(--text-danger)' }}>Error: {error}</p>}
-      {!loading && !error && repos.length === 0 && (
-        <p style={{ color: 'var(--text-muted)' }}>No repos configured.</p>
-      )}
-
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
-        {repos.map(repo => {
-          const activeBindings = repo.bindings.filter(b => b.enabled !== false)
-          const disabledBindings = repo.bindings.filter(b => b.enabled === false)
-          const activeGroups = groupByAgent(activeBindings)
-          const disabledGroups = groupByAgent(disabledBindings)
-          const cardMuted = !repo.enabled
-          return (
-            <Card key={repo.name} style={{ opacity: cardMuted ? 0.65 : 1 }}>
-              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '0.75rem' }}>
-                <div>
-                  <div style={{ fontWeight: 700, color: 'var(--text-heading)', fontSize: '1rem' }}>{repo.name}</div>
-                  <div style={{ display: 'flex', gap: '0.4rem', alignItems: 'center', marginTop: '3px', flexWrap: 'wrap' }}>
-                    <span style={{
-                      display: 'inline-block', fontSize: '0.75rem', fontWeight: 700,
-                      padding: '2px 9px', borderRadius: '10px',
-                      background: repo.enabled ? 'var(--success-bg)' : 'rgba(100,116,139,0.2)',
-                      color: repo.enabled ? 'var(--success)' : 'var(--text-muted)',
-                      border: `1px solid ${repo.enabled ? 'var(--success-border)' : 'var(--border-subtle)'}`,
-                      textTransform: 'uppercase', letterSpacing: '0.03em',
-                    }}>
-                      {repo.enabled ? 'enabled' : 'disabled'}
-                    </span>
-                    <span style={{ fontSize: '0.72rem', color: 'var(--text-muted)' }}>
-                      {activeBindings.length} active{disabledBindings.length > 0 ? `, ${disabledBindings.length} disabled` : ''}
-                    </span>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+          {repos.map(repo => {
+            const activeBindings = repo.bindings.filter(b => b.enabled !== false)
+            const disabledBindings = repo.bindings.filter(b => b.enabled === false)
+            const activeGroups = groupByAgent(activeBindings)
+            const disabledGroups = groupByAgent(disabledBindings)
+            const cardMuted = !repo.enabled
+            return (
+              <Card key={repo.name} style={{ opacity: cardMuted ? 0.65 : 1 }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '0.75rem' }}>
+                  <div>
+                    <div style={{ fontWeight: 700, color: 'var(--text-heading)', fontSize: '1rem' }}>{repo.name}</div>
+                    <div style={{ display: 'flex', gap: '0.4rem', alignItems: 'center', marginTop: '3px', flexWrap: 'wrap' }}>
+                      <span style={{
+                        display: 'inline-block', fontSize: '0.75rem', fontWeight: 700,
+                        padding: '2px 9px', borderRadius: '10px',
+                        background: repo.enabled ? 'var(--success-bg)' : 'rgba(100,116,139,0.2)',
+                        color: repo.enabled ? 'var(--success)' : 'var(--text-muted)',
+                        border: `1px solid ${repo.enabled ? 'var(--success-border)' : 'var(--border-subtle)'}`,
+                        textTransform: 'uppercase', letterSpacing: '0.03em',
+                      }}>
+                        {repo.enabled ? 'enabled' : 'disabled'}
+                      </span>
+                      <span style={{ fontSize: '0.72rem', color: 'var(--text-muted)' }}>
+                        {activeBindings.length} active{disabledBindings.length > 0 ? `, ${disabledBindings.length} disabled` : ''}
+                      </span>
+                    </div>
+                  </div>
+                  <div style={{ display: 'flex', gap: '0.5rem' }}>
+                    <button onClick={() => openEdit(repo)} style={{ padding: '3px 10px', borderRadius: '5px', border: '1px solid var(--border)', background: 'var(--bg-input)', cursor: 'pointer', fontSize: '0.75rem', color: 'var(--accent)' }}>Edit</button>
+                    <button onClick={() => confirmDelete(repo.name)} style={{ padding: '3px 10px', borderRadius: '5px', border: '1px solid var(--border-danger)', background: 'var(--bg-danger)', cursor: 'pointer', fontSize: '0.75rem', color: 'var(--text-danger)' }}>Delete</button>
                   </div>
                 </div>
-                <div style={{ display: 'flex', gap: '0.5rem' }}>
-                  <button onClick={() => openEdit(repo)} style={{ padding: '3px 10px', borderRadius: '5px', border: '1px solid var(--border)', background: 'var(--bg-input)', cursor: 'pointer', fontSize: '0.75rem', color: 'var(--accent)' }}>Edit</button>
-                  <button onClick={() => confirmDelete(repo.name)} style={{ padding: '3px 10px', borderRadius: '5px', border: '1px solid var(--border-danger)', background: 'var(--bg-danger)', cursor: 'pointer', fontSize: '0.75rem', color: 'var(--text-danger)' }}>Delete</button>
-                </div>
-              </div>
 
-              {repo.bindings.length === 0 && (
-                <p style={{ color: 'var(--text-muted)', fontSize: '0.8rem' }}>No bindings.</p>
-              )}
+                {repo.bindings.length === 0 && (
+                  <p style={{ color: 'var(--text-muted)', fontSize: '0.8rem' }}>No bindings.</p>
+                )}
 
               {activeGroups.map(([agent, bindings]) => (
                 <div key={`active-${agent}`} style={{ marginBottom: '0.5rem' }}>
@@ -661,7 +658,8 @@ export default function ReposPage() {
             </Card>
           )
         })}
-      </div>
+        </div>
+      </PaginatedDataSection>
 
       {(modal === 'create' || modal === 'edit') && (
         <Modal title={modal === 'create' ? 'Add repo' : `Edit, ${selected.name}`} onClose={() => setModal(null)}>

--- a/internal/ui/src/app/runners/page.tsx
+++ b/internal/ui/src/app/runners/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link'
 import Card from '@/components/Card'
 import LiveTraceModal, { type LiveTraceSpan } from '@/components/LiveTraceModal'
 import Modal from '@/components/Modal'
-import PaginationControls from '@/components/PaginationControls'
+import PaginatedDataSection from '@/components/PaginatedDataSection'
 import RepoFilter from '@/components/RepoFilter'
 import WorkspaceSelect from '@/components/WorkspaceSelect'
 import { formatDateTime, formatTime } from '@/lib/datetime'
@@ -285,13 +285,6 @@ function RunnersInner() {
               padding: '4px 10px', borderRadius: '4px', cursor: 'pointer', fontSize: '0.8rem',
             }}>{s || 'All'}</button>
           ))}
-          <PaginationControls
-            total={total}
-            limit={limit}
-            offset={offset}
-            onLimitChange={(next) => { setLimit(next); setOffset(0) }}
-            onOffsetChange={setOffset}
-          />
         </div>
       </div>
 
@@ -327,6 +320,13 @@ function RunnersInner() {
         </Card>
       )}
 
+      <PaginatedDataSection
+        total={total}
+        limit={limit}
+        offset={offset}
+        onLimitChange={(next) => { setLimit(next); setOffset(0) }}
+        onOffsetChange={setOffset}
+      >
       <Card title="Runner Rows">
         <div style={{
           display: 'grid',
@@ -539,6 +539,7 @@ function RunnersInner() {
           })}
         </div>
       </Card>
+      </PaginatedDataSection>
       {streamSpan && <LiveTraceModal span={streamSpan} onClose={() => setStreamSpan(null)} />}
       {dialog?.kind === 'confirm-delete' && (
         <Modal title={`Delete runner #${dialog.id}?`} onClose={() => setDialog(null)}>

--- a/internal/ui/src/app/skills/page.tsx
+++ b/internal/ui/src/app/skills/page.tsx
@@ -2,7 +2,7 @@
 import { useState, useEffect } from 'react'
 import Card from '@/components/Card'
 import Modal from '@/components/Modal'
-import PaginationControls from '@/components/PaginationControls'
+import PaginatedDataSection from '@/components/PaginatedDataSection'
 import MarkdownEditor from '@/components/MarkdownEditor'
 import CatalogVersionsPanel from '@/components/CatalogVersionsPanel'
 import { apiRoutes } from '@/lib/api-routes'
@@ -390,56 +390,54 @@ export default function SkillsPage() {
         </div>
       </div>
 
-      <div style={{ marginBottom: '1rem' }}>
-        <PaginationControls
+      <PaginatedDataSection
           total={total}
           limit={limit}
           offset={offset}
           onLimitChange={(next) => { setLimit(next); setOffset(0) }}
           onOffsetChange={setOffset}
-        />
-      </div>
+        >
+        {loading && <p style={{ color: 'var(--text-muted)' }}>Loading…</p>}
+        {error && <p style={{ color: 'var(--text-danger)' }}>Error: {error}</p>}
+        {!loading && !error && skills.length === 0 && (
+          <p style={{ color: 'var(--text-muted)' }}>No skills configured.</p>
+        )}
 
-      {loading && <p style={{ color: 'var(--text-muted)' }}>Loading…</p>}
-      {error && <p style={{ color: 'var(--text-danger)' }}>Error: {error}</p>}
-      {!loading && !error && skills.length === 0 && (
-        <p style={{ color: 'var(--text-muted)' }}>No skills configured.</p>
-      )}
-
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
-        {visibleSkills.map(sk => (
-          <Card key={stableSkillID(sk) || sk.name}>
-            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '1rem' }}>
-              <div style={{ flex: 1, minWidth: 0 }}>
-                <div
-                  title={skillIdentityTooltip(sk)}
-                  style={{ fontWeight: 700, color: 'var(--text-heading)', marginBottom: '0.2rem', overflowWrap: 'anywhere' }}
-                >
-                  {skillDisplayLabel(sk)}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+          {visibleSkills.map(sk => (
+            <Card key={stableSkillID(sk) || sk.name}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '1rem' }}>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div
+                    title={skillIdentityTooltip(sk)}
+                    style={{ fontWeight: 700, color: 'var(--text-heading)', marginBottom: '0.2rem', overflowWrap: 'anywhere' }}
+                  >
+                    {skillDisplayLabel(sk)}
+                  </div>
+                  <div
+                    title={scopeLabel(sk)}
+                    style={{ color: 'var(--text-muted)', fontSize: '0.72rem', marginBottom: '0.35rem' }}
+                  >
+                    {shortScopeLabel(sk)}{sk.version ? ` · v${sk.version}` : ''}
+                  </div>
+                  <pre style={{
+                    fontSize: '0.78rem', color: 'var(--text-faint)', background: 'var(--bg)',
+                    border: '1px solid var(--border-subtle)', borderRadius: '4px', padding: '0.5rem',
+                    maxHeight: '80px', overflow: 'hidden', whiteSpace: 'pre-wrap', wordBreak: 'break-word',
+                    fontFamily: 'inherit',
+                  }}>
+                    {sk.prompt ? sk.prompt.slice(0, 200) + (sk.prompt.length > 200 ? '…' : '') : '-'}
+                  </pre>
                 </div>
-                <div
-                  title={scopeLabel(sk)}
-                  style={{ color: 'var(--text-muted)', fontSize: '0.72rem', marginBottom: '0.35rem' }}
-                >
-                  {shortScopeLabel(sk)}{sk.version ? ` · v${sk.version}` : ''}
+                <div style={{ display: 'flex', gap: '0.5rem', flexShrink: 0 }}>
+                  <button onClick={() => openEdit(sk)} style={{ padding: '3px 10px', borderRadius: '5px', border: '1px solid var(--border)', background: 'var(--bg)', cursor: 'pointer', fontSize: '0.75rem', color: 'var(--accent)' }}>Edit</button>
+                  <button onClick={() => confirmDelete(sk)} style={{ padding: '3px 10px', borderRadius: '5px', border: '1px solid var(--border-danger)', background: 'var(--bg-danger)', cursor: 'pointer', fontSize: '0.75rem', color: 'var(--text-danger)' }}>Delete</button>
                 </div>
-                <pre style={{
-                  fontSize: '0.78rem', color: 'var(--text-faint)', background: 'var(--bg)',
-                  border: '1px solid var(--border-subtle)', borderRadius: '4px', padding: '0.5rem',
-                  maxHeight: '80px', overflow: 'hidden', whiteSpace: 'pre-wrap', wordBreak: 'break-word',
-                  fontFamily: 'inherit',
-                }}>
-                  {sk.prompt ? sk.prompt.slice(0, 200) + (sk.prompt.length > 200 ? '…' : '') : '-'}
-                </pre>
               </div>
-              <div style={{ display: 'flex', gap: '0.5rem', flexShrink: 0 }}>
-                <button onClick={() => openEdit(sk)} style={{ padding: '3px 10px', borderRadius: '5px', border: '1px solid var(--border)', background: 'var(--bg)', cursor: 'pointer', fontSize: '0.75rem', color: 'var(--accent)' }}>Edit</button>
-                <button onClick={() => confirmDelete(sk)} style={{ padding: '3px 10px', borderRadius: '5px', border: '1px solid var(--border-danger)', background: 'var(--bg-danger)', cursor: 'pointer', fontSize: '0.75rem', color: 'var(--text-danger)' }}>Delete</button>
-              </div>
-            </div>
-          </Card>
-        ))}
-      </div>
+            </Card>
+          ))}
+        </div>
+      </PaginatedDataSection>
 
       {(modal === 'create' || modal === 'edit') && (
         <Modal title={modal === 'create' ? 'Create skill' : `Edit, ${skillDisplayLabel(selected)}`} onClose={() => setModal(null)} maxWidth={modal === 'edit' ? '1100px' : undefined}>

--- a/internal/ui/src/app/traces/page.tsx
+++ b/internal/ui/src/app/traces/page.tsx
@@ -2,7 +2,7 @@
 import React, { useState, useEffect, useRef, Suspense } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
 import Card from '@/components/Card'
-import PaginationControls from '@/components/PaginationControls'
+import PaginatedDataSection from '@/components/PaginatedDataSection'
 import StatusBadge from '@/components/StatusBadge'
 import Link from 'next/link'
 import RepoFilter, { useRepoFilter } from '@/components/RepoFilter'
@@ -453,13 +453,6 @@ function TracesContent() {
         <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
           <WorkspaceSelect compact />
           <RepoFilter selected={repoFilter} onChange={setRepoFilter} workspace={workspace} />
-          <PaginationControls
-            total={total}
-            limit={limit}
-            offset={offset}
-            onLimitChange={(next) => { setLimit(next); setOffset(0) }}
-            onOffsetChange={setOffset}
-          />
           <input
             placeholder="Filter by agent, repo, or ID…"
             value={filter}
@@ -472,11 +465,19 @@ function TracesContent() {
         </div>
       </div>
 
-      {loading && <p style={{ color: 'var(--text-muted)' }}>Loading…</p>}
-      {!loading && rootIds.length === 0 && <p style={{ color: 'var(--text-muted)' }}>No traces yet.</p>}
-      {rootIds.map(id => (
-        <TraceListItem key={id} rootId={id} spans={grouped[id]} onSelect={handleSelect} />
-      ))}
+      <PaginatedDataSection
+        total={total}
+        limit={limit}
+        offset={offset}
+        onLimitChange={(next) => { setLimit(next); setOffset(0) }}
+        onOffsetChange={setOffset}
+      >
+        {loading && <p style={{ color: 'var(--text-muted)' }}>Loading…</p>}
+        {!loading && rootIds.length === 0 && <p style={{ color: 'var(--text-muted)' }}>No traces yet.</p>}
+        {rootIds.map(id => (
+          <TraceListItem key={id} rootId={id} spans={grouped[id]} onSelect={handleSelect} />
+        ))}
+      </PaginatedDataSection>
     </div>
   )
 }

--- a/internal/ui/src/app/workspaces/page.tsx
+++ b/internal/ui/src/app/workspaces/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react'
 import Card from '@/components/Card'
 import Modal from '@/components/Modal'
-import PaginationControls from '@/components/PaginationControls'
+import PaginatedDataSection from '@/components/PaginatedDataSection'
 import { apiRoutes } from '@/lib/api-routes'
 import { itemsFromResponse } from '@/lib/pagination'
 import { defaultWorkspaceID } from '@/lib/workspace'
@@ -218,16 +218,14 @@ export default function WorkspacesPage() {
         </button>
       </div>
 
+      <PaginatedDataSection
+        total={total}
+        limit={limit}
+        offset={offset}
+        onLimitChange={(next) => { setLimit(next); setOffset(0) }}
+        onOffsetChange={setOffset}
+      >
       <Card>
-        <div style={{ marginBottom: '1rem' }}>
-          <PaginationControls
-            total={total}
-            limit={limit}
-            offset={offset}
-            onLimitChange={(next) => { setLimit(next); setOffset(0) }}
-            onOffsetChange={setOffset}
-          />
-        </div>
         {loading && <p style={{ color: 'var(--text-muted)' }}>Loading…</p>}
         {error && <p style={{ color: 'var(--text-danger)' }}>{error}</p>}
         {!loading && !error && workspaces.length === 0 && (
@@ -275,6 +273,7 @@ export default function WorkspacesPage() {
           </div>
         )}
       </Card>
+      </PaginatedDataSection>
 
       {(modal === 'create' || modal === 'edit') && (
         <Modal title={modal === 'create' ? 'Add Workspace' : `Edit ${selected.name || selected.id}`} onClose={() => setModal(null)}>

--- a/internal/ui/src/components/GuardrailsManager.tsx
+++ b/internal/ui/src/components/GuardrailsManager.tsx
@@ -6,7 +6,7 @@ import FullscreenModal from '@/components/FullscreenModal'
 import MarkdownEditor from '@/components/MarkdownEditor'
 import WorkspaceSelect from '@/components/WorkspaceSelect'
 import CatalogVersionsPanel from '@/components/CatalogVersionsPanel'
-import PaginationControls from '@/components/PaginationControls'
+import PaginatedDataSection from '@/components/PaginatedDataSection'
 import { apiRoutes } from '@/lib/api-routes'
 import { itemsFromResponse, pageFromResponse, selectorURL } from '@/lib/pagination'
 import { useSelectedWorkspace } from '@/lib/workspace'
@@ -546,56 +546,54 @@ export default function GuardrailsManager() {
         </button>
       </div>
 
-      <div style={{ marginBottom: '1rem' }}>
-        <PaginationControls
+      <PaginatedDataSection
           total={guardrailsTotal}
           limit={guardrailsLimit}
           offset={guardrailsOffset}
           onLimitChange={(next) => { setGuardrailsLimit(next); setGuardrailsOffset(0) }}
           onOffsetChange={setGuardrailsOffset}
-        />
-      </div>
-
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
-        {guardrails.map(g => (
-          <div
-            key={guardrailID(g)}
-            onClick={() => { setSelected(g); setModal('edit') }}
-            style={{
-              background: 'var(--bg-card)', border: '1px solid var(--border)',
-              borderRadius: '8px', padding: '1rem',
-              cursor: 'pointer', display: 'flex', alignItems: 'center', gap: '0.75rem',
-            }}
-          >
-            <div style={{ flex: 1, minWidth: 0 }}>
-              <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
-                <span style={{ fontWeight: 600, color: 'var(--text-heading)' }}>{g.name}</span>
-                {workspaceRefByID.has(guardrailID(g)) && (
-                  <span style={{ fontSize: '0.7rem', padding: '2px 6px', borderRadius: '4px', background: 'var(--bg-input)', color: workspaceRefByID.get(guardrailID(g))?.enabled ? 'var(--accent)' : 'var(--text-muted)', border: `1px solid ${workspaceRefByID.get(guardrailID(g))?.enabled ? 'var(--accent)' : 'var(--border)'}` }}>
-                    {workspaceRefByID.get(guardrailID(g))?.enabled ? 'selected' : 'selected (disabled)'}
-                  </span>
+        >
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+          {guardrails.map(g => (
+            <div
+              key={guardrailID(g)}
+              onClick={() => { setSelected(g); setModal('edit') }}
+              style={{
+                background: 'var(--bg-card)', border: '1px solid var(--border)',
+                borderRadius: '8px', padding: '1rem',
+                cursor: 'pointer', display: 'flex', alignItems: 'center', gap: '0.75rem',
+              }}
+            >
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
+                  <span style={{ fontWeight: 600, color: 'var(--text-heading)' }}>{g.name}</span>
+                  {workspaceRefByID.has(guardrailID(g)) && (
+                    <span style={{ fontSize: '0.7rem', padding: '2px 6px', borderRadius: '4px', background: 'var(--bg-input)', color: workspaceRefByID.get(guardrailID(g))?.enabled ? 'var(--accent)' : 'var(--text-muted)', border: `1px solid ${workspaceRefByID.get(guardrailID(g))?.enabled ? 'var(--accent)' : 'var(--border)'}` }}>
+                      {workspaceRefByID.get(guardrailID(g))?.enabled ? 'selected' : 'selected (disabled)'}
+                    </span>
+                  )}
+                  {g.is_builtin && (
+                    <span style={{ fontSize: '0.7rem', padding: '2px 6px', borderRadius: '4px', background: 'var(--accent)', color: 'var(--bg-card)' }}>built-in</span>
+                  )}
+                  {!g.enabled && (
+                    <span style={{ fontSize: '0.7rem', padding: '2px 6px', borderRadius: '4px', background: 'var(--bg-input)', color: 'var(--text-danger)', border: '1px solid var(--text-danger)' }}>disabled</span>
+                  )}
+                  <span style={{ fontSize: '0.7rem', color: 'var(--text-faint)' }}>position {g.position}</span>
+                  {g.version && <span style={{ fontSize: '0.7rem', color: 'var(--text-faint)' }}>v{g.version}</span>}
+                  <span style={{ fontSize: '0.7rem', color: 'var(--text-faint)' }}>{guardrailScope(g)}</span>
+                </div>
+                {g.description && (
+                  <p style={{ fontSize: '0.8rem', color: 'var(--text-muted)', marginTop: '4px' }}>{g.description}</p>
                 )}
-                {g.is_builtin && (
-                  <span style={{ fontSize: '0.7rem', padding: '2px 6px', borderRadius: '4px', background: 'var(--accent)', color: 'var(--bg-card)' }}>built-in</span>
-                )}
-                {!g.enabled && (
-                  <span style={{ fontSize: '0.7rem', padding: '2px 6px', borderRadius: '4px', background: 'var(--bg-input)', color: 'var(--text-danger)', border: '1px solid var(--text-danger)' }}>disabled</span>
-                )}
-                <span style={{ fontSize: '0.7rem', color: 'var(--text-faint)' }}>position {g.position}</span>
-                {g.version && <span style={{ fontSize: '0.7rem', color: 'var(--text-faint)' }}>v{g.version}</span>}
-                <span style={{ fontSize: '0.7rem', color: 'var(--text-faint)' }}>{guardrailScope(g)}</span>
               </div>
-              {g.description && (
-                <p style={{ fontSize: '0.8rem', color: 'var(--text-muted)', marginTop: '4px' }}>{g.description}</p>
-              )}
+              <span style={{ color: 'var(--text-faint)', fontSize: '0.85rem' }}>edit →</span>
             </div>
-            <span style={{ color: 'var(--text-faint)', fontSize: '0.85rem' }}>edit →</span>
-          </div>
-        ))}
-        {guardrails.length === 0 && (
-          <p style={{ color: 'var(--text-muted)', fontStyle: 'italic' }}>No guardrails yet. The 'security' default should ship with the daemon, check that migrations applied.</p>
-        )}
-      </div>
+          ))}
+          {guardrails.length === 0 && (
+            <p style={{ color: 'var(--text-muted)', fontStyle: 'italic' }}>No guardrails yet. The 'security' default should ship with the daemon, check that migrations applied.</p>
+          )}
+        </div>
+      </PaginatedDataSection>
 
       {(modal === 'create' || modal === 'edit') && (
         <FullscreenModal

--- a/internal/ui/src/components/PaginatedDataSection.tsx
+++ b/internal/ui/src/components/PaginatedDataSection.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import PaginationControls from '@/components/PaginationControls'
+
+interface PaginatedDataSectionProps {
+  total: number
+  limit: number
+  offset: number
+  onLimitChange: (limit: number) => void
+  onOffsetChange: (offset: number) => void
+  children: ReactNode
+  pageSizes?: number[]
+  topLeft?: ReactNode
+  style?: React.CSSProperties
+  contentStyle?: React.CSSProperties
+}
+
+export default function PaginatedDataSection({
+  total,
+  limit,
+  offset,
+  onLimitChange,
+  onOffsetChange,
+  children,
+  pageSizes,
+  topLeft,
+  style,
+  contentStyle,
+}: PaginatedDataSectionProps) {
+  const controls = (
+    <PaginationControls
+      total={total}
+      limit={limit}
+      offset={offset}
+      onLimitChange={onLimitChange}
+      onOffsetChange={onOffsetChange}
+      pageSizes={pageSizes}
+    />
+  )
+
+  return (
+    <section style={{ display: 'grid', gap: '0.85rem', ...style }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+        <div>{topLeft}</div>
+        <div style={{ marginLeft: 'auto' }}>{controls}</div>
+      </div>
+      <div style={contentStyle}>{children}</div>
+      <div style={{ display: 'flex', justifyContent: 'center' }}>
+        {controls}
+      </div>
+    </section>
+  )
+}

--- a/internal/ui/src/lib/auth.test.tsx
+++ b/internal/ui/src/lib/auth.test.tsx
@@ -143,20 +143,20 @@ describe('AuthTokenSettings', () => {
 
     expect(await screen.findByText('operator')).toBeInTheDocument()
     expect(await screen.findByText('first token')).toBeInTheDocument()
-    expect(screen.getByText('1-50 of 75')).toBeInTheDocument()
-    expect(screen.getByText('1-50 of 120')).toBeInTheDocument()
+    expect(screen.getAllByText('1-50 of 75')).toHaveLength(2)
+    expect(screen.getAllByText('1-50 of 120')).toHaveLength(2)
 
     const nextButtons = screen.getAllByRole('button', { name: 'Next' })
     fireEvent.click(nextButtons[0])
 
     expect(await screen.findByText('viewer')).toBeInTheDocument()
-    expect(screen.getByText('51-75 of 75')).toBeInTheDocument()
+    expect(screen.getAllByText('51-75 of 75')).toHaveLength(2)
     expect(fetchMock).toHaveBeenCalledWith('/auth/users?limit=50&offset=50', { cache: 'no-store' })
 
-    fireEvent.click(nextButtons[1])
+    fireEvent.click(screen.getAllByRole('button', { name: 'Next' })[2])
 
     expect(await screen.findByText('second token')).toBeInTheDocument()
-    expect(screen.getByText('51-100 of 120')).toBeInTheDocument()
+    expect(screen.getAllByText('51-100 of 120')).toHaveLength(2)
     expect(fetchMock).toHaveBeenCalledWith('/auth/tokens?limit=50&offset=50', { cache: 'no-store' })
   })
 })

--- a/internal/ui/src/lib/auth.tsx
+++ b/internal/ui/src/lib/auth.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import PaginationControls from '@/components/PaginationControls'
+import PaginatedDataSection from '@/components/PaginatedDataSection'
 import { apiRoutes } from '@/lib/api-routes'
 import { formatDateTime } from '@/lib/datetime'
 import { pageFromResponse } from '@/lib/pagination'
@@ -264,27 +264,38 @@ export function AuthTokenSettings() {
               <h4 style={sectionTitleStyle}>Users</h4>
               <p style={sectionHelpStyle}>Admin users can create or remove dashboard users. Every user can manage daemon configuration and create their own API tokens.</p>
             </div>
-            <div style={{ display: 'grid', gap: '0.5rem' }}>
-              {users.map(user => (
-                <div key={user.id} style={rowStyle}>
-                  <div>
-                    <strong style={{ color: 'var(--text-heading)', fontSize: '0.82rem' }}>{user.username}</strong>
-                    <p style={{ color: 'var(--text-muted)', fontSize: '0.74rem' }}>
-                      created {formatDate(user.created_at)}
-                      {user.last_login_at ? ` · last login ${formatDate(user.last_login_at)}` : ''}
-                      {user.disabled_at ? ' · disabled' : ''}
-                    </p>
+            <PaginatedDataSection
+              total={usersTotal}
+              limit={usersLimit}
+              offset={usersOffset}
+              onLimitChange={limit => {
+                setUsersLimit(limit)
+                setUsersOffset(0)
+              }}
+              onOffsetChange={setUsersOffset}
+            >
+              <div style={{ display: 'grid', gap: '0.5rem' }}>
+                {users.map(user => (
+                  <div key={user.id} style={rowStyle}>
+                    <div>
+                      <strong style={{ color: 'var(--text-heading)', fontSize: '0.82rem' }}>{user.username}</strong>
+                      <p style={{ color: 'var(--text-muted)', fontSize: '0.74rem' }}>
+                        created {formatDate(user.created_at)}
+                        {user.last_login_at ? ` · last login ${formatDate(user.last_login_at)}` : ''}
+                        {user.disabled_at ? ' · disabled' : ''}
+                      </p>
+                    </div>
+                    <div style={{ display: 'flex', gap: '0.45rem', alignItems: 'center', flexWrap: 'wrap', justifyContent: 'flex-end' }}>
+                      {user.is_admin && <span style={pillStyle}>admin</span>}
+                      {status.user?.username === user.username && <span style={pillStyle}>current</span>}
+                      {status.user?.is_admin && !user.is_admin && status.user?.username !== user.username && (
+                        <button type="button" onClick={() => deleteUser(user.id)} style={secondaryButtonStyle}>Remove</button>
+                      )}
+                    </div>
                   </div>
-                  <div style={{ display: 'flex', gap: '0.45rem', alignItems: 'center', flexWrap: 'wrap', justifyContent: 'flex-end' }}>
-                    {user.is_admin && <span style={pillStyle}>admin</span>}
-                    {status.user?.username === user.username && <span style={pillStyle}>current</span>}
-                    {status.user?.is_admin && !user.is_admin && status.user?.username !== user.username && (
-                      <button type="button" onClick={() => deleteUser(user.id)} style={secondaryButtonStyle}>Remove</button>
-                    )}
-                  </div>
-                </div>
-              ))}
-            </div>
+                ))}
+              </div>
+            </PaginatedDataSection>
             {status.user?.is_admin ? (
               <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
                 <input value={newUsername} onChange={e => setNewUsername(e.target.value)} placeholder="Username" style={{ ...inputStyle, maxWidth: '220px' }} />
@@ -295,16 +306,6 @@ export function AuthTokenSettings() {
               <p style={{ color: 'var(--text-muted)', fontSize: '0.78rem' }}>Only the admin user can create or remove dashboard users.</p>
             )}
             {userError && <p style={{ color: 'var(--text-danger)', fontSize: '0.78rem' }}>{userError}</p>}
-            <PaginationControls
-              total={usersTotal}
-              limit={usersLimit}
-              offset={usersOffset}
-              onLimitChange={limit => {
-                setUsersLimit(limit)
-                setUsersOffset(0)
-              }}
-              onOffsetChange={setUsersOffset}
-            />
           </section>
 
           <section style={sectionStyle}>
@@ -322,18 +323,7 @@ export function AuthTokenSettings() {
                 {created}
               </code>
             )}
-            <div style={{ display: 'grid', gap: '0.5rem' }}>
-              {tokens.map(token => (
-                <div key={token.id} style={rowStyle}>
-                  <div>
-                    <strong style={{ color: 'var(--text-heading)', fontSize: '0.82rem' }}>{token.name}</strong>
-                    <p style={{ color: 'var(--text-muted)', fontSize: '0.74rem' }}>{token.kind} · {token.prefix} · {token.revoked_at ? 'revoked' : 'active'}</p>
-                  </div>
-                  {!token.revoked_at && <button type="button" onClick={() => revoke(token.id)} style={secondaryButtonStyle}>Revoke</button>}
-                </div>
-              ))}
-            </div>
-            <PaginationControls
+            <PaginatedDataSection
               total={tokensTotal}
               limit={tokensLimit}
               offset={tokensOffset}
@@ -342,7 +332,19 @@ export function AuthTokenSettings() {
                 setTokensOffset(0)
               }}
               onOffsetChange={setTokensOffset}
-            />
+            >
+              <div style={{ display: 'grid', gap: '0.5rem' }}>
+                {tokens.map(token => (
+                  <div key={token.id} style={rowStyle}>
+                    <div>
+                      <strong style={{ color: 'var(--text-heading)', fontSize: '0.82rem' }}>{token.name}</strong>
+                      <p style={{ color: 'var(--text-muted)', fontSize: '0.74rem' }}>{token.kind} · {token.prefix} · {token.revoked_at ? 'revoked' : 'active'}</p>
+                    </div>
+                    {!token.revoked_at && <button type="button" onClick={() => revoke(token.id)} style={secondaryButtonStyle}>Revoke</button>}
+                  </div>
+                ))}
+              </div>
+            </PaginatedDataSection>
           </section>
         </>
       )}


### PR DESCRIPTION
## Summary
- add a reusable PaginatedDataSection wrapper that renders controls at the top right and bottom center
- migrate paginated dashboard lists to use the shared wrapper
- update UI tests for the duplicated pagination controls

## Validation
- npm test -- --run
- npm run build