### PR TITLE
fix: auto-remove runner containers

### DIFF
--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -110,6 +110,9 @@ func (d *Docker) Run(ctx context.Context, spec ContainerSpec) (ExitStatus, error
 		removeCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
 		if err := d.client.ContainerRemove(removeCtx, containerID, container.RemoveOptions{Force: true, RemoveVolumes: true}); err != nil {
+			if errdefs.IsNotFound(err) {
+				return
+			}
 			d.logger.Warn().Err(err).Str("container", containerID).Msg("remove runner container")
 		}
 	}
@@ -185,6 +188,7 @@ func (d *Docker) Run(ctx context.Context, spec ContainerSpec) (ExitStatus, error
 func hostConfig(spec ContainerSpec) (*container.HostConfig, error) {
 	cfg := &container.HostConfig{
 		NetworkMode: container.NetworkMode(spec.Policy.NetworkMode),
+		AutoRemove:  true,
 	}
 	if spec.Policy.NetworkMode == "" {
 		cfg.NetworkMode = "bridge"

--- a/internal/runtime/docker_test.go
+++ b/internal/runtime/docker_test.go
@@ -23,6 +23,9 @@ func TestHostConfigAppliesRuntimeConstraints(t *testing.T) {
 	if cfg.NetworkMode != "none" {
 		t.Fatalf("NetworkMode = %q, want none", cfg.NetworkMode)
 	}
+	if !cfg.AutoRemove {
+		t.Fatal("AutoRemove = false, want true")
+	}
 	if cfg.Resources.NanoCPUs != 500_000_000 {
 		t.Fatalf("NanoCPUs = %d, want 500000000", cfg.Resources.NanoCPUs)
 	}


### PR DESCRIPTION
## Summary
- enable Docker AutoRemove for ephemeral runner containers
- keep the explicit forced remove fallback for early failure and cancellation paths
- tolerate containers already removed by Docker during fallback cleanup

## Why
Stopped runner containers accumulated on ts-lonestar and consumed ~35GB of Docker writable-layer storage. AutoRemove makes Docker clean up exited runners even if the daemon does not reach its deferred cleanup path.

## Tests
- GOCACHE=/tmp/go-build-agents go test ./internal/runtime